### PR TITLE
Opendata Refactor

### DIFF
--- a/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
+++ b/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
@@ -12,6 +12,13 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.open4goods.config.yml.ui.VerticalConfig;
+import org.open4goods.exceptions.ResourceNotFoundException;
+import org.open4goods.model.BarcodeType;
+import org.open4goods.model.constants.CacheConstants;
+import org.open4goods.model.product.Product;
+import org.open4goods.store.repository.ProductIndexationWorker;
+import org.open4goods.store.repository.redis.RedisProductRepository;
 import org.open4goods.commons.config.yml.IndexationConfig;
 import org.open4goods.commons.config.yml.ui.VerticalConfig;
 import org.open4goods.commons.exceptions.ResourceNotFoundException;
@@ -63,10 +70,10 @@ public class ProductRepository {
 	
 	// The file queue implementation for Full products (no partial updates)
 	private BlockingQueue<Product> fullProductQueue;
-	
+
 	// The file queue implementation for Full products (no partial updates)
 	private BlockingQueue<ProductPartialUpdateHolder> partialProductQueue;
-	
+
 	
 	
 	/**
@@ -83,32 +90,32 @@ public class ProductRepository {
 	private @Autowired ElasticsearchOperations elasticsearchOperations;
 
 	private @Autowired SerialisationService serialisationService;
-	
+
 //	private @Autowired RedisProductRepository redisRepository;
 	
 //	private @Autowired RedisOperations<String, Product> redisRepo;
 
 	public ProductRepository() {
-		
-		
+
+
 	}
 
 //	private ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
 
 	//TODO(p3,perf) : Virtual threads, but ko with visualVM profiling
 	public ProductRepository(IndexationConfig indexationConfig) {
-				
+
 		this.fullProductQueue = new LinkedBlockingQueue<>(indexationConfig.getProductsQueueMaxSize());
 		this.partialProductQueue = new LinkedBlockingQueue<>(indexationConfig.getPartialProductsQueueMaxSize());
 
 		for (int i = 0; i < indexationConfig.getProductWorkers(); i++) {
 			new Thread((new FullProductIndexationWorker(this, indexationConfig.getProductsbulkPageSize(), indexationConfig.getPauseDuration(),"full-products-worker-"+i))).start();
 		}
-		
+
 		for (int i = 0; i < indexationConfig.getPartialProductWorkers(); i++) {
 			new Thread((new PartialProductIndexationWorker(this, indexationConfig.getPartialProductsbulkPageSize(), indexationConfig.getPauseDuration(),"partial-products-worker-"+i))).start();
 		}
-		
+
 	}
 
 	/**
@@ -149,20 +156,20 @@ public class ProductRepository {
 	            .map(SearchHit::getContent);
 	}
 
-	
+
 
 	public Stream<Product> exportAll(String vertical) {
-		
+
 		Criteria c = new Criteria("vertical").is(vertical);
 
 		final NativeQuery initialQuery = new NativeQueryBuilder()
 				.withQuery(new CriteriaQuery(c)).build();
-		
+
 		return elasticsearchOperations.searchForStream(initialQuery, Product.class, current_index).stream()
 				.map(SearchHit::getContent);
 	}
 
-	
+
 	public Stream<Product> searchInValidPrices(String query, final String indexName, int from, int to) {
 
 		Criteria c = new Criteria().expression(query).and(getRecentPriceQuery());
@@ -267,24 +274,24 @@ public class ProductRepository {
 		return elasticsearchOperations.searchForStream(initialQuery, Product.class, current_index).stream().map(SearchHit::getContent);
 	}
 
-	
+
 	public Stream<Product> getAllHavingVertical() {
 		Criteria c = new Criteria("vertical").exists()
 				;
 
-		
+
 		NativeQueryBuilder initialQueryBuilder = new NativeQueryBuilder().withQuery(new CriteriaQuery(c));
-		
-		initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.value")));									
+
+		initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.value")));
 
 		NativeQuery initialQuery = initialQueryBuilder.build();
-		
+
 		return elasticsearchOperations.searchForStream(initialQuery, Product.class, current_index).stream().map(SearchHit::getContent);
-		
+
 	}
-	
-	
-	
+
+
+
 	/**
 	 * Export all aggregateddatas for a vertical, ordered by ecoscore descending
 	 * 
@@ -306,9 +313,9 @@ public class ProductRepository {
 
 	}
 
-	
-	
-	
+
+
+
 //	/**
 //	 * Index an Product
 //	 *
@@ -370,15 +377,15 @@ public class ProductRepository {
 	public void addToFullindexationQueue(Collection<Product> data) {
 
 		logger.info("Queuing {} products", data.size());
-		
+
 		data.forEach(e -> {
-			
+
 			try {
 				fullProductQueue.put(e) ;
 			} catch (Exception e1) {
 				logger.error("!!!! exception, cannot enqueue product {}",e);
 			}
-			
+
 		});
 	}
 
@@ -399,7 +406,7 @@ public class ProductRepository {
 	
 	public void store(Collection<Product> data) {
 	    logger.info("Indexing {} products", data.size());
-	    
+
 	    List<IndexQuery> indexQueries = data.stream()
 	        .map(p -> new IndexQueryBuilder()
 	            .withId(String.valueOf(p.getId()))
@@ -410,8 +417,8 @@ public class ProductRepository {
 	    elasticsearchOperations.bulkIndex(indexQueries, current_index);
 	}
 
-	
-	
+
+
 	public void forceIndex(Product data) {
 		logger.info("Indexing  product {}", data.gtin());
 
@@ -447,9 +454,9 @@ public class ProductRepository {
 //		try {
 //			result = redisRepository.findById(productId).orElseThrow(ResourceNotFoundException::new);
 //		} catch (ResourceNotFoundException e) {
-//			
+//
 //			result = null;
-//			
+//
 //		} catch (Exception e) {
 //			logger.error("Error getting product {} from redis", productId, e);
 //			result = null;
@@ -522,7 +529,7 @@ public class ProductRepository {
 //				ret.put(e.gtin(), e);
 //			}
 //		});
-//		
+//
 		// Getting the one we don't have in redis from elastic 		
 		Set<String> missingIds = ids.stream().filter(e -> !ret.containsKey(e)).map(e-> String.valueOf(e)) .collect(Collectors.toSet());
 		logger.info("redis hits : {}, missing : {}, queue size : {}",ret.size(), missingIds.size(),fullProductQueue.size());
@@ -575,6 +582,18 @@ public class ProductRepository {
 		CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery());
 		return elasticsearchOperations.count(query, current_index);
 	}
+
+    @Cacheable(cacheNames = CacheConstants.ONE_DAY_LOCAL_CACHE_NAME)
+    public long countItemsByBarcodeType(BarcodeType... barcodeTypes) {
+        Criteria criteria = new Criteria("gtinInfos.upcType").in((Object[]) barcodeTypes);
+        CriteriaQuery query = new CriteriaQuery(criteria);
+        return elasticsearchTemplate.count(query, current_index);
+    }
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+    public Long countMainIndexHavingPrice() {
+        CriteriaQuery query = new CriteriaQuery(getValidDateQuery());
+        return elasticsearchTemplate.count(query, current_index);
+    }
 
 	
 	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
@@ -630,7 +649,7 @@ public class ProductRepository {
 	    // Perform the bulk update
 	    elasticsearchOperations.bulkUpdate(updateQueries, current_index);
 	}
-	
+
 //	/**
 //	 * Bulk update, using script
 //	 * @param partialItemsResults
@@ -658,7 +677,7 @@ public class ProductRepository {
 //	    // Perform the bulk update
 //	    elasticsearchOperations.bulkUpdate(updateQueries, current_index);
 //	}
-//	
+//
 
 
 	/**
@@ -667,7 +686,7 @@ public class ProductRepository {
 	 */
 	public Criteria getRecentPriceQuery() {
 		return getRecentProducts().and(new Criteria("offersCount").greaterThan(0));
-				
+
 	}
 
 	/**
@@ -677,7 +696,7 @@ public class ProductRepository {
 	public Criteria getRecentProducts() {
 		return new Criteria("lastChange").greaterThan(expirationClause());
 	}
-	
+
 	/**
 	 *
 	 * @return Criteria representing the valid dates

--- a/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
+++ b/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
@@ -169,7 +169,21 @@ public class ProductRepository {
 				.map(SearchHit::getContent);
 	}
 
-
+	/**
+	 * Export all aggregated data, corresponding to the given Barcodes
+	 * 
+	 * @return
+	 */
+	public Stream<Product> exportAll(BarcodeType... barcodeTypes) {
+		
+		Criteria criteria = new Criteria("gtinInfos.upcType").in((Object[]) barcodeTypes);
+		CriteriaQuery query = new CriteriaQuery(criteria);
+		
+		return elasticsearchTemplate.searchForStream(query, Product.class, current_index).stream()
+				.map(SearchHit::getContent);
+	}
+	
+	
 	public Stream<Product> searchInValidPrices(String query, final String indexName, int from, int to) {
 
 		Criteria c = new Criteria().expression(query).and(getRecentPriceQuery());
@@ -582,6 +596,8 @@ public class ProductRepository {
 		CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery());
 		return elasticsearchOperations.count(query, current_index);
 	}
+
+
 
     @Cacheable(cacheNames = CacheConstants.ONE_DAY_LOCAL_CACHE_NAME)
     public long countItemsByBarcodeType(BarcodeType... barcodeTypes) {

--- a/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
+++ b/commons/src/main/java/org/open4goods/commons/dao/ProductRepository.java
@@ -12,13 +12,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.open4goods.config.yml.ui.VerticalConfig;
-import org.open4goods.exceptions.ResourceNotFoundException;
 import org.open4goods.model.BarcodeType;
-import org.open4goods.model.constants.CacheConstants;
-import org.open4goods.model.product.Product;
-import org.open4goods.store.repository.ProductIndexationWorker;
-import org.open4goods.store.repository.redis.RedisProductRepository;
 import org.open4goods.commons.config.yml.IndexationConfig;
 import org.open4goods.commons.config.yml.ui.VerticalConfig;
 import org.open4goods.commons.exceptions.ResourceNotFoundException;
@@ -179,7 +173,7 @@ public class ProductRepository {
 		Criteria criteria = new Criteria("gtinInfos.upcType").in((Object[]) barcodeTypes);
 		CriteriaQuery query = new CriteriaQuery(criteria);
 		
-		return elasticsearchTemplate.searchForStream(query, Product.class, current_index).stream()
+		return elasticsearchOperations.searchForStream(query, Product.class, current_index).stream()
 				.map(SearchHit::getContent);
 	}
 	
@@ -597,20 +591,12 @@ public class ProductRepository {
 		return elasticsearchOperations.count(query, current_index);
 	}
 
-
-
     @Cacheable(cacheNames = CacheConstants.ONE_DAY_LOCAL_CACHE_NAME)
     public long countItemsByBarcodeType(BarcodeType... barcodeTypes) {
         Criteria criteria = new Criteria("gtinInfos.upcType").in((Object[]) barcodeTypes);
         CriteriaQuery query = new CriteriaQuery(criteria);
-        return elasticsearchTemplate.count(query, current_index);
+        return elasticsearchOperations.count(query, current_index);
     }
-    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-    public Long countMainIndexHavingPrice() {
-        CriteriaQuery query = new CriteriaQuery(getValidDateQuery());
-        return elasticsearchTemplate.count(query, current_index);
-    }
-
 	
 	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
 	public Map<Integer, Long> byTaxonomy() {

--- a/commons/src/main/java/org/open4goods/commons/model/BarcodeType.java
+++ b/commons/src/main/java/org/open4goods/commons/model/BarcodeType.java
@@ -1,7 +1,12 @@
 package org.open4goods.commons.model;
 
 public enum BarcodeType {
-	ISBN_13, GTIN_13, GTIN_8, GTIN_12, GTIN_14, UNKNOWN,
+	ISBN_13,
+	GTIN_13,
+	GTIN_8,
+	GTIN_12,
+	GTIN_14,
+	UNKNOWN,
 
 
 }

--- a/commons/src/main/java/org/open4goods/commons/model/product/AggregatedAttributes.java
+++ b/commons/src/main/java/org/open4goods/commons/model/product/AggregatedAttributes.java
@@ -18,7 +18,7 @@ public class AggregatedAttributes  {
 	private Map<ReferentielKey, String> referentielAttributes = new HashMap<>();
 
 	//TODO: rename
-	
+
 	private Map<String,AggregatedAttribute> aggregatedAttributes = new HashMap<>();
 
 
@@ -96,4 +96,13 @@ public class AggregatedAttributes  {
 	public void setReferentielAttributes(Map<ReferentielKey, String> referentielAttributes) {
 		this.referentielAttributes = referentielAttributes;
 	}
+
+
+
+
+
+
+
+
+
 }

--- a/commons/src/main/java/org/open4goods/model/BarcodeType.java
+++ b/commons/src/main/java/org/open4goods/model/BarcodeType.java
@@ -1,0 +1,12 @@
+package org.open4goods.model;
+
+public enum BarcodeType {
+	ISBN_13,
+	GTIN_13,
+	GTIN_8,
+	GTIN_12,
+	GTIN_14,
+	UNKNOWN,
+
+
+}

--- a/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
@@ -195,9 +195,7 @@ public class AppConfig {
 
 
 	@Bean
-	OpenDataService openDataService(@Autowired ProductRepository aggregatedDataRepository,
-									@Autowired UiConfig props,
-									@Autowired OpenDataConfig openDataConfig) {
+	OpenDataService openDataService(@Autowired ProductRepository aggregatedDataRepository, @Autowired UiConfig props, @Autowired OpenDataConfig openDataConfig) {
 		return new OpenDataService(aggregatedDataRepository, props, openDataConfig);
 	}
 

--- a/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
@@ -192,11 +192,13 @@ public class AppConfig {
 		// TODO : xmlMapper not injected because corruct the springdoc used one. Should use a @Primary derivation
 		return new IcecatService(new XmlMapper(), properties.getIcecatFeatureConfig(), fileCachingService, properties.getRemoteCachingFolder(), brandService, verticalConfigService);
 	}
-	
-	
+
+
 	@Bean
-	OpenDataService openDataService(@Autowired ProductRepository aggregatedDataRepository, @Autowired UiConfig props) {
-		return new OpenDataService(aggregatedDataRepository, props);
+	OpenDataService openDataService(@Autowired ProductRepository aggregatedDataRepository,
+									@Autowired UiConfig props,
+									@Autowired OpenDataConfig openDataConfig) {
+		return new OpenDataService(aggregatedDataRepository, props, openDataConfig);
 	}
 
 

--- a/ui/src/main/java/org/open4goods/ui/config/OpenDataConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/OpenDataConfig.java
@@ -1,0 +1,44 @@
+package org.open4goods.ui.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenDataConfig {
+
+    private int downloadSpeedKb;
+    private int concurrentDownloads;
+    private long initialDelay;
+    private long fixedDelay;
+
+    public int getDownloadSpeedKb() {
+        return downloadSpeedKb;
+    }
+
+    public void setDownloadSpeedKb(int downloadSpeedKb) {
+        this.downloadSpeedKb = downloadSpeedKb;
+    }
+
+    public int getConcurrentDownloads() {
+        return concurrentDownloads;
+    }
+
+    public void setConcurrentDownloads(int concurrentDownloads) {
+        this.concurrentDownloads = concurrentDownloads;
+    }
+
+    public long getInitialDelay() {
+        return initialDelay;
+    }
+
+    public void setInitialDelay(long initialDelay) {
+        this.initialDelay = initialDelay;
+    }
+
+    public long getFixedDelay() {
+        return fixedDelay;
+    }
+
+    public void setFixedDelay(long fixedDelay) {
+        this.fixedDelay = fixedDelay;
+    }
+}

--- a/ui/src/main/java/org/open4goods/ui/config/OpenDataConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/OpenDataConfig.java
@@ -7,8 +7,6 @@ public class OpenDataConfig {
 
     private int downloadSpeedKb;
     private int concurrentDownloads;
-    private long initialDelay;
-    private long fixedDelay;
 
     public int getDownloadSpeedKb() {
         return downloadSpeedKb;
@@ -26,19 +24,5 @@ public class OpenDataConfig {
         this.concurrentDownloads = concurrentDownloads;
     }
 
-    public long getInitialDelay() {
-        return initialDelay;
-    }
-
-    public void setInitialDelay(long initialDelay) {
-        this.initialDelay = initialDelay;
-    }
-
-    public long getFixedDelay() {
-        return fixedDelay;
-    }
-
-    public void setFixedDelay(long fixedDelay) {
-        this.fixedDelay = fixedDelay;
-    }
+  
 }

--- a/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
@@ -236,10 +236,21 @@ public class UiConfig {
 		return new File(rootFolder + File.separator+"opendata"+File.separator+"full.zip");
 	}
 
-	public File tmpOpenDataFile() {
-		return new File(rootFolder + File.separator+"opendata"+File.separator+"full-tmp.zip");
+	public File isbnZipFile() {
+		return new File(rootFolder + File.separator + "opendata" + File.separator + "isbn.zip");
 	}
 
+	public File tmpIsbnZipFile() {
+		return new File(rootFolder + File.separator + "opendata" + File.separator + "isbn-tmp.zip");
+	}
+
+	public File gtinZipFile() {
+		return new File(rootFolder + File.separator + "opendata" + File.separator + "gtin.zip");
+	}
+
+	public File tmpGtinZipFile() {
+		return new File(rootFolder + File.separator + "opendata" + File.separator + "gtin-tmp.zip");
+	}
 
 	public String getRootFolder() {
 		return rootFolder;

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -2,6 +2,8 @@ package org.open4goods.ui.controllers.ui.pages;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.open4goods.commons.exceptions.TechnicalException;
@@ -53,6 +55,15 @@ public class OpenDataController  implements SitemapExposedController{
 	public SitemapEntry getExposedUrls() {
 		return SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, DEFAULT_PATH, 0.3, ChangeFreq.YEARLY);
 	}
+
+	@Override
+	public List<SitemapEntry> getMultipleExposedUrls() {
+		return Arrays.asList(
+				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, DEFAULT_PATH, 0.3, ChangeFreq.YEARLY),
+				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/gtin-open-data.zip", 0.3, ChangeFreq.YEARLY),
+				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/isbn-open-data.zip", 0.3, ChangeFreq.YEARLY)
+		);
+	}
 	
 	@GetMapping(value = {DEFAULT_PATH})	
 	public ModelAndView opendata(final HttpServletRequest request) {
@@ -62,6 +73,16 @@ public class OpenDataController  implements SitemapExposedController{
 		ret.addObject("fileSize", openDataService.fileSize());
 		ret.addObject("page","open data");
 		return ret;
+	}
+
+	@GetMapping(path = "/opendata/gtin-open-data.zip")
+	public void downloadGtinData(final HttpServletResponse response) throws IOException {
+
+	}
+
+	@GetMapping(path = "/opendata/isbn-open-data.zip")
+	public void downloadIsbnData(final HttpServletResponse response) throws IOException {
+
 	}
 
 	@GetMapping(path = "/opendata/gtin-open-data.zip")

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -68,8 +68,8 @@ public class OpenDataController  implements SitemapExposedController{
 	public List<SitemapEntry> getMultipleExposedUrls() {
 		return Arrays.asList(
 				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, DEFAULT_PATH, 0.3, ChangeFreq.YEARLY),
-				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/gtin-open-data.zip", 0.3, ChangeFreq.YEARLY),
-				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/isbn-open-data.zip", 0.3, ChangeFreq.YEARLY)
+				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/gtin", 0.3, ChangeFreq.YEARLY),
+				SitemapEntry.of(SitemapEntry.LANGUAGE_DEFAULT, "/opendata/isbn", 0.3, ChangeFreq.YEARLY)
 		);
 	}
 
@@ -82,6 +82,24 @@ public class OpenDataController  implements SitemapExposedController{
 		ret.addObject("gtinLastUpdated", openDataService.gtinLastUpdate());
 		ret.addObject("gtinFileSize", openDataService.gtinFileSize());
 		ret.addObject("page", "open data");
+		return ret;
+	}
+
+	@GetMapping(value = {DEFAULT_PATH + "/gtin"})
+	public ModelAndView opendataGtin(final HttpServletRequest request) {
+		final ModelAndView ret = uiService.defaultModelAndView("opendata-gtin", request);
+		ret.addObject("lastUpdated", openDataService.gtinLastUpdate());
+		ret.addObject("fileSize", openDataService.gtinFileSize());
+		ret.addObject("page", "gtin data");
+		return ret;
+	}
+
+	@GetMapping(value = {DEFAULT_PATH + "/isbn"})
+	public ModelAndView opendataIsbn(final HttpServletRequest request) {
+		final ModelAndView ret = uiService.defaultModelAndView("opendata-isbn", request);
+		ret.addObject("lastUpdated", openDataService.isbnLastUpdate());
+		ret.addObject("fileSize", openDataService.isbnFileSize());
+		ret.addObject("page", "isbn data");
 		return ret;
 	}
 

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -89,6 +89,7 @@ public class OpenDataController  implements SitemapExposedController{
 	public ModelAndView opendataGtin(final HttpServletRequest request) {
 		final ModelAndView ret = uiService.defaultModelAndView("opendata-gtin", request);
 		ret.addObject("lastUpdated", openDataService.gtinLastUpdate());
+		ret.addObject("countGTIN", openDataService.totalItemsGTIN());
 		ret.addObject("fileSize", openDataService.gtinFileSize());
 		ret.addObject("page", "gtin data");
 		return ret;
@@ -98,6 +99,7 @@ public class OpenDataController  implements SitemapExposedController{
 	public ModelAndView opendataIsbn(final HttpServletRequest request) {
 		final ModelAndView ret = uiService.defaultModelAndView("opendata-isbn", request);
 		ret.addObject("lastUpdated", openDataService.isbnLastUpdate());
+		ret.addObject("countISBN", openDataService.totalItemsISBN());
 		ret.addObject("fileSize", openDataService.isbnFileSize());
 		ret.addObject("page", "isbn data");
 		return ret;

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.open4goods.exceptions.TechnicalException;
 import org.open4goods.ui.config.yml.UiConfig;
 import org.open4goods.ui.controllers.ui.UiService;
 import org.open4goods.ui.services.OpenDataService;
@@ -18,8 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.mashape.unirest.http.exceptions.UnirestException;
 
 import cz.jiripinkas.jsitemapgenerator.ChangeFreq;
 import jakarta.servlet.http.HttpServletRequest;

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -35,29 +35,17 @@ import jakarta.servlet.http.HttpServletResponse;
 public class OpenDataController  implements SitemapExposedController{
 
 	public static final String DEFAULT_PATH="/opendata";
-	
 	private static final Logger LOGGER = LoggerFactory.getLogger(OpenDataController.class);
 
-	// The siteConfig
 	private final OpenDataService openDataService;
 	private @Autowired UiService uiService;
 	private final UiConfig uiConfig;
-
 
 	@Autowired
 	public OpenDataController(OpenDataService openDataService, UiConfig uiConfig) {
 		this.openDataService = openDataService;
 		this.uiConfig = uiConfig;
 	}
-
-	/**
-	 * The Home page.
-	 *
-	 * @param request
-	 * @param response
-	 * @return
-	 * @throws UnirestException
-	 */
 
 	@Override
 	public SitemapEntry getExposedUrls() {

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/OpenDataController.java
@@ -65,6 +65,8 @@ public class OpenDataController  implements SitemapExposedController{
 	public ModelAndView opendata(final HttpServletRequest request) {
 		final ModelAndView ret = uiService.defaultModelAndView("opendata", request);
 		ret.addObject("count", openDataService.totalItems());
+		ret.addObject("countGTIN", openDataService.totalItemsGTIN());
+		ret.addObject("countISBN", openDataService.totalItemsISBN());
 		ret.addObject("isbnLastUpdated", openDataService.isbnLastUpdate());
 		ret.addObject("isbnFileSize", openDataService.isbnFileSize());
 		ret.addObject("gtinLastUpdated", openDataService.gtinLastUpdate());

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -124,7 +124,7 @@ public class OpenDataService implements HealthIndicator {
 	 * This method is scheduled to run periodically.
 	 * TODO : Schedule in conf
 	 */
-	//@Scheduled(initialDelay = 1000L * 3600, fixedDelay = 1000L * 3600 * 24 * 7)
+	@Scheduled(initialDelay = 1000L * 3600, fixedDelay = 1000L * 3600 * 24 * 7)
 	@Timed(value = "OpenDataService.generateOpendata.time", description = "Time taken to generate the OpenData ZIP files", extraTags = {"service", "OpenDataService"})
 	public void generateOpendata() {
 
@@ -152,27 +152,6 @@ public class OpenDataService implements HealthIndicator {
 		uiConfig.tmpIsbnZipFile().getParentFile().mkdirs();
 		uiConfig.tmpGtinZipFile().getParentFile().mkdirs();
 	}
-
-	private void processDataFiles() throws IOException {
-		LOGGER.info("Starting process for ISBN_13");
-		processAndCreateZip(ISBN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpIsbnZipFile());
-
-		LOGGER.info("Starting process for GTIN/EAN");
-		processAndCreateZip(GTIN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpGtinZipFile(), true);
-	}
-
-	private void moveTmpFilesToFinalDestination() throws IOException {
-		moveFile(uiConfig.tmpIsbnZipFile(), uiConfig.isbnZipFile());
-		moveFile(uiConfig.tmpGtinZipFile(), uiConfig.gtinZipFile());
-	}
-
-	private void moveFile(File src, File dest) throws IOException {
-		if (dest.exists()) {
-			FileUtils.deleteQuietly(dest);
-		}
-		FileUtils.moveFile(src, dest);
-	}
-
 
 	/**
 	 * Processes and creates the ZIP files for the opendata.

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -232,22 +232,24 @@ public class OpenDataService {
 		concurrentDownloads.decrementAndGet();
 	}
 
-	/**
-	 * Return the file size in human readable way
-	 * @return
-	 */
-	@Cacheable(key = "#root.method.name", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-	public String fileSize() {
-		return humanReadableByteCountBin(uiConfig.openDataFile().length());
+	@Cacheable(key = "#root.method.name + 'Isbn'", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+	public String isbnFileSize() {
+		return humanReadableByteCountBin(uiConfig.isbnZipFile().length());
 	}
 
-	/**
-	 *
-	 * @return the last update date
-	 */
-	@Cacheable(key = "#root.method.name", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-	public Date lastUpdate() {
-		return Date.from(Instant.ofEpochMilli(uiConfig.openDataFile().lastModified()));
+	@Cacheable(key = "#root.method.name + 'Gtin'", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+	public String gtinFileSize() {
+		return humanReadableByteCountBin(uiConfig.gtinZipFile().length());
+	}
+
+	@Cacheable(key = "#root.method.name + 'Isbn'", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+	public Date isbnLastUpdate() {
+		return Date.from(Instant.ofEpochMilli(uiConfig.isbnZipFile().lastModified()));
+	}
+
+	@Cacheable(key = "#root.method.name + 'Gtin'", cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+	public Date gtinLastUpdate() {
+		return Date.from(Instant.ofEpochMilli(uiConfig.gtinZipFile().lastModified()));
 	}
 
 	/**

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -154,7 +154,6 @@ public class OpenDataService {
 		FileUtils.moveFile(src, dest);
 	}
 
-
 	private void processAndCreateZip(String filename, BarcodeType barcodeType, File zipFile, boolean invertCondition) throws IOException {
 		try (FileOutputStream fos = new FileOutputStream(zipFile);
 			 ZipOutputStream zos = new ZipOutputStream(fos);
@@ -165,7 +164,7 @@ public class OpenDataService {
 			writer.writeNext(header);
 
 			AtomicLong count = new AtomicLong();
-			aggregatedDataRepository.exportAll().limit(500).filter(e ->
+			aggregatedDataRepository.exportAll().filter(e ->
 					invertCondition ? !e.getGtinInfos().getUpcType().equals(barcodeType) : e.getGtinInfos().getUpcType().equals(barcodeType)
 			).forEach(e -> {
 				count.incrementAndGet();

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -168,6 +168,27 @@ public class OpenDataService implements HealthIndicator {
 		uiConfig.tmpGtinZipFile().getParentFile().mkdirs();
 	}
 
+	private void processDataFiles() throws IOException {
+		LOGGER.info("Starting process for ISBN_13");
+		processAndCreateZip(ISBN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpIsbnZipFile());
+
+		LOGGER.info("Starting process for GTIN/EAN");
+		processAndCreateZip(GTIN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpGtinZipFile(), true);
+	}
+
+	private void moveTmpFilesToFinalDestination() throws IOException {
+		moveFile(uiConfig.tmpIsbnZipFile(), uiConfig.isbnZipFile());
+		moveFile(uiConfig.tmpGtinZipFile(), uiConfig.gtinZipFile());
+	}
+
+	private void moveFile(File src, File dest) throws IOException {
+		if (dest.exists()) {
+			FileUtils.deleteQuietly(dest);
+		}
+		FileUtils.moveFile(src, dest);
+	}
+
+
 	/**
 	 * Processes and creates the ZIP files for the opendata.
 	 */

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -76,7 +76,6 @@ public class OpenDataService {
 		this.aggregatedDataRepository = aggregatedDataRepository;
 		this.uiConfig = uiConfig;
         this.openDataConfig = openDataConfig;
-        generateOpendata();
 	}
 
 	/**
@@ -241,7 +240,7 @@ public class OpenDataService {
 			line[8] = String.valueOf(data.bestPrice().getPrice()); // "min_price"
 			line[9] = String.valueOf(data.bestPrice().getCompensation()); // "min_price_compensation"
 			line[10] = data.bestPrice().getCurrency().toString(); // "currency"
-			line[12] = ""; // TODO: Construct the URL
+			line[12] = ""; // TODO: uiConfig.getBaseUrl(Locale.FRANCE) + data.getNames().getName();
 		}
 
 		line[11] = StringUtils.join(data.getDatasourceCategories(), " ; "); // "categories"
@@ -268,7 +267,7 @@ public class OpenDataService {
 			line[8] = String.valueOf(data.bestPrice().getPrice()); // "min_price"
 			line[9] = String.valueOf(data.bestPrice().getCompensation()); // "min_price_compensation"
 			line[10] = data.bestPrice().getCurrency().toString(); // "currency"
-			line[12] = ""; // TODO: Construct the URL
+			line[12] = ""; // TODO: uiConfig.getBaseUrl(Locale.FRANCE) + data.getNames().getName();
 		}
 
 		line[11] = StringUtils.join(data.getDatasourceCategories(), " ; "); // "categories"
@@ -287,7 +286,7 @@ public class OpenDataService {
 
 	/**
 	 * Retrieves a specific attribute from the product data.
-	 * TODO : Review when all attributes acessible by map
+	 * TODO : Review when all attributes accessible by map
 	 */
 	private String getAttribute(Product data, String key) {
 

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -63,7 +63,6 @@ public class OpenDataService {
 	public OpenDataService(ProductRepository aggregatedDataRepository, UiConfig uiConfig){
 		this.aggregatedDataRepository = aggregatedDataRepository;
 		this.uiConfig = uiConfig;
-		generateOpendata();
 	}
 
 	/**

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -5,6 +5,7 @@ import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -14,21 +15,19 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-<<<<<<< HEAD
 import org.open4goods.commons.dao.ProductRepository;
 import org.open4goods.commons.exceptions.TechnicalException;
 import org.open4goods.commons.helper.ThrottlingInputStream;
 import org.open4goods.commons.model.constants.CacheConstants;
 import org.open4goods.commons.model.product.Product;
-=======
 import org.open4goods.dao.ProductRepository;
 import org.open4goods.exceptions.TechnicalException;
 import org.open4goods.helper.ThrottlingInputStream;
 import org.open4goods.model.BarcodeType;
 import org.open4goods.model.constants.CacheConstants;
+import org.open4goods.model.product.AggregatedAttribute;
 import org.open4goods.model.product.Product;
 import org.open4goods.ui.config.OpenDataConfig;
->>>>>>> 562a43e0 (Frontend Tweaks + ISBN Headers)
 import org.open4goods.ui.config.yml.UiConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,48 +39,29 @@ import com.google.common.util.concurrent.RateLimiter;
 import com.opencsv.CSVWriter;
 
 /**
- * Service in charge of generating the CSV opendata file
- *
- * @author Goulven.Furet
- *
- * TODO : Methods comments
- * 
- * 
- * TODO : Add the below attributes only for ISBN dataset 
- * 
- * CLASSIFICATION DECITRE 1	Loisirs et Jeux	 1
-CLASSIFICATION DECITRE 2	Jeux et activités	 1
-CLASSIFICATION DECITRE 3	Coloriage Gommettes Autocollants
-EDITEUR
-FORMAT
-
-NB DE PAGES
-SOUSCATEGORIE	Enfant-jeunesse	 1
-SOUSCATEGORIE2	Sport-et-loisirs
- * 
- * 
+ * Service responsible for generating and managing the CSV opendata files.
+ * Handles the creation of GTIN and ISBN datasets, their compression into ZIP files,
+ * and the management of download limits and rates.
  */
 public class OpenDataService {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(OpenDataService.class);
 
-//	// Allowed download speed in kb
-//	// TODO : In config (OpenDataConfig)
-//	private static final int DOWNLOAD_SPEED_KB = 256;
-//	public static final int CONCURRENT_DOWNLOADS = 4;
-
-	
 	private static final String ISBN_DATASET_FILENAME = "open4goods-isbn-dataset.csv";
 	private static final String GTIN_DATASET_FILENAME = "open4goods-gtin-dataset.csv";
 
-	// GTIN headers
-	private static final String[] gtinHeader = { "code", "brand", "model", "name", "last_updated", "gs1_country", "gtinType",
-			"offers_count", "min_price", "min_price_compensation", "currency", "categories", "url" };
+	private static final String[] GTIN_HEADER = {
+			"code", "brand", "model", "name", "last_updated", "gs1_country", "gtinType",
+			"offers_count", "min_price", "min_price_compensation", "currency", "categories", "url"
+	};
 
-	// ISBN headers
-	private static final String[] isbnHeader = { "code", "brand", "model", "name", "last_updated", "gs1_country", "gtinType",
-			"offers_count", "min_price", "min_price_compensation", "currency", "categories", "url", "editeur", "format" };
-
+	private static final String[] ISBN_HEADER = {
+			"code", "brand", "model", "name", "last_updated", "gs1_country", "gtintype",
+			"offers_count", "min_price", "min_price_compensation", "currency", "categories", "url",
+			"editeur", "format", "nb de pages",
+			"classification decitre 1", "classification decitre 2", "classification decitre 3",
+			"souscategorie", "souscategorie2"
+	};
 
 	private ProductRepository aggregatedDataRepository;
 	private UiConfig uiConfig;
@@ -89,7 +69,6 @@ public class OpenDataService {
 
 	// The flag that indicates wether opendata export is running or not
 	private AtomicBoolean exportRunning = new AtomicBoolean(false);
-
 	private AtomicInteger concurrentDownloadsCounter = new AtomicInteger(0);
 
 
@@ -101,18 +80,13 @@ public class OpenDataService {
 	}
 
 	/**
-	 *
-	 * @return a limited stream pageSize the opendata set. Limited in bandwith, and
-	 *         limited in number of conccurent downloads Limited
-	 * @throws FileNotFoundException
-	 * @throws TechnicalException
+	 * Provides a limited bandwidth stream for downloading the opendata file.
+	 * Enforces a limit on the number of concurrent downloads.
 	 */
 	public InputStream limitedRateStream() throws TechnicalException, FileNotFoundException {
 
-		// TODO : in conf
 		RateLimiter rateLimiter = RateLimiter.create(openDataConfig.getDownloadSpeedKb() * FileUtils.ONE_KB);
 
-		// TODO : in conf
 		if (concurrentDownloadsCounter.get() >= openDataConfig.getConcurrentDownloads()) {
 			throw new TechnicalException("Too many requests ");
 		} else {
@@ -121,8 +95,7 @@ public class OpenDataService {
 
 		try {
 			LOGGER.info("Starting opendata dataset download");
-			return new ThrottlingInputStream(new BufferedInputStream(new FileInputStream(uiConfig.openDataFile())),
-					rateLimiter) {
+			return new ThrottlingInputStream(new BufferedInputStream(new FileInputStream(uiConfig.openDataFile())), rateLimiter) {
 				@Override
 				public void close() throws IOException {
 					super.close();
@@ -137,12 +110,13 @@ public class OpenDataService {
 	}
 
 	/**
-	 * Iterates over all aggregated data to generate the zipped opendata CSV file.
-	 *
+	 * Generates the opendata CSV files and compresses them into ZIP files.
+	 * This method is scheduled to run periodically.
 	 * TODO : Schedule in conf
 	 */
-	//@Scheduled(  initialDelay = 1000L *3600, fixedDelay = 1000L * 3600 * 24 * 7)
+	@Scheduled(initialDelay = 1000L * 3600, fixedDelay = 1000L * 3600 * 24 * 7)
 	public void generateOpendata() {
+
 		if (exportRunning.getAndSet(true)) {
 			LOGGER.error("Opendata export is already running");
 			return;
@@ -160,15 +134,17 @@ public class OpenDataService {
 		}
 	}
 
-	private void processAndCreateZip(String filename, BarcodeType barcodeType, File zipFile) throws IOException {
-		processAndCreateZip(filename, barcodeType, zipFile, false);
-	}
-
+	/**
+	 * Prepares the necessary directories for storing temporary files.
+	 */
 	private void prepareDirectories() throws IOException {
 		uiConfig.tmpIsbnZipFile().getParentFile().mkdirs();
 		uiConfig.tmpGtinZipFile().getParentFile().mkdirs();
 	}
 
+	/**
+	 * Processes and creates the ZIP files for the opendata.
+	 */
 	private void processDataFiles() throws IOException {
 		LOGGER.info("Starting process for ISBN_13");
 		processAndCreateZip(ISBN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpIsbnZipFile());
@@ -177,11 +153,17 @@ public class OpenDataService {
 		processAndCreateZip(GTIN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpGtinZipFile(), true);
 	}
 
+	/**
+	 * Moves the temporary files to their final destination.
+	 */
 	private void moveTmpFilesToFinalDestination() throws IOException {
 		moveFile(uiConfig.tmpIsbnZipFile(), uiConfig.isbnZipFile());
 		moveFile(uiConfig.tmpGtinZipFile(), uiConfig.gtinZipFile());
 	}
 
+	/**
+	 * Moves a file from the source to the destination.
+	 */
 	private void moveFile(File src, File dest) throws IOException {
 		if (dest.exists()) {
 			FileUtils.deleteQuietly(dest);
@@ -189,6 +171,19 @@ public class OpenDataService {
 		FileUtils.moveFile(src, dest);
 	}
 
+	private void processAndCreateZip(String filename, BarcodeType barcodeType, File zipFile) throws IOException {
+		processAndCreateZip(filename, barcodeType, zipFile, false);
+	}
+
+	/**
+	 * Processes the data and creates a ZIP file for the specified barcode type.
+	 *
+	 * @param filename    The name of the file to be created.
+	 * @param barcodeType The type of barcode being processed.
+	 * @param zipFile     The file object representing the ZIP file to be created.
+	 * @param isGtinFile  Indicates if the file is a GTIN file.
+	 * @throws IOException If there is an error during file creation or writing.
+	 */
 	private void processAndCreateZip(String filename, BarcodeType barcodeType, File zipFile, boolean isGtinFile) throws IOException {
 		try (FileOutputStream fos = new FileOutputStream(zipFile);
 			 ZipOutputStream zos = new ZipOutputStream(fos);
@@ -197,26 +192,23 @@ public class OpenDataService {
 			ZipEntry entry = new ZipEntry(filename);
 			zos.putNextEntry(entry);
 
-			
-			BarcodeType[] types = null;
-			
-			// Headers selon type de fichier
+			// Set the appropriate header and barcode types
+			BarcodeType[] types;
 			if (isGtinFile) {
-				writer.writeNext(gtinHeader);
-				types = new BarcodeType[] { BarcodeType.GTIN_8, BarcodeType.GTIN_12, BarcodeType.GTIN_13, BarcodeType.GTIN_14 };
+				writer.writeNext(GTIN_HEADER);
+				types = new BarcodeType[]{BarcodeType.GTIN_8, BarcodeType.GTIN_12, BarcodeType.GTIN_13, BarcodeType.GTIN_14};
 			} else {
-				writer.writeNext(isbnHeader);
-				types = new BarcodeType[] { BarcodeType.ISBN_13 };
+				writer.writeNext(ISBN_HEADER);
+				types = new BarcodeType[]{BarcodeType.ISBN_13};
 			}
 
 			AtomicLong count = new AtomicLong();
-			//TODO : Remind to remove limit
+
 			aggregatedDataRepository.exportAll(types)
-				.limit(1000)
-				.forEach(e -> {
-					count.incrementAndGet();
-					writer.writeNext(isGtinFile ?  toGtinEntry(e) : toIsbnEntry(e));
-			});
+					.forEach(e -> {
+						count.incrementAndGet();
+						writer.writeNext(isGtinFile ? toGtinEntry(e) : toIsbnEntry(e));
+					});
 
 			writer.flush();
 			zos.closeEntry();
@@ -231,142 +223,100 @@ public class OpenDataService {
 
 
 	/**
-	 * Convert an aggregateddata pageSize a csv row
-	 *
-	 * @param data
-	 * @return
+	 * Converts a Product object into a CSV row for GTIN.
 	 */
 	private String[] toGtinEntry(Product data) {
-		String[] line = new String[gtinHeader.length];
+		String[] line = new String[GTIN_HEADER.length];
 
-		//	"gtin"
-		line[0] = data.gtin();
-		//	"brand"
-		line[1] = data.brand();
-		//	"model"
-		line[2] = data.model();
-<<<<<<< HEAD
-		//		"shortest_name"
-		line[3] = data.shortestOfferName();
-		//		"last_updated"
-=======
-		//	"shortest_name"
-		line[3] = data.getNames().shortestOfferName();
-		//	"last_updated"
->>>>>>> 562a43e0 (Frontend Tweaks + ISBN Headers)
-		line[4] = String.valueOf(data.getLastChange());
-		//	"gs1_country"
-		line[5] = data.getGtinInfos().getCountry();
-		//	"upcType"
-		line[6] = data.getGtinInfos().getUpcType().toString();
-		//	"offers_count"
-		line[7] = String.valueOf(data.getOffersCount());
-		//	"min_price"
+		line[0] = data.gtin(); // "code"
+		line[1] = data.brand(); // "brand"
+		line[2] = data.model(); // "model"
+		line[3] = data.shortestOfferName(); // "name"
+		line[4] = String.valueOf(data.getLastChange()); // "last_updated"
+		line[5] = data.getGtinInfos().getCountry(); // "gs1_country"
+		line[6] = data.getGtinInfos().getUpcType().toString(); // "gtinType"
+		line[7] = String.valueOf(data.getOffersCount()); // "offers_count"
+
 		if (null != data.bestPrice()) {
-			line[8] = String.valueOf(data.bestPrice().getPrice());
-			// "compensation"
-			line[9] = String.valueOf(data.bestPrice().getCompensation());
-			// "currency"
-			line[10] = data.bestPrice().getCurrency().toString();
-			// "url"
-			line[12] = ""; //uiConfig.getBaseUrl(Locale.FRANCE) + data.getNames().getName();
+			line[8] = String.valueOf(data.bestPrice().getPrice()); // "min_price"
+			line[9] = String.valueOf(data.bestPrice().getCompensation()); // "min_price_compensation"
+			line[10] = data.bestPrice().getCurrency().toString(); // "currency"
+			line[12] = ""; // TODO: Construct the URL
 		}
-		// "Categories"
-		line[11] = StringUtils.join(data.getDatasourceCategories()," ; ");
 
-//		// Modifier classe Product
-//		if (isIsbn) {
-//			line[13] = data.getAttributes().getReferentielAttributes().get("editeur");
-//			line[14] = data.getAttributes().getReferentielAttributes().get("format");
-//		}
+		line[11] = StringUtils.join(data.getDatasourceCategories(), " ; "); // "categories"
 
 		return line;
 	}
 
-	
-	
 	/**
-	 * Convert an aggregateddata pageSize a csv row
-	 *
-	 * @param data
-	 * @return
+	 * Converts a Product object into a CSV row for ISBN.
 	 */
 	private String[] toIsbnEntry(Product data) {
-		String[] line = new String[isbnHeader.length];
+		String[] line = new String[ISBN_HEADER.length];
 
-		//	"gtin"
-		line[0] = data.gtin();
-		//	"brand"
-		line[1] = data.brand();
-		//	"model"
-		line[2] = data.model();
-		//	"shortest_name"
-		line[3] = data.getNames().shortestOfferName();
-		//	"last_updated"
-		line[4] = String.valueOf(data.getLastChange());
-		//	"gs1_country"
-		line[5] = data.getGtinInfos().getCountry();
-		//	"upcType"
-		line[6] = data.getGtinInfos().getUpcType().toString();
-		//	"offers_count"
-		line[7] = String.valueOf(data.getOffersCount());
-		//	"min_price"
+		line[0] = data.gtin(); // "code"
+		line[1] = data.brand(); // "brand"
+		line[2] = data.model(); // "model"
+		line[3] = data.shortestOfferName(); // "name"
+		line[4] = String.valueOf(data.getLastChange()); // "last_updated"
+		line[5] = data.getGtinInfos().getCountry(); // "gs1_country"
+		line[6] = data.getGtinInfos().getUpcType().toString(); // "gtintype"
+		line[7] = String.valueOf(data.getOffersCount()); // "offers_count"
+
 		if (null != data.bestPrice()) {
-			line[8] = String.valueOf(data.bestPrice().getPrice());
-			// "compensation"
-			line[9] = String.valueOf(data.bestPrice().getCompensation());
-			// "currency"
-			line[10] = data.bestPrice().getCurrency().toString();
-			// "url"
-			line[12] = ""; //uiConfig.getBaseUrl(Locale.FRANCE) + data.getNames().getName();
+			line[8] = String.valueOf(data.bestPrice().getPrice()); // "min_price"
+			line[9] = String.valueOf(data.bestPrice().getCompensation()); // "min_price_compensation"
+			line[10] = data.bestPrice().getCurrency().toString(); // "currency"
+			line[12] = ""; // TODO: Construct the URL
 		}
-		// "Categories"
-		line[11] = StringUtils.join(data.getDatasourceCategories()," ; ");
-		
-		
-		
-		String attrVal = getAttribute(data, "editeur");
 
-//		// Modifier classe Product
-//		if (isIsbn) {
-//			line[13] = data.getAttributes().getReferentielAttributes().get("editeur");
-//			line[14] = data.getAttributes().getReferentielAttributes().get("format");
-//		}
+		line[11] = StringUtils.join(data.getDatasourceCategories(), " ; "); // "categories"
+
+		line[13] = getAttribute(data, "EDITEUR");
+		line[14] = getAttribute(data, "FORMAT");
+		line[15] = getAttribute(data, "NB DE PAGES");
+		line[16] = getAttribute(data, "CLASSIFICATION DECITRE 1");
+		line[17] = getAttribute(data, "CLASSIFICATION DECITRE 2");
+		line[18] = getAttribute(data, "CLASSIFICATION DECITRE 3");
+		line[19] = getAttribute(data, "SOUSCATEGORIE");
+		line[20] = getAttribute(data, "SOUSCATEGORIE2");
 
 		return line;
 	}
 
 	/**
-	 * Try a direct access to aggregatedattributes, if fail iterate over unmapped ones
+	 * Retrieves a specific attribute from the product data.
 	 * TODO : Review when all attributes acessible by map
-	 * @param data
-	 * @param key
-	 * @return
 	 */
 	private String getAttribute(Product data, String key) {
-		
-		// Direct check against aggregatedAttributes
-		String value = data.getAttributes().getAggregatedAttributes().get(key).getValue();
-		
+
+		String value = null;
+
+		Map<String, AggregatedAttribute> aggregatedAttributes = data.getAttributes().getAggregatedAttributes();
+
+		if (aggregatedAttributes.containsKey(key)) {
+			AggregatedAttribute attribute = aggregatedAttributes.get(key);
+
+			if (attribute != null) {
+				value = attribute.getValue();
+			}
+		}
+
 		if (StringUtils.isEmpty(value)) {
 			// Checking in unmapped attributes
-			
 			value = data.getAttributes().getUnmapedAttributes().stream()
-									.filter(a -> a.getName().equalsIgnoreCase(key))
-									.findFirst()
-									.map(a -> a.getValue())
-									.orElse(null);
-			
+					.filter(a -> a.getName().equalsIgnoreCase(key))
+					.findFirst()
+					.map(AggregatedAttribute::getValue)
+					.orElse(null);
 		}
 
 		return value;
 	}
-	
-	
-	
+
 	/**
-	 * Used pageSize decrement the download counter, for instance when IOexception occurs
-	 * (user stop the download)
+	 * Decrements the download counter, for instance when an IOException occurs (e.g., user stops the download).
 	 */
 	public void decrementDownloadCounter() {
 		concurrentDownloadsCounter.decrementAndGet();
@@ -404,8 +354,9 @@ public class OpenDataService {
 	}
 
 	/**
+	 * Retrieves the total number of items in the main index.
 	 *
-	 * @return number of items
+	 * @return The total number of items.
 	 */
 	@Cacheable(key = "#root.method.name", cacheNames = CacheConstants.ONE_DAY_LOCAL_CACHE_NAME)
 	public long totalItems() {
@@ -413,9 +364,10 @@ public class OpenDataService {
 	}
 
 	/**
-	 * Convert a size in human readable form
-	 * @param bytes
-	 * @return
+	 * Converts a size in bytes to a human-readable format.
+	 *
+	 * @param bytes The size in bytes.
+	 * @return The size in a human-readable format (e.g., "1.2 MB").
 	 */
 	public static String humanReadableByteCountBin(long bytes) {
 		if (-1000 < bytes && bytes < 1000) {
@@ -428,6 +380,4 @@ public class OpenDataService {
 		}
 		return String.format("%.1f %cB", bytes / 1000.0, ci.current());
 	}
-
-
 }

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -369,6 +369,7 @@ public class OpenDataService implements HealthIndicator {
 
 		line[11] = StringUtils.join(data.getDatasourceCategories(), " ; "); // "categories"
 
+		//TODO : Asconsts
 		line[13] = getAttribute(data, "EDITEUR");
 		line[14] = getAttribute(data, "FORMAT");
 		line[15] = getAttribute(data, "NB DE PAGES");

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -1,12 +1,6 @@
 package org.open4goods.ui.services;
 
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.time.Instant;
@@ -139,6 +133,27 @@ public class OpenDataService {
 		uiConfig.tmpIsbnZipFile().getParentFile().mkdirs();
 		uiConfig.tmpGtinZipFile().getParentFile().mkdirs();
 	}
+
+	private void processDataFiles() throws IOException {
+		LOGGER.info("Starting process for ISBN_13");
+		processAndCreateZip(ISBN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpIsbnZipFile());
+
+		LOGGER.info("Starting process for GTIN/EAN");
+		processAndCreateZip(GTIN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpGtinZipFile(), true);
+	}
+
+	private void moveTmpFilesToFinalDestination() throws IOException {
+		moveFile(uiConfig.tmpIsbnZipFile(), uiConfig.isbnZipFile());
+		moveFile(uiConfig.tmpGtinZipFile(), uiConfig.gtinZipFile());
+	}
+
+	private void moveFile(File src, File dest) throws IOException {
+		if (dest.exists()) {
+			FileUtils.deleteQuietly(dest);
+		}
+		FileUtils.moveFile(src, dest);
+	}
+
 
 	/**
 	 * Processes the data and adds it to the zip output stream.

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -197,10 +197,10 @@ public class OpenDataService {
 			ZipEntry entry = new ZipEntry(filename);
 			zos.putNextEntry(entry);
 
-			// Sélection des en-têtes basés sur le type de fichier
-			if (!isGtinFile) {  // Fichier ISBN
+			// Headers selon type de fichier
+			if (!isGtinFile) {
 				writer.writeNext(isbnHeader);
-			} else {  // Fichier GTIN
+			} else {
 				writer.writeNext(gtinHeader);
 			}
 
@@ -279,11 +279,11 @@ public class OpenDataService {
 		// "Categories"
 		line[11] = StringUtils.join(data.getDatasourceCategories()," ; ");
 
-		// Modifier classe Product
-		if (isIsbn) {
-			line[13] = data.getAttributes().getReferentielAttributes().get("editeur");
-			line[14] = data.getAttributes().getReferentielAttributes().get("format");
-		}
+//		// Modifier classe Product
+//		if (isIsbn) {
+//			line[13] = data.getAttributes().getReferentielAttributes().get("editeur");
+//			line[14] = data.getAttributes().getReferentielAttributes().get("format");
+//		}
 
 		return line;
 	}

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -69,7 +69,6 @@ public class OpenDataService {
 	public OpenDataService(ProductRepository aggregatedDataRepository, UiConfig uiConfig){
 		this.aggregatedDataRepository = aggregatedDataRepository;
 		this.uiConfig = uiConfig;
-		generateOpendata();
 	}
 
 	/**
@@ -113,7 +112,7 @@ public class OpenDataService {
 	 *
 	 * TODO : Schedule in conf
 	 */
-	//@Scheduled(initialDelay = 1000L *3600, fixedDelay = 1000L * 3600 * 24 * 7)
+	@Scheduled(initialDelay = 1000L *3600, fixedDelay = 1000L * 3600 * 24 * 7)
 	public void generateOpendata() {
 
 		if (exportRunning.get()) {

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -153,6 +153,27 @@ public class OpenDataService implements HealthIndicator {
 		uiConfig.tmpGtinZipFile().getParentFile().mkdirs();
 	}
 
+	private void processDataFiles() throws IOException {
+		LOGGER.info("Starting process for ISBN_13");
+		processAndCreateZip(ISBN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpIsbnZipFile());
+
+		LOGGER.info("Starting process for GTIN/EAN");
+		processAndCreateZip(GTIN_DATASET_FILENAME, BarcodeType.ISBN_13, uiConfig.tmpGtinZipFile(), true);
+	}
+
+	private void moveTmpFilesToFinalDestination() throws IOException {
+		moveFile(uiConfig.tmpIsbnZipFile(), uiConfig.isbnZipFile());
+		moveFile(uiConfig.tmpGtinZipFile(), uiConfig.gtinZipFile());
+	}
+
+	private void moveFile(File src, File dest) throws IOException {
+		if (dest.exists()) {
+			FileUtils.deleteQuietly(dest);
+		}
+		FileUtils.moveFile(src, dest);
+	}
+
+
 	/**
 	 * Processes and creates the ZIP files for the opendata.
 	 */

--- a/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/OpenDataService.java
@@ -163,7 +163,27 @@ public class OpenDataService {
 		processAndAddToZip(zos, filename, barcodeType, false);
 	}
 
-	private void processAndAddToZip(ZipOutputStream zos, String filename, BarcodeType barcodeType, boolean invertCondition) throws IOException {}
+	private void processAndAddToZip(ZipOutputStream zos, String filename, BarcodeType barcodeType, boolean invertCondition) throws IOException {
+		ZipEntry entry = new ZipEntry(filename);
+		zos.putNextEntry(entry);
+		CSVWriter writer = new CSVWriter(new OutputStreamWriter(zos));
+		writer.writeNext(header);
+
+		AtomicLong count = new AtomicLong();
+		try {
+			aggregatedDataRepository.exportAll().filter(e ->
+					invertCondition ? !e.getGtinInfos().getUpcType().equals(barcodeType) : e.getGtinInfos().getUpcType().equals(barcodeType)
+			).forEach(e -> {
+				count.incrementAndGet();
+				writer.writeNext(toEntry(e));
+			});
+			writer.flush();
+			zos.closeEntry();
+			LOGGER.info("{} rows exported in {}.", count.get(), filename);
+		} catch (Exception e) {
+			LOGGER.error("Error during processing of {}: {}", filename, e.getMessage());
+		}
+	}
 
 	/**
 	 * Convert an aggregateddata pageSize a csv row

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -16,12 +16,12 @@ management:
     web:
       exposure:
         include:
-          - "*"          
+          - "*"
   endpoint:
-    health:      
+    health:
       enabled: true
       show-details: always
-      
+
 amazonConfig:
   affiliate-tag: nudger-21
   amazon-search-link: "https://www.amazon.fr/s?k={search_terms}&tag={affiliate_tag}"
@@ -161,7 +161,7 @@ blogConfig:
    feedDescription:
       default: "The Nudger blog, the best way to keep up with the latest news about eco-nudging"
       fr: "Le blog Nudger, la meilleure façon de suivre les dernières actualités sur l'éco-nudging"
-      
+
 # Configuration for the Image Generation service
 imageGenerationConfig:
   prompt: |

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -119,9 +119,15 @@ apiConfig:
   apiLicence: "May vary"
 
 
-tagListUrl: https://open4good.github.io/open4goods/maven/taglist/taglist.xml 
+tagListUrl: https://open4good.github.io/open4goods/maven/taglist/taglist.xml
 
-  
+openDataConfig:
+  downloadSpeedKb: 256
+  concurrentDownloads: 4
+  initialDelay: 3600000  # 1 heure
+  fixedDelay: 604800000  # 1 semaine
+
+
 feedbackConfig:      
   githubConfig:
     accessToken: GITHUB_ACCESS_TOKEN

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -124,8 +124,6 @@ tagListUrl: https://open4good.github.io/open4goods/maven/taglist/taglist.xml
 openDataConfig:
   downloadSpeedKb: 256
   concurrentDownloads: 4
-  initialDelay: 3600000  # 1 heure
-  fixedDelay: 604800000  # 1 semaine
 
 
 feedbackConfig:      

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -11,7 +11,7 @@ server:
 management:
   health:
     diskspace:
-      threshold: 100GB  
+      threshold: 100GB
   endpoints:
     web:
       exposure:
@@ -40,6 +40,7 @@ spring:
       enabled: true
 
       
+      
   mail:
 #   host: 
     port: 587
@@ -63,20 +64,20 @@ wikiPagesMapping:
   "[webpages/default/legal-notice/WebHome]":
     fr: "mentions-legales"
   "[webpages/opensource-contribution/WebHome]":
-      fr: "opensource/contribution-ecologique"    
+      fr: "opensource/contribution-ecologique"
 
 team-config:
   cores:
   - name: Goulven Furet
     title: CEO / CTO
-    linkedInUrl: https://www.linkedin.com/in/goulven-furet-b448b582/ 
+    linkedInUrl: https://www.linkedin.com/in/goulven-furet-b448b582/
     imageUrl: /assets/img/team/Goulven.jpeg
-  
+
   - name: Bérangère Leven
     title: Communication et pilotage
     linkedInUrl: https://www.linkedin.com/in/b%C3%A9rang%C3%A8re-leven/
     imageUrl: /assets/img/team/Berangere.jpeg
-    
+
   - name: Thomas Vandewalle
     title: Stratégie SEO & contenus
     linkedInUrl: https://www.linkedin.com/in/thomas-vandewalle-fr001/
@@ -85,13 +86,13 @@ team-config:
   - name: Louis-Marie Toudoire
     title: Développeur Backend
     linkedInUrl: https://www.linkedin.com/in/scezen/?originalSubdomain=fr
-    imageUrl: /assets/img/team/Louis-Marie.jpeg      
+    imageUrl: /assets/img/team/Louis-Marie.jpeg
 
   - name: Laurent Blondel
     title: Développeur & intégrateur frontend
     linkedInUrl: https://www.linkedin.com/in/laurent-blondel-33543532/
-    imageUrl: /assets/img/team/Laurent.jpeg            
-    
+    imageUrl: /assets/img/team/Laurent.jpeg
+
   - name: Max Ziliani
     title: Identité visuelle et artistique
     linkedInUrl: https://www.linkedin.com/in/maxziliani/
@@ -103,14 +104,14 @@ team-config:
     linkedInUrl: https://www.linkedin.com/in/thierry-ledan-43650a183/
     imageUrl: /assets/img/team/Thierry.jpeg
 
-    
+
   - name: Nicolas Bonamy
     title: Dev backend & infra
     linkedInUrl: https://www.linkedin.com/in/nicolas-bonamy-827b63a3/
     imageUrl: /assets/img/team/Nicolas.jpeg
-        
-      
-      
+
+
+
 apiConfig:
   apiTitle: "Open4goods API"
   apiDescription: "This API allows you to browse eco-nudger content"
@@ -129,7 +130,7 @@ feedbackConfig:
      
 reversement-config:
   contributed-organisations:
-    greenpeace: 
+    greenpeace:
       name: Green Peace
       img: /assets/img/greenpeace_logo.png
       url: https://www.greenpeace.fr/
@@ -139,7 +140,7 @@ reversement-config:
       img: /assets/img/goodplanet_logo.svg
       url: https://www.goodplanet.org/fr/
       description: La Fondation GoodPlanet, créée par Yann Arthus-Bertrand en 2005, est une organisation dédiée à la promotion du développement durable et de la sensibilisation environnementale. Elle œuvre pour la protection de la biodiversité, la lutte contre le changement climatique, et la promotion d'une transition écologique et solidaire. La fondation mène des projets éducatifs, organise des événements, et soutient des initiatives locales et internationales. Elle propose également des solutions concrètes pour réduire l'empreinte écologique, tout en favorisant l'engagement citoyen et en cultivant une prise de conscience collective autour des enjeux environnementaux.
-           
+
   reversements:
   - date: 2021-11-01
     amount: 72

--- a/ui/src/main/resources/templates/opendata-gtin.html
+++ b/ui/src/main/resources/templates/opendata-gtin.html
@@ -90,16 +90,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="alert alert-warning p-4" role="alert">
-                            <div class="media">
-                                <div class="media-body">
-                                    <strong>Important :</strong> La mise à disposition de notre jeu de données monopolise beaucoup de bande passante. Nous limitons les téléchargements en quantité et en débit. Pour des besoins spécifiques, contactez-nous. Un jeu de données moins à jour est également disponible :
-                                    <ul>
-                                        <li><a target="_blank" rel="nofollow" href="https://files.opendatarchives.fr/data.cquest.org/open4goods/">opendata archives, thanks @cquest</a></li>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
                         <h2 class="h3">Format des données</h2>
                         <div class="alert alert-info" role="alert">
                             Les données sont au format <b>CSV</b>, compressées au format <b>zip</b>.

--- a/ui/src/main/resources/templates/opendata-gtin.html
+++ b/ui/src/main/resources/templates/opendata-gtin.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>GTIN Open Data</title>
+</head>
+<body>
+<h1>GTIN Open Data</h1>
+<p>Last Updated: <span th:text="${lastUpdated}"></span></p>
+<p>File Size: <span th:text="${fileSize}"></span></p>
+<a href="/opendata/gtin-open-data.zip">Download GTIN Data</a>
+</body>
+</html>

--- a/ui/src/main/resources/templates/opendata-gtin.html
+++ b/ui/src/main/resources/templates/opendata-gtin.html
@@ -50,16 +50,7 @@
                         <ul class="list-unstyled">
                             <li><i class="fas fa-globe"></i>&nbsp;&nbsp;&nbsp;Utilisé internationalement</li>
                             <li><i class="fas fa-boxes"></i>&nbsp;&nbsp;&nbsp;Facilite la gestion des stocks</li>
-                            <li><i class="fas fa-truck"></i>&nbsp;&nbsp;&nbsp;Optimise la logistique</li>
-                        </ul>
-                        <h2 class="h3 mt-3">L'importance des GTIN pour l'écologie</h2>
-                        <p>
-                            Les <strong>GTIN</strong> jouent un rôle clé dans la traçabilité des produits, ce qui est essentiel pour une gestion écologique efficace. En permettant un suivi précis des produits tout au long de la chaîne d'approvisionnement, les GTIN aident à réduire le gaspillage et à optimiser l'utilisation des ressources.
-                        </p>
-                        <ul class="list-unstyled">
-                            <li><i class="fas fa-leaf"></i>&nbsp;&nbsp;&nbsp;Réduction du gaspillage</li>
-                            <li><i class="fas fa-recycle"></i>&nbsp;&nbsp;&nbsp;Optimisation des ressources</li>
-                            <li><i class="fas fa-seedling"></i>&nbsp;&nbsp;&nbsp;Support à l'économie circulaire</li>
+                            <li><i class="fas fa-truck"></i>&nbsp;&nbsp;Optimise la logistique</li>
                         </ul>
                         <h2 class="h3 mt-3">Conditions d'utilisation</h2>
                         <ul class="text-secondary">

--- a/ui/src/main/resources/templates/opendata-gtin.html
+++ b/ui/src/main/resources/templates/opendata-gtin.html
@@ -1,12 +1,201 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html th:lang="${siteLocale.language}">
+
 <head>
-    <title>GTIN Open Data</title>
+    <th:block th:insert="~{inc/header-meta.html}"></th:block>
+    <title>Base de données GTIN en libre accès | Nudger</title>
+    <meta name="description" content="Accédez à notre base de données GTIN gratuitement et librement. Découvrez l'importance des GTIN pour le commerce et l'industrie.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" th:content="${url}">
+    <meta property="og:title" content="Base de données GTIN en libre accès">
+    <meta property="og:description" content="Accédez à notre base de données GTIN gratuitement et librement. Découvrez l'importance des GTIN pour le commerce et l'industrie.">
+    <meta property="og:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" th:content="${url}">
+    <meta name="twitter:title" content="Base de données GTIN en libre accès">
+    <meta name="twitter:description" content="Accédez à notre base de données GTIN gratuitement et librement. Découvrez l'importance des GTIN pour le commerce et l'industrie.">
+    <meta name="twitter:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
 </head>
+
 <body>
-<h1>GTIN Open Data</h1>
-<p>Last Updated: <span th:text="${lastUpdated}"></span></p>
-<p>File Size: <span th:text="${fileSize}"></span></p>
-<a href="/opendata/gtin-open-data.zip">Download GTIN Data</a>
+<th:block th:with="page = 'opendata'" th:insert="~{inc/navbar/navbar-page.html}"></th:block>
+<th:block th:insert="~{inc/preloader.html}"></th:block>
+<main>
+    <section class="section-header bg-primary text-white pb-9 pb-lg-12 mb-4 mb-lg-6">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-8 text-center">
+                    <h1 class="display-2 mb-3">Open Data : Base de données GTIN en libre accès</h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="section section-lg pt-0">
+        <div class="container mt-n8 mt-lg-n12 z-2">
+            <div class="row justify-content-center">
+                <div class="col">
+                    <div class="card shadow border-gray-300 p-2 p-lg-5">
+                        <div class="row">
+                            <div class="col-lg-3 text-center">
+                                <img height="200" src="/assets/img/opendata.jpg" alt="code barre en opendata">
+                            </div>
+                            <div class="col-lg-9 my-auto">
+                                <p class="lead"><strong>Accédez à notre base de données GTIN.</strong> Ces données sont mises à jour <b>une fois par semaine</b> et proviennent de notre agrégation de contenu autour des catalogues d'affiliation.</p>
+                            </div>
+                        </div>
+                        <h2 class="h3 mt-3">Qu'est-ce qu'un GTIN ?</h2>
+                        <p>
+                            Le <strong>GTIN (Global Trade Item Number)</strong> est un identifiant unique utilisé mondialement pour identifier les produits et services. Il est crucial pour le commerce international et facilite la gestion des stocks, la logistique, et les transactions commerciales.
+                        </p>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-globe"></i>&nbsp;&nbsp;&nbsp;Utilisé internationalement</li>
+                            <li><i class="fas fa-boxes"></i>&nbsp;&nbsp;&nbsp;Facilite la gestion des stocks</li>
+                            <li><i class="fas fa-truck"></i>&nbsp;&nbsp;&nbsp;Optimise la logistique</li>
+                        </ul>
+                        <h2 class="h3 mt-3">L'importance des GTIN pour l'écologie</h2>
+                        <p>
+                            Les <strong>GTIN</strong> jouent un rôle clé dans la traçabilité des produits, ce qui est essentiel pour une gestion écologique efficace. En permettant un suivi précis des produits tout au long de la chaîne d'approvisionnement, les GTIN aident à réduire le gaspillage et à optimiser l'utilisation des ressources.
+                        </p>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-leaf"></i>&nbsp;&nbsp;&nbsp;Réduction du gaspillage</li>
+                            <li><i class="fas fa-recycle"></i>&nbsp;&nbsp;&nbsp;Optimisation des ressources</li>
+                            <li><i class="fas fa-seedling"></i>&nbsp;&nbsp;&nbsp;Support à l'économie circulaire</li>
+                        </ul>
+                        <h2 class="h3 mt-3">Conditions d'utilisation</h2>
+                        <ul class="text-secondary">
+                            <li class="pb-2">Ces données sont délivrées sous <a href="/assets/ETALAB-Licence-Ouverte-v2.0.pdf" target="_blank">licence ouverte</a>, et sont donc librement utilisables, sans restrictions d'usages.</li>
+                            <li class="pb-2">Vous devez indiquer la provenance des données, en mentionnant la page produit quand disponible, ou en ajoutant un lien vers la page d'accueil de <a href="https://nudger.fr">nudger.fr</a>.</li>
+                        </ul>
+                        <div class="card shadow px-4 py-1 mb-3">
+                            <div class="card-body text-center text-md-left">
+                                <div class="row align-items-center">
+                                    <div class="col-md-6">
+                                        <h2 class="mb-3">Obtenir les données</h2>
+                                        <table class="table table-hover">
+                                            <tbody>
+                                            <tr>
+                                                <th scope="row">Mise à jour</th>
+                                                <td scope="row" th:text="${#dates.format(lastUpdated, 'dd MMM yyyy, HH:mm')}"></td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><b>Taille du fichier</b></th>
+                                                <td scope="row" th:text="${fileSize}"></td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><b>Nombre de produits</b></th>
+                                                <td scope="row" th:text="${#numbers.formatDecimal(countGTIN, 0, 'COMMA', 0, 'POINT')}"></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="col-12 col-md-6 mt-4 mt-md-0 text-center">
+                                        <a download href="/opendata/gtin-open-data.zip" style="width:95%" class="btn btn-primary">
+                                                <span class="me-1">
+                                                    <span class="fas fa-download"></span>
+                                                </span>
+                                            Télécharger
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="alert alert-warning p-4" role="alert">
+                            <div class="media">
+                                <div class="media-body">
+                                    <strong>Important :</strong> La mise à disposition de notre jeu de données monopolise beaucoup de bande passante. Nous limitons les téléchargements en quantité et en débit. Pour des besoins spécifiques, contactez-nous. Un jeu de données moins à jour est également disponible :
+                                    <ul>
+                                        <li><a target="_blank" rel="nofollow" href="https://files.opendatarchives.fr/data.cquest.org/open4goods/">opendata archives, thanks @cquest</a></li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <h2 class="h3">Format des données</h2>
+                        <div class="alert alert-info" role="alert">
+                            Les données sont au format <b>CSV</b>, compressées au format <b>zip</b>.
+                            <ul>
+                                <li>Séparateur de champs : <b>,</b> </li>
+                                <li>Séparateur de texte : <b>"</b> </li>
+                            </ul>
+                        </div>
+                        <div class="mb-5">
+                            <div class="mb-4">
+                                <span class="h5">Colonnes</span>
+                            </div>
+                            <table class="table table-hover">
+                                <tbody>
+                                <tr>
+                                    <th scope="row"><b>barcode</b></th>
+                                    <td scope="row">Le code barre GTIN du produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>brand</b></th>
+                                    <td>Marque du produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>model</b></th>
+                                    <td scope="row">Référence constructeur du produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>last_updated</b></th>
+                                    <td scope="row">Dernière mise à jour de ce produit, au format epoch en millisecondes</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>gs1_country</b></th>
+                                    <td scope="row">Pays de l'organisme GS1 qui a délivré le code barre pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>gtinType</b></th>
+                                    <td scope="row">Type du code barre. Peut être GTIN_13, GTIN_8, GTIN_12, GTIN_14</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>offers_count</b></th>
+                                    <td scope="row">Nombre d'offres commerciales pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>min_price</b></th>
+                                    <td scope="row">Prix le plus faible pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>min_price_compensation</b></th>
+                                    <td scope="row">Compensation carbone reversée, correspondant au prix le plus faible pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>currency</b></th>
+                                    <td scope="row">Devise du prix le plus faible et de la compensation carbone associée</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>categories</b></th>
+                                    <td scope="row">Catégories dans lesquelles ce produit a été rencontré</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>url</b></th>
+                                    <td scope="row">URL de la fiche produit, uniquement si des offres commerciales sont disponibles</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+<th:block th:insert="~{inc/footer.html}"></th:block>
+<script src="../../vendor/@popperjs/core/dist/umd/popper.min.js"></script>
+<script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+<script src="../../vendor/headroom.js/dist/headroom.min.js"></script>
+<script src="../../vendor/smooth-scroll/dist/smooth-scroll.polyfills.min.js"></script>
+<script src="../../vendor/vivus/dist/vivus.min.js"></script>
+<script src="/webjars/jquery/jquery.min.js"></script>
+<script src="../../assets/js/pixel.js"></script>
+<script src="../../assets/js/pixel-custom.js"></script>
+<script>
+    $(document).ready(function() {
+        $('#searchInput').on("change", function(e) {
+            $('#searchForm').attr("action", "/recherche/" + encodeURIComponent($('#searchInput').val()));
+        });
+    });
+</script>
 </body>
+
 </html>

--- a/ui/src/main/resources/templates/opendata-isbn.html
+++ b/ui/src/main/resources/templates/opendata-isbn.html
@@ -4,16 +4,16 @@
 <head>
     <th:block th:insert="~{inc/header-meta.html}"></th:block>
     <title>Base de données ISBN en libre accès | Nudger</title>
-    <meta name="description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta name="description" content="Accédez à notre base de données ISBN gratuitement et librement. Découvrez l'importance des ISBN pour l'industrie du livre et de l'édition.">
     <meta property="og:type" content="website">
     <meta property="og:url" th:content="${url}">
     <meta property="og:title" content="Base de données ISBN en libre accès">
-    <meta property="og:description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta property="og:description" content="Accédez à notre base de données ISBN gratuitement et librement. Découvrez l'importance des ISBN pour l'industrie du livre et de l'édition.">
     <meta property="og:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" th:content="${url}">
     <meta name="twitter:title" content="Base de données ISBN en libre accès">
-    <meta name="twitter:description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta name="twitter:description" content="Accédez à notre base de données ISBN gratuitement et librement. Découvrez l'importance des ISBN pour l'industrie du livre et de l'édition.">
     <meta name="twitter:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
 </head>
 
@@ -40,9 +40,18 @@
                                 <img height="200" src="/assets/img/opendata.jpg" alt="code barre en opendata">
                             </div>
                             <div class="col-lg-9 my-auto">
-                                <p class="lead"><strong>Libérez les données !</strong> Accédez à notre base de données ISBN. Ces données sont mises à jour <b>une fois par semaine</b> et proviennent de notre agrégation de contenu autour des catalogues d'affiliation.</p>
+                                <p class="lead"><strong>Accédez à notre base de données ISBN.</strong> Ces données sont mises à jour <b>une fois par semaine</b> et proviennent de notre agrégation de contenu autour des catalogues d'affiliation.</p>
                             </div>
                         </div>
+                        <h2 class="h3 mt-3">Qu'est-ce qu'un ISBN ?</h2>
+                        <p>
+                            L'<strong>ISBN (International Standard Book Number)</strong> est un identifiant unique pour les livres et autres publications. Il est essentiel dans le monde de l'édition pour identifier, gérer, et suivre les publications à travers les librairies, éditeurs et distributeurs.
+                        </p>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-book"></i>&nbsp;&nbsp;&nbsp;Utilisé mondialement dans l'édition</li>
+                            <li><i class="fas fa-tags"></i>&nbsp;&nbsp;&nbsp;Identification unique pour les publications</li>
+                            <li><i class="fas fa-truck"></i>&nbsp;&nbsp;Facilite la distribution et la gestion des stocks</li>
+                        </ul>
                         <h2 class="h3 mt-3">Conditions d'utilisation</h2>
                         <ul class="text-secondary">
                             <li class="pb-2">Ces données sont délivrées sous <a href="/assets/ETALAB-Licence-Ouverte-v2.0.pdf" target="_blank">licence ouverte</a>, et sont donc librement utilisables, sans restrictions d'usages.</li>
@@ -56,15 +65,15 @@
                                         <table class="table table-hover">
                                             <tbody>
                                             <tr>
-                                                <th scope="row">mise à jour</th>
-                                                <td scope="row" th:text="${#dates.format(lastUpdated, 'dd-MMM-yyyy, HH:mm')}"></td>
+                                                <th scope="row">Mise à jour</th>
+                                                <td scope="row" th:text="${#dates.format(lastUpdated, 'dd MMM yyyy, HH:mm')}"></td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><b>Taille du fichier</b></th>
                                                 <td scope="row" th:text="${fileSize}"></td>
                                             </tr>
                                             <tr>
-                                                <th scope="row"><b>Nombre de produits</b></th>
+                                                <th scope="row"><b>Nombre de publications</b></th>
                                                 <td scope="row" th:text="${#numbers.formatDecimal(countISBN, 0, 'COMMA', 0, 'POINT')}"></td>
                                             </tr>
                                             </tbody>
@@ -106,48 +115,40 @@
                             <table class="table table-hover">
                                 <tbody>
                                 <tr>
-                                    <th scope="row"><b>barcode</b></th>
-                                    <td scope="row">Le code barre du produit, qui est un ISBN</td>
+                                    <th scope="row"><b>isbn</b></th>
+                                    <td scope="row">Le code ISBN de la publication</td>
                                 </tr>
                                 <tr>
-                                    <th scope="row"><b>brand</b></th>
-                                    <td>Marque de l'éditeur</td>
+                                    <th scope="row"><b>author</b></th>
+                                    <td>Auteur de la publication</td>
                                 </tr>
                                 <tr>
-                                    <th scope="row"><b>model</b></th>
-                                    <td scope="row">Référence de l'ouvrage</td>
+                                    <th scope="row"><b>title</b></th>
+                                    <td scope="row">Titre de la publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>publisher</b></th>
+                                    <td scope="row">Éditeur de la publication</td>
                                 </tr>
                                 <tr>
                                     <th scope="row"><b>last_updated</b></th>
-                                    <td scope="row">Dernière mise à jour de ce produit, au format epoch en millisecondes</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>gs1_country</b></th>
-                                    <td scope="row">Pays de l'organisme GS1 qui a délivré le code barre pour ce produit</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>gtinType</b></th>
-                                    <td scope="row">Type du code barre. Pour ISBN, cela sera toujours ISBN_13</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>offers_count</b></th>
-                                    <td scope="row">Nombre d'offres commerciales pour ce produit</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>min_price</b></th>
-                                    <td scope="row">Prix le plus faible pour ce produit</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>min_price_compensation</b></th>
-                                    <td scope="row">Compensation carbone reversée, correspondant au prix le plus faible pour ce produit</td>
-                                </tr>
-                                <tr>
-                                    <th scope="row"><b>currency</b></th>
-                                    <td scope="row">Devise du prix le plus faible et de la compensation carbone associée</td>
+                                    <td scope="row">Dernière mise à jour de cette publication, au format epoch en millisecondes</td>
                                 </tr>
                                 <tr>
                                     <th scope="row"><b>categories</b></th>
-                                    <td scope="row">Catégories dans lesquelles ce produit a été rencontré</td>
+                                    <td scope="row">Catégories dans lesquelles cette publication a été rencontrée</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>offers_count</b></th>
+                                    <td scope="row">Nombre d'offres commerciales pour cette publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>min_price</b></th>
+                                    <td scope="row">Prix le plus faible pour cette publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>currency</b></th>
+                                    <td scope="row">Devise du prix le plus faible</td>
                                 </tr>
                                 <tr>
                                     <th scope="row"><b>url</b></th>

--- a/ui/src/main/resources/templates/opendata-isbn.html
+++ b/ui/src/main/resources/templates/opendata-isbn.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>ISBN Open Data</title>
+</head>
+<body>
+<h1>ISBN Open Data</h1>
+<p>Last Updated: <span th:text="${lastUpdated}"></span></p>
+<p>File Size: <span th:text="${fileSize}"></span></p>
+<a href="/opendata/isbn-open-data.zip">Download ISBN Data</a>
+</body>
+</html>

--- a/ui/src/main/resources/templates/opendata-isbn.html
+++ b/ui/src/main/resources/templates/opendata-isbn.html
@@ -90,16 +90,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="alert alert-warning p-4" role="alert">
-                            <div class="media">
-                                <div class="media-body">
-                                    <strong>Important :</strong> La mise à disposition de notre jeu de données monopolise beaucoup de bande passante. Nous limitons les téléchargements en quantité et en débit. Pour des besoins spécifiques, contactez-nous. Un jeu de données moins à jour est également disponible :
-                                    <ul>
-                                        <li><a target="_blank" rel="nofollow" href="https://files.opendatarchives.fr/data.cquest.org/open4goods/">opendata archives, thanks @cquest</a></li>
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
                         <h2 class="h3">Format des données</h2>
                         <div class="alert alert-info" role="alert">
                             Les données sont au format <b>CSV</b>, compressées au format <b>zip</b>.
@@ -153,6 +143,38 @@
                                 <tr>
                                     <th scope="row"><b>url</b></th>
                                     <td scope="row">URL de la fiche produit, uniquement si des offres commerciales sont disponibles</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>editeur</b></th>
+                                    <td scope="row">Éditeur de la publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>format</b></th>
+                                    <td scope="row">Format de la publication (ex. broché, numérique)</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>nb de pages</b></th>
+                                    <td scope="row">Nombre de pages de la publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>classification decitre 1</b></th>
+                                    <td scope="row">Classification principale de Decitre pour cette publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>classification decitre 2</b></th>
+                                    <td scope="row">Deuxième niveau de classification de Decitre</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>classification decitre 3</b></th>
+                                    <td scope="row">Troisième niveau de classification de Decitre</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>souscategorie</b></th>
+                                    <td scope="row">Sous-catégorie principale pour cette publication</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>souscategorie2</b></th>
+                                    <td scope="row">Deuxième sous-catégorie pour cette publication</td>
                                 </tr>
                                 </tbody>
                             </table>

--- a/ui/src/main/resources/templates/opendata-isbn.html
+++ b/ui/src/main/resources/templates/opendata-isbn.html
@@ -1,12 +1,183 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html th:lang="${siteLocale.language}">
+
 <head>
-    <title>ISBN Open Data</title>
+    <th:block th:insert="~{inc/header-meta.html}"></th:block>
+    <title>Base de données ISBN en libre accès | Nudger</title>
+    <meta name="description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta property="og:type" content="website">
+    <meta property="og:url" th:content="${url}">
+    <meta property="og:title" content="Base de données ISBN en libre accès">
+    <meta property="og:description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta property="og:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:url" th:content="${url}">
+    <meta name="twitter:title" content="Base de données ISBN en libre accès">
+    <meta name="twitter:description" content="Accédez à notre base de données ISBN gratuitement et librement">
+    <meta name="twitter:image" th:content="${baseUrl} + 'assets/img/brand/light.svg'">
 </head>
+
 <body>
-<h1>ISBN Open Data</h1>
-<p>Last Updated: <span th:text="${lastUpdated}"></span></p>
-<p>File Size: <span th:text="${fileSize}"></span></p>
-<a href="/opendata/isbn-open-data.zip">Download ISBN Data</a>
+<th:block th:with="page = 'opendata'" th:insert="~{inc/navbar/navbar-page.html}"></th:block>
+<th:block th:insert="~{inc/preloader.html}"></th:block>
+<main>
+    <section class="section-header bg-primary text-white pb-9 pb-lg-12 mb-4 mb-lg-6">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-md-8 text-center">
+                    <h1 class="display-2 mb-3">Open Data : Base de données ISBN en libre accès</h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="section section-lg pt-0">
+        <div class="container mt-n8 mt-lg-n12 z-2">
+            <div class="row justify-content-center">
+                <div class="col">
+                    <div class="card shadow border-gray-300 p-2 p-lg-5">
+                        <div class="row">
+                            <div class="col-lg-3 text-center">
+                                <img height="200" src="/assets/img/opendata.jpg" alt="code barre en opendata">
+                            </div>
+                            <div class="col-lg-9 my-auto">
+                                <p class="lead"><strong>Libérez les données !</strong> Accédez à notre base de données ISBN. Ces données sont mises à jour <b>une fois par semaine</b> et proviennent de notre agrégation de contenu autour des catalogues d'affiliation.</p>
+                            </div>
+                        </div>
+                        <h2 class="h3 mt-3">Conditions d'utilisation</h2>
+                        <ul class="text-secondary">
+                            <li class="pb-2">Ces données sont délivrées sous <a href="/assets/ETALAB-Licence-Ouverte-v2.0.pdf" target="_blank">licence ouverte</a>, et sont donc librement utilisables, sans restrictions d'usages.</li>
+                            <li class="pb-2">Vous devez indiquer la provenance des données, en mentionnant la page produit quand disponible, ou en ajoutant un lien vers la page d'accueil de <a href="https://nudger.fr">nudger.fr</a>.</li>
+                        </ul>
+                        <div class="card shadow px-4 py-1 mb-3">
+                            <div class="card-body text-center text-md-left">
+                                <div class="row align-items-center">
+                                    <div class="col-md-6">
+                                        <h2 class="mb-3">Obtenir les données</h2>
+                                        <table class="table table-hover">
+                                            <tbody>
+                                            <tr>
+                                                <th scope="row">mise à jour</th>
+                                                <td scope="row" th:text="${#dates.format(lastUpdated, 'dd-MMM-yyyy, HH:mm')}"></td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><b>Taille du fichier</b></th>
+                                                <td scope="row" th:text="${fileSize}"></td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><b>Nombre de produits</b></th>
+                                                <td scope="row" th:text="${#numbers.formatDecimal(countISBN, 0, 'COMMA', 0, 'POINT')}"></td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <div class="col-12 col-md-6 mt-4 mt-md-0 text-center">
+                                        <a download href="/opendata/isbn-open-data.zip" style="width:95%" class="btn btn-primary">
+                                                <span class="me-1">
+                                                    <span class="fas fa-download"></span>
+                                                </span>
+                                            Télécharger
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="alert alert-warning p-4" role="alert">
+                            <div class="media">
+                                <div class="media-body">
+                                    <strong>Important :</strong> La mise à disposition de notre jeu de données monopolise beaucoup de bande passante. Nous limitons les téléchargements en quantité et en débit. Pour des besoins spécifiques, contactez-nous. Un jeu de données moins à jour est également disponible :
+                                    <ul>
+                                        <li><a target="_blank" rel="nofollow" href="https://files.opendatarchives.fr/data.cquest.org/open4goods/">opendata archives, thanks @cquest</a></li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <h2 class="h3">Format des données</h2>
+                        <div class="alert alert-info" role="alert">
+                            Les données sont au format <b>CSV</b>, compressées au format <b>zip</b>.
+                            <ul>
+                                <li>Séparateur de champs : <b>,</b> </li>
+                                <li>Séparateur de texte : <b>"</b> </li>
+                            </ul>
+                        </div>
+                        <div class="mb-5">
+                            <div class="mb-4">
+                                <span class="h5">Colonnes</span>
+                            </div>
+                            <table class="table table-hover">
+                                <tbody>
+                                <tr>
+                                    <th scope="row"><b>barcode</b></th>
+                                    <td scope="row">Le code barre du produit, qui est un ISBN</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>brand</b></th>
+                                    <td>Marque de l'éditeur</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>model</b></th>
+                                    <td scope="row">Référence de l'ouvrage</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>last_updated</b></th>
+                                    <td scope="row">Dernière mise à jour de ce produit, au format epoch en millisecondes</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>gs1_country</b></th>
+                                    <td scope="row">Pays de l'organisme GS1 qui a délivré le code barre pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>gtinType</b></th>
+                                    <td scope="row">Type du code barre. Pour ISBN, cela sera toujours ISBN_13</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>offers_count</b></th>
+                                    <td scope="row">Nombre d'offres commerciales pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>min_price</b></th>
+                                    <td scope="row">Prix le plus faible pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>min_price_compensation</b></th>
+                                    <td scope="row">Compensation carbone reversée, correspondant au prix le plus faible pour ce produit</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>currency</b></th>
+                                    <td scope="row">Devise du prix le plus faible et de la compensation carbone associée</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>categories</b></th>
+                                    <td scope="row">Catégories dans lesquelles ce produit a été rencontré</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row"><b>url</b></th>
+                                    <td scope="row">URL de la fiche produit, uniquement si des offres commerciales sont disponibles</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+<th:block th:insert="~{inc/footer.html}"></th:block>
+<script src="../../vendor/@popperjs/core/dist/umd/popper.min.js"></script>
+<script src="/webjars/bootstrap/js/bootstrap.min.js"></script>
+<script src="../../vendor/headroom.js/dist/headroom.min.js"></script>
+<script src="../../vendor/smooth-scroll/dist/smooth-scroll.polyfills.min.js"></script>
+<script src="../../vendor/vivus/dist/vivus.min.js"></script>
+<script src="/webjars/jquery/jquery.min.js"></script>
+<script src="../../assets/js/pixel.js"></script>
+<script src="../../assets/js/pixel-custom.js"></script>
+<script>
+    $(document).ready(function() {
+        $('#searchInput').on("change", function(e) {
+            $('#searchForm').attr("action", "/recherche/" + encodeURIComponent($('#searchInput').val()));
+        });
+    });
+</script>
 </body>
+
 </html>

--- a/ui/src/main/resources/templates/opendata.html
+++ b/ui/src/main/resources/templates/opendata.html
@@ -7,7 +7,7 @@
 	<th:block th:insert="~{inc/header-meta.html}"></th:block>
     
 	<!-- Primary Meta Tags -->
-	<title>Base de données ISBN en libre accès | Nudger</title>
+	<title>Base de données GTIN, EAN et ISBN en libre accès | Nudger</title>
 	<meta name="description" content="Nudger vous donne la possibilité d'accéder à une grande base de données ISBN gratuitement et librement">
 		
 	<!-- Open Graph / Facebook -->

--- a/ui/src/main/resources/templates/opendata.html
+++ b/ui/src/main/resources/templates/opendata.html
@@ -78,7 +78,7 @@
 												<table class="table table-hover">
 													<tbody>
 													<tr>
-														<th scope="row">mise à jour</th>
+														<th scope="row">Mise à jour</th>
 														<td scope="row" th:text="${#dates.format(lastUpdated, 'dd-MMM-yyyy, HH:mm')}"></td>
 													</tr>
 													

--- a/ui/src/main/resources/templates/opendata.html
+++ b/ui/src/main/resources/templates/opendata.html
@@ -46,161 +46,98 @@
                 </div>
             </div>
         </section>
-        
-        
-        <section class="section section-lg pt-0">
-            <div class="container mt-n8 mt-lg-n12 z-2">
-                <div class="row justify-content-center">
-                    <div class="col">
-                        <div class="card shadow border-gray-300 p-2 p-lg-5">
-                            
-                            <div class="row">
-	                            <div class="col-lg-3 text-center">
-	                            	<img height="200" src="/assets/img/opendata.jpg" alt="code barre en opendata">
-	                            </div>
-	                            <div class="col-lg-9 my-auto">
-	                            	<p class="lead"><strong>Liberez, la donnée !</strong> Nous mettons à disposition une extraction complète de notre base de données, celle-ci est notament utile pour le grand nombre d'articles identifiés par leurs codes barres (gtin / ean13 / UPC / ISBN). Ces données sont mises à jour <b>une fois par semaine</b>, et proviennent de l'aggrégation de contenu que nous réalisons autour des catalogues d'affiliations.</p>
-	                            </div>
-                            </div>
-                                                     
-                            <h2 class="h3 mt-3">Conditions d'utilisation</h2>
+
+
+		<section class="section section-lg pt-0">
+			<div class="container mt-n8 mt-lg-n12 z-2">
+				<div class="row justify-content-center">
+					<div class="col">
+						<div class="card shadow border-gray-300 p-4">
+							<div class="row">
+								<div class="col-lg-3 text-center">
+									<img height="200" src="/assets/img/opendata.jpg" alt="code barre en opendata">
+								</div>
+								<div class="col-lg-9 my-auto">
+									<p class="lead"><strong>Libérez la donnée !</strong> Nous mettons à disposition une extraction complète de notre base de données, celle-ci est notamment utile pour le grand nombre d'articles identifiés par leurs codes barres (GTIN / EAN13 / UPC / ISBN). Ces données sont mises à jour <b>une fois par semaine</b>, et proviennent de l'agrégation de contenu que nous réalisons autour des catalogues d'affiliations.</p>
+								</div>
+							</div>
+
+							<h2 class="h3 mt-4">Conditions d'utilisation</h2>
 							<ul class="text-secondary">
 								<li class="pb-2">Ces données sont délivrées sous <a href="/assets/ETALAB-Licence-Ouverte-v2.0.pdf" target="_blank">licence ouverte</a>, et sont donc librement utilisables, sans restrictions d'usages.</li>
 								<li class="pb-2">Vous devez par contre <b>indiquer la provenance de ces données</b>, en mentionnant la page produit quand elle est disponible, ou avec un lien vers la page d'accueil de <a href="https://nudger.fr">nudger.fr</a> quand la page produit n'est pas disponible.</li>
-                            </ul>
+							</ul>
 
-							<div class="card shadow px-4 py-1 mb-3">
-								<div class="card-body text-center text-md-left">
-									<div class="row align-items-center">
-										<div class="col-md-6">
-											<h2 class="mb-3">Obtenir les données</h2>
-											
-												<table class="table table-hover">
-													<tbody>
-													<tr>
-														<th scope="row">Mise à jour</th>
-														<td scope="row" th:text="${#dates.format(lastUpdated, 'dd-MMM-yyyy, HH:mm')}"></td>
-													</tr>
-													
-													<tr>
-														<th scope="row"><b>Taille du fichier</b></th>
-														<td scope="row" th:text="${fileSize}"></td>
-													</tr>
-													<tr>
-														<th scope="row"><b>Nombre de produits</b></th>
-														<td scope="row" th:text="${#numbers.formatDecimal(count, 0, 'COMMA', 0, 'POINT')}"></td>
-													</tr>
-													</tbody>
-												</table>
-										
+							<div class="card shadow px-4 py-4">
+								<div class="card-body">
+									<div class="row text-center">
+										<div class="col-md-4">
+											<h3 class="h5">&nbsp;</h3>
+											<table class="table table-borderless">
+												<tbody>
+												<tr>
+													<th scope="row">Mise à jour</th>
+												</tr>
+												<tr>
+													<th scope="row">Taille du fichier</th>
+												</tr>
+												<tr>
+													<th scope="row">Nombre de produits</th>
+												</tr>
+												</tbody>
+											</table>
 										</div>
-										<div class="col-12 col-md-6 mt-4 mt-md-0 text-center">
-											
-											<a download href="/opendata/gtin-open-data.zip" style="width:95%"  class="btn btn-primary">
-												<span class="me-1">
-													<span class="fas fa-download"></span>
-												</span>
-												Télécharger
+
+										<div class="col-md-4">
+											<h3 class="h5">Dataset GTIN</h3>
+											<table class="table table-hover">
+												<tbody>
+												<tr>
+													<td th:text="${#dates.format(gtinLastUpdated, 'dd MMM yyyy, HH:mm')}"></td>
+												</tr>
+												<tr>
+													<td th:text="${gtinFileSize}"></td>
+												</tr>
+												<tr>
+													<td th:text="${#numbers.formatDecimal(countGTIN, 0, 'COMMA', 0, 'POINT')}"></td>
+												</tr>
+												</tbody>
+											</table>
+											<a href="/opendata/gtin" class="btn btn-primary mt-3">
+												Voir les détails et télécharger
+											</a>
+										</div>
+
+										<div class="col-md-4">
+											<h3 class="h5">Dataset ISBN</h3>
+											<table class="table table-hover">
+												<tbody>
+												<tr>
+													<td th:text="${#dates.format(isbnLastUpdated, 'dd MMM yyyy, HH:mm')}"></td>
+												</tr>
+												<tr>
+													<td th:text="${isbnFileSize}"></td>
+												</tr>
+												<tr>
+													<td th:text="${#numbers.formatDecimal(countISBN, 0, 'COMMA', 0, 'POINT')}"></td>
+												</tr>
+												</tbody>
+											</table>
+											<a href="/opendata/isbn" class="btn btn-primary mt-3">
+												Voir les détails et télécharger
 											</a>
 										</div>
 									</div>
 								</div>
-							</div>     
-							
-                            <div class="alert alert-warning p-4" role="alert">
-	                            <div class="media">
-	                                <div class="media-body">
-	                                <strong>Important :</strong> La mise à disposition de notre jeu de données monopolise beaucoup de bande passante. Afin de ne pas pénaliser la qualité de service pour le reste du site, nous limitons les téléchargements, en quantité et en débit.
-	                                si vous avez des besoins spécifiques, n'hésitez pas à <a href="/contact">nous contacter</a>. <br/><br/> Un jeu de données moins à jour (novembre 2021), mais sans restriction de débit est également disponible :
-	                                <ul>
-	                                	<li><a target="_blank" rel="nofollow" href ="https://files.opendatarchives.fr/data.cquest.org/open4goods/">opendata archives, thanks @cquest</a></li>
-	                                </ul>
-	                                </div>
-	                            </div>
-                            </div>
-                            
-                            <h2 class="h3">Format des données</h2>
-                            <div class="alert alert-info" role="alert">
-								Les données sont au format <b>CSV</b>, compressées au format <b>zip</b>.
-								<ul>
-									<li>Séparateur de champs : <b>,</b> </li>
-									<li>Séparateur de texte : <b>"</b> </li>
-								</ul>
-							</div>
-			
-															
-							<div class="mb-5">
-								<div class="mb-4">
-									<span class="h5">Colonnes</span>
-								</div>
-								<table class="table table-hover">
-									<tbody>
-									<tr>
-										<th scope="row"><b>barcode</b></th>
-										<td scope="row">Le code barre du produit, qui peut être un GTIN, EAN13 ou ISBN</td>
-									</tr>
-									
-									<tr>
-										<th scope="row"><b>brand</b></th>
-										<td>Marque du produit</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>model</b></th>
-										<td scope="row">Réference constructeur du produit</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>last_updated</b></th>
-										<td scope="row">Dernière mise à jour de ce produit, au format epoch en millisecondes</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>gs1_country</b></th>
-										<td scope="row">Pays de l'organisme GS1 qui a délivré le code barre pour ce produit (hors ISBN)</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>gtinType</b></th>
-										<td scope="row">Type du code barre. Peut être ISBN_13, GTIN_13, GTIN_8, GTIN_12</td>
-									</tr>																											
-									<tr>
-										<th scope="row"><b>offers_count</b></th>
-										<td scope="row">Nombre d'offres commerciales pour ce produit</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>min_price</b></th>
-										<td scope="row">Prix le plus faible pour ce produit</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>min_price_compensation</b></th>
-										<td scope="row">Compensation carbone reversée, correspondant au prix le plus faible pour ce produit</td>
-									</tr>									
-									<tr>
-										<th scope="row"><b>currency</b></th>
-										<td scope="row">Devise du prix le plus faible et de la compensation carbone associée </td>
-									</tr>									
-									<tr>
-										<th scope="row"><b>categories</b></th>
-										<td scope="row">Catégories dans lesquelles ce produit a été rencontré</td>
-									</tr>
-									<tr>
-										<th scope="row"><b>url</b></th>
-										<td scope="row">URL de la fiche produit, uniquement si des offres commerciales sont disponibles</td>
-									</tr>	
-																		
-								</tbody></table>
 							</div>
 
-                       
-                            
-                           
-							
-                   
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-       
-       
-    </main>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+
+	</main>
 
 	<!--/* Footer */-->
 	<th:block th:insert="~{inc/footer.html}"></th:block>	


### PR DESCRIPTION
#### Objective
Improve Opendata pages and services by splitting the data between GTIN and ISBN datasets with enhanced UI.

#### Summary of Changes
- **OpenDataController**: 
  - Added new routes for GTIN and ISBN datasets (`/opendata/gtin`, `/opendata/isbn`).
  - Enhanced model with additional attributes (e.g., `gtinLastUpdated`, `isbnFileSize`, etc.).
  - Implemented `getMultipleExposedUrls()` method to expose multiple sitemap entries.

- **OpenDataService**: 
  - Added generation and management of both GTIN and ISBN datasets.
  - Implemented `processAndCreateZip()` to handle dataset compression.
  - Implemented HealthIndicator to monitor the availability of GTIN and ISBN ZIP files.
  - New OpenDataConfig conf file (download speed and concurrent download limits)

- **Frontend Pages**: 
  - Updated main Opendata page to display separate GTIN and ISBN datasets.
  - Added new detailed pages for GTIN and ISBN downloads, with individual file size and last updated information.