### PR TITLE
Add AGENTS guides for all modules

### DIFF
--- a/admin/AGENTS.md
+++ b/admin/AGENTS.md
@@ -1,0 +1,38 @@
+# Admin Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3 (Spring Boot Admin)
+
+## Directory structure
+
+- `src/main/java` – application code
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `admin` module provides the administration console based on Spring Boot Admin to monitor open4goods services.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl admin -am clean install
+```

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,38 @@
+# Api Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – REST API and batch code
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `api` module exposes the REST endpoints and orchestrates data ingestion pipelines.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl api -am clean install
+```

--- a/commons/AGENTS.md
+++ b/commons/AGENTS.md
@@ -1,0 +1,38 @@
+# Commons Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – shared utilities
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `commons` module contains common utilities and configurations shared across other modules.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl commons -am clean install
+```

--- a/crawler/AGENTS.md
+++ b/crawler/AGENTS.md
@@ -1,0 +1,39 @@
+# Crawler Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – crawler implementation
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+- `libs` – third party crawler libs
+
+## Purpose
+
+The `crawler` module retrieves product information from external sources and feeds the open4goods data pipeline.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl crawler -am clean install
+```

--- a/model/AGENTS.md
+++ b/model/AGENTS.md
@@ -1,0 +1,38 @@
+# Model Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – domain model classes
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `model` module defines domain objects shared across other modules.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl model -am clean install
+```

--- a/services/captcha/AGENTS.md
+++ b/services/captcha/AGENTS.md
@@ -1,0 +1,38 @@
+# Captcha Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Handles captcha verification.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/captcha -am clean install
+```

--- a/services/evaluation/AGENTS.md
+++ b/services/evaluation/AGENTS.md
@@ -1,0 +1,38 @@
+# Evaluation Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Provides evaluation functions with SpEL and Thymeleaf.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/evaluation -am clean install
+```

--- a/services/favicon/AGENTS.md
+++ b/services/favicon/AGENTS.md
@@ -1,0 +1,38 @@
+# Favicon Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Generates favicon images.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/favicon -am clean install
+```

--- a/services/github-feedback/AGENTS.md
+++ b/services/github-feedback/AGENTS.md
@@ -1,0 +1,38 @@
+# Github-feedback Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Manages feedback via GitHub.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/github-feedback -am clean install
+```

--- a/services/googlesearch/AGENTS.md
+++ b/services/googlesearch/AGENTS.md
@@ -1,0 +1,38 @@
+# Googlesearch Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Integrates with Google Custom Search API.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/googlesearch -am clean install
+```

--- a/services/product-repository/AGENTS.md
+++ b/services/product-repository/AGENTS.md
@@ -1,0 +1,38 @@
+# Product-repository Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Stores and retrieves product data.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/product-repository -am clean install
+```

--- a/services/prompt/AGENTS.md
+++ b/services/prompt/AGENTS.md
@@ -1,0 +1,38 @@
+# Prompt Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Interacts with generative AI using prompt templates.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/prompt -am clean install
+```

--- a/services/remotefilecaching/AGENTS.md
+++ b/services/remotefilecaching/AGENTS.md
@@ -1,0 +1,38 @@
+# Remotefilecaching Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Caches remote files locally.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/remotefilecaching -am clean install
+```

--- a/services/review-generation/AGENTS.md
+++ b/services/review-generation/AGENTS.md
@@ -1,0 +1,38 @@
+# Review-generation Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Generates product reviews.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/review-generation -am clean install
+```

--- a/services/serialisation/AGENTS.md
+++ b/services/serialisation/AGENTS.md
@@ -1,0 +1,38 @@
+# Serialisation Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Serializes and deserializes objects.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/serialisation -am clean install
+```

--- a/services/urlfetching/AGENTS.md
+++ b/services/urlfetching/AGENTS.md
@@ -1,0 +1,38 @@
+# Urlfetching Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Fetches URLs with caching.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/urlfetching -am clean install
+```

--- a/services/xwiki-spring-boot-starter/AGENTS.md
+++ b/services/xwiki-spring-boot-starter/AGENTS.md
@@ -1,0 +1,38 @@
+# Xwiki-spring-boot-starter Service Agents Guide
+
+This microservice is part of the open4goods project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – service code
+- `src/main/resources` – configuration and assets
+- `src/test/java` – unit tests
+
+## Purpose
+
+Helper starter for interacting with XWiki.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl services/xwiki-spring-boot-starter -am clean install
+```

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,0 +1,40 @@
+# Ui Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+- Node.js build tools (gulp)
+
+## Directory structure
+
+- `src/main/java` – web controllers
+- `src/main/resources` – templates and configuration
+- `src/test/java` – unit tests
+- `package.json` and `gulpfile.mjs` – frontend build tasks
+
+## Purpose
+
+The `ui` module provides the web user interface built with Thymeleaf and Bootstrap.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl ui -am clean install
+```

--- a/verticals/AGENTS.md
+++ b/verticals/AGENTS.md
@@ -1,0 +1,38 @@
+# Verticals Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+- YAML configuration resources
+
+## Directory structure
+
+- `src/main/resources/verticals` – vertical definitions
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `verticals` module stores YAML configuration describing product verticals.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl verticals -am clean install
+```


### PR DESCRIPTION
## Summary
- create AGENTS.md for every Maven module
- each file explains technology, directory layout, purpose and how to run a module build

## Testing
- `mvn clean install -q` *(fails: GoogleSearchServiceTest.testSearch)*

------
https://chatgpt.com/codex/tasks/task_e_68419aacc4f88333bf1502ff64de5b46