### PR TITLE
Convert simple POJOs to records

### DIFF
--- a/model/src/main/java/org/open4goods/model/ai/AiDescription.java
+++ b/model/src/main/java/org/open4goods/model/ai/AiDescription.java
@@ -1,37 +1,34 @@
 package org.open4goods.model.ai;
 
-public class AiDescription {
-	
-	private long ts;
-	
-	private String content;
-	
-	public AiDescription() {
-		super();
-	}
+/**
+ * Simple holder for AI generated text along with its creation timestamp.
+ */
+public record AiDescription(long ts, String content) {
 
-	public AiDescription(String content) {
-		this.ts = System.currentTimeMillis();
-		this.content = content;
-	}
+    /**
+     * Convenience constructor initializing the timestamp to the current time.
+     *
+     * @param content the generated text
+     */
+    public AiDescription(String content) {
+        this(System.currentTimeMillis(), content);
+    }
 
-	public long getTs() {
-		return ts;
-	}
+    /**
+     * Accessor preserving the former {@code getTs()} API.
+     *
+     * @return the timestamp of creation
+     */
+    public long getTs() {
+        return ts;
+    }
 
-	public void setTs(long ts) {
-		this.ts = ts;
-	}
-
-	public String getContent() {
-		return content;
-	}
-
-	public void setContent(String content) {
-		this.content = content;
-	}
-
-	
-
-
+    /**
+     * Accessor preserving the former {@code getContent()} API.
+     *
+     * @return the textual content
+     */
+    public String getContent() {
+        return content;
+    }
 }

--- a/model/src/main/java/org/open4goods/model/ai/AiReview.java
+++ b/model/src/main/java/org/open4goods/model/ai/AiReview.java
@@ -191,130 +191,42 @@ public class AiReview {
     /**
      * Represents a source of information for an AI-generated review.
      */
-    public static class AiSource {
+    public static record AiSource(
+            @JsonProperty(required = true, value = "number")
+            @AiGeneratedField(instruction = "Le numéro de la source documentaire fournie")
+            Integer number,
+            @JsonProperty(required = true, value = "name")
+            @AiGeneratedField(instruction = "Le nom de la source documentaire fournie")
+            String name,
+            @JsonProperty(required = true, value = "description")
+            @AiGeneratedField(instruction = "Courte description de la source documentaire fournie")
+            String description,
+            @JsonProperty(required = true, value = "url")
+            @AiGeneratedField(instruction = "URL de la source documentaire fournie")
+            String url) {
 
-        public AiSource() {
-			super();
-		}
-
-		public AiSource(Integer number, String name, String description, String url) {
-			super();
-			this.number = number;
-			this.name = name;
-			this.description = description;
-			this.url = url;
-		}
-
-		/** The reference number of the source. */
-        @JsonProperty(required = true, value = "number")
-        @AiGeneratedField(instruction = "Le numéro de la source documentaire fournie")
-        private Integer number;
-
-        /** The name of the source. */
-        @JsonProperty(required = true, value = "name")
-        @AiGeneratedField(instruction = "Le nom de la source documentaire fournie")
-        private String name;
-
-        /** A description of the source. */
-        @JsonProperty(required = true, value = "description")
-        @AiGeneratedField(instruction = "Courte description de la source documentaire fournie")
-        private String description;
-
-        /** The URL of the source. */
-        @JsonProperty(required = true, value = "url")
-        @AiGeneratedField(instruction = "URL de la source documentaire fournie")
-        private String url;
-
-
-        public Integer getNumber() {
-            return number;
-        }
-
-        public void setNumber(Integer number) {
-            this.number = number;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public void setDescription(String description) {
-            this.description = description;
-        }
-
-        public String getUrl() {
-            return url;
-        }
-
-        public void setUrl(String url) {
-            this.url = url;
-        }
+        public Integer getNumber() { return number; }
+        public String getName() { return name; }
+        public String getDescription() { return description; }
+        public String getUrl() { return url; }
     }
 
     /**
      * Represents an attribute of the product.
      */
-    public static class AiAttribute {
-    	
-    	
+    public static record AiAttribute(
+            @JsonProperty(required = true, value = "name")
+            @AiGeneratedField(instruction = "Le nom de l'attribut")
+            String name,
+            @JsonProperty(required = true, value = "value")
+            @AiGeneratedField(instruction = "La valeur de l'attribut")
+            String value,
+            @JsonProperty(required = true, value = "number")
+            @AiGeneratedField(instruction = "La référence de la source qui indique cet attribut")
+            Integer number) {
 
-        public AiAttribute() {
-			super();
-		}
-
-		public AiAttribute(String name, String value, Integer number) {
-			super();
-			this.name = name;
-			this.value = value;
-			this.number = number;
-		}
-
-		/** The name of the attribute. */
-        @JsonProperty(required = true, value = "name")
-        @AiGeneratedField(instruction = "Le nom de l'attribut")
-        private String name;
-
-        /** The value of the attribute. */
-        @JsonProperty(required = true, value = "value")
-        @AiGeneratedField(instruction = "La valeur de l'attribut")
-        private String value;
-
-        /** The source number of the attribute. */
-        @JsonProperty(required = true, value = "number")
-        @AiGeneratedField(instruction = "La référence de la source qui indique cet attribut")
-        private Integer number;
-
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public void setValue(String value) {
-            this.value = value;
-        }
-
-        public Integer getNumber() {
-            return number;
-        }
-
-        public void setNumber(Integer number) {
-            this.number = number;
-        }
+        public String getName() { return name; }
+        public String getValue() { return value; }
+        public Integer getNumber() { return number; }
     }
 }

--- a/model/src/main/java/org/open4goods/model/price/PriceHistory.java
+++ b/model/src/main/java/org/open4goods/model/price/PriceHistory.java
@@ -1,54 +1,42 @@
 package org.open4goods.model.price;
 
-import org.springframework.data.elasticsearch.annotations.DateFormat;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
+/**
+ * Historical price entry consisting of a timestamp and the associated price.
+ */
+public record PriceHistory(Long timestamp, Double price) {
 
-public class PriceHistory {
+    /**
+     * Creates a history entry from an {@link AggregatedPrice} instance.
+     *
+     * @param minPrice the aggregated price to build from
+     */
+    public PriceHistory(AggregatedPrice minPrice) {
+        this(minPrice.getTimeStamp(), minPrice.getPrice());
+    }
 
-	private Long timestamp;
+    /**
+     * Number of days corresponding to this history timestamp.
+     *
+     * @return the day count
+     */
+    public Long getDay() {
+        return timestamp / (1000 * 60 * 60 * 24);
+    }
 
-	private Double price;
+    // Compatibility accessors ----------------------------------------------
 
+    /** @return timestamp accessor mirroring the former getter */
+    public Long getTimestamp() {
+        return timestamp;
+    }
 
-	
-	@Override
-	public String toString() {
-		return timestamp+":"+price;
-	}
-	public PriceHistory() {
-	}
+    /** @return price accessor mirroring the former getter */
+    public Double getPrice() {
+        return price;
+    }
 
-	
-	/**
-	 * Get the number of the day this timestamp refers to
-	 * @return
-	 */
-	public Long getDay() {
-		return getTimestamp() / (1000 * 60 * 60 * 24); 
-	}
-
-	
-	public PriceHistory(AggregatedPrice minPrice) {
-		timestamp = minPrice.getTimeStamp();
-		price = minPrice.getPrice();
-	}
-
-	public Long getTimestamp() {
-		return timestamp;
-	}
-
-	public void setTimestamp(Long timestamp) {
-		this.timestamp = timestamp;
-	}
-
-	public Double getPrice() {
-		return price;
-	}
-
-	public void setPrice(Double price) {
-		this.price = price;
-	}
-
-
+    @Override
+    public String toString() {
+        return timestamp + ":" + price;
+    }
 }

--- a/model/src/main/java/org/open4goods/model/price/PriceTrend.java
+++ b/model/src/main/java/org/open4goods/model/price/PriceTrend.java
@@ -15,15 +15,14 @@ import org.joda.time.format.PeriodFormatter;
  *
 
  */
-public class PriceTrend {
-
-	private Integer trend; // 1 = increase, -1 = decrease, 0 = stable or unknown
-	private Long period; // milliseconds between the two last price records
-	private Double actualPrice;
-	private Double lastPrice;
-	private Double variation;
-	private Double historicalLowestPrice;
-	private Double historicalVariation;
+public record PriceTrend(
+                Integer trend,
+                Long period,
+                Double actualPrice,
+                Double lastPrice,
+                Double variation,
+                Double historicalLowestPrice,
+                Double historicalVariation) {
 
 	/**
 	 * Computes a PriceTrend instance based on price history and current price.
@@ -32,42 +31,41 @@ public class PriceTrend {
 	 * @param actual  The current aggregated price information.
 	 * @return A populated PriceTrend object.
 	 */
-	public static PriceTrend of(List<PriceHistory> history, AggregatedPrice actual) {
-		PriceTrend trend = new PriceTrend();
+        public static PriceTrend of(List<PriceHistory> history, AggregatedPrice actual) {
+                if (history.size() > 1 && actual != null) {
+                        PriceHistory last = history.get(history.size() - 2);
+                        double actualVal = actual.getPrice();
+                        double lastVal = last.getPrice();
+                        long timeDiff = actual.getTimeStamp() - last.getTimestamp();
 
-		if (history.size() > 1 && actual != null) {
-			PriceHistory last = history.get(history.size() - 2);
-			double actualVal = actual.getPrice();
-			double lastVal = last.getPrice();
-			long timeDiff = actual.getTimeStamp() - last.getTimestamp();
+                        double variation = actualVal - lastVal;
+                        double historicalLowest = history.stream()
+                                        .mapToDouble(PriceHistory::getPrice)
+                                        .min()
+                                        .orElse(0.0);
+                        double historicalVar = actualVal - historicalLowest;
 
-			trend.setActualPrice(actualVal);
-			trend.setLastPrice(lastVal);
-			trend.setVariation(actualVal - lastVal);
-			trend.setPeriod(timeDiff);
-			trend.setTrend(Double.compare(trend.getVariation(), 0));
-			trend.setHistoricalLowestPrice(
-				history.stream()
-					.mapToDouble(PriceHistory::getPrice)
-					.min()
-					.orElse(0.0)
-			);
-			trend.setHistoricalVariation(actualVal - trend.getHistoricalLowestPrice());
-		} else {
-			trend.setTrend(0);
-		}
+                        return new PriceTrend(
+                                        Double.compare(variation, 0),
+                                        timeDiff,
+                                        actualVal,
+                                        lastVal,
+                                        variation,
+                                        historicalLowest,
+                                        historicalVar);
+                }
 
-		return trend;
-	}
+                return new PriceTrend(0, null, null, null, null, null, null);
+        }
 
 	/**
 	 * Formats the duration since the last price change in a localized format.
 	 *
 	 * @return A localized string describing the time since the last price change.
 	 */
-	public String formatedDuration() {
-		return ago(Locale.FRANCE, period); // TODO: localize dynamically
-	}
+        public String formatedDuration() {
+                return ago(Locale.FRANCE, period); // TODO: localize dynamically
+        }
 
 	/**
 	 * Localized "ago" time formatter.
@@ -107,61 +105,33 @@ public class PriceTrend {
 		return (variation / lastPrice) * 100;
 	}
 
-	// Getters and setters
+        // Compatibility accessors ------------------------------------------
 
-	public Integer getTrend() {
-		return trend;
-	}
+        public Integer getTrend() {
+                return trend;
+        }
 
-	public void setTrend(Integer trend) {
-		this.trend = trend;
-	}
+        public Long getPeriod() {
+                return period;
+        }
 
-	public Long getPeriod() {
-		return period;
-	}
+        public Double getActualPrice() {
+                return actualPrice;
+        }
 
-	public void setPeriod(Long period) {
-		this.period = period;
-	}
+        public Double getLastPrice() {
+                return lastPrice;
+        }
 
-	public Double getActualPrice() {
-		return actualPrice;
-	}
+        public Double getVariation() {
+                return variation;
+        }
 
-	public void setActualPrice(Double actualPrice) {
-		this.actualPrice = actualPrice;
-	}
+        public Double getHistoricalLowestPrice() {
+                return historicalLowestPrice;
+        }
 
-	public Double getLastPrice() {
-		return lastPrice;
-	}
-
-	public void setLastPrice(Double lastPrice) {
-		this.lastPrice = lastPrice;
-	}
-
-	public Double getVariation() {
-		return variation;
-	}
-
-	public void setVariation(Double variation) {
-		this.variation = variation;
-	}
-
-	public Double getHistoricalLowestPrice() {
-		return historicalLowestPrice;
-	}
-
-	public void setHistoricalLowestPrice(Double historicalLowestPrice) {
-		this.historicalLowestPrice = historicalLowestPrice;
-	}
-
-	public Double getHistoricalVariation() {
-		return historicalVariation;
-	}
-
-	public void setHistoricalVariation(Double historicalVariation) {
-		this.historicalVariation = historicalVariation;
-	}
+        public Double getHistoricalVariation() {
+                return historicalVariation;
+        }
 }


### PR DESCRIPTION
## Summary
- refactor several model classes to Java records
- simplify `AiDescription`
- convert `PriceHistory` to an immutable record
- refactor `PriceTrend` and keep compatibility helpers
- convert inner classes of `AiReview` to records

## Testing
- `mvn clean install -q` *(fails: GoogleSearchServiceTest.testSearch)*

------
https://chatgpt.com/codex/tasks/task_e_684203629fa483338430ff7d14611e20