### PR TITLE
Fix orphan closing tag in product template

### DIFF
--- a/ui/src/main/resources/templates/default/product.html
+++ b/ui/src/main/resources/templates/default/product.html
@@ -76,8 +76,6 @@
                 -->
                 <th:block th:insert="~{inc/product-header.html}"></th:block>
 
-			</th:block>
-
 
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove stray `</th:block>` from product.html

## Testing
- `mvn -DskipTests clean install`


------
https://chatgpt.com/codex/tasks/task_e_684217fed29883339246ee5681055ce8