### PR TITLE
Refactor properties and DTOs to records

### DIFF
--- a/commons/src/main/java/org/open4goods/commons/config/yml/datasource/FeedConfigProperties.java
+++ b/commons/src/main/java/org/open4goods/commons/config/yml/datasource/FeedConfigProperties.java
@@ -8,50 +8,18 @@ import java.util.Set;
 
 @Configuration
 @ConfigurationProperties(prefix = "feedconfig")
-public class FeedConfigProperties {
+public record FeedConfigProperties(Map<String, FeedProviderProperties> providers) {
 
-    private Map<String, FeedProviderProperties> providers;
-
-    public Map<String, FeedProviderProperties> getProviders() {
-        return providers;
-    }
-
-    public void setProviders(Map<String, FeedProviderProperties> providers) {
-        this.providers = providers;
-    }
-
-    public static class FeedProviderProperties {
-        private String catalogUrl;
-        private String datasourceKeyAttribute;
-        private String datasourceUrlAttribute;
-        private String datasourceFeedNameAttribute;
-        private String datasourceRegionAttribute;
-        private String datasourceLanguageAttribute;
-        private Map<String, String> filterAttributes;
-        private Set<String> excludeFeedKeyContains;
-        private CsvDataSourceProperties defaultCsvProperties;
-        private String cron; // Optional custom cron expression
-
-        // Getters and setters
-        public String getCatalogUrl() { return catalogUrl; }
-        public void setCatalogUrl(String catalogUrl) { this.catalogUrl = catalogUrl; }
-        public String getDatasourceKeyAttribute() { return datasourceKeyAttribute; }
-        public void setDatasourceKeyAttribute(String datasourceKeyAttribute) { this.datasourceKeyAttribute = datasourceKeyAttribute; }
-        public String getDatasourceUrlAttribute() { return datasourceUrlAttribute; }
-        public void setDatasourceUrlAttribute(String datasourceUrlAttribute) { this.datasourceUrlAttribute = datasourceUrlAttribute; }
-        public String getDatasourceFeedNameAttribute() { return datasourceFeedNameAttribute; }
-        public void setDatasourceFeedNameAttribute(String datasourceFeedNameAttribute) { this.datasourceFeedNameAttribute = datasourceFeedNameAttribute; }
-        public String getDatasourceRegionAttribute() { return datasourceRegionAttribute; }
-        public void setDatasourceRegionAttribute(String datasourceRegionAttribute) { this.datasourceRegionAttribute = datasourceRegionAttribute; }
-        public String getDatasourceLanguageAttribute() { return datasourceLanguageAttribute; }
-        public void setDatasourceLanguageAttribute(String datasourceLanguageAttribute) { this.datasourceLanguageAttribute = datasourceLanguageAttribute; }
-        public Map<String, String> getFilterAttributes() { return filterAttributes; }
-        public void setFilterAttributes(Map<String, String> filterAttributes) { this.filterAttributes = filterAttributes; }
-        public Set<String> getExcludeFeedKeyContains() { return excludeFeedKeyContains; }
-        public void setExcludeFeedKeyContains(Set<String> excludeFeedKeyContains) { this.excludeFeedKeyContains = excludeFeedKeyContains; }
-        public CsvDataSourceProperties getDefaultCsvProperties() { return defaultCsvProperties; }
-        public void setDefaultCsvProperties(CsvDataSourceProperties defaultCsvProperties) { this.defaultCsvProperties = defaultCsvProperties; }
-        public String getCron() { return cron; }
-        public void setCron(String cron) { this.cron = cron; }
+    public record FeedProviderProperties(
+            String catalogUrl,
+            String datasourceKeyAttribute,
+            String datasourceUrlAttribute,
+            String datasourceFeedNameAttribute,
+            String datasourceRegionAttribute,
+            String datasourceLanguageAttribute,
+            Map<String, String> filterAttributes,
+            Set<String> excludeFeedKeyContains,
+            CsvDataSourceProperties defaultCsvProperties,
+            String cron) {
     }
 }

--- a/services/captcha/src/main/java/org/open4goods/services/captcha/config/HcaptchaProperties.java
+++ b/services/captcha/src/main/java/org/open4goods/services/captcha/config/HcaptchaProperties.java
@@ -11,40 +11,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @ConfigurationProperties(prefix = "captcha")
-public class HcaptchaProperties {
+public record HcaptchaProperties(String key, String secretKey, String validRole) {
 
-	
-    /**
-     * The (public) key identifying captcha app.
-     */
-    private String key;
-
-    
-    
-    /**
-     * The secret key for captcha verification.
-     */
-    private String secretKey;
-
-    /**
-     * The Spring Security role assigned to users upon successful captcha verification.
-     */
-    private String validRole = "ROLE_HUMAN";
-
-    public String getSecretKey() {
-        return secretKey;
-    }
-
-    public void setSecretKey(String secretKey) {
-        this.secretKey = secretKey;
-    }
-
-    public String getValidRole() {
-        return validRole;
-    }
-
-    public void setValidRole(String validRole) {
-        this.validRole = validRole;
+    public HcaptchaProperties {
+        validRole = (validRole == null || validRole.isBlank()) ? "ROLE_HUMAN" : validRole;
     }
 
     /**
@@ -57,14 +27,4 @@ public class HcaptchaProperties {
     public String toString() {
         return "CaptchaProperties{secretKey=****, validRole='" + validRole + '\'' + '}';
     }
-
-	public String getKey() {
-		return key;
-	}
-
-	public void setKey(String key) {
-		this.key = key;
-	}
-    
-    
 }

--- a/services/captcha/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/captcha/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -2,8 +2,8 @@
   "groups": [
     {
       "name": "captcha",
-      "type": "org.open4goods.services.captcha.config.CaptchaProperties",
-      "sourceType": "org.open4goods.services.captcha.config.CaptchaProperties"
+      "type": "org.open4goods.services.captcha.config.HcaptchaProperties",
+      "sourceType": "org.open4goods.services.captcha.config.HcaptchaProperties"
     }
   ],
   "properties": [
@@ -23,7 +23,7 @@
       "name": "captcha.valid-role",
       "type": "java.lang.String",
       "description": "Spring Security role assigned to users upon successful captcha verification.",
-      "defaultValue": "ROLE_CAPTCHA_VERIFIED"
+      "defaultValue": "ROLE_HUMAN"
     }
   ]
 }

--- a/services/captcha/src/test/java/org/open4goods/services/captcha/service/HcaptchaServiceTest.java
+++ b/services/captcha/src/test/java/org/open4goods/services/captcha/service/HcaptchaServiceTest.java
@@ -34,9 +34,7 @@ public class HcaptchaServiceTest {
 
     @BeforeEach
     public void setUp() {
-        captchaProperties = new HcaptchaProperties();
-        captchaProperties.setSecretKey("dummySecret");
-        captchaProperties.setValidRole("ROLE_CAPTCHA_VERIFIED");
+        captchaProperties = new HcaptchaProperties("dummyKey", "dummySecret", "ROLE_CAPTCHA_VERIFIED");
 
         restTemplate = Mockito.mock(RestTemplate.class);
         restTemplateBuilder = Mockito.mock(RestTemplateBuilder.class);

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/config/GoogleSearchConfig.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/config/GoogleSearchConfig.java
@@ -123,108 +123,16 @@ public class GoogleSearchConfig {
     /**
      * Nested class to encapsulate default values for additional search options.
      */
-    public static class Defaults {
-        /**
-         * Default language restriction (lr).
-         */
-        private String lr = "lang_fr";
-        /**
-         * Default country restriction (cr).
-         */
-        private String cr = "countryFR";
-        /**
-         * Default safe search filtering (safe).
-         */
-        private String safe = "off";
-        /**
-         * Default sort option.
-         */
-        private String sort = "";
-        /**
-         * Default geolocation (gl).
-         */
-        private String gl = "fr";
-        /**
-         * Default interface language (hl).
-         */
-        private String hl = "fr";
+    public static record Defaults(
+            String lr,
+            String cr,
+            String safe,
+            String sort,
+            String gl,
+            String hl) {
 
-        public String getLr() {
-            return lr;
-        }
-
-        public void setLr(String lr) {
-            this.lr = lr;
-        }
-
-        public String getCr() {
-            return cr;
-        }
-
-        public void setCr(String cr) {
-            this.cr = cr;
-        }
-
-        public String getSafe() {
-            return safe;
-        }
-
-        public void setSafe(String safe) {
-            this.safe = safe;
-        }
-
-        public String getSort() {
-            return sort;
-        }
-
-        public void setSort(String sort) {
-            this.sort = sort;
-        }
-
-        public String getGl() {
-            return gl;
-        }
-
-        public void setGl(String gl) {
-            this.gl = gl;
-        }
-
-        public String getHl() {
-            return hl;
-        }
-
-        public void setHl(String hl) {
-            this.hl = hl;
-        }
-
-        @Override
-        public String toString() {
-            return "Defaults{" +
-                    "lr='" + lr + '\'' +
-                    ", cr='" + cr + '\'' +
-                    ", safe='" + safe + '\'' +
-                    ", sort='" + sort + '\'' +
-                    ", gl='" + gl + '\'' +
-                    ", hl='" + hl + '\'' +
-                    '}';
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(lr, cr, safe, sort, gl, hl);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Defaults)) return false;
-            Defaults defaults = (Defaults) o;
-            return Objects.equals(lr, defaults.lr) &&
-                   Objects.equals(cr, defaults.cr) &&
-                   Objects.equals(safe, defaults.safe) &&
-                   Objects.equals(sort, defaults.sort) &&
-                   Objects.equals(gl, defaults.gl) &&
-                   Objects.equals(hl, defaults.hl);
+        public Defaults() {
+            this("lang_fr", "countryFR", "off", "", "fr", "fr");
         }
     }
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchRequest.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchRequest.java
@@ -1,141 +1,25 @@
 package org.open4goods.services.googlesearch.dto;
 
-import java.util.Objects;
-
 /**
  * Data Transfer Object representing a Google Search Request.
  */
-public class GoogleSearchRequest {
-    
+public record GoogleSearchRequest(
+        String query,
+        int numResults,
+        String lr,
+        String cr,
+        String safe,
+        String sort,
+        String gl,
+        String hl) {
+
     private static final int DEFAULT_SEARCH_RESULTS = 10;
-	private final String query;
-    private final int numResults;
-
-    // New optional search parameters corresponding to Google API options.
-    private String lr;   // Language restriction (e.g., lang_en)
-    private String cr;   // Country restriction (e.g., countryUS)
-    private String safe = "off"; // Safe search parameter (e.g., active, off)
-    private String sort; // Sort option
-    private String gl;   // Geolocation (e.g., us)
-    private String hl;   // Interface language (e.g., en)
-
-  
-    /**
-     * Constructs a new GoogleSearchRequest with all options.
-     *
-     * @param query      the search query (must not be null or empty)
-     * @param numResults the number of results to retrieve
-     * @param lr         language restriction parameter (optional)
-     * @param cr         country restriction parameter (optional)
-     * @param safe       safe search option (optional)
-     * @param sort       sort option (optional)
-     * @param gl         geolocation parameter (optional)
-     * @param hl         interface language parameter (optional)
-     */
-    public GoogleSearchRequest(String query, int numResults, String lr, String cr, String safe, String sort, String gl, String hl) {
-        this.lr = lr;
-        this.cr = cr;
-        this.safe = safe;
-        this.sort = sort;
-        this.gl = gl;
-        this.hl = hl;
-		this.query = query;
-		this.numResults = numResults;
-    }
 
     public GoogleSearchRequest(String query, String lr, String cr) {
-        this.lr = lr;
-        this.cr = cr;
-		this.query = query;
-		this.numResults = DEFAULT_SEARCH_RESULTS;
-    }
-	public String getQuery() {
-        return query;
+        this(query, DEFAULT_SEARCH_RESULTS, lr, cr, "off", null, null, null);
     }
 
-    public int getNumResults() {
-        return numResults;
-    }
-    
-    public String getLr() {
-        return lr;
-    }
-    
-    public void setLr(String lr) {
-        this.lr = lr;
-    }
-    
-    public String getCr() {
-        return cr;
-    }
-    
-    public void setCr(String cr) {
-        this.cr = cr;
-    }
-    
-    public String getSafe() {
-        return safe;
-    }
-    
-    public void setSafe(String safe) {
-        this.safe = safe;
-    }
-    
-    public String getSort() {
-        return sort;
-    }
-    
-    public void setSort(String sort) {
-        this.sort = sort;
-    }
-    
-    public String getGl() {
-        return gl;
-    }
-    
-    public void setGl(String gl) {
-        this.gl = gl;
-    }
-    
-    public String getHl() {
-        return hl;
-    }
-    
-    public void setHl(String hl) {
-        this.hl = hl;
-    }
-
-    @Override
-    public String toString() {
-        return "GoogleSearchRequest{" +
-                "query='" + query + '\'' +
-                ", numResults=" + numResults +
-                ", lr='" + lr + '\'' +
-                ", cr='" + cr + '\'' +
-                ", safe='" + safe + '\'' +
-                ", sort='" + sort + '\'' +
-                ", gl='" + gl + '\'' +
-                ", hl='" + hl + '\'' +
-                '}';
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(query, numResults, lr, cr, safe, sort, gl, hl);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GoogleSearchRequest)) return false;
-        GoogleSearchRequest that = (GoogleSearchRequest) o;
-        return numResults == that.numResults &&
-               Objects.equals(query, that.query) &&
-               Objects.equals(lr, that.lr) &&
-               Objects.equals(cr, that.cr) &&
-               Objects.equals(safe, that.safe) &&
-               Objects.equals(sort, that.sort) &&
-               Objects.equals(gl, that.gl) &&
-               Objects.equals(hl, that.hl);
+    public GoogleSearchRequest {
+        safe = (safe == null || safe.isBlank()) ? "off" : safe;
     }
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResponse.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResponse.java
@@ -2,59 +2,13 @@ package org.open4goods.services.googlesearch.dto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Data Transfer Object representing a Google Search Response.
  */
-public class GoogleSearchResponse {
+public record GoogleSearchResponse(List<GoogleSearchResult> results) {
 
-    private List<GoogleSearchResult> results = new ArrayList<GoogleSearchResult>();
-
-
-    /**
-     * Constructs a new GoogleSearchResponse.
-     *
-     */
     public GoogleSearchResponse() {
+        this(new ArrayList<>());
     }
-    
-    /**
-     * Constructs a new GoogleSearchResponse.
-     *
-     * @param results the list of search results
-     */
-    public GoogleSearchResponse(List<GoogleSearchResult> results) {
-        this.results = results;
-    }
-
-    public List<GoogleSearchResult> getResults() {
-        return results;
-    }
-
-    @Override
-    public String toString() {
-        return "GoogleSearchResponse{" +
-                "results=" + results +
-                '}';
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(results);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GoogleSearchResponse)) return false;
-        GoogleSearchResponse that = (GoogleSearchResponse) o;
-        return Objects.equals(results, that.results);
-    }
-
-	public void setResults(List<GoogleSearchResult> results) {
-		this.results = results;
-	}
-    
-    
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResult.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResult.java
@@ -5,64 +5,9 @@ import java.util.Objects;
 /**
  * Data Transfer Object representing an individual search result.
  */
-public class GoogleSearchResult {
-
-    private String title;
-    private String link;
-
-    /**
-     * Constructs a new GoogleSearchResult.
-     *
-     * @param title the title of the search result
-     * @param link  the URL of the search result
-     */
-    public GoogleSearchResult(String title, String link) {
-        this.title = title;
-        this.link = link;
-    }
+public record GoogleSearchResult(String title, String link) {
 
     public GoogleSearchResult() {
-        this.title = null;
-        this.link = null;
+        this(null, null);
     }
-    
-    public String getTitle() {
-        return title;
-    }
-
-    public String getLink() {
-        return link;
-    }
-
-    @Override
-    public String toString() {
-        return "GoogleSearchResult{" +
-                "title='" + title + '\'' +
-                ", link='" + link + '\'' +
-                '}';
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(title, link);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GoogleSearchResult)) return false;
-        GoogleSearchResult that = (GoogleSearchResult) o;
-        return Objects.equals(title, that.title) &&
-               Objects.equals(link, that.link);
-    }
-
-	public void setTitle(String title) {
-		this.title = title;
-	}
-
-	public void setLink(String link) {
-		this.link = link;
-	}
-    
-    
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/service/GoogleSearchService.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/service/GoogleSearchService.java
@@ -85,7 +85,7 @@ public class GoogleSearchService implements HealthIndicator {
         meterRegistry.counter("google.search.count").increment();
 
         // Validate input query (constructor of GoogleSearchRequest already does basic validation)
-        final String encodedQuery = URLEncoder.encode(request.getQuery(), Charset.defaultCharset());
+        final String encodedQuery = URLEncoder.encode(request.query(), Charset.defaultCharset());
 
         // Build the API URL using externalized configuration.
         StringBuilder urlBuilder = new StringBuilder(String.format("%s?q=%s&key=%s&cx=%s&num=%d",
@@ -93,15 +93,15 @@ public class GoogleSearchService implements HealthIndicator {
                 encodedQuery,
                 properties.getApiKey(),
                 properties.getCx(),
-                request.getNumResults()));
+                request.numResults()));
 
         // Resolve additional parameters: use the request value if provided; otherwise, fallback to configuration defaults.
-        String lr = (request.getLr() != null && !request.getLr().isBlank()) ? request.getLr() : properties.getDefaults().getLr();
-        String cr = (request.getCr() != null && !request.getCr().isBlank()) ? request.getCr() : properties.getDefaults().getCr();
-        String safe = (request.getSafe() != null && !request.getSafe().isBlank()) ? request.getSafe() : properties.getDefaults().getSafe();
-        String sort = (request.getSort() != null && !request.getSort().isBlank()) ? request.getSort() : properties.getDefaults().getSort();
-        String gl = (request.getGl() != null && !request.getGl().isBlank()) ? request.getGl() : properties.getDefaults().getGl();
-        String hl = (request.getHl() != null && !request.getHl().isBlank()) ? request.getHl() : properties.getDefaults().getHl();
+        String lr = (request.lr() != null && !request.lr().isBlank()) ? request.lr() : properties.getDefaults().lr();
+        String cr = (request.cr() != null && !request.cr().isBlank()) ? request.cr() : properties.getDefaults().cr();
+        String safe = (request.safe() != null && !request.safe().isBlank()) ? request.safe() : properties.getDefaults().safe();
+        String sort = (request.sort() != null && !request.sort().isBlank()) ? request.sort() : properties.getDefaults().sort();
+        String gl = (request.gl() != null && !request.gl().isBlank()) ? request.gl() : properties.getDefaults().gl();
+        String hl = (request.hl() != null && !request.hl().isBlank()) ? request.hl() : properties.getDefaults().hl();
 
         // Append additional parameters to the URL if non-empty.
         if (lr != null && !lr.isBlank()) {
@@ -150,7 +150,7 @@ public class GoogleSearchService implements HealthIndicator {
             lastErrorMessage = null;
         }
 
-        logger.info("Search performed for query: '{}' with HTTP status: {}", request.getQuery(), response.statusCode());
+        logger.info("Search performed for query: '{}' with HTTP status: {}", request.query(), response.statusCode());
 
         // Parse the JSON response into our DTO.
         GoogleSearchResponse result = parseResponse(response.body());
@@ -159,8 +159,8 @@ public class GoogleSearchService implements HealthIndicator {
         if (properties.isRecordEnabled() && properties.getRecordFolder() != null && !properties.getRecordFolder().isBlank()) {
             try {
                 // Sanitize the query for a safe file name.
-                String sanitizedQuery = sanitizeUrlToFileName(request.getQuery());
-                String fileName = sanitizedQuery + "-" + request.getNumResults() + ".json";
+                String sanitizedQuery = sanitizeUrlToFileName(request.query());
+                String fileName = sanitizedQuery + "-" + request.numResults() + ".json";
                 Path folderPath = Paths.get(properties.getRecordFolder());
                 if (!Files.exists(folderPath)) {
                     Files.createDirectories(folderPath);
@@ -168,7 +168,7 @@ public class GoogleSearchService implements HealthIndicator {
                 Path filePath = folderPath.resolve(fileName);
                 String jsonContent = serialisationService.toJson(result,true);
                 Files.writeString(filePath, jsonContent);
-                logger.info("Search results for {} are : \n{}",request.getQuery(), jsonContent);
+                logger.info("Search results for {} are : \n{}",request.query(), jsonContent);
                 logger.info("Recorded search result to file: {}", filePath.toAbsolutePath());
 
             } catch (Exception e) {

--- a/services/googlesearch/src/test/java/org/open4goods/googlesearch/mock/GoogleSearchServiceMock.java
+++ b/services/googlesearch/src/test/java/org/open4goods/googlesearch/mock/GoogleSearchServiceMock.java
@@ -43,8 +43,8 @@ public class GoogleSearchServiceMock {
         Mockito.when(mockService.search(Mockito.any())).thenAnswer(invocation -> {
             GoogleSearchRequest request = invocation.getArgument(0);
             // Sanitize the query to create a safe file name.
-            String sanitizedQuery = GoogleSearchService.sanitizeUrlToFileName(request.getQuery());
-            String fileName = sanitizedQuery + "-" + request.getNumResults() + ".json";
+            String sanitizedQuery = GoogleSearchService.sanitizeUrlToFileName(request.query());
+            String fileName = sanitizedQuery + "-" + request.numResults() + ".json";
             // Define the path where mocks are expected in the classpath.
             String resourcePath = "googlesearch/mocks/" + fileName;
 


### PR DESCRIPTION
## Summary
- refactor `FeedConfigProperties` into a record
- use a record for `HcaptchaProperties` and adjust metadata
- convert captcha tests to new record constructor
- convert Google Search DTOs to records
- adapt `GoogleSearchService` and test mocks to new accessors

## Testing
- `mvn clean install -q` *(fails: TemplateEvaluationException)*

------
https://chatgpt.com/codex/tasks/task_e_68430e3260b88333bdfc6e18ad60f986