### PR TITLE
Externalize configuration properties

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -58,6 +58,7 @@ import org.open4goods.services.imageprocessing.service.ImageMagickService;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.prompt.service.PromptService;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.serialisation.service.SerialisationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -261,23 +262,19 @@ public class ApiConfig {
 	}
 
 	@Bean
-	GoogleTaxonomyService googleTaxonomyService(@Autowired RemoteFileCachingService remoteFileCachingService) {
-		GoogleTaxonomyService gts = new GoogleTaxonomyService(remoteFileCachingService);
+        GoogleTaxonomyService googleTaxonomyService( RemoteFileCachingService remoteFileCachingService,
+                        ApiProperties apiProperties) {
+                GoogleTaxonomyService gts = new GoogleTaxonomyService(remoteFileCachingService);
 
-		// TODO : From conf
-		// TODO : Add others
-		try {
-			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.fr-FR.txt", "fr");
-			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt", "en");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.de-DE.txt", "de");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.es-ES.txt", "es");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.nl-NL.txt", "nl");
+                try {
+                        for (var entry : apiProperties.getGoogleTaxonomy().entrySet()) {
+                                gts.loadGoogleTaxonUrl(entry.getValue(), entry.getKey());
+                        }
+                } catch (Exception e) {
+                        logger.error("Error loading google taxonomy", e);
+                }
 
-		} catch (Exception e) {
-			logger.error("Error loading google taxonomy", e);
-		}
-
-		return gts;
+                return gts;
 	}
 
 	@Bean
@@ -391,10 +388,11 @@ public class ApiConfig {
 		return new ImageMagickService();
 	}
 
-	@Bean
-	RemoteFileCachingService remoteFileCachingService(@Autowired final ApiProperties config) {
-		return new RemoteFileCachingService(config.remoteCachingFolder());
-	}
+        @Bean
+        RemoteFileCachingService remoteFileCachingService(@Autowired final ApiProperties config,
+                        RemoteFileCachingProperties remoteFileCachingProperties) {
+                return new RemoteFileCachingService(config.remoteCachingFolder(), remoteFileCachingProperties);
+        }
 
 	@Bean
 	DataFragmentStoreService dataFragmentStoreService(final ApiProperties config, @Autowired StandardiserService standardiserService, @Autowired AggregationFacadeService generationService, @Autowired ProductRepository aggregatedDataRepository) {

--- a/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
@@ -4,6 +4,8 @@ package org.open4goods.api.config.yml;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.open4goods.api.services.feed.AffiliationConfig;
@@ -144,7 +146,10 @@ public class ApiProperties {
 	/**
 	 * The configuration for developpement mode services
 	 */
-	private DevModeConfiguration devModeConfig = new DevModeConfiguration();
+        private DevModeConfiguration devModeConfig = new DevModeConfiguration();
+
+        /** Map of language to Google taxonomy URL */
+        private Map<String, String> googleTaxonomy = new HashMap<>();
 
 
 	/**
@@ -484,9 +489,17 @@ public class ApiProperties {
 
 
 
-	public void setDevModeConfig(DevModeConfiguration devModeConfig) {
-		this.devModeConfig = devModeConfig;
-	}
+        public void setDevModeConfig(DevModeConfiguration devModeConfig) {
+                this.devModeConfig = devModeConfig;
+        }
+
+        public Map<String, String> getGoogleTaxonomy() {
+                return googleTaxonomy;
+        }
+
+        public void setGoogleTaxonomy(Map<String, String> googleTaxonomy) {
+                this.googleTaxonomy = googleTaxonomy;
+        }
 
 
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -63,5 +63,13 @@ springdoc:
   swagger-ui:
     disable-swagger-default-url: true
 
-genAiPauseDurationMs: 100          
+genAiPauseDurationMs: 100
+
+remote-file-caching:
+  connection-timeout: 30000
+  read-timeout: 30000
+
+google-taxonomy:
+  fr: https://www.google.com/basepages/producttype/taxonomy-with-ids.fr-FR.txt
+  en: https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt
 

--- a/services/remotefilecaching/pom.xml
+++ b/services/remotefilecaching/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/services/remotefilecaching/src/main/java/org/open4goods/services/remotefilecaching/config/RemoteFileCachingProperties.java
+++ b/services/remotefilecaching/src/main/java/org/open4goods/services/remotefilecaching/config/RemoteFileCachingProperties.java
@@ -1,0 +1,34 @@
+package org.open4goods.services.remotefilecaching.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for {@code RemoteFileCachingService}.
+ */
+@Component
+@ConfigurationProperties(prefix = "remote-file-caching")
+public class RemoteFileCachingProperties {
+
+    /** Connection timeout in milliseconds. */
+    private int connectionTimeout = 30000;
+
+    /** Read timeout in milliseconds. */
+    private int readTimeout = 30000;
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public void setConnectionTimeout(int connectionTimeout) {
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+}

--- a/services/remotefilecaching/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/remotefilecaching/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,21 @@
+{
+  "groups": [
+    {
+      "name": "remote-file-caching",
+      "type": "org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties",
+      "sourceType": "org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "remote-file-caching.connectionTimeout",
+      "type": "java.lang.Integer",
+      "description": "Connection timeout in milliseconds for downloading remote files."
+    },
+    {
+      "name": "remote-file-caching.readTimeout",
+      "type": "java.lang.Integer",
+      "description": "Read timeout in milliseconds for downloading remote files."
+    }
+  ]
+}

--- a/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
@@ -34,6 +34,7 @@ import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.prompt.config.PromptServiceConfig;
 import org.open4goods.services.prompt.service.PromptService;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.serialisation.service.SerialisationService;
 import org.open4goods.ui.config.yml.UiConfig;
 import org.open4goods.ui.interceptors.GenericTemplateInterceptor;
@@ -332,35 +333,24 @@ public class AppConfig {
 
 
 	// TODO : should not be required at ui side
-	@Bean RemoteFileCachingService remoteFileCachingService() {
-		return new RemoteFileCachingService(config.getRemoteCachingFolder());
-	}
+        @Bean RemoteFileCachingService remoteFileCachingService(RemoteFileCachingProperties remoteFileCachingProperties) {
+                return new RemoteFileCachingService(config.getRemoteCachingFolder(), remoteFileCachingProperties);
+        }
 
     // TODO : should not be required at ui side
-    @Bean
     GoogleTaxonomyService googleTaxonomyService(@Autowired RemoteFileCachingService remoteFileCachingService) {
-		GoogleTaxonomyService gts = new GoogleTaxonomyService(remoteFileCachingService);
+                GoogleTaxonomyService gts = new GoogleTaxonomyService(remoteFileCachingService);
 
-		// TODO : From conf
-		// TODO : Add others
         try {
-			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.fr-FR.txt", "fr");
-			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt", "en");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.de-DE.txt", "de");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.es-ES.txt", "es");
-//			gts.loadGoogleTaxonUrl("https://www.google.com/basepages/producttype/taxonomy-with-ids.nl-NL.txt", "nl");
-
-
-
-
-		} catch (Exception e) {
-			// TODO
-			e.printStackTrace();
-		}
-
+                        for (var entry : config.getGoogleTaxonomy().entrySet()) {
+                                gts.loadGoogleTaxonUrl(entry.getValue(), entry.getKey());
+                        }
+                } catch (Exception e) {
+                        e.printStackTrace();
+                }
 
         return gts;
-	}
+        }
 
 
 	@Bean
@@ -450,7 +440,7 @@ public class AppConfig {
 //				registry.addInterceptor(new BanCheckerInterceptor(config.getBancheckerConfig()));
 //				registry.addInterceptor(AppConfig.localeChangeInterceptor());
 				registry.addInterceptor(new GenericTemplateInterceptor());
-				registry.addInterceptor(new ImageResizeInterceptor(resourceService(),config.getAllowedImagesSizeSuffixes()));
+                                registry.addInterceptor(new ImageResizeInterceptor(resourceService(), config.getAllowedImagesSizeSuffixes(), config.getImageBaseUrl()));
 
 			}
 

--- a/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
@@ -72,7 +72,15 @@ public class UiConfig {
 	/**
 	 * The list of authorized dynamic image resizing suffixes
 	 */
-	private Set<String> allowedImagesSizeSuffixes = new HashSet<>();
+        private Set<String> allowedImagesSizeSuffixes = new HashSet<>();
+
+        /**
+         * Base URL used by the {@link ImageResizeInterceptor} to fetch source images.
+         */
+        private String imageBaseUrl = "https://nudger.fr";
+
+        /** Map of language code to Google taxonomy URL */
+        private Map<String, String> googleTaxonomy = new HashMap<>();
 
 	/**
 	 * The mapped wiki pages
@@ -491,9 +499,25 @@ public class UiConfig {
 	}
 
 
-	public void setAllowedImagesSizeSuffixes(Set<String> allowedImagesSizeSuffixes) {
-		this.allowedImagesSizeSuffixes = allowedImagesSizeSuffixes;
-	}
+        public void setAllowedImagesSizeSuffixes(Set<String> allowedImagesSizeSuffixes) {
+                this.allowedImagesSizeSuffixes = allowedImagesSizeSuffixes;
+        }
+
+        public String getImageBaseUrl() {
+                return imageBaseUrl;
+        }
+
+        public void setImageBaseUrl(String imageBaseUrl) {
+                this.imageBaseUrl = imageBaseUrl;
+        }
+
+        public Map<String, String> getGoogleTaxonomy() {
+                return googleTaxonomy;
+        }
+
+        public void setGoogleTaxonomy(Map<String, String> googleTaxonomy) {
+                this.googleTaxonomy = googleTaxonomy;
+        }
 
 
 	public UrlCheckConfig getUrlcheck() {

--- a/ui/src/main/java/org/open4goods/ui/interceptors/ImageResizeInterceptor.java
+++ b/ui/src/main/java/org/open4goods/ui/interceptors/ImageResizeInterceptor.java
@@ -45,9 +45,8 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
 
     private static final Logger logger = LoggerFactory.getLogger(ImageResizeInterceptor.class);
 
-    /** Base URL for fetching source images. Can be configured for deployment. */
-    // TODO(p1, conf) a big hack here, to bypass 401 on beta. Means that we cache the prod, on every environments !
-    private static final String IMAGE_BASE_URL = "https://nudger.fr";
+    /** Base URL for fetching source images. Configured via application properties. */
+    private final String imageBaseUrl;
 
     /** Regex pattern for parsing dimensions from the request URI. */
     private static final Pattern DIMENSION_PATTERN = Pattern.compile(
@@ -63,9 +62,10 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
      * 
      * @param resourceService the service for managing cached resources
      */
-    public ImageResizeInterceptor(ResourceService resourceService, Set<String> allowedResize) {
+    public ImageResizeInterceptor(ResourceService resourceService, Set<String> allowedResize, String imageBaseUrl) {
         this.resourceService = resourceService;
         this.allowedResize = allowedResize;
+        this.imageBaseUrl = imageBaseUrl;
     }
 
     /**
@@ -189,7 +189,7 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
         // TODO(p1,feature) : Enable original webp handling, (infinite loop cause re intercepted)
         String[] extensions = { "png", "jpg", "jpeg"};
         for (String ext : extensions) {
-            String url = IMAGE_BASE_URL + baseName + "." + ext;
+            String url = imageBaseUrl + baseName + "." + ext;
             logger.info("Testing image url  {} for basename {} (hasDimensions:{})",url,baseName, hasDimensionsArgument);
             BufferedImage image = fetchImageFromURL(url);
             if (image != null) {

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -64,12 +64,19 @@ spring:
         enabled: true
 
 allowedImagesSizeSuffixes:
-  - 30     
-  - 50    
-  
+  - 30
+  - 50
+
   - 100
-  - 360 
-  - 1000 
+  - 360
+  - 1000
+imageBaseUrl: https://nudger.fr
+googleTaxonomy:
+  fr: https://www.google.com/basepages/producttype/taxonomy-with-ids.fr-FR.txt
+  en: https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt
+remote-file-caching:
+  connection-timeout: 30000
+  read-timeout: 30000
               
 wikiPagesMapping:
   "[webpages/default/legal-notice/WebHome]":


### PR DESCRIPTION
## Summary
- add `RemoteFileCachingProperties` for timeouts
- inject `ApiProperties` and `UiConfig` for Google taxonomy URLs
- allow ImageResizeInterceptor base URL configuration
- wire new configuration beans and YAML defaults

## Testing
- `mvn -q clean install` *(fails: cannot find symbol getLink in ReviewGenerationService)*

------
https://chatgpt.com/codex/tasks/task_e_68431b1e5f3c833394ef7d5683c5126b