### PR TITLE
Resolve p1 TODOs in aggregation services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ui/src/main/resources/application-devsec.yml
 /generated-images/
 /code
 
+apache-maven-*-bin.tar.gz

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationService.java
@@ -31,9 +31,10 @@ public class Attribute2ScoreAggregationService extends AbstractScoreAggregationS
 			// Scoring from attribute
 			try {
 				
-				AttributesConfig attributesConfig = vConf.getAttributesConfig();
-				// TODO(p1, design) : check
-				AttributeConfig attrConfig = attributesConfig.getAttributeConfigByKey(attributesConfig.getKeyForValue(aga.getName()));
+                AttributesConfig attributesConfig = vConf.getAttributesConfig();
+                // Resolve the attribute configuration directly using the provided name
+                // to leverage synonym mapping in {@link AttributesConfig}
+                AttributeConfig attrConfig = attributesConfig.getConfigFor(aga.getName());
 				if (null == attrConfig) {
                     dedicatedLogger.error("No attribute config for {}",aga);
                     continue;

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/MediaAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/MediaAggregationService.java
@@ -87,17 +87,26 @@ public class MediaAggregationService extends AbstractAggregationService{
 	@Override
 	public void onProduct(Product data, VerticalConfig vConf) throws AggregationSkipException {
 		
-		// TODO(p1, perf) : Remove when sure there are no more protected urls
-		// We clean icecat protected items
-		data.getResources().removeIf(e -> {
-			if (e.getUrl().contains("icecat.biz") && e.getUrl().contains("?access")) {
-				logger.error("Removing icecat protected url : {}",e.getUrl());
-				return true;
-			} else {
-				return false;
-			}
-		});
-	}
+                // Clean protected Icecat resources that cannot be accessed anonymously
+                data.getResources().removeIf(r -> isProtectedIcecatUrl(r.getUrl()));
+        }
+
+        /**
+         * Detect Icecat URLs requiring authentication.
+         *
+         * @param url the resource URL
+         * @return {@code true} if the URL points to a protected Icecat resource
+         */
+        private boolean isProtectedIcecatUrl(String url) {
+                if (url == null) {
+                        return false;
+                }
+                boolean protectedLink = url.contains("icecat.biz") && url.contains("?access");
+                if (protectedLink) {
+                        logger.error("Removing icecat protected url : {}", url);
+                }
+                return protectedLink;
+        }
 
 
 }

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
@@ -91,17 +91,17 @@ public class NamesAggregationService extends AbstractAggregationService {
 					data.getNames().getH1Title().put(lang, computePrefixedText(data, tConf.getH1Title(), " "));
 				}
 
-				// TODO(p1, seo)  : Implement product meta data
-				// metaDescription
-				//data.getNames().getMetaDescription().put(lang, blablaService.generateBlabla(tConf.getProductMetaDescription(), data));
-				// productMetaOpenGraphTitle
-				//data.getNames().getProductMetaOpenGraphTitle().put(lang, blablaService.generateBlabla(tConf.getProductMetaOpenGraphTitle(), data));
-				// productMetaOpenGraphDescription
-				//data.getNames().getProductMetaOpenGraphDescription().put(lang, blablaService.generateBlabla(tConf.getProductMetaOpenGraphDescription(), data));
-				// productMetaTwitterTitle
-				//data.getNames().getProductMetaTwitterTitle().put(lang, blablaService.generateBlabla(tConf.getProductMetaTwitterTitle(), data));
-				// productMetaTwitterDescription
-				//data.getNames().getProductMetaTwitterDescription().put(lang, blablaService.generateBlabla(tConf.getProductMetaTwitterDescription(), data));
+                                // Generating SEO meta data using BlablaService templates
+                                data.getNames().getMetaDescription().put(lang,
+                                                blablaService.generateBlabla(tConf.getProductMetaDescription(), data));
+                                data.getNames().getProductMetaOpenGraphTitle().put(lang,
+                                                blablaService.generateBlabla(tConf.getProductMetaOpenGraphTitle(), data));
+                                data.getNames().getProductMetaOpenGraphDescription().put(lang,
+                                                blablaService.generateBlabla(tConf.getProductMetaOpenGraphDescription(), data));
+                                data.getNames().getProductMetaTwitterTitle().put(lang,
+                                                blablaService.generateBlabla(tConf.getProductMetaTwitterTitle(), data));
+                                data.getNames().getProductMetaTwitterDescription().put(lang,
+                                                blablaService.generateBlabla(tConf.getProductMetaTwitterDescription(), data));
 
 
 

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/PriceAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/PriceAggregationService.java
@@ -164,11 +164,11 @@ public class PriceAggregationService extends AbstractAggregationService {
      */
     private void computePriceHistory(AggregatedPrices prices, ProductCondition state) {
     	
-    	// TODO(p1, migration)  : put back when sanisation done
         AggregatedPrice minPrice = prices.getMinPrice(state).orElse(null);
-//        if (minPrice.isEmpty()) {
-//            return; // Exit if no minimum price is found for the condition
-//        }
+        // Skip history computation when no price is available for the condition
+        if (minPrice == null) {
+            return;
+        }
 
         ////////////////////
         // Normalization

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/TaxonomyRealTimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/TaxonomyRealTimeAggregationService.java
@@ -13,6 +13,7 @@ import org.open4goods.commons.services.GoogleTaxonomyService;
 import org.open4goods.commons.services.VerticalsConfigService;
 import org.open4goods.model.datafragment.DataFragment;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.product.ProductTexts;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.slf4j.Logger;
 
@@ -82,11 +83,14 @@ public class TaxonomyRealTimeAggregationService extends AbstractAggregationServi
 				dedicatedLogger.warn("Will erase existing vertical {} with {} for product {}, because of category {}", data.getVertical(), vertical.getId(), data.bestName());
 			}
 			data.setVertical(vertical.getId());
-		} else {
-			// Unsetting the vertical
-			// TODO(p1,design) : Should erase ai descriptions and generated names / urls : a telivision that unmaches continue to have "television" generated stuff 
-			data.setVertical(null);
-		}
+                } else {
+                        // Unsetting the vertical also requires cleaning previously generated
+                        // texts that may no longer be relevant when the product has no
+                        // associated category.
+                        data.setVertical(null);
+                        data.setNames(new ProductTexts());
+                        data.getGenaiTexts().clear();
+                }
 		
 		
 		/////////////////////////////////////

--- a/api/src/main/java/org/open4goods/api/services/completion/AmazonCompletionService.java
+++ b/api/src/main/java/org/open4goods/api/services/completion/AmazonCompletionService.java
@@ -80,7 +80,12 @@ public class AmazonCompletionService extends AbstractCompletionService {
 	// The amazon api componsnets
 	private DefaultApi api;
 	private ArrayList<GetItemsResource> getItemsResources;
-	private ArrayList<SearchItemsResource> searchItemsResources;
+        private ArrayList<SearchItemsResource> searchItemsResources;
+
+        /**
+         * Amazon completion will be triggered again only after this delay.
+         */
+        private static final int REFRESH_IN_DAYS = 30;
 
 
 	public AmazonCompletionService(ProductRepository dataRepository, VerticalsConfigService verticalConfigService,
@@ -126,11 +131,15 @@ public class AmazonCompletionService extends AbstractCompletionService {
 	}
 
 	
-	@Override
-	public boolean shouldProcess(VerticalConfig vertical, Product data) {
-		// TODO(p1,feature) : amazon completion disabled for now
-		return false;
-	}
+        @Override
+        public boolean shouldProcess(VerticalConfig vertical, Product data) {
+                Long lastProcessed = data.getDatasourceCodes().get(getDatasourceName());
+                if (lastProcessed == null) {
+                        return true;
+                }
+                long elapsed = System.currentTimeMillis() - lastProcessed;
+                return elapsed > REFRESH_IN_DAYS * 24L * 3600L * 1000L;
+        }
 
 	@Override
 	public String getDatasourceName() {


### PR DESCRIPTION
## Summary
- map attributes to config via `AttributesConfig#getConfigFor`
- generate SEO meta data during name aggregation
- reset names and AI texts when vertical can't be determined
- skip price history computation when no price exists
- detect protected Icecat resources via helper method
- reactivate Amazon completion based on last run timestamp
- ignore downloaded Maven archive

## Testing
- `mvn -pl api -am clean install` *(fails: cannot find symbol `getLink` in `ReviewGenerationService`)*
- `mvn clean install` *(fails during prompt service tests)*

------
https://chatgpt.com/codex/tasks/task_e_68431b15d0f08333aa99dbb0c7d38355