### PR TITLE
Refactor API sub configs into records

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/yml/AmazonCompletionConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/AmazonCompletionConfig.java
@@ -1,71 +1,41 @@
 package org.open4goods.api.config.yml;
 
+/**
+ * Configuration for Amazon completion service.
+ */
+public record AmazonCompletionConfig(
+        String accessKey,
+        String secretKey,
+        String partnerTag,
+        String host,
+        String region,
+        Long sleepDuration,
+        int maxCallsPerBatch,
+        String datasourceName) {
 
-public class AmazonCompletionConfig {
+    /**
+     * Creates a config with default values.
+     */
+    public AmazonCompletionConfig() {
+        this(null, null, null, null, null, 1100L, 8640, "amazon.fr.yml");
+    }
 
-	private String accessKey;
-	private String secretKey;
-	private String partnerTag;
-	private String host;        
-	private String region;
-	// Wait time between 2 calls
-//	https://webservices.amazon.com/paapi5/documentation/troubleshooting/api-rates.html
-	private Long sleepDuration = 1100L;	
-	private int maxCallsPerBatch = 8640;
-	
-	// Yaml datasource config for amazon
-	private String datasourceName = "amazon.fr.yml";
-	
-	public String getAccessKey() {
-		return accessKey;
-	}
-	public void setAccessKey(String accessKey) {
-		this.accessKey = accessKey;
-	}
-	public String getSecretKey() {
-		return secretKey;
-	}
-	public void setSecretKey(String secretKey) {
-		this.secretKey = secretKey;
-	}
-	public String getPartnerTag() {
-		return partnerTag;
-	}
-	public void setPartnerTag(String partnerTag) {
-		this.partnerTag = partnerTag;
-	}
-	public String getHost() {
-		return host;
-	}
-	public void setHost(String host) {
-		this.host = host;
-	}
-	public String getRegion() {
-		return region;
-	}
-	public void setRegion(String region) {
-		this.region = region;
-	}
-	public Long getSleepDuration() {
-		return sleepDuration;
-	}
-	public void setSleepDuration(Long sleepDuration) {
-		this.sleepDuration = sleepDuration;
-	}
-	public int getMaxCallsPerBatch() {
-		return maxCallsPerBatch;
-	}
-	public void setMaxCallsPerBatch(int maxCallsPerBatch) {
-		this.maxCallsPerBatch = maxCallsPerBatch;
-	}
-	public String getDatasourceName() {
-		return datasourceName;
-	}
-	public void setDatasourceName(String datasourceName) {
-		this.datasourceName = datasourceName;
-	}
+    /**
+     * Canonical constructor applying defaults when values are missing.
+     */
+    public AmazonCompletionConfig {
+        sleepDuration = sleepDuration == null ? 1100L : sleepDuration;
+        maxCallsPerBatch = maxCallsPerBatch == 0 ? 8640 : maxCallsPerBatch;
+        datasourceName = datasourceName == null ? "amazon.fr.yml" : datasourceName;
+    }
 
-	
-	
-    
+    // Compatibility accessors -------------------------------------------------
+    public String getAccessKey() { return accessKey; }
+    public String getSecretKey() { return secretKey; }
+    public String getPartnerTag() { return partnerTag; }
+    public String getHost() { return host; }
+    public String getRegion() { return region; }
+    public Long getSleepDuration() { return sleepDuration; }
+    public int getMaxCallsPerBatch() { return maxCallsPerBatch; }
+    public String getDatasourceName() { return datasourceName; }
 }

--- a/api/src/main/java/org/open4goods/api/config/yml/BackupConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/BackupConfig.java
@@ -1,152 +1,53 @@
 package org.open4goods.api.config.yml;
 
 import org.springframework.validation.annotation.Validated;
-
 import jakarta.validation.constraints.NotEmpty;
 
+/**
+ * Configuration of backup locations and parameters.
+ */
 @Validated
-public class BackupConfig {
-	
-	/**
-	 * Location of the file where xwiki backup must be stored
-	 */
-	@NotEmpty
-	private String xwikiBackupFile;
-	
-	/**
-	 * Location of the folder where products backups files must be stored
-	 */
-	@NotEmpty
-	private String dataBackupFolder;
+public record BackupConfig(
+        @NotEmpty String xwikiBackupFile,
+        @NotEmpty String dataBackupFolder,
+        @NotEmpty String importProductPath,
+        int importBulkSize,
+        int productImportThreads,
+        int productsExportThreads,
+        int minXwikiBackupFileSizeInMb,
+        int minProductsBackupFolderSizeInMb,
+        int maxWikiBackupAgeInHours,
+        long maxProductsBackupAgeInHours) {
 
-	/**
-	 * Location of the file used by import phase
-	 */
-	@NotEmpty
-	private String importProductPath;
-	
+    /**
+     * Default constructor initializing sensible defaults.
+     */
+    public BackupConfig() {
+        this(null, null, null, 100, 4, 4, 30, 16000, 14, 1000L * 3600 * 24 * 8);
+    }
 
-	/**
-	 * Size of the bulk to use for products importation
-	 */
-	private  int importBulkSize = 100;
+    /**
+     * Canonical constructor applying defaults for unset values.
+     */
+    public BackupConfig {
+        importBulkSize = importBulkSize == 0 ? 100 : importBulkSize;
+        productImportThreads = productImportThreads == 0 ? 4 : productImportThreads;
+        productsExportThreads = productsExportThreads == 0 ? 4 : productsExportThreads;
+        minXwikiBackupFileSizeInMb = minXwikiBackupFileSizeInMb == 0 ? 30 : minXwikiBackupFileSizeInMb;
+        minProductsBackupFolderSizeInMb = minProductsBackupFolderSizeInMb == 0 ? 16000 : minProductsBackupFolderSizeInMb;
+        maxWikiBackupAgeInHours = maxWikiBackupAgeInHours == 0 ? 14 : maxWikiBackupAgeInHours;
+        maxProductsBackupAgeInHours = maxProductsBackupAgeInHours == 0 ? 1000L * 3600 * 24 * 8 : maxProductsBackupAgeInHours;
+    }
 
-	/**
-	 * Number of concurent threads running import (1 thread per file, so should be less or equals than productsExportThreads)
-	 */
-	private int productImportThreads = 4;
-	
-	/**
-	 * Number of threads (and of files) to operate export with
-	 */
-	private int productsExportThreads = 4;
-
-	
-	/**
-	 * Min size in MB the xwiki backup file should have (Will Raise an healthcheck.down() if this criteria is not met)
-	 */
-	private int minXwikiBackupFileSizeInMb = 30;
-	
-	/**
-	 * Min size in MB the product backup folder should have (Will Raise an healthcheck.down() if this criteria is not met)
-	 */
-	
-	private int minProductsBackupFolderSizeInMb = 16000;
-
-
-	/**
-	 * Max age the wiki must have, in hours. (Will Raise an healthcheck.down() if this criteria is not met)
-	 */
-	private int maxWikiBackupAgeInHours = 14;
-	
-
-	/**
-	 * Max age the products file must have, in hours. (Will Raise an healthcheck.down() if this criteria is not met)
-	 */
-	private long maxProductsBackupAgeInHours = 1000 * 3600 * 24 * 8;
-	
-	
-	
-	
-	public String getXwikiBackupFile() {
-		return xwikiBackupFile;
-	}
-
-	public void setXwikiBackupFile(String xwikiBackupFile) {
-		this.xwikiBackupFile = xwikiBackupFile;
-	}
-
-	public String getDataBackupFolder() {
-		return dataBackupFolder;
-	}
-
-	public void setDataBackupFolder(String dataBackupFile) {
-		this.dataBackupFolder = dataBackupFile;
-	}
-
-	public String getImportProductPath() {
-		return importProductPath;
-	}
-
-	public void setImportProductPath(String importProductPath) {
-		this.importProductPath = importProductPath;
-	}
-
-	public int getImportBulkSize() {
-		return importBulkSize;
-	}
-
-	public void setImportBulkSize(int importBulkSize) {
-		this.importBulkSize = importBulkSize;
-	}
-
-	public int getProductsExportThreads() {
-		return productsExportThreads;
-	}
-
-	public void setProductsExportThreads(int productsExportThreads) {
-		this.productsExportThreads = productsExportThreads;
-	}
-
-	public int getMinXwikiBackupFileSizeInMb() {
-		return minXwikiBackupFileSizeInMb;
-	}
-
-	public void setMinXwikiBackupFileSizeInMb(int minXwikiBackupFileSizeInMb) {
-		this.minXwikiBackupFileSizeInMb = minXwikiBackupFileSizeInMb;
-	}
-
-	public int getMinProductsBackupFolderSizeInMb() {
-		return minProductsBackupFolderSizeInMb;
-	}
-
-	public void setMinProductsBackupFolderSizeInMb(int minProductsBackupFolderSizeInMb) {
-		this.minProductsBackupFolderSizeInMb = minProductsBackupFolderSizeInMb;
-	}
-
-	public int getMaxWikiBackupAgeInHours() {
-		return maxWikiBackupAgeInHours;
-	}
-
-	public void setMaxWikiBackupAgeInHours(int maxWikiBackupAgeInHours) {
-		this.maxWikiBackupAgeInHours = maxWikiBackupAgeInHours;
-	}
-
-	public long getMaxProductsBackupAgeInHours() {
-		return maxProductsBackupAgeInHours;
-	}
-
-	public void setMaxProductsBackupAgeInHours(long maxProductsBackupAgeInHours) {
-		this.maxProductsBackupAgeInHours = maxProductsBackupAgeInHours;
-	}
-
-	public int getProductImportThreads() {
-		return productImportThreads;
-	}
-
-	public void setProductImportThreads(int productImportThreads) {
-		this.productImportThreads = productImportThreads;
-	}
-	
-	
+    // Compatibility accessors -------------------------------------------------
+    public String getXwikiBackupFile() { return xwikiBackupFile; }
+    public String getDataBackupFolder() { return dataBackupFolder; }
+    public String getImportProductPath() { return importProductPath; }
+    public int getImportBulkSize() { return importBulkSize; }
+    public int getProductImportThreads() { return productImportThreads; }
+    public int getProductsExportThreads() { return productsExportThreads; }
+    public int getMinXwikiBackupFileSizeInMb() { return minXwikiBackupFileSizeInMb; }
+    public int getMinProductsBackupFolderSizeInMb() { return minProductsBackupFolderSizeInMb; }
+    public int getMaxWikiBackupAgeInHours() { return maxWikiBackupAgeInHours; }
+    public long getMaxProductsBackupAgeInHours() { return maxProductsBackupAgeInHours; }
 }

--- a/api/src/main/java/org/open4goods/api/config/yml/IcecatCompletionConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/IcecatCompletionConfig.java
@@ -1,21 +1,24 @@
 package org.open4goods.api.config.yml;
 
-public class IcecatCompletionConfig {
+/**
+ * Configuration for Icecat completion service.
+ */
+public record IcecatCompletionConfig(String iceCatUrlPrefix, Integer politnessDelayMs) {
 
-	private String iceCatUrlPrefix="https://live.icecat.biz/api?UserName=openIcecat-live&Language=fr&GTIN=";
-	private Integer politnessDelayMs=500;
-	public String getIceCatUrlPrefix() {
-		return iceCatUrlPrefix;
-	}
-	public void setIceCatUrlPrefix(String iceCatUrlPrefix) {
-		this.iceCatUrlPrefix = iceCatUrlPrefix;
-	}
-	public Integer getPolitnessDelayMs() {
-		return politnessDelayMs;
-	}
-	public void setPolitnessDelayMs(Integer politnessDelayMs) {
-		this.politnessDelayMs = politnessDelayMs;
-	}
-	
-	
+    /** Default constructor setting sane defaults. */
+    public IcecatCompletionConfig() {
+        this("https://live.icecat.biz/api?UserName=openIcecat-live&Language=fr&GTIN=", 500);
+    }
+
+    /** Canonical constructor applying defaults when null. */
+    public IcecatCompletionConfig {
+        iceCatUrlPrefix = iceCatUrlPrefix == null
+                ? "https://live.icecat.biz/api?UserName=openIcecat-live&Language=fr&GTIN="
+                : iceCatUrlPrefix;
+        politnessDelayMs = politnessDelayMs == null ? 500 : politnessDelayMs;
+    }
+
+    // Compatibility accessors -------------------------------------------------
+    public String getIceCatUrlPrefix() { return iceCatUrlPrefix; }
+    public Integer getPolitnessDelayMs() { return politnessDelayMs; }
 }

--- a/api/src/main/java/org/open4goods/api/config/yml/ResourceCompletionConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/ResourceCompletionConfig.java
@@ -3,17 +3,25 @@ package org.open4goods.api.config.yml;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ResourceCompletionConfig {
+/**
+ * Configuration for static resource completion URLs.
+ */
+public record ResourceCompletionConfig(List<ResourceCompletionUrlTemplate> urlTemplates) {
 
-	private List<ResourceCompletionUrlTemplate> urlTemplates = new ArrayList<>();
+    /**
+     * Default constructor with an empty list.
+     */
+    public ResourceCompletionConfig() {
+        this(new ArrayList<>());
+    }
 
-	public List<ResourceCompletionUrlTemplate> getUrlTemplates() {
-		return urlTemplates;
-	}
+    /**
+     * Canonical constructor ensuring non-null list.
+     */
+    public ResourceCompletionConfig {
+        urlTemplates = urlTemplates == null ? new ArrayList<>() : urlTemplates;
+    }
 
-	public void setUrlTemplates(List<ResourceCompletionUrlTemplate> urlTemplates) {
-		this.urlTemplates = urlTemplates;
-	}
-	
-	
+    // Compatibility accessor ---------------------------------------------------
+    public List<ResourceCompletionUrlTemplate> getUrlTemplates() { return urlTemplates; }
 }

--- a/api/src/main/java/org/open4goods/api/config/yml/ResourceCompletionUrlTemplate.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/ResourceCompletionUrlTemplate.java
@@ -5,45 +5,32 @@ import java.util.List;
 
 import org.open4goods.model.resource.ResourceTag;
 
-public class ResourceCompletionUrlTemplate {
-    private String url;
-    private String datasourceName;
-    private String language;
-    private List<ResourceTag> hardTags = new ArrayList<>();
+/**
+ * Template definition for building completion resource URLs.
+ */
+public record ResourceCompletionUrlTemplate(
+        String url,
+        String datasourceName,
+        String language,
+        List<ResourceTag> hardTags) {
 
-    // Getters and Setters
-    public String getUrl() {
-        return url;
+    /**
+     * Creates an empty template.
+     */
+    public ResourceCompletionUrlTemplate() {
+        this(null, null, null, new ArrayList<>());
     }
 
-    public void setUrl(String url) {
-        this.url = url;
+    /**
+     * Canonical constructor ensuring non-null list of tags.
+     */
+    public ResourceCompletionUrlTemplate {
+        hardTags = hardTags == null ? new ArrayList<>() : hardTags;
     }
 
-    public String getDatasourceName() {
-        return datasourceName;
-    }
-
-    public void setDatasourceName(String datasourceName) {
-        this.datasourceName = datasourceName;
-    }
-
-    public String getLanguage() {
-        return language;
-    }
-
-    public void setLanguage(String language) {
-        this.language = language;
-    }
-
-	public List<ResourceTag> getHardTags() {
-		return hardTags;
-	}
-
-	public void setHardTags(List<ResourceTag> hardTags) {
-		this.hardTags = hardTags;
-	}
-
-    
-
+    // Compatibility accessors -------------------------------------------------
+    public String getUrl() { return url; }
+    public String getDatasourceName() { return datasourceName; }
+    public String getLanguage() { return language; }
+    public List<ResourceTag> getHardTags() { return hardTags; }
 }

--- a/api/src/main/java/org/open4goods/api/config/yml/VerticalsGenerationConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/VerticalsGenerationConfig.java
@@ -3,76 +3,33 @@ package org.open4goods.api.config.yml;
 import java.util.HashSet;
 import java.util.Set;
 
-public class VerticalsGenerationConfig {
+/**
+ * Configuration driving the verticals generation batch.
+ */
+public record VerticalsGenerationConfig(
+        Integer limit,
+        String mappingFilePath,
+        Set<String> mustExistsFields,
+        Double associatedCategoriesEvictionPercent,
+        Integer minimumTotalHits) {
 
-	/**
-	 * Max number of items to process
-	 */
-	private Integer limit;
-	
-	/**
-	 * Used to fast load mappings
-	 */
-	private String mappingFilePath = "/opt/open4goods/config/categories-comappings.json";
-	
-	/**
-	 * Only products for which those attributes are not empty will be processed
-	 */
-	private Set<String> mustExistsFields = new HashSet<>();
+    /** Creates config with default values. */
+    public VerticalsGenerationConfig() {
+        this(null, "/opt/open4goods/config/categories-comappings.json", new HashSet<>(), 0.05, 1);
+    }
 
-	/**
-	 * The minimum percent of product covrage an associated category must have to be conservated
-	 */
-	private Double associatedCategoriesEvictionPercent = 0.05;
-	
-	/**
-	 * The minimum total hits a category must have
-	 */
-	private Integer minimumTotalHits = 1;
-	
-	
-	public String getMappingFilePath() {
-		return mappingFilePath;
-	}
+    /** Canonical constructor applying defaults where necessary. */
+    public VerticalsGenerationConfig {
+        mappingFilePath = mappingFilePath == null ? "/opt/open4goods/config/categories-comappings.json" : mappingFilePath;
+        mustExistsFields = mustExistsFields == null ? new HashSet<>() : mustExistsFields;
+        associatedCategoriesEvictionPercent = associatedCategoriesEvictionPercent == null ? 0.05 : associatedCategoriesEvictionPercent;
+        minimumTotalHits = minimumTotalHits == null ? 1 : minimumTotalHits;
+    }
 
-	public void setMappingFilePath(String mappingFilePath) {
-		this.mappingFilePath = mappingFilePath;
-	}
-
-	public Set<String> getMustExistsFields() {
-		return mustExistsFields;
-	}
-
-	public void setMustExistsFields(Set<String> attributesFilters) {
-		this.mustExistsFields = attributesFilters;
-	}
-
-	public Integer getLimit() {
-		return limit;
-	}
-
-	public void setLimit(Integer limit) {
-		this.limit = limit;
-	}
-
-	public Double getAssociatedCategoriesEvictionPercent() {
-		return associatedCategoriesEvictionPercent;
-	}
-
-	public void setAssociatedCategoriesEvictionPercent(Double associatedCatgoriesEvictionPercent) {
-		this.associatedCategoriesEvictionPercent = associatedCatgoriesEvictionPercent;
-	}
-
-	public Integer getMinimumTotalHits() {
-		return minimumTotalHits;
-	}
-
-	public void setMinimumTotalHits(Integer minimumTotalHits) {
-		this.minimumTotalHits = minimumTotalHits;
-	}
-
-	
-	
-	
-	
+    // Compatibility accessors -------------------------------------------------
+    public Integer getLimit() { return limit; }
+    public String getMappingFilePath() { return mappingFilePath; }
+    public Set<String> getMustExistsFields() { return mustExistsFields; }
+    public Double getAssociatedCategoriesEvictionPercent() { return associatedCategoriesEvictionPercent; }
+    public Integer getMinimumTotalHits() { return minimumTotalHits; }
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResponse.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResponse.java
@@ -11,4 +11,7 @@ public record GoogleSearchResponse(List<GoogleSearchResult> results) {
     public GoogleSearchResponse() {
         this(new ArrayList<>());
     }
+
+    /** Compatibility accessor preserving former API */
+    public List<GoogleSearchResult> getResults() { return results; }
 }

--- a/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResult.java
+++ b/services/googlesearch/src/main/java/org/open4goods/services/googlesearch/dto/GoogleSearchResult.java
@@ -10,4 +10,10 @@ public record GoogleSearchResult(String title, String link) {
     public GoogleSearchResult() {
         this(null, null);
     }
+
+    /** Compatibility accessor preserving former API */
+    public String getTitle() { return title; }
+
+    /** Compatibility accessor preserving former API */
+    public String getLink() { return link; }
 }


### PR DESCRIPTION
## Summary
- convert `BackupConfig`, `AmazonCompletionConfig`, `ResourceCompletionConfig`, `ResourceCompletionUrlTemplate`, `IcecatCompletionConfig`, and `VerticalsGenerationConfig` into Java records
- keep compatibility getters and provide default constructors
- update GoogleSearch DTOs with getter methods to satisfy downstream services
- run module build with `mvn -pl api -am clean install`

## Testing
- `mvn -pl api -am clean install`

------
https://chatgpt.com/codex/tasks/task_e_68431af40d8c833385f9b9227a2017f0