### PR TITLE
Fix duplicate spring-boot-maven-plugin in UI pom

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -338,18 +338,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
 
                 <configuration>
                     <layers>


### PR DESCRIPTION
## Summary
- clean up duplicate `spring-boot-maven-plugin` entries in `ui/pom.xml`

## Testing
- `mvn -pl ui -am clean install` *(fails: `Could not transfer artifact spring-boot-dependencies` - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68474f51e9048333bb1fb0962b57caba