### PR TITLE
Fix DataFragment worker shutdown loop

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/store/DataFragmentAggregationWorker.java
+++ b/api/src/main/java/org/open4goods/api/services/store/DataFragmentAggregationWorker.java
@@ -42,11 +42,11 @@ public class DataFragmentAggregationWorker implements Runnable {
 		this.workerName = workerName;
 	}
 
-	@Override
-	public void run() {
+        @Override
+        public void run() {
 
-		while (true) {
-			try {
+                while (!service.getServiceShutdown().get()) {
+                        try {
 				if (!service.getQueue().isEmpty()) {
 					// There is data to consume and queue consummation is enabled
 					final Set<DataFragment> buffer = new HashSet<>();	
@@ -68,8 +68,9 @@ public class DataFragmentAggregationWorker implements Runnable {
 					}
 				}
 			} catch (final Exception e) {
-				logger.error("Error while dequeing DataFragments",e);
-			}
-		}
-	}
+                                logger.error("Error while dequeing DataFragments",e);
+                        }
+                }
+                logger.info("{} thread terminated", workerName);
+        }
 }


### PR DESCRIPTION
## Summary
- stop `DataFragmentAggregationWorker` when `serviceShutdown` is set
- log a message when the worker thread terminates

## Testing
- `mvn -pl api -am clean install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474ec831808333828d9df85027154d