### PR TITLE
Cleanup Maven config

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -47,16 +47,16 @@
 			<version>0.0.1</version>
 		</dependency>
 
-		<dependency>
-			<groupId>de.codecentric</groupId>
-			<artifactId>spring-boot-admin-starter-server</artifactId>
-			<version>3.4.6</version>
-		</dependency>
-		<dependency>
-			<groupId>de.codecentric</groupId>
-			<artifactId>spring-boot-admin-server-ui</artifactId>
-			<version>3.5.0</version>
-		</dependency>
+                <dependency>
+                        <groupId>de.codecentric</groupId>
+                        <artifactId>spring-boot-admin-starter-server</artifactId>
+                        <version>${spring-boot-admin.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>de.codecentric</groupId>
+                        <artifactId>spring-boot-admin-server-ui</artifactId>
+                        <version>${spring-boot-admin-ui.version}</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -78,18 +78,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>de.codecentric</groupId>
             <artifactId>spring-boot-admin-starter-client</artifactId>
-            <version>3.4.6</version>
+            <version>${spring-boot-admin.version}</version>
         </dependency>
 
         <dependency>
@@ -167,18 +167,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -182,7 +182,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.20.1</version>
+            <version>${jsoup.version}</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,52 +10,50 @@
 	<description>The open4goods project parent pom</description>
 	<url>https://github.com/open4good/open4goods</url>
 	<properties>
-		<github.global.server>github</github.global.server>
-		<springboot.version>3.5.0</springboot.version>
-		<java.version>21</java.version>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
-		<global.version>0.0.1-SNAPSHOT</global.version>
-		<swagger.version>2.9.2</swagger.version>
-		<jacoco.version>0.8.13</jacoco.version>
-		<xwiki.version>11.10.2</xwiki.version>
+                <springboot.version>3.5.0</springboot.version>
+                <java.version>21</java.version>
+                <maven.compiler.source>21</maven.compiler.source>
+                <maven.compiler.target>21</maven.compiler.target>
+                <global.version>0.0.1-SNAPSHOT</global.version>
+                <jacoco.version>0.8.13</jacoco.version>
+                <xwiki.version>11.10.2</xwiki.version>
 
-		<processDependencyManagement>false</processDependencyManagement>
-		<processPluginDependenciesInPluginManagement>true</processPluginDependenciesInPluginManagement>
-		<maven-compiler-plugin-version>3.14.0</maven-compiler-plugin-version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<dependency.locations.enabled>false</dependency.locations.enabled>
-		<exclude.tests>nothing-to-exclude</exclude.tests>
-	</properties>
+                <!-- Library versions -->
+                <jsoup.version>1.20.1</jsoup.version>
+                <commons-io.version>2.19.0</commons-io.version>
+                <spring-boot-admin.version>3.4.6</spring-boot-admin.version>
+                <spring-boot-admin-ui.version>3.5.0</spring-boot-admin-ui.version>
 
-	<modules>
-		<module>admin</module>
-        <module>model</module>
-		<module>commons</module>
-		<module>verticals</module>
-		<module>crawler</module>
-		<module>api</module>
-		<module>ui</module>
-		<module>services/urlfetching</module>
-        <module>services/googlesearch</module>
-        <module>services/evaluation</module>
-        <module>services/serialisation</module>
-        <module>services/prompt</module>
-        <module>services/review-generation</module>
-        <module>services/product-repository</module>
-        <module>services/captcha</module>
-        <module>services/remotefilecaching</module>
+                <processDependencyManagement>false</processDependencyManagement>
+                <processPluginDependenciesInPluginManagement>true</processPluginDependenciesInPluginManagement>
+                <maven-compiler-plugin-version>3.14.0</maven-compiler-plugin-version>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <dependency.locations.enabled>false</dependency.locations.enabled>
+        </properties>
 
-        <module>services/favicon</module>
-        <module>services/github-feedback</module>
-        <module>services/xwiki-spring-boot-starter</module>
-        <module>services/image-processing</module>
-        <module>services/icecat</module>
-
-
-
-
-	</modules>
+        <modules>
+            <module>admin</module>
+            <module>model</module>
+            <module>commons</module>
+            <module>verticals</module>
+            <module>crawler</module>
+            <module>api</module>
+            <module>ui</module>
+            <module>services/urlfetching</module>
+            <module>services/googlesearch</module>
+            <module>services/evaluation</module>
+            <module>services/serialisation</module>
+            <module>services/prompt</module>
+            <module>services/review-generation</module>
+            <module>services/product-repository</module>
+            <module>services/captcha</module>
+            <module>services/remotefilecaching</module>
+            <module>services/favicon</module>
+            <module>services/github-feedback</module>
+            <module>services/xwiki-spring-boot-starter</module>
+            <module>services/image-processing</module>
+            <module>services/icecat</module>
+        </modules>
 
 	<issueManagement>
 		<url>https://github.com/open4good/open4goods/issues</url>
@@ -335,10 +333,6 @@
                             <directory>node_modules</directory>
                             <followSymlinks>false</followSymlinks>
                         </fileset>
-                        <fileset>
-                            <directory>node_modules</directory>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
 
 						<fileset>
 							<directory>src/test/resources/last</directory>
@@ -408,6 +402,18 @@
                                         <groupId>org.springframework.boot</groupId>
                                         <artifactId>spring-boot-maven-plugin</artifactId>
                                         <version>${springboot.version}</version>
+                                        <executions>
+                                                <execution>
+                                                        <goals>
+                                                                <goal>repackage</goal>
+                                                        </goals>
+                                                </execution>
+                                        </executions>
+                                        <configuration>
+                                                <layers>
+                                                        <enabled>true</enabled>
+                                                </layers>
+                                        </configuration>
                                 </plugin>
 			</plugins>
 		</pluginManagement>

--- a/services/captcha/pom.xml
+++ b/services/captcha/pom.xml
@@ -58,14 +58,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/evaluation/pom.xml
+++ b/services/evaluation/pom.xml
@@ -47,14 +47,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/favicon/pom.xml
+++ b/services/favicon/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.20.1</version>
+      <version>${jsoup.version}</version>
     </dependency>
     
     <!-- Dependency on commons services (for RemoteFileCachingService) -->
@@ -75,14 +75,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>

--- a/services/github-feedback/pom.xml
+++ b/services/github-feedback/pom.xml
@@ -59,14 +59,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/googlesearch/pom.xml
+++ b/services/googlesearch/pom.xml
@@ -62,14 +62,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/icecat/pom.xml
+++ b/services/icecat/pom.xml
@@ -68,14 +68,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/image-processing/pom.xml
+++ b/services/image-processing/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.19.0</version>
+      <version>${commons-io.version}</version>
     </dependency>
 
     <dependency>
@@ -50,13 +50,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/product-repository/pom.xml
+++ b/services/product-repository/pom.xml
@@ -53,14 +53,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/prompt/pom.xml
+++ b/services/prompt/pom.xml
@@ -60,14 +60,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/remotefilecaching/pom.xml
+++ b/services/remotefilecaching/pom.xml
@@ -67,14 +67,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/review-generation/pom.xml
+++ b/services/review-generation/pom.xml
@@ -99,14 +99,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/serialisation/pom.xml
+++ b/services/serialisation/pom.xml
@@ -42,14 +42,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/urlfetching/pom.xml
+++ b/services/urlfetching/pom.xml
@@ -54,14 +54,6 @@
         </execution>
       </executions>
     </plugin>
-      <!-- Maven Compiler Plugin -->
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
-      </plugin>
       <!-- Spring Boot Maven Plugin -->
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/services/xwiki-spring-boot-starter/pom.xml
+++ b/services/xwiki-spring-boot-starter/pom.xml
@@ -144,11 +144,11 @@
 
 	<dependencies>
 
-		<dependency>
-			<groupId>org.jsoup</groupId>
-			<artifactId>jsoup</artifactId>
-			<version>1.20.1</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.jsoup</groupId>
+                        <artifactId>jsoup</artifactId>
+                        <version>${jsoup.version}</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.security</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>de.codecentric</groupId>
             <artifactId>spring-boot-admin-starter-client</artifactId>
-            <version>3.4.6</version>
+            <version>${spring-boot-admin.version}</version>
         </dependency>
 
         <dependency>
@@ -328,18 +328,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- centralize library versions and drop unused properties
- unify `spring-boot-maven-plugin` setup via parent POM
- remove duplicate plugin declarations in modules
- drop redundant `maven-compiler-plugin` usages
- fix module list formatting and clean task

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q clean install` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848aa516ec08333840c592164fa6f18