### PR TITLE
Add nudger-front-api module

### DIFF
--- a/nudger-front-api/AGENTS.md
+++ b/nudger-front-api/AGENTS.md
@@ -1,0 +1,38 @@
+# Nudger-front-api Agents Guide
+
+This module is part of the open4goods multi-module Maven project.
+
+## Technology
+
+- Java 21
+- Spring Boot 3
+
+## Directory structure
+
+- `src/main/java` – REST API code
+- `src/main/resources` – configuration
+- `src/test/java` – unit tests
+
+## Purpose
+
+The `nudger-front-api` module exposes the public REST API protected with JWT tokens.
+
+## Build and test this module only
+
+From this directory:
+
+```bash
+mvn clean install
+```
+
+Run only the tests with:
+
+```bash
+mvn test
+```
+
+From the repository root you can also execute:
+
+```bash
+mvn -pl nudger-front-api -am clean install
+```

--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -1,0 +1,107 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.open4goods</groupId>
+    <artifactId>org.open4goods</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>nudger-front-api</artifactId>
+  <name>nudger-front-api</name>
+  <description>Nudger public API</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>model</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>product-repository</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-tomcat</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/application-devsec.yml</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <layers>
+            <enabled>true</enabled>
+          </layers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
@@ -1,0 +1,12 @@
+package org.open4goods.nudgerfrontapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NudgerFrontApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NudgerFrontApiApplication.class, args);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
+            .csrf(AbstractHttpConfigurer::disable)
+            .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PingController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PingController.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+public class PingController {
+
+    @GetMapping("/ping")
+    @Operation(summary = "Simple health check")
+    public Map<String, String> ping() {
+        return Map.of("status", "ok");
+    }
+}

--- a/nudger-front-api/src/main/resources/application.yml
+++ b/nudger-front-api/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+server:
+  port: 8082
+
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://auth.example.com/issuer
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
@@ -1,0 +1,13 @@
+package org.open4goods.nudgerfrontapi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NudgerFrontApiApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // Context load test
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,11 @@
         <module>model</module>
 		<module>commons</module>
 		<module>verticals</module>
-		<module>crawler</module>
-		<module>api</module>
-		<module>ui</module>
-		<module>services/urlfetching</module>
+                <module>crawler</module>
+                <module>api</module>
+                <module>ui</module>
+                <module>nudger-front-api</module>
+                <module>services/urlfetching</module>
         <module>services/googlesearch</module>
         <module>services/evaluation</module>
         <module>services/serialisation</module>


### PR DESCRIPTION
## Summary
- add new child module `nudger-front-api`
- expose simple ping controller
- secure endpoints with JWT resource server
- document build instructions in AGENTS guide
- register the module in the parent POM

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513de2e0688333810448be9f336793