### PR TITLE
Fix release workflow order

### DIFF
--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
 
       ############################################
+      # Checkout Main Repository
+      ###########################################
+      - uses: actions/checkout@v4
+
+      ############################################
       # Cache Maven Dependencies
       ###########################################
       - name: Cache Maven Dependencies
@@ -69,11 +74,6 @@ jobs:
 
             
      
-
-      ############################################
-      # Checkout Main Repository
-      ###########################################
-      - uses: actions/checkout@v4
 
       ############################################
       # Build Maven site and Artifacts


### PR DESCRIPTION
## Summary
- move checkout step earlier to let actions/setup-java cache locate `pom.xml`

## Testing
- `mvn -q clean install` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859b0e5a968833390b71fac84d6ba85