### PR TITLE
Introduce product repository port

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/ElasticProductRepositoryAdapter.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/ElasticProductRepositoryAdapter.java
@@ -1,0 +1,30 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import java.util.Optional;
+
+import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.model.product.Product;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Adapter delegating calls to {@link ProductRepository}.
+ */
+@Service
+public class ElasticProductRepositoryAdapter implements ProductRepositoryPort {
+
+    private final ProductRepository productRepository;
+
+    public ElasticProductRepositoryAdapter(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public Optional<Product> findByGtin(long gtin) {
+        try {
+            return Optional.ofNullable(productRepository.getById(gtin));
+        } catch (ResourceNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/ProductRepositoryPort.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/ProductRepositoryPort.java
@@ -1,0 +1,19 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import java.util.Optional;
+
+import org.open4goods.model.product.Product;
+
+/**
+ * Port for product repository access used by the front API service.
+ */
+public interface ProductRepositoryPort {
+
+    /**
+     * Retrieves a product by its GTIN.
+     *
+     * @param gtin the product GTIN
+     * @return optional product
+     */
+    Optional<Product> findByGtin(long gtin);
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductViewService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductViewService.java
@@ -2,22 +2,25 @@ package org.open4goods.nudgerfrontapi.service;
 
 import org.open4goods.nudgerfrontapi.dto.ProductViewRequest;
 import org.open4goods.nudgerfrontapi.dto.ProductViewResponse;
+import org.open4goods.nudgerfrontapi.repository.ProductRepositoryPort;
+import org.springframework.stereotype.Service;
 
 /**
- * This service takes in input repository objects (through the DAO), then apply frontend transformation logic (internationalisation, enrichment)
+ * Applies frontend transformation logic on products fetched from the repository.
  */
+@Service
 public class ProductViewService {
 
+    private final ProductRepositoryPort productRepository;
 
-	//  TODO : Inject productRepository OR a easy mock repository if in dev mode
+    public ProductViewService(ProductRepositoryPort productRepository) {
+        this.productRepository = productRepository;
+    }
 
-	public ProductViewResponse render(ProductViewRequest productViewRequest) {
-    	ProductViewResponse response = new ProductViewResponse(productViewRequest);
-    	// TODO : fetch in repository
-
-
-    	// TODO : Transform
-		return response;
-
-	}
+    public ProductViewResponse render(ProductViewRequest productViewRequest) {
+        ProductViewResponse response = new ProductViewResponse(productViewRequest);
+        // TODO: fetch from repository and transform
+        productRepository.findByGtin(0); // placeholder usage
+        return response;
+    }
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
@@ -1,10 +1,15 @@
 package org.open4goods.nudgerfrontapi;
 
 import org.junit.jupiter.api.Test;
+import org.open4goods.services.productrepository.services.ProductRepository;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 class NudgerFrontApiApplicationTests {
+
+    @MockBean
+    ProductRepository productRepository;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
## Summary
- add `ProductRepositoryPort` interface
- implement `ElasticProductRepositoryAdapter`
- refactor service to use the port
- mock `ProductRepository` in context test

## Testing
- `mvn -pl nudger-front-api -am test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6ba138c83338554f6f45b46208a