### PR TITLE
Add ProductApi IT test with Testcontainers

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -61,6 +61,24 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.19.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>1.19.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>redis</artifactId>
+      <version>1.19.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/ProductApiIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/ProductApiIT.java
@@ -1,0 +1,64 @@
+package org.open4goods.nudgerfrontapi;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import org.open4goods.model.product.Product;
+import org.open4goods.services.productrepository.services.ProductRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ProductApiIT {
+
+    @Container
+    static ElasticsearchContainer elastic = new ElasticsearchContainer(
+            DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.13.2"))
+            .withEnv("discovery.type", "single-node");
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.elasticsearch.uris", elastic::getHttpHostAddress);
+    }
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ProductRepository repository;
+
+    private final long gtin = 1234567890123L;
+
+    @BeforeEach
+    void setup() {
+        Product p = new Product();
+        p.setId(gtin);
+        repository.forceIndex(p);
+    }
+
+    @Test
+    void productEndpointReturnsIndexedItem() {
+        ResponseEntity<Map> response = restTemplate.getForEntity("/product/" + gtin, Map.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("gtin")).isEqualTo(String.valueOf(gtin));
+    }
+}


### PR DESCRIPTION
## Summary
- add Testcontainers dependencies for integration tests
- introduce `ProductApiIT` to verify `/product/{gtin}` endpoint using an Elasticsearch container

## Testing
- `mvn -pl nudger-front-api test` *(fails: Non-resolvable import POM: spring-boot-dependencies 3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6dd7b0c8333abf14547d9f915ae