### PR TITLE
Enforce tests for nudger-front-api

### DIFF
--- a/nudger-front-api/AGENTS.md
+++ b/nudger-front-api/AGENTS.md
@@ -40,6 +40,8 @@ Run only the tests with:
 mvn test
 ```
 
+The `maven-surefire-plugin` is configured with `failIfNoTests=true` so the build fails if no tests are present.
+
 From the repository root you can also execute:
 
 ```bash

--- a/nudger-front-api/README.md
+++ b/nudger-front-api/README.md
@@ -27,3 +27,5 @@ Execute the tests with:
 ```bash
 mvn test
 ```
+
+Tests are mandatory: the build will fail if none are found.

--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -101,6 +101,14 @@
           </layers>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.3</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Summary
- ensure nudger-front-api fails the build when no tests are present
- document the new rule in AGENTS and README

## Testing
- `mvn -pl nudger-front-api -am test -q` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859ea6e376483339ebe4ec21bd4391e