### PR TITLE
Fix redundant Spring Boot plugin in nudger-front-api POM

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -84,17 +84,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <layers>
             <enabled>true</enabled>


### PR DESCRIPTION
## Summary
- remove duplicated `spring-boot-maven-plugin` block in nudger-front-api

## Testing
- `mvn -pl nudger-front-api -am clean install` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6859eeb8912c8333bd801bda9cd4aa6d