### PR TITLE
Add SpringDoc config and docs test

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public GroupedOpenApi frontApi() {
+        return GroupedOpenApi.builder()
+                .group("front")
+                .pathsToMatch("/api/v1/**")
+                .build();
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -16,7 +16,9 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                    .anyRequest().authenticated())
             .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(Customizer.withDefaults());

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.controller.advice;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleException(Exception ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
+        pd.setTitle("Internal Server Error");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.docs;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class OpenApiDocsIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void apiDocsAreExposed() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.openapi").exists());
+    }
+}


### PR DESCRIPTION
## Summary
- configure SpringDoc to generate OpenAPI for `/api/v1/**`
- expose docs and Swagger UI without authentication
- add RFC9457 style global exception handler
- test that `/v3/api-docs` endpoint works

## Testing
- `mvn -pl nudger-front-api -am clean install` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a83f6b3b48333a3f7a78cff2afc06