### PR TITLE
Add feedback REST endpoints

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -133,6 +133,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.open4goods</groupId>
+            <artifactId>github-feedback</artifactId>
+            <version>${global.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.open4goods</groupId>
+            <artifactId>captcha</artifactId>
+            <version>${global.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>dev.brachtendorf</groupId>
             <artifactId>JImageHash</artifactId>
             <version>1.0.0</version>

--- a/api/src/main/java/org/open4goods/api/controller/api/FeedbackController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/FeedbackController.java
@@ -1,0 +1,106 @@
+package org.open4goods.api.controller.api;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.kohsuke.github.GHIssue;
+import org.open4goods.api.dto.CreateIssueRequest;
+import org.open4goods.commons.helper.IpHelper;
+import org.open4goods.services.captcha.service.HcaptchaService;
+import org.open4goods.services.feedback.dto.IssueDTO;
+import org.open4goods.services.feedback.exception.VotingLimitExceededException;
+import org.open4goods.services.feedback.exception.VotingNotAllowedException;
+import org.open4goods.services.feedback.service.IssueService;
+import org.open4goods.services.feedback.service.VoteResponse;
+import org.open4goods.services.feedback.service.VoteService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * REST endpoints for creating feedback issues and voting on them.
+ */
+@RestController
+public class FeedbackController {
+
+    private final IssueService issueService;
+    private final VoteService voteService;
+    private final HcaptchaService hcaptchaService;
+
+    public FeedbackController(IssueService issueService,
+                              VoteService voteService,
+                              HcaptchaService hcaptchaService) {
+        this.issueService = issueService;
+        this.voteService = voteService;
+        this.hcaptchaService = hcaptchaService;
+    }
+
+    @GetMapping("/issues")
+    @Operation(summary = "List open feedback issues")
+    public List<IssueDTO> listIssues() throws IOException {
+        return issueService.listIssues().stream()
+                .map(issue -> new IssueDTO(
+                        String.valueOf(issue.getNumber()),
+                        issue.getNumber(),
+                        issue.getTitle(),
+                        issue.getHtmlUrl().toString(),
+                        voteService.getTotalVotes(String.valueOf(issue.getNumber()))
+                ))
+                .sorted((a, b) -> Integer.compare(b.votes(), a.votes()))
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping(value = "/issues", headers = "X-Hcaptcha-Response")
+    @Operation(summary = "Create a new feedback issue")
+    public ResponseEntity<Void> createIssue(
+            @RequestHeader("X-Hcaptcha-Response") String captcha,
+            @RequestBody CreateIssueRequest request,
+            HttpServletRequest httpRequest
+    ) throws IOException {
+        String ip = IpHelper.getIp(httpRequest);
+        hcaptchaService.verifyRecaptcha(ip, captcha);
+
+        Set<String> labels = request.labels() == null ? new HashSet<>() : new HashSet<>(request.labels());
+        GHIssue issue;
+        if ("bug".equalsIgnoreCase(request.type())) {
+            issue = issueService.createBug(request.title(), request.message(), request.url(), request.author(), labels);
+        } else {
+            issue = issueService.createIdea(request.title(), request.message(), request.url(), request.author(), labels);
+        }
+        URI location = issue.getHtmlUrl().toURI();
+        return ResponseEntity.created(location).build();
+    }
+
+    @PostMapping(value = "/issues/{id}/votes", headers = "X-Hcaptcha-Response")
+    @Operation(summary = "Cast a vote on an issue")
+    public ResponseEntity<?> vote(
+            @PathVariable String id,
+            @RequestHeader("X-Hcaptcha-Response") String captcha,
+            HttpServletRequest httpRequest
+    ) {
+        String ip = IpHelper.getIp(httpRequest);
+        hcaptchaService.verifyRecaptcha(ip, captcha);
+        try {
+            VoteResponse resp = voteService.vote(id, ip);
+            return ResponseEntity.ok(resp);
+        } catch (VotingNotAllowedException ex) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(java.util.Map.of("message", ex.getMessage()));
+        } catch (VotingLimitExceededException ex) {
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .body(java.util.Map.of("message", ex.getMessage()));
+        }
+    }
+}

--- a/api/src/main/java/org/open4goods/api/dto/CreateIssueRequest.java
+++ b/api/src/main/java/org/open4goods/api/dto/CreateIssueRequest.java
@@ -1,0 +1,15 @@
+package org.open4goods.api.dto;
+
+import java.util.Set;
+
+/**
+ * Request body for creating a feedback issue.
+ */
+public record CreateIssueRequest(
+        String type,
+        String title,
+        String message,
+        String url,
+        String author,
+        Set<String> labels
+) {}

--- a/api/src/test/java/org/open4goods/api/controller/api/FeedbackControllerTest.java
+++ b/api/src/test/java/org/open4goods/api/controller/api/FeedbackControllerTest.java
@@ -1,0 +1,104 @@
+package org.open4goods.api.controller.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHIssue;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.open4goods.api.dto.CreateIssueRequest;
+import org.open4goods.services.captcha.service.HcaptchaService;
+import org.open4goods.services.feedback.dto.IssueDTO;
+import org.open4goods.services.feedback.service.IssueService;
+import org.open4goods.services.feedback.service.VoteResponse;
+import org.open4goods.services.feedback.service.VoteService;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class FeedbackControllerTest {
+
+    private MockMvc mvc;
+
+    @Mock
+    private IssueService issueService;
+    @Mock
+    private VoteService voteService;
+    @Mock
+    private HcaptchaService hcaptchaService;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        issueService = Mockito.mock(IssueService.class);
+        voteService = Mockito.mock(VoteService.class);
+        hcaptchaService = Mockito.mock(HcaptchaService.class);
+        FeedbackController controller = new FeedbackController(issueService, voteService, hcaptchaService);
+        mvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void createIssueReturnsLocation() throws Exception {
+        GHIssue issue = Mockito.mock(GHIssue.class);
+        when(issue.getHtmlUrl()).thenReturn(new URL("https://example.com/1"));
+        when(issueService.createBug(any(), any(), any(), any(), any())).thenReturn(issue);
+
+        CreateIssueRequest req = new CreateIssueRequest("bug", "t", "m", "u", "a", Set.of());
+        mvc.perform(MockMvcRequestBuilders.post("/issues")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("X-Hcaptcha-Response", "token")
+                .content(mapper.writeValueAsString(req)))
+                .andExpect(result -> assertThat(result.getResponse().getStatus()).isEqualTo(201))
+                .andExpect(result -> assertThat(result.getResponse().getHeader("Location")).isEqualTo("https://example.com/1"));
+
+        verify(hcaptchaService).verifyRecaptcha(any(), Mockito.eq("token"));
+    }
+
+    @Test
+    void listIssuesReturnsData() throws Exception {
+        GHIssue issue = Mockito.mock(GHIssue.class, Mockito.RETURNS_DEEP_STUBS);
+        when(issue.getNumber()).thenReturn(1);
+        when(issue.getTitle()).thenReturn("A");
+        when(issue.getHtmlUrl()).thenReturn(new URL("https://example.com/1"));
+        when(issueService.listIssues()).thenReturn(List.of(issue));
+        when(voteService.getTotalVotes("1")).thenReturn(2);
+
+        mvc.perform(MockMvcRequestBuilders.get("/issues"))
+                .andExpect(result -> {
+                    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+                    String json = result.getResponse().getContentAsString();
+                    IssueDTO[] dtos = mapper.readValue(json, IssueDTO[].class);
+                    assertThat(dtos).hasSize(1);
+                    assertThat(dtos[0].votes()).isEqualTo(2);
+                });
+    }
+
+    @Test
+    void voteEndpointReturnsTotals() throws Exception {
+        when(voteService.vote("1", "127.0.0.1")).thenReturn(new VoteResponse(4, 10));
+
+        mvc.perform(MockMvcRequestBuilders.post("/issues/1/votes")
+                .header("X-Hcaptcha-Response", "tok")
+                .with(req -> { req.setRemoteAddr("127.0.0.1"); return req; }))
+                .andExpect(result -> {
+                    assertThat(result.getResponse().getStatus()).isEqualTo(200);
+                    String json = result.getResponse().getContentAsString();
+                    VoteResponse resp = mapper.readValue(json, VoteResponse.class);
+                    assertThat(resp.totalVotes()).isEqualTo(10);
+                });
+
+        verify(hcaptchaService).verifyRecaptcha("127.0.0.1", "tok");
+    }
+}


### PR DESCRIPTION
## Summary
- expose IssueService and VoteService via new FeedbackController
- validate hCaptcha on POST endpoints
- return Location header on issue creation
- document new API routes and extend POM dependencies
- add unit tests for controller

## Testing
- `mvn -pl api -am clean install` *(fails: Could not resolve dependencies offline)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6dd41ec8333acb13ac3c5b03cb8