### PR TITLE
Add basic home/stats endpoints

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/HomeController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/HomeController.java
@@ -1,0 +1,33 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import java.util.concurrent.TimeUnit;
+
+import org.open4goods.nudgerfrontapi.dto.HomeCompositeResponse;
+import org.open4goods.nudgerfrontapi.service.HomeService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoint providing aggregated data for the home page.
+ */
+@RestController
+public class HomeController {
+
+    private static final long TTL_SECONDS = 300;
+
+    private final HomeService homeService;
+
+    public HomeController(HomeService homeService) {
+        this.homeService = homeService;
+    }
+
+    @GetMapping("/home")
+    public ResponseEntity<HomeCompositeResponse> home() {
+        HomeCompositeResponse resp = homeService.getHome();
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(resp);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PartnerController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PartnerController.java
@@ -1,0 +1,34 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.open4goods.nudgerfrontapi.dto.PartnerDto;
+import org.open4goods.nudgerfrontapi.service.PartnerService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoint exposing partners.
+ */
+@RestController
+public class PartnerController {
+
+    private static final long TTL_SECONDS = 300;
+
+    private final PartnerService partnerService;
+
+    public PartnerController(PartnerService partnerService) {
+        this.partnerService = partnerService;
+    }
+
+    @GetMapping("/partners")
+    public ResponseEntity<List<PartnerDto>> partners() {
+        List<PartnerDto> list = partnerService.fetchPartners();
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(list);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/StatsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/StatsController.java
@@ -1,0 +1,33 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import java.util.concurrent.TimeUnit;
+
+import org.open4goods.nudgerfrontapi.dto.StatsDto;
+import org.open4goods.nudgerfrontapi.service.StatsService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoint exposing statistics.
+ */
+@RestController
+public class StatsController {
+
+    private static final long TTL_SECONDS = 300;
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/stats")
+    public ResponseEntity<StatsDto> stats() {
+        StatsDto dto = statsService.fetchStats();
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(dto);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/HomeCompositeResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/HomeCompositeResponse.java
@@ -1,0 +1,9 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.List;
+
+/**
+ * Aggregated response used by the home page.
+ */
+public record HomeCompositeResponse(StatsDto stats, List<PartnerDto> partners) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PartnerDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PartnerDto.java
@@ -1,0 +1,7 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+/**
+ * Partner information shown in partners list.
+ */
+public record PartnerDto(String name, String url) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/StatsDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/StatsDto.java
@@ -1,0 +1,7 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+/**
+ * Simple statistics information returned by the API.
+ */
+public record StatsDto(long products, long partners) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/HomeService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/HomeService.java
@@ -1,0 +1,32 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.dto.HomeCompositeResponse;
+import org.open4goods.nudgerfrontapi.dto.PartnerDto;
+import org.open4goods.nudgerfrontapi.dto.StatsDto;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Aggregates data for the home endpoint.
+ */
+@Service
+public class HomeService {
+
+    private final StatsService statsService;
+    private final PartnerService partnerService;
+
+    public HomeService(StatsService statsService, PartnerService partnerService) {
+        this.statsService = statsService;
+        this.partnerService = partnerService;
+    }
+
+    /**
+     * Retrieve the home composite response.
+     */
+    public HomeCompositeResponse getHome() {
+        StatsDto stats = statsService.fetchStats();
+        List<PartnerDto> partners = partnerService.fetchPartners();
+        return new HomeCompositeResponse(stats, partners);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/PartnerService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/PartnerService.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.dto.PartnerDto;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides partner information to the frontend.
+ */
+@Service
+public class PartnerService {
+
+    /**
+     * Retrieve partner list. Stubbed for now.
+     */
+    public List<PartnerDto> fetchPartners() {
+        return List.of();
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.dto.StatsDto;
+import org.springframework.stereotype.Service;
+
+/**
+ * Provides statistics for the frontend.
+ */
+@Service
+public class StatsService {
+
+    /**
+     * Retrieve statistics. In this early stage the data is stubbed.
+     */
+    public StatsDto fetchStats() {
+        return new StatsDto(0, 0);
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/HomeControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/HomeControllerIT.java
@@ -1,0 +1,43 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.HomeCompositeResponse;
+import org.open4goods.nudgerfrontapi.dto.PartnerDto;
+import org.open4goods.nudgerfrontapi.dto.StatsDto;
+import org.open4goods.nudgerfrontapi.service.HomeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HomeControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private HomeService homeService;
+
+    @Test
+    void homeEndpointReturnsBodyAndCacheHeader() throws Exception {
+        HomeCompositeResponse response = new HomeCompositeResponse(new StatsDto(1, 2), List.of(new PartnerDto("name", "url")));
+        given(homeService.getHome()).willReturn(response);
+
+        mockMvc.perform(get("/home").with(jwt()))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.stats.products").value(1))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PartnerControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PartnerControllerIT.java
@@ -1,0 +1,40 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.PartnerDto;
+import org.open4goods.nudgerfrontapi.service.PartnerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PartnerControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PartnerService partnerService;
+
+    @Test
+    void partnersEndpointReturnsBodyAndCacheHeader() throws Exception {
+        given(partnerService.fetchPartners()).willReturn(List.of(new PartnerDto("name", "url")));
+
+        mockMvc.perform(get("/partners").with(jwt()))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$[0].name").value("name"))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/StatsControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/StatsControllerIT.java
@@ -1,0 +1,38 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.StatsDto;
+import org.open4goods.nudgerfrontapi.service.StatsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class StatsControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StatsService statsService;
+
+    @Test
+    void statsEndpointReturnsBodyAndCacheHeader() throws Exception {
+        given(statsService.fetchStats()).willReturn(new StatsDto(1, 2));
+
+        mockMvc.perform(get("/stats").with(jwt()))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.products").value(1))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for home, partner and stats data
- implement HomeController, PartnerController and StatsController
- create service layer stubs
- include caching headers using CacheControl
- add integration tests for new controllers

## Testing
- `mvn -pl nudger-front-api -am clean install` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6d7ca7c83339b30a075465f86fe