### PR TITLE
Add category and search endpoints

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -24,6 +24,26 @@
       <artifactId>product-repository</artifactId>
       <version>${global.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>commons</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>serialisation</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>remotefilecaching</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>verticals</artifactId>
+      <version>${global.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
@@ -2,8 +2,10 @@ package org.open4goods.nudgerfrontapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "org.open4goods")
+@EnableCaching
 public class NudgerFrontApiApplication {
 
     public static void main(String[] args) {

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -1,0 +1,46 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.io.IOException;
+
+import org.open4goods.commons.services.SearchService;
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.open4goods.commons.services.GoogleTaxonomyService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    RemoteFileCachingService remoteFileCachingService(RemoteFileCachingProperties props) {
+        return new RemoteFileCachingService("./cache", props);
+    }
+
+    @Bean
+    GoogleTaxonomyService googleTaxonomyService(RemoteFileCachingService cachingService) {
+        return new GoogleTaxonomyService(cachingService);
+    }
+
+    @Bean
+    ProductRepository productRepository() {
+        return new ProductRepository();
+    }
+
+    @Bean
+    VerticalsConfigService verticalsConfigService(ResourcePatternResolver resolver,
+                                                  SerialisationService serialisationService,
+                                                  GoogleTaxonomyService gts,
+                                                  ProductRepository productRepository) throws IOException {
+        return new VerticalsConfigService(serialisationService, gts, productRepository, resolver);
+    }
+
+    @Bean
+    SearchService searchService(ProductRepository repository) {
+        return new SearchService(repository, "./logs");
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/CategoryController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/CategoryController.java
@@ -1,0 +1,35 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import org.open4goods.nudgerfrontapi.dto.CategoryListResponse;
+import org.open4goods.nudgerfrontapi.dto.CategoryRequest;
+import org.open4goods.nudgerfrontapi.service.CategoryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/categories")
+    public CategoryListResponse categories(CategoryRequest request) {
+        int page = request.page() == null ? 0 : request.page();
+        int size = request.size() == null ? 10 : request.size();
+        var all = categoryService.listRootCategories(request.include());
+        int from = Math.min(page * size, all.size());
+        int to = Math.min(from + size, all.size());
+        return new CategoryListResponse(page, size, all.size(), all.subList(from, to));
+    }
+
+    @GetMapping("/categories/{id}")
+    public CategoryService.CategoryDto category(@PathVariable int id, CategoryRequest request) {
+        return categoryService.getCategory(id, request.include());
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/SearchController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/SearchController.java
@@ -1,0 +1,42 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import java.util.HashSet;
+
+import org.open4goods.commons.model.dto.VerticalSearchResponse;
+import org.open4goods.commons.services.SearchService;
+import org.open4goods.model.product.ProductCondition;
+import org.open4goods.nudgerfrontapi.dto.SearchRequest;
+import org.open4goods.nudgerfrontapi.dto.SearchResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequestMapping("/api/v1")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    @GetMapping("/search")
+    public SearchResponse search(SearchRequest request) {
+        VerticalSearchResponse resp = searchService.globalSearch(
+                request.query(),
+                request.fromPrice(),
+                request.toPrice(),
+                request.categories() == null ? null : new HashSet<>(request.categories()),
+                request.condition() == null ? null : ProductCondition.valueOf(request.condition()),
+                request.page() == null ? 0 : request.page(),
+                request.size() == null ? 10 : request.size(),
+                0,
+                request.sort());
+        return new SearchResponse(resp.getTotalResults(),
+                request.page() == null ? 0 : request.page(),
+                request.size() == null ? 10 : request.size(),
+                resp.getData());
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryListResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryListResponse.java
@@ -1,0 +1,11 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.service.CategoryService.CategoryDto;
+
+public record CategoryListResponse(int page,
+                                   int size,
+                                   long total,
+                                   List<CategoryDto> items) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryRequest.java
@@ -1,0 +1,4 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+public record CategoryRequest(Integer page, Integer size, boolean include) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchRequest.java
@@ -1,0 +1,13 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.List;
+
+public record SearchRequest(String query,
+                            Integer fromPrice,
+                            Integer toPrice,
+                            List<String> categories,
+                            String condition,
+                            Integer page,
+                            Integer size,
+                            boolean sort) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchResponse.java
@@ -1,0 +1,11 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.List;
+
+import org.open4goods.model.product.Product;
+
+public record SearchResponse(long total,
+                             int page,
+                             int size,
+                             List<Product> items) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryService.java
@@ -1,0 +1,54 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.open4goods.commons.model.ProductCategory;
+import org.open4goods.commons.services.GoogleTaxonomyService;
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.open4goods.model.constants.CacheConstants;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryService {
+
+    private final GoogleTaxonomyService taxonomyService;
+    private final VerticalsConfigService verticalsService;
+
+    public CategoryService(GoogleTaxonomyService taxonomyService, VerticalsConfigService verticalsService) {
+        this.taxonomyService = taxonomyService;
+        this.verticalsService = verticalsService;
+    }
+
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
+    public List<CategoryDto> listRootCategories(boolean includeChildren) {
+        return taxonomyService.getCategories().getNodes().stream()
+                .map(c -> toDto(c, includeChildren))
+                .toList();
+    }
+
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
+    public CategoryDto getCategory(int id, boolean includeChildren) {
+        ProductCategory pc = taxonomyService.byId(id);
+        if (pc == null) {
+            return null;
+        }
+        return toDto(pc, includeChildren);
+    }
+
+    private CategoryDto toDto(ProductCategory pc, boolean includeChildren) {
+        List<CategoryDto> children = includeChildren
+                ? pc.getChildren().stream().map(c -> toDto(c, true)).toList()
+                : List.of();
+        String vertical = null;
+        if (verticalsService.getVerticalForTaxonomy(pc.getGoogleCategoryId()) != null) {
+            vertical = verticalsService.getVerticalForTaxonomy(pc.getGoogleCategoryId()).getId();
+        }
+        return new CategoryDto(pc.getGoogleCategoryId(), pc.getGoogleNames(), vertical, children);
+    }
+
+    public record CategoryDto(Integer id, Map<String, String> names, String vertical, List<CategoryDto> children) {
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoryControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoryControllerIT.java
@@ -1,0 +1,31 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CategoryControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void categoriesEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/api/v1/categories").with(jwt()))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    void categoryByIdEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/api/v1/categories/{id}", 1).with(jwt()))
+               .andExpect(status().isOk());
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/SearchControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/SearchControllerIT.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SearchControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void searchEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/api/v1/search").param("query", "test").with(jwt()))
+               .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- expose new /categories and /search REST endpoints in nudger-front-api
- implement CategoryService using VerticalsConfigService
- add configuration for repository, taxonomy and search beans
- enable caching in NudgerFrontApiApplication
- provide integration tests for new controllers

## Testing
- `mvn -pl nudger-front-api -am clean test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6d3c7d083338615dee6a1f746f5