### PR TITLE
Add product view API endpoints

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -24,6 +24,21 @@
       <artifactId>product-repository</artifactId>
       <version>${global.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>commons</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>reviewgeneration</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>captcha</artifactId>
+      <version>${global.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/ProductController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/ProductController.java
@@ -1,32 +1,75 @@
 package org.open4goods.nudgerfrontapi.controller;
 
-import java.util.Map;
+import java.time.Duration;
+import java.util.List;
 
-import org.open4goods.nudgerfrontapi.dto.ProductViewRequest;
+import org.open4goods.nudgerfrontapi.dto.ImpactScoreDto;
+import org.open4goods.nudgerfrontapi.dto.OfferDto;
 import org.open4goods.nudgerfrontapi.dto.ProductViewResponse;
-import org.open4goods.nudgerfrontapi.service.ProductViewService;
-import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.nudgerfrontapi.dto.ReviewDto;
+import org.open4goods.nudgerfrontapi.service.ProductService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 
 @RestController
 public class ProductController {
 
+    private final ProductService service;
 
-	private ProductRepository repository;
-	private ProductViewService renderingService;
-
+    public ProductController(ProductService service) {
+        this.service = service;
+    }
 
     @GetMapping("/product/{gtin}")
-    @Operation(summary = "Get a ptoduct")
-	// TODO : Add spring doc maximum documentation
+    @Operation(summary = "Get product view")
+    public ResponseEntity<ProductViewResponse> product(@PathVariable long gtin) throws Exception {
+        ProductViewResponse body = service.getProduct(gtin);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofHours(1)).cachePublic())
+                .body(body);
+    }
 
-    public ProductViewResponse product(ProductViewRequest productViewRequest) {
+    @GetMapping("/product/{gtin}/reviews")
+    @Operation(summary = "Get product reviews")
+    public ResponseEntity<List<ReviewDto>> reviews(@PathVariable long gtin) throws Exception {
+        List<ReviewDto> body = service.getReviews(gtin);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofHours(1)).cachePublic())
+                .body(body);
+    }
 
-    	ProductViewResponse ret = renderingService.render(productViewRequest);
+    @PostMapping("/product/{gtin}/reviews")
+    @Operation(summary = "Generate AI review")
+    public ResponseEntity<Void> generateReview(@PathVariable long gtin,
+                                               @RequestParam("hcaptchaResponse") String captcha,
+                                               HttpServletRequest request) throws Exception {
+        service.createReview(gtin, captcha, request);
+        return ResponseEntity.accepted().build();
+    }
 
-        return ret;
+    @GetMapping("/product/{gtin}/offers")
+    @Operation(summary = "Get product offers")
+    public ResponseEntity<List<OfferDto>> offers(@PathVariable long gtin) throws Exception {
+        List<OfferDto> body = service.getOffers(gtin);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofHours(1)).cachePublic())
+                .body(body);
+    }
+
+    @GetMapping("/product/{gtin}/impact")
+    @Operation(summary = "Get product impact score")
+    public ResponseEntity<ImpactScoreDto> impact(@PathVariable long gtin) throws Exception {
+        ImpactScoreDto body = service.getImpactScore(gtin);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(Duration.ofHours(1)).cachePublic())
+                .body(body);
     }
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
@@ -1,0 +1,5 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.Map;
+
+public record ImpactScoreDto(Map<String, Double> scores, double average) {}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/OfferDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/OfferDto.java
@@ -1,0 +1,3 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+public record OfferDto(String datasourceName, String offerName, double price, String currency, String url) {}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ReviewDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ReviewDto.java
@@ -1,0 +1,5 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import org.open4goods.model.ai.AiReview;
+
+public record ReviewDto(String language, AiReview review, long createdMs) {}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductService.java
@@ -1,0 +1,19 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.List;
+
+import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.nudgerfrontapi.dto.ImpactScoreDto;
+import org.open4goods.nudgerfrontapi.dto.OfferDto;
+import org.open4goods.nudgerfrontapi.dto.ProductViewResponse;
+import org.open4goods.nudgerfrontapi.dto.ReviewDto;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface ProductService {
+    ProductViewResponse getProduct(long gtin) throws ResourceNotFoundException;
+    List<ReviewDto> getReviews(long gtin) throws ResourceNotFoundException;
+    List<OfferDto> getOffers(long gtin) throws ResourceNotFoundException;
+    ImpactScoreDto getImpactScore(long gtin) throws ResourceNotFoundException;
+    void createReview(long gtin, String captchaResponse, HttpServletRequest request) throws ResourceNotFoundException, SecurityException;
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductServiceImpl.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductServiceImpl.java
@@ -1,0 +1,93 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.open4goods.commons.helper.IpHelper;
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.model.price.AggregatedPrice;
+import org.open4goods.model.price.AggregatedPrices;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.product.ProductCondition;
+import org.open4goods.model.product.Score;
+import org.open4goods.services.captcha.service.HcaptchaService;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.services.reviewgeneration.service.ReviewGenerationService;
+import org.open4goods.nudgerfrontapi.dto.ImpactScoreDto;
+import org.open4goods.nudgerfrontapi.dto.OfferDto;
+import org.open4goods.nudgerfrontapi.dto.ProductViewRequest;
+import org.open4goods.nudgerfrontapi.dto.ProductViewResponse;
+import org.open4goods.nudgerfrontapi.dto.ReviewDto;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Service
+public class ProductServiceImpl implements ProductService {
+
+    private final ProductRepository repository;
+    private final ReviewGenerationService reviewGenerationService;
+    private final VerticalsConfigService verticalsConfigService;
+    private final HcaptchaService captchaService;
+
+    public ProductServiceImpl(ProductRepository repository,
+                              ReviewGenerationService reviewGenerationService,
+                              VerticalsConfigService verticalsConfigService,
+                              HcaptchaService captchaService) {
+        this.repository = repository;
+        this.reviewGenerationService = reviewGenerationService;
+        this.verticalsConfigService = verticalsConfigService;
+        this.captchaService = captchaService;
+    }
+
+    @Override
+    public ProductViewResponse getProduct(long gtin) throws ResourceNotFoundException {
+        Product p = repository.getById(gtin);
+        return new ProductViewResponse(new ProductViewRequest(gtin), null, p.gtin());
+    }
+
+    @Override
+    public List<ReviewDto> getReviews(long gtin) throws ResourceNotFoundException {
+        Product p = repository.getById(gtin);
+        return p.getReviews().entrySet().stream()
+                .map(e -> new ReviewDto(e.getKey(), e.getValue().getReview(), e.getValue().getCreatedMs()))
+                .toList();
+    }
+
+    @Override
+    public List<OfferDto> getOffers(long gtin) throws ResourceNotFoundException {
+        Product p = repository.getById(gtin);
+        AggregatedPrices prices = p.getPrice();
+        return prices.sortedOffers(ProductCondition.NEW).stream()
+                .map(this::toOfferDto)
+                .collect(Collectors.toList());
+    }
+
+    private OfferDto toOfferDto(AggregatedPrice price) {
+        return new OfferDto(price.getDatasourceName(), price.getOfferName(), price.getPrice(),
+                price.getCurrency().getCurrencyCode(), price.getUrl());
+    }
+
+    @Override
+    public ImpactScoreDto getImpactScore(long gtin) throws ResourceNotFoundException {
+        Product p = repository.getById(gtin);
+        Map<String, Double> scores = p.getScores().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> {
+                    Score s = e.getValue();
+                    return s.getValue() == null ? 0d : s.getValue();
+                }));
+        double avg = scores.values().stream().mapToDouble(Double::doubleValue).average().orElse(0);
+        return new ImpactScoreDto(scores, avg);
+    }
+
+    @Override
+    public void createReview(long gtin, String captchaResponse, HttpServletRequest request)
+            throws ResourceNotFoundException, SecurityException {
+        captchaService.verifyRecaptcha(IpHelper.getIp(request), captchaResponse);
+        Product product = repository.getById(gtin);
+        reviewGenerationService.generateReviewAsync(product,
+                verticalsConfigService.getConfigById(product.getVertical()), null);
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -4,22 +4,30 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import org.open4goods.model.ai.AiReview;
+import org.open4goods.nudgerfrontapi.dto.ImpactScoreDto;
+import org.open4goods.nudgerfrontapi.dto.OfferDto;
 import org.open4goods.nudgerfrontapi.dto.ProductViewRequest;
 import org.open4goods.nudgerfrontapi.dto.ProductViewResponse;
-import org.open4goods.nudgerfrontapi.service.ProductViewService;
-import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.nudgerfrontapi.dto.ReviewDto;
+import org.open4goods.nudgerfrontapi.service.ProductService;
+import java.util.Map;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -33,30 +41,66 @@ class ProductControllerIT {
     private ProductController controller;
 
     @MockBean
-    private ProductViewService renderingService;
-
-    @MockBean
-    private ProductRepository repository;
+    private ProductService service;
 
     @Autowired
     private HealthEndpoint healthEndpoint;
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(controller, "renderingService", renderingService);
-        ReflectionTestUtils.setField(controller, "repository", repository);
+        ReflectionTestUtils.setField(controller, "service", service);
     }
 
     @Test
     void productEndpointReturnsViewAndHealthUp() throws Exception {
         long gtin = 123L;
         ProductViewRequest req = new ProductViewRequest(gtin);
-        given(renderingService.render(any())).willReturn(new ProductViewResponse(req));
+        given(service.getProduct(any())).willReturn(new ProductViewResponse(req));
 
         mockMvc.perform(get("/product/{gtin}", gtin).with(jwt()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.gtin").value(gtin));
 
         assert healthEndpoint.health().getStatus().equals(Status.UP);
+    }
+
+    @Test
+    void reviewsEndpointReturnsList() throws Exception {
+        long gtin = 123L;
+        given(service.getReviews(any())).willReturn(List.of(new ReviewDto("fr", new AiReview(), 1L)));
+
+        mockMvc.perform(get("/product/{gtin}/reviews", gtin).with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "public, max-age=3600"));
+    }
+
+    @Test
+    void offersEndpointReturnsList() throws Exception {
+        long gtin = 123L;
+        given(service.getOffers(any())).willReturn(List.of(new OfferDto("ds","offer",1.0,"EUR","url")));
+
+        mockMvc.perform(get("/product/{gtin}/offers", gtin).with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "public, max-age=3600"));
+    }
+
+    @Test
+    void impactEndpointReturnsScore() throws Exception {
+        long gtin = 123L;
+        given(service.getImpactScore(any())).willReturn(new ImpactScoreDto(Map.of("S",1d),1d));
+
+        mockMvc.perform(get("/product/{gtin}/impact", gtin).with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Cache-Control", "public, max-age=3600"));
+    }
+
+    @Test
+    void postReviewUsesCaptcha() throws Exception {
+        long gtin = 123L;
+
+        mockMvc.perform(post("/product/{gtin}/reviews", gtin)
+                .param("hcaptchaResponse", "resp")
+                .with(jwt()))
+            .andExpect(status().isAccepted());
     }
 }


### PR DESCRIPTION
## Summary
- implement new product endpoints in nudger-front-api
- introduce ProductService layer
- add DTOs for reviews, offers and impact score
- connect captcha verification for review POST
- test each controller route

## Testing
- `mvn -pl nudger-front-api -am clean install -q` *(fails: Could not transfer artifact spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ac6b1954883339a6e368e7ed1bdb7