### PR TITLE
Document DTO fields with @Schema annotations

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AssociationDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AssociationDto.java
@@ -1,7 +1,14 @@
 package org.open4goods.nudgerfrontapi.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Association information returned by API.
  */
-public record AssociationDto(String id, String name) {
+public record AssociationDto(
+        @Schema(description = "Association identifier", example = "asso-123")
+        String id,
+
+        @Schema(description = "Association name", example = "Zero Waste France")
+        String name) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AuthRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AuthRequest.java
@@ -3,5 +3,12 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Authentication request containing credentials.
  */
-public record AuthRequest(String username, String password) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AuthRequest(
+        @Schema(description = "User login name", example = "user@example.com")
+        String username,
+
+        @Schema(description = "Plain-text password", example = "secret")
+        String password) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AuthResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/AuthResponse.java
@@ -3,5 +3,9 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Authentication response containing a bearer token.
  */
-public record AuthResponse(String token) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AuthResponse(
+        @Schema(description = "JWT bearer token", example = "eyJhbGciOiJIUzI1NiJ9...")
+        String token) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/BlogPostDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/BlogPostDto.java
@@ -1,14 +1,27 @@
 package org.open4goods.nudgerfrontapi.dto;
 
 import java.util.Date;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Minimal representation of a blog post.
  */
-public record BlogPostDto(String slug,
-                          String title,
-                          String locale,
-                          String summary,
-                          String body,
-                          Date created) {
+public record BlogPostDto(
+        @Schema(description = "URL slug of the post", example = "new-feature")
+        String slug,
+
+        @Schema(description = "Post title", example = "Introducing a new feature")
+        String title,
+
+        @Schema(description = "IETF BCP 47 language tag", example = "en")
+        String locale,
+
+        @Schema(description = "Short summary", example = "Highlights of our update")
+        String summary,
+
+        @Schema(description = "Full markdown body")
+        String body,
+
+        @Schema(description = "Creation date in epoch ms", example = "1690972800000")
+        Date created) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/HomeCompositeResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/HomeCompositeResponse.java
@@ -1,9 +1,15 @@
 package org.open4goods.nudgerfrontapi.dto;
 
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Aggregated response used by the home page.
  */
-public record HomeCompositeResponse(StatsDto stats, List<PartnerDto> partners) {
+public record HomeCompositeResponse(
+        @Schema(description = "Global statistics")
+        StatsDto stats,
+
+        @Schema(description = "List of homepage partners")
+        List<PartnerDto> partners) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
@@ -1,5 +1,11 @@
 package org.open4goods.nudgerfrontapi.dto;
 
 import java.util.Map;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ImpactScoreDto(Map<String, Double> scores, double average) {}
+public record ImpactScoreDto(
+        @Schema(description = "Individual scores by key", example = "{\"water\":1.0}")
+        Map<String, Double> scores,
+
+        @Schema(description = "Average score", example = "0.75")
+        double average) {}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PartnerDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PartnerDto.java
@@ -3,5 +3,12 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Partner information shown in partners list.
  */
-public record PartnerDto(String name, String url) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PartnerDto(
+        @Schema(description = "Partner display name", example = "WWF")
+        String name,
+
+        @Schema(description = "Partner website", format = "uri", example = "https://wwf.fr")
+        String url) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewRequest.java
@@ -3,5 +3,9 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Request object used when retrieving a product view.
  */
-public record ProductViewRequest(Long gtin) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProductViewRequest(
+        @Schema(description = "Global Trade Item Number", example = "7612345678901")
+        Long gtin) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewResponse.java
@@ -3,9 +3,17 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Frontend view of a product.
  */
-public record ProductViewResponse(ProductViewRequest request,
-                                  RequestMetadata metadatas,
-                                  long gtin) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProductViewResponse(
+        @Schema(description = "Original request")
+        ProductViewRequest request,
+
+        @Schema(description = "Timing metadata")
+        RequestMetadata metadatas,
+
+        @Schema(description = "Requested GTIN", example = "7612345678901")
+        long gtin) {
 
     /**
      * Convenience constructor keeping existing usage.

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RefreshRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RefreshRequest.java
@@ -3,5 +3,9 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Refresh token request.
  */
-public record RefreshRequest(String refreshToken) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RefreshRequest(
+        @Schema(description = "Previous refresh token", example = "abcd1234")
+        String refreshToken) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RequestMetadata.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RequestMetadata.java
@@ -3,5 +3,15 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Metadata describing a request lifecycle.
  */
-public record RequestMetadata(Long startDate, Long endDate, String fishtag) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RequestMetadata(
+        @Schema(description = "Request start timestamp ms", example = "1690972800000")
+        Long startDate,
+
+        @Schema(description = "Request end timestamp ms", example = "1690972810000")
+        Long endDate,
+
+        @Schema(description = "Internal fishtag", example = "front-home")
+        String fishtag) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ReviewDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ReviewDto.java
@@ -1,5 +1,14 @@
 package org.open4goods.nudgerfrontapi.dto;
 
 import org.open4goods.model.ai.AiReview;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ReviewDto(String language, AiReview review, long createdMs) {}
+public record ReviewDto(
+        @Schema(description = "Review language", example = "en")
+        String language,
+
+        @Schema(description = "AI-generated review")
+        AiReview review,
+
+        @Schema(description = "Creation timestamp ms", example = "1690972800000")
+        long createdMs) {}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/StatsDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/StatsDto.java
@@ -3,5 +3,12 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Simple statistics information returned by the API.
  */
-public record StatsDto(long products, long partners) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StatsDto(
+        @Schema(description = "Number of indexed products", example = "152")
+        long products,
+
+        @Schema(description = "Number of partner organisations", example = "6")
+        long partners) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/TeamMemberDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/TeamMemberDto.java
@@ -3,5 +3,12 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Team member information.
  */
-public record TeamMemberDto(String name, String title) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TeamMemberDto(
+        @Schema(description = "Full name", example = "Jane Doe")
+        String name,
+
+        @Schema(description = "Role or position", example = "Lead Developer")
+        String title) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/VoteRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/VoteRequest.java
@@ -3,5 +3,12 @@ package org.open4goods.nudgerfrontapi.dto;
 /**
  * Incoming vote payload.
  */
-public record VoteRequest(String itemId, int value) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record VoteRequest(
+        @Schema(description = "Target item identifier", example = "post-123")
+        String itemId,
+
+        @Schema(description = "Vote value", example = "1")
+        int value) {
 }


### PR DESCRIPTION
## Summary
- document every field in nudger-front-api DTOs using `@Schema`
- include descriptions and examples for OpenAPI generation

## Testing
- `mvn -pl nudger-front-api -am clean install -q` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b3c608a1c8333960aa9115d444354