### PR TITLE
Wrap controller results in ResponseEntity

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AssociationsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AssociationsController.java
@@ -1,9 +1,12 @@
 package org.open4goods.nudgerfrontapi.controller;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.open4goods.nudgerfrontapi.dto.AssociationDto;
 import org.open4goods.nudgerfrontapi.service.AssociationsService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +14,8 @@ import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
 public class AssociationsController {
+
+    private static final long TTL_SECONDS = 300;
 
     private final AssociationsService associationsService;
 
@@ -20,7 +25,10 @@ public class AssociationsController {
 
     @GetMapping("/associations")
     @Operation(summary = "List associations")
-    public List<AssociationDto> associations() {
-        return associationsService.getAssociations();
+    public ResponseEntity<List<AssociationDto>> associations() {
+        List<AssociationDto> list = associationsService.getAssociations();
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(list);
     }
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PostsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PostsController.java
@@ -1,9 +1,12 @@
 package org.open4goods.nudgerfrontapi.controller;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.open4goods.nudgerfrontapi.dto.BlogPostDto;
 import org.open4goods.nudgerfrontapi.service.BlogService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +17,8 @@ import io.swagger.v3.oas.annotations.Operation;
 @RestController
 public class PostsController {
 
+    private static final long TTL_SECONDS = 300;
+
     private final BlogService blogService;
 
     public PostsController(BlogService blogService) {
@@ -22,13 +27,22 @@ public class PostsController {
 
     @GetMapping("/posts")
     @Operation(summary = "List blog posts")
-    public List<BlogPostDto> posts(@RequestParam(required = false) String locale) {
-        return blogService.getPosts(locale);
+    public ResponseEntity<List<BlogPostDto>> posts(@RequestParam(required = false) String locale) {
+        List<BlogPostDto> posts = blogService.getPosts(locale);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(posts);
     }
 
     @GetMapping("/posts/{slug}")
     @Operation(summary = "Get blog post by slug")
-    public BlogPostDto post(@PathVariable String slug, @RequestParam(name = "locale", required = false) String locale) {
-        return blogService.getPost(slug, locale);
+    public ResponseEntity<BlogPostDto> post(@PathVariable String slug, @RequestParam(name = "locale", required = false) String locale) {
+        BlogPostDto post = blogService.getPost(slug, locale);
+        if (post == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(post);
     }
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/TeamController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/TeamController.java
@@ -1,9 +1,12 @@
 package org.open4goods.nudgerfrontapi.controller;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.open4goods.nudgerfrontapi.dto.TeamMemberDto;
 import org.open4goods.nudgerfrontapi.service.TeamService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,6 +14,8 @@ import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
 public class TeamController {
+
+    private static final long TTL_SECONDS = 300;
 
     private final TeamService teamService;
 
@@ -20,7 +25,10 @@ public class TeamController {
 
     @GetMapping("/team")
     @Operation(summary = "List team members")
-    public List<TeamMemberDto> team() {
-        return teamService.getMembers();
+    public ResponseEntity<List<TeamMemberDto>> team() {
+        List<TeamMemberDto> members = teamService.getMembers();
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(TTL_SECONDS, TimeUnit.SECONDS))
+                .body(members);
     }
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AssociationsControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AssociationsControllerIT.java
@@ -1,14 +1,21 @@
 package org.open4goods.nudgerfrontapi.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import org.open4goods.nudgerfrontapi.dto.AssociationDto;
+import org.open4goods.nudgerfrontapi.service.AssociationsService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -17,9 +24,16 @@ class AssociationsControllerIT {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private AssociationsService associationsService;
+
     @Test
-    void associationsEndpoint() throws Exception {
+    void associationsEndpointReturnsBodyAndCacheHeader() throws Exception {
+        given(associationsService.getAssociations()).willReturn(List.of(new AssociationDto("id", "name")));
+
         mockMvc.perform(get("/associations").with(jwt()))
-            .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$[0].id").value("id"))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
     }
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -1,14 +1,22 @@
 package org.open4goods.nudgerfrontapi.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.Date;
+import java.util.List;
+import org.open4goods.nudgerfrontapi.dto.BlogPostDto;
+import org.open4goods.nudgerfrontapi.service.BlogService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -17,15 +25,26 @@ class PostsControllerIT {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private BlogService blogService;
+
     @Test
     void listPosts() throws Exception {
+        given(blogService.getPosts(null)).willReturn(List.of(new BlogPostDto("slug", "title", "en", "s", "b", new Date())));
+
         mockMvc.perform(get("/posts").with(jwt()))
-            .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$[0].slug").value("slug"))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
     }
 
     @Test
     void getPost() throws Exception {
+        given(blogService.getPost("hello-world", null)).willReturn(new BlogPostDto("hello-world", "title", "en", "s", "b", new Date()));
+
         mockMvc.perform(get("/posts/hello-world").with(jwt()))
-            .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.slug").value("hello-world"))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
     }
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/TeamControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/TeamControllerIT.java
@@ -1,14 +1,21 @@
 package org.open4goods.nudgerfrontapi.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import org.open4goods.nudgerfrontapi.dto.TeamMemberDto;
+import org.open4goods.nudgerfrontapi.service.TeamService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -17,9 +24,16 @@ class TeamControllerIT {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private TeamService teamService;
+
     @Test
-    void teamEndpoint() throws Exception {
+    void teamEndpointReturnsBodyAndCacheHeader() throws Exception {
+        given(teamService.getMembers()).willReturn(List.of(new TeamMemberDto("n", "t")));
+
         mockMvc.perform(get("/team").with(jwt()))
-            .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$[0].name").value("n"))
+               .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("max-age")));
     }
 }


### PR DESCRIPTION
## Summary
- ensure TeamController, PostsController and AssociationsController return `ResponseEntity`
- add cache headers and 404 on missing blog post
- expand ITs to verify JSON and cache headers

## Testing
- `mvn -pl nudger-front-api -am clean install -q` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685b3c5f32908333b8a1b679412b5822