### PR TITLE
Document nullable fields in front API DTOs

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ProductViewResponse.java
@@ -9,7 +9,7 @@ public record ProductViewResponse(
         @Schema(description = "Original request")
         ProductViewRequest request,
 
-        @Schema(description = "Timing metadata")
+        @Schema(description = "Timing metadata", nullable = true)
         RequestMetadata metadatas,
 
         @Schema(description = "Requested GTIN", example = "7612345678901")

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RequestMetadata.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/RequestMetadata.java
@@ -6,12 +6,12 @@ package org.open4goods.nudgerfrontapi.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RequestMetadata(
-        @Schema(description = "Request start timestamp ms", example = "1690972800000")
+        @Schema(description = "Request start timestamp ms", example = "1690972800000", nullable = true)
         Long startDate,
 
-        @Schema(description = "Request end timestamp ms", example = "1690972810000")
+        @Schema(description = "Request end timestamp ms", example = "1690972810000", nullable = true)
         Long endDate,
 
-        @Schema(description = "Internal fishtag", example = "front-home")
+        @Schema(description = "Internal fishtag", example = "front-home", nullable = true)
         String fishtag) {
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -53,7 +53,8 @@ class ProductControllerIT {
 
         mockMvc.perform(get("/product/{gtin}", gtin).with(jwt()))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.gtin").value(gtin));
+            .andExpect(jsonPath("$.gtin").value(gtin))
+            .andExpect(jsonPath("$.metadatas").doesNotExist());
 
         assert healthEndpoint.health().getStatus().equals(Status.UP);
     }


### PR DESCRIPTION
## Summary
- document optional `metadatas` field in `ProductViewResponse`
- mark `RequestMetadata` attributes as nullable
- extend product controller test to ensure `metadatas` can be null

## Testing
- `mvn -pl nudger-front-api test` *(fails: Non‑resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_685ba6fa0e188333b8338f25503aebc5