### PR TITLE
Add Swagger annotations to front controllers

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AssociationsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AssociationsController.java
@@ -10,9 +10,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
+@Tag(name = "Associations", description = "Environmental associations data")
 public class AssociationsController {
 
     private static final long TTL_SECONDS = 300;
@@ -24,7 +32,16 @@ public class AssociationsController {
     }
 
     @GetMapping("/associations")
-    @Operation(summary = "List associations")
+    @Operation(
+            summary = "List associations",
+            description = "Return the list of partner associations.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Associations returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AssociationDto.class, type = "array")))
+    })
     public ResponseEntity<List<AssociationDto>> associations() {
         List<AssociationDto> list = associationsService.getAssociations();
         return ResponseEntity.ok()

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AuthController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/AuthController.java
@@ -9,9 +9,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
+@Tag(name = "Authentication", description = "Access and refresh bearer tokens")
 public class AuthController {
 
     private final AuthService authService;
@@ -21,14 +28,32 @@ public class AuthController {
     }
 
     @PostMapping("/auth/token")
-    @Operation(summary = "Issue an access token")
+    @Operation(
+            summary = "Issue an access token",
+            description = "Authenticate user credentials and return a JWT with refresh token"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Token issued",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    })
     public ResponseEntity<AuthResponse> token(@RequestBody AuthRequest request) {
         String token = authService.token(request.username(), request.password());
         return ResponseEntity.ok(new AuthResponse(token));
     }
 
     @PostMapping("/auth/refresh")
-    @Operation(summary = "Refresh an access token")
+    @Operation(
+            summary = "Refresh an access token",
+            description = "Exchange a refresh token for a new access token"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Token refreshed",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Refresh token invalid")
+    })
     public ResponseEntity<AuthResponse> refresh(@RequestBody RefreshRequest request) {
         String token = authService.refresh(request.refreshToken());
         if (token == null) {

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/HomeController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/HomeController.java
@@ -9,10 +9,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * REST endpoint providing aggregated data for the home page.
  */
 @RestController
+@Tag(name = "Home", description = "Aggregated data for the home page")
 public class HomeController {
 
     private static final long TTL_SECONDS = 300;
@@ -24,6 +33,16 @@ public class HomeController {
     }
 
     @GetMapping("/home")
+    @Operation(
+            summary = "Get home data",
+            description = "Return aggregated statistics and partners used on the home page.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Data returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = HomeCompositeResponse.class)))
+    })
     public ResponseEntity<HomeCompositeResponse> home() {
         HomeCompositeResponse resp = homeService.getHome();
         return ResponseEntity.ok()

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PartnerController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PartnerController.java
@@ -10,10 +10,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * REST endpoint exposing partners.
  */
 @RestController
+@Tag(name = "Partners", description = "Information about project partners")
 public class PartnerController {
 
     private static final long TTL_SECONDS = 300;
@@ -25,6 +34,16 @@ public class PartnerController {
     }
 
     @GetMapping("/partners")
+    @Operation(
+            summary = "List partners",
+            description = "Return all partner organisations.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Partners returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PartnerDto.class, type = "array")))
+    })
     public ResponseEntity<List<PartnerDto>> partners() {
         List<PartnerDto> list = partnerService.fetchPartners();
         return ResponseEntity.ok()

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PostsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/PostsController.java
@@ -13,8 +13,16 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
+@Tag(name = "Blog", description = "Access blog posts for the website")
 public class PostsController {
 
     private static final long TTL_SECONDS = 300;
@@ -26,7 +34,17 @@ public class PostsController {
     }
 
     @GetMapping("/posts")
-    @Operation(summary = "List blog posts")
+    @Operation(
+            summary = "List blog posts",
+            description = "Return published blog posts. Optionally filter by locale.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
+            parameters = @Parameter(name = "locale", description = "Locale code", required = false)
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Posts returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogPostDto.class, type = "array")))
+    })
     public ResponseEntity<List<BlogPostDto>> posts(@RequestParam(required = false) String locale) {
         List<BlogPostDto> posts = blogService.getPosts(locale);
         return ResponseEntity.ok()
@@ -35,7 +53,21 @@ public class PostsController {
     }
 
     @GetMapping("/posts/{slug}")
-    @Operation(summary = "Get blog post by slug")
+    @Operation(
+            summary = "Get blog post",
+            description = "Return a single blog post identified by its slug.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
+            parameters = {
+                    @Parameter(name = "slug", description = "Post slug", required = true),
+                    @Parameter(name = "locale", description = "Locale code", required = false)
+            }
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Post returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = BlogPostDto.class))),
+            @ApiResponse(responseCode = "404", description = "Post not found")
+    })
     public ResponseEntity<BlogPostDto> post(@PathVariable String slug, @RequestParam(name = "locale", required = false) String locale) {
         BlogPostDto post = blogService.getPost(slug, locale);
         if (post == null) {

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/ProductController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/ProductController.java
@@ -53,6 +53,7 @@ public class ProductController {
     @Operation(
             summary = "Get product view",
             description = "Return high‑level product information and aggregated scores.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
             parameters = @Parameter(name = "gtin",
                     description = "Global Trade Item Number (8–14 digit numeric code)",
                     example = "00012345600012",
@@ -76,6 +77,7 @@ public class ProductController {
     @Operation(
             summary = "Get product reviews",
             description = "Return customer or AI‑generated reviews for a product.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
             parameters = @Parameter(name = "gtin",
                     description = "Global Trade Item Number (8–14 digit numeric code)",
                     example = "00012345600012",
@@ -104,7 +106,10 @@ public class ProductController {
                     @Parameter(name = "hcaptchaResponse", required = true,
                                description = "Token returned by hCaptcha widget for bot mitigation.")
             },
-            security = @SecurityRequirement(name = "hCaptcha"),
+            security = {
+                    @SecurityRequirement(name = "bearer-jwt"),
+                    @SecurityRequirement(name = "hCaptcha")
+            },
             responses = {
                     @ApiResponse(responseCode = "202", description = "Accepted – review generation enqueued"),
                     @ApiResponse(responseCode = "400", description = "Invalid GTIN or hCaptcha token"),
@@ -122,6 +127,7 @@ public class ProductController {
     @Operation(
             summary = "Get product offers",
             description = "Return available commercial offers for a product, sorted by total price ascending.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
             parameters = @Parameter(name = "gtin", description = "Global Trade Item Number", example = "00012345600012", required = true),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Offers returned",
@@ -141,6 +147,7 @@ public class ProductController {
     @Operation(
             summary = "Get product impact score",
             description = "Return environmental and social impact composite score for a product.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
             parameters = @Parameter(name = "gtin", description = "Global Trade Item Number", example = "00012345600012", required = true),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Impact score returned",

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/StatsController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/StatsController.java
@@ -9,10 +9,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 /**
  * REST endpoint exposing statistics.
  */
 @RestController
+@Tag(name = "Statistics", description = "Site usage and product statistics")
 public class StatsController {
 
     private static final long TTL_SECONDS = 300;
@@ -24,6 +33,16 @@ public class StatsController {
     }
 
     @GetMapping("/stats")
+    @Operation(
+            summary = "Get statistics",
+            description = "Return site statistics such as product and review counts.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Statistics returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = StatsDto.class)))
+    })
     public ResponseEntity<StatsDto> stats() {
         StatsDto dto = statsService.fetchStats();
         return ResponseEntity.ok()

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/TeamController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/TeamController.java
@@ -10,9 +10,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
+@Tag(name = "Team", description = "Information about project team members")
 public class TeamController {
 
     private static final long TTL_SECONDS = 300;
@@ -24,7 +32,16 @@ public class TeamController {
     }
 
     @GetMapping("/team")
-    @Operation(summary = "List team members")
+    @Operation(
+            summary = "List team members",
+            description = "Return all team members contributing to the project.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Team returned",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = TeamMemberDto.class, type = "array")))
+    })
     public ResponseEntity<List<TeamMemberDto>> team() {
         List<TeamMemberDto> members = teamService.getMembers();
         return ResponseEntity.ok()

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/VoteController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/VoteController.java
@@ -7,9 +7,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
+@Tag(name = "Votes", description = "Submit user feedback votes")
 public class VoteController {
 
     private final VoteService voteService;
@@ -19,7 +27,15 @@ public class VoteController {
     }
 
     @PostMapping("/vote")
-    @Operation(summary = "Submit a vote")
+    @Operation(
+            summary = "Submit a vote",
+            description = "Record a user vote for a content item.",
+            security = @SecurityRequirement(name = "bearer-jwt")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Vote recorded"),
+            @ApiResponse(responseCode = "400", description = "Invalid vote request")
+    })
     public ResponseEntity<Void> vote(@RequestBody VoteRequest request) {
         voteService.submit(request);
         return ResponseEntity.ok().build();


### PR DESCRIPTION
## Summary
- document all Nudger Front API controllers with OpenAPI annotations
- mark operations requiring bearer JWT auth and hCaptcha

## Testing
- `mvn -pl nudger-front-api -am clean install` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ba681c4dc83338c15b1bb95279520