### PR TITLE
Add javadoc and schema for DTOs

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryListResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryListResponse.java
@@ -1,11 +1,23 @@
 package org.open4goods.nudgerfrontapi.dto;
 
+/**
+ * Paginated list of product categories returned by the API.
+ */
 import java.util.List;
 
 import org.open4goods.nudgerfrontapi.service.CategoryService.CategoryDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record CategoryListResponse(int page,
-                                   int size,
-                                   long total,
-                                   List<CategoryDto> items) {
+public record CategoryListResponse(
+        @Schema(description = "Current page index (1-based)", example = "1")
+        int page,
+
+        @Schema(description = "Page size", example = "10")
+        int size,
+
+        @Schema(description = "Total number of categories", example = "20")
+        long total,
+
+        @Schema(description = "Returned categories")
+        List<CategoryDto> items) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/CategoryRequest.java
@@ -1,4 +1,17 @@
 package org.open4goods.nudgerfrontapi.dto;
 
-public record CategoryRequest(Integer page, Integer size, boolean include) {
+/**
+ * Parameters for listing categories.
+ */
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CategoryRequest(
+        @Schema(description = "Page number (1-based)", example = "1")
+        Integer page,
+
+        @Schema(description = "Requested page size", example = "10")
+        Integer size,
+
+        @Schema(description = "Whether to include children", example = "true")
+        boolean include) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/ImpactScoreDto.java
@@ -1,5 +1,8 @@
 package org.open4goods.nudgerfrontapi.dto;
 
+/**
+ * Aggregated impact score information for a product.
+ */
 import java.util.Map;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchRequest.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchRequest.java
@@ -1,13 +1,33 @@
 package org.open4goods.nudgerfrontapi.dto;
 
+/**
+ * Parameters controlling a product search query.
+ */
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record SearchRequest(String query,
-                            Integer fromPrice,
-                            Integer toPrice,
-                            List<String> categories,
-                            String condition,
-                            Integer page,
-                            Integer size,
-                            boolean sort) {
+public record SearchRequest(
+        @Schema(description = "Search keywords", example = "eco detergent")
+        String query,
+
+        @Schema(description = "Minimum price filter", example = "0")
+        Integer fromPrice,
+
+        @Schema(description = "Maximum price filter", example = "50")
+        Integer toPrice,
+
+        @Schema(description = "Category identifiers", example = "[\"cleaning\"]")
+        List<String> categories,
+
+        @Schema(description = "Item condition", example = "new")
+        String condition,
+
+        @Schema(description = "Page number (1-based)", example = "1")
+        Integer page,
+
+        @Schema(description = "Page size", example = "20")
+        Integer size,
+
+        @Schema(description = "Sort by relevance", example = "true")
+        boolean sort) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchResponse.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/SearchResponse.java
@@ -1,11 +1,23 @@
 package org.open4goods.nudgerfrontapi.dto;
 
+/**
+ * Result of a product search query.
+ */
 import java.util.List;
 
 import org.open4goods.model.product.Product;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record SearchResponse(long total,
-                             int page,
-                             int size,
-                             List<Product> items) {
+public record SearchResponse(
+        @Schema(description = "Total number of matching products", example = "42")
+        long total,
+
+        @Schema(description = "Current page index (1-based)", example = "1")
+        int page,
+
+        @Schema(description = "Page size", example = "20")
+        int size,
+
+        @Schema(description = "Page content")
+        List<Product> items) {
 }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.open4goods.model.constants.CacheConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,20 @@ public class CategoryService {
     }
 
 
-    public record CategoryDto(Integer id, Map<String, String> names, String vertical, List<CategoryDto> children) {
+    /**
+     * Lightweight category representation used by API responses.
+     */
+    public record CategoryDto(
+            @Schema(description = "Category identifier", example = "5")
+            Integer id,
+
+            @Schema(description = "Localized names", example = "{\"en\":\"Beverages\"}")
+            Map<String, String> names,
+
+            @Schema(description = "Associated vertical", example = "food")
+            String vertical,
+
+            @Schema(description = "Child categories", nullable = true)
+            List<CategoryDto> children) {
     }
 }


### PR DESCRIPTION
## Summary
- document impact score, category and search DTOs
- describe CategoryDto record in CategoryService
- annotate all fields with `@Schema` examples

## Testing
- `mvn -pl nudger-front-api -am clean install` *(fails: missing dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685bc170e4d48333bc727573fe527e33