### PR TITLE
Document CategoryController

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoryController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoryController.java
@@ -3,13 +3,27 @@ package org.open4goods.nudgerfrontapi.controller.api;
 import org.open4goods.nudgerfrontapi.dto.CategoryListResponse;
 import org.open4goods.nudgerfrontapi.dto.CategoryRequest;
 import org.open4goods.nudgerfrontapi.service.CategoryService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing the public category hierarchy used by the frontend.
+ */
 @RestController
 @RequestMapping("/api/v1")
+@Tag(name = "Categories", description = "Retrieve product categories")
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -18,18 +32,66 @@ public class CategoryController {
         this.categoryService = categoryService;
     }
 
+    /**
+     * List available root categories.
+     *
+     * @param request pagination and inclusion parameters
+     * @return paged list of categories
+     */
     @GetMapping("/categories")
-    public CategoryListResponse categories(CategoryRequest request) {
+    @Operation(
+            summary = "List root categories",
+            description = "Return paged root categories optionally with child nodes.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
+            parameters = {
+                    @Parameter(name = "page", description = "Page index", required = false),
+                    @Parameter(name = "size", description = "Page size", required = false),
+                    @Parameter(name = "include", description = "Include child categories", required = false)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Categories returned",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = CategoryListResponse.class)))
+            }
+    )
+    public ResponseEntity<CategoryListResponse> categories(CategoryRequest request) {
         int page = request.page() == null ? 0 : request.page();
         int size = request.size() == null ? 10 : request.size();
         var all = categoryService.listRootCategories(request.include());
         int from = Math.min(page * size, all.size());
         int to = Math.min(from + size, all.size());
-        return new CategoryListResponse(page, size, all.size(), all.subList(from, to));
+        var body = new CategoryListResponse(page, size, all.size(), all.subList(from, to));
+        return ResponseEntity.ok(body);
     }
 
+    /**
+     * Return a single category by its identifier.
+     *
+     * @param id      category identifier
+     * @param request options such as including child categories
+     * @return the category description
+     */
     @GetMapping("/categories/{id}")
-    public CategoryService.CategoryDto category(@PathVariable int id, CategoryRequest request) {
-        return categoryService.getCategory(id, request.include());
+    @Operation(
+            summary = "Get category",
+            description = "Return a single category optionally with its children.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
+            parameters = {
+                    @Parameter(name = "id", description = "Category identifier", required = true),
+                    @Parameter(name = "include", description = "Include child categories", required = false)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Category returned",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = CategoryService.CategoryDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Category not found")
+            }
+    )
+    public ResponseEntity<CategoryService.CategoryDto> category(@PathVariable int id, CategoryRequest request) {
+        var body = categoryService.getCategory(id, request.include());
+        if (body == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(body);
     }
 }

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoryControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoryControllerIT.java
@@ -2,13 +2,19 @@ package org.open4goods.nudgerfrontapi.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import java.util.Map;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -17,15 +23,27 @@ class CategoryControllerIT {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private CategoryService categoryService;
+
     @Test
-    void categoriesEndpointReturnsOk() throws Exception {
+    void categoriesEndpointReturnsList() throws Exception {
+        var dto = new CategoryService.CategoryDto(1, Map.of("en", "root"), "vert", List.of());
+        given(categoryService.listRootCategories(false)).willReturn(List.of(dto));
+
         mockMvc.perform(get("/api/v1/categories").with(jwt()))
-               .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.total").value(1))
+               .andExpect(jsonPath("$.items[0].id").value(1));
     }
 
     @Test
-    void categoryByIdEndpointReturnsOk() throws Exception {
+    void categoryByIdEndpointReturnsDto() throws Exception {
+        var dto = new CategoryService.CategoryDto(1, Map.of("en", "root"), "vert", List.of());
+        given(categoryService.getCategory(1, false)).willReturn(dto);
+
         mockMvc.perform(get("/api/v1/categories/{id}", 1).with(jwt()))
-               .andExpect(status().isOk());
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.id").value(1));
     }
 }


### PR DESCRIPTION
## Summary
- document CategoryController endpoints with Swagger and Javadoc
- return `ResponseEntity` in CategoryController
- assert response body values in CategoryControllerIT

## Testing
- `mvn -pl nudger-front-api -am clean install -q` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bc1644c888333856aaa2aff3abf76