### PR TITLE
Add request-scoped context interceptor

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/RequestContextConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/RequestContextConfig.java
@@ -1,0 +1,24 @@
+package org.open4goods.api.config;
+
+import org.open4goods.commons.interceptors.RequestContextInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers web interceptors for the API module.
+ */
+@Configuration
+public class RequestContextConfig implements WebMvcConfigurer {
+
+    private final RequestContextInterceptor requestContextInterceptor;
+
+    public RequestContextConfig(RequestContextInterceptor requestContextInterceptor) {
+        this.requestContextInterceptor = requestContextInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(requestContextInterceptor);
+    }
+}

--- a/api/src/test/java/org/open4goods/api/config/RequestContextInterceptorTest.java
+++ b/api/src/test/java/org/open4goods/api/config/RequestContextInterceptorTest.java
@@ -1,0 +1,45 @@
+package org.open4goods.api.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.commons.model.dto.RequestContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = {RequestContextConfig.class, RequestContextInterceptorTest.TestController.class})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class RequestContextInterceptorTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void headerStoredInContext() throws Exception {
+        mockMvc.perform(get("/test").header("X-Test", "abc"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("abc"));
+    }
+
+    @RestController
+    static class TestController {
+        private final RequestContext requestContext;
+
+        TestController(RequestContext requestContext) {
+            this.requestContext = requestContext;
+        }
+
+        @GetMapping("/test")
+        String value() {
+            return requestContext.getHeaders().get("X-Test");
+        }
+    }
+}

--- a/commons/src/main/java/org/open4goods/commons/interceptors/RequestContextInterceptor.java
+++ b/commons/src/main/java/org/open4goods/commons/interceptors/RequestContextInterceptor.java
@@ -1,0 +1,42 @@
+package org.open4goods.commons.interceptors;
+
+import java.util.Enumeration;
+
+import org.open4goods.commons.model.dto.RequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Interceptor populating the {@link RequestContext} with request headers.
+ */
+@Component
+public class RequestContextInterceptor implements HandlerInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestContextInterceptor.class);
+
+    private final RequestContext requestContext;
+
+    public RequestContextInterceptor(RequestContext requestContext) {
+        this.requestContext = requestContext;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        requestContext.clear();
+        Enumeration<String> names = request.getHeaderNames();
+        if (names != null) {
+            while (names.hasMoreElements()) {
+                String name = names.nextElement();
+                String value = request.getHeader(name);
+                requestContext.getHeaders().put(name, value);
+            }
+        }
+        logger.debug("Stored {} headers in RequestContext", requestContext.getHeaders().size());
+        return true;
+    }
+}

--- a/commons/src/main/java/org/open4goods/commons/model/dto/RequestContext.java
+++ b/commons/src/main/java/org/open4goods/commons/model/dto/RequestContext.java
@@ -1,0 +1,25 @@
+package org.open4goods.commons.model.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+/**
+ * Holds request-scoped information extracted from HTTP headers.
+ */
+@Component
+@RequestScope
+public class RequestContext {
+
+    private final Map<String, String> headers = new HashMap<>();
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void clear() {
+        headers.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- provide `RequestContext` bean with `@RequestScope`
- populate headers with new `RequestContextInterceptor`
- register the interceptor in API module
- test interceptor integration with MockMvc

## Testing
- `mvn -pl api -am clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685bc3721c8c83339b51e37d0e364bee