### PR TITLE
Implement dynamic inclusion for nudger-front-api

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -1,10 +1,22 @@
 package org.open4goods.nudgerfrontapi.config;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
+import org.open4goods.nudgerfrontapi.config.IncludeArgumentResolver;
+
+import com.fasterxml.jackson.databind.ser.FilterProvider;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 @Configuration
 public class AppConfig {
@@ -22,6 +34,27 @@ public class AppConfig {
     @Bean
     ProductRepository productRepository() {
         return new ProductRepository();
+    }
+
+    @Bean
+    @RequestScope
+    FilterProvider filterProvider(HttpServletRequest request) {
+        @SuppressWarnings("unchecked")
+        Set<String> includes = (Set<String>) request.getAttribute(IncludeArgumentResolver.ATTRIBUTE_NAME);
+        if (includes == null) {
+            includes = Collections.emptySet();
+        }
+        SimpleBeanPropertyFilter filter = includes.isEmpty()
+                ? SimpleBeanPropertyFilter.serializeAll()
+                : SimpleBeanPropertyFilter.filterOutAllExcept(includes);
+        return new SimpleFilterProvider()
+                .setFailOnUnknownId(false)
+                .addFilter("inc", filter);
+    }
+
+    @Bean
+    Jackson2ObjectMapperBuilderCustomizer jacksonCustomizer(FilterProvider filterProvider) {
+        return builder -> builder.filters(filterProvider);
     }
 //
 //    @Bean

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/IncludeArgumentResolver.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/IncludeArgumentResolver.java
@@ -1,0 +1,56 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * Resolves the optional {@code include} query parameter into a {@link Set} of
+ * field names. The resulting set is also stored as a request attribute so that
+ * Jackson filters can access it later on.
+ */
+@Component
+public class IncludeArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /** Request attribute holding the parsed includes set. */
+    public static final String ATTRIBUTE_NAME = IncludeArgumentResolver.class.getName() + ".INCLUDES";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        if (!Set.class.isAssignableFrom(parameter.getParameterType())) {
+            return false;
+        }
+        if (!(parameter.getGenericParameterType() instanceof ParameterizedType type)) {
+            return false;
+        }
+        if (!type.getActualTypeArguments()[0].equals(String.class)) {
+            return false;
+        }
+        return "includes".equals(parameter.getParameterName());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String raw = webRequest.getParameter("include");
+        if (raw == null || raw.isBlank()) {
+            Set<String> empty = Collections.emptySet();
+            webRequest.setAttribute(ATTRIBUTE_NAME, empty, RequestAttributes.SCOPE_REQUEST);
+            return empty;
+        }
+        Set<String> includes = new LinkedHashSet<>(Arrays.asList(raw.split(",")));
+        includes.removeIf(String::isBlank);
+        webRequest.setAttribute(ATTRIBUTE_NAME, includes, RequestAttributes.SCOPE_REQUEST);
+        return includes;
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebConfig.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC configuration registering custom argument resolvers.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final IncludeArgumentResolver includeArgumentResolver;
+
+    public WebConfig(IncludeArgumentResolver includeArgumentResolver) {
+        this.includeArgumentResolver = includeArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(includeArgumentResolver);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import java.util.Set;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,10 +51,15 @@ public class ProductController {
             summary = "Get product view",
             description = "Return high‑level product information and aggregated scores.",
             security = @SecurityRequirement(name = "bearer-jwt"),
-            parameters = @Parameter(name = "gtin",
-                    description = "Global Trade Item Number (8–14 digit numeric code)",
-                    example = "8806095491998",
-                    required = true),
+            parameters = {
+                    @Parameter(name = "gtin",
+                            description = "Global Trade Item Number (8–14 digit numeric code)",
+                            example = "8806095491998",
+                            required = true),
+                    @Parameter(name = "include",
+                            description = "Comma-separated list of fields to include",
+                            required = false)
+            },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Product found",
                             content = @Content(mediaType = "application/json",
@@ -62,8 +68,9 @@ public class ProductController {
             }
     )
     public ResponseEntity<ProductDto> product(@PathVariable
-                                                       @Pattern(regexp = "\\d{8,14}") String gtin) throws Exception {
-        ProductDto body = service.getProduct(Long.parseLong(gtin));
+                                                       @Pattern(regexp = "\\d{8,14}") String gtin,
+                                               Set<String> includes) throws Exception {
+        ProductDto body = service.getProduct(Long.parseLong(gtin), includes);
         return ResponseEntity.ok()
                 .cacheControl(ONE_HOUR_PUBLIC_CACHE)
                 .body(body);
@@ -79,10 +86,15 @@ public class ProductController {
             summary = "Get product reviews",
             description = "Return customer or AI‑generated reviews for a product.",
             security = @SecurityRequirement(name = "bearer-jwt"),
-            parameters = @Parameter(name = "gtin",
-                    description = "Global Trade Item Number (8–14 digit numeric code)",
-                    example = "00012345600012",
-                    required = true),
+            parameters = {
+                    @Parameter(name = "gtin",
+                            description = "Global Trade Item Number (8–14 digit numeric code)",
+                            example = "00012345600012",
+                            required = true),
+                    @Parameter(name = "include",
+                            description = "Comma-separated list of fields to include",
+                            required = false)
+            },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Reviews returned",
                             content = @Content(mediaType = "application/json",
@@ -91,8 +103,9 @@ public class ProductController {
             }
     )
     public ResponseEntity<List<ProductReviewDto>> reviews(@PathVariable
-                                                   @Pattern(regexp = "\\d{8,14}") String gtin) throws Exception {
-        List<ProductReviewDto> body = service.getReviews(Long.parseLong(gtin));
+                                                   @Pattern(regexp = "\\d{8,14}") String gtin,
+                                                   Set<String> includes) throws Exception {
+        List<ProductReviewDto> body = service.getReviews(Long.parseLong(gtin), includes);
         return ResponseEntity.ok()
                 .cacheControl(ONE_HOUR_PUBLIC_CACHE)
                 .body(body);

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -1,5 +1,6 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import org.open4goods.nudgerfrontapi.dto.RequestMetadata;
 
 /**
@@ -7,6 +8,7 @@ import org.open4goods.nudgerfrontapi.dto.RequestMetadata;
  */
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonFilter("inc")
 public record ProductDto(
 
 

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductReviewDto.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductReviewDto.java
@@ -1,8 +1,10 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import org.open4goods.model.ai.AiReview;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonFilter("inc")
 public record ProductReviewDto(
         @Schema(description = "Review language", example = "en")
         String language,

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductService.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductService.java
@@ -2,6 +2,7 @@ package org.open4goods.nudgerfrontapi.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
@@ -19,11 +20,11 @@ public class ProductService {
 
     }
 
-    public ProductDto getProduct(long gtin) throws ResourceNotFoundException {
+    public ProductDto getProduct(long gtin, Set<String> includes) throws ResourceNotFoundException {
         return new ProductDto(null, gtin);
     }
 
-    public List<ProductReviewDto> getReviews(long gtin) throws ResourceNotFoundException {
+    public List<ProductReviewDto> getReviews(long gtin, Set<String> includes) throws ResourceNotFoundException {
         return new ArrayList<>();
     }
 

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -1,6 +1,7 @@
 package org.open4goods.nudgerfrontapi.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -44,7 +45,7 @@ class ProductControllerIT {
     @Test
     void reviewsEndpointReturnsList() throws Exception {
         long gtin = 123L;
-        given(service.getReviews(any())).willReturn(List.of(new ProductReviewDto("fr", new AiReview(), 1L)));
+        given(service.getReviews(anyLong(), any())).willReturn(List.of(new ProductReviewDto("fr", new AiReview(), 1L)));
 
         mockMvc.perform(get("/product/{gtin}/reviews", gtin).with(jwt()))
             .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- add `IncludeArgumentResolver` and register via `WebConfig`
- configure `SimpleFilterProvider` per request in `AppConfig`
- annotate DTOs with `@JsonFilter`
- pass `includes` to service in `ProductController`
- update `ProductService` signature
- adjust controller tests for new service method

## Testing
- `mvn -pl nudger-front-api -am clean install -q` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685be3ec0e8083338d2d14de6fac3ad8