### PR TITLE
Add generic filter parser and spec builder

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.8.9</version>
@@ -86,6 +90,11 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/filter/FilterCriteria.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/filter/FilterCriteria.java
@@ -1,0 +1,19 @@
+package org.open4goods.nudgerfrontapi.dto.filter;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Criteria parsed from a filter query parameter, e.g. {@code filter[price_lt]=20}.
+ *
+ * @param field    the entity field to test
+ * @param operator the comparison operator
+ * @param value    the comparison value as String
+ */
+public record FilterCriteria(
+        @Schema(description = "Entity field name", example = "price")
+        String field,
+        @Schema(description = "Comparison operator", example = "LT")
+        FilterOperator operator,
+        @Schema(description = "Filter value as string", example = "20")
+        String value) {
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/filter/FilterOperator.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/filter/FilterOperator.java
@@ -1,0 +1,8 @@
+package org.open4goods.nudgerfrontapi.dto.filter;
+
+/**
+ * Supported comparison operators for filtering.
+ */
+public enum FilterOperator {
+    EQ, NE, LT, LTE, GT, GTE, LIKE
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/util/FilterCriteriaParser.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/util/FilterCriteriaParser.java
@@ -1,0 +1,44 @@
+package org.open4goods.nudgerfrontapi.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.open4goods.nudgerfrontapi.dto.filter.FilterCriteria;
+import org.open4goods.nudgerfrontapi.dto.filter.FilterOperator;
+
+/**
+ * Utility to parse query parameters following the form {@code filter[field_op]=value}.
+ */
+public final class FilterCriteriaParser {
+
+    private static final Pattern FILTER_PATTERN = Pattern.compile("filter\\[([a-zA-Z0-9_]+)\\]=(.+)");
+
+    private FilterCriteriaParser() {
+    }
+
+    /**
+     * Parse all parameters of the form {@code filter[field_op]=value} into {@link FilterCriteria} objects.
+     *
+     * @param parameters raw request parameters
+     * @return list of parsed criteria
+     */
+    public static List<FilterCriteria> parse(Map<String, String[]> parameters) {
+        List<FilterCriteria> result = new ArrayList<>();
+        parameters.forEach((key, values) -> {
+            Matcher m = FILTER_PATTERN.matcher(key);
+            if (m.matches()) {
+                String expr = m.group(1); // e.g. price_lt
+                String[] parts = expr.split("_");
+                String field = parts[0];
+                FilterOperator op = parts.length > 1 ?
+                        FilterOperator.valueOf(parts[1].toUpperCase()) : FilterOperator.EQ;
+                String value = values.length > 0 ? values[0] : null;
+                result.add(new FilterCriteria(field, op, value));
+            }
+        });
+        return result;
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/util/SpecificationUtils.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/util/SpecificationUtils.java
@@ -1,0 +1,69 @@
+package org.open4goods.nudgerfrontapi.util;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.dto.filter.FilterCriteria;
+import org.open4goods.nudgerfrontapi.dto.filter.FilterOperator;
+import org.springframework.data.jpa.domain.Specification;
+
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+
+/**
+ * Build JPA {@link Specification} objects from {@link FilterCriteria} lists.
+ */
+public final class SpecificationUtils {
+
+    private SpecificationUtils() {
+    }
+
+    /**
+     * Convert a list of filter criteria to a JPA {@link Specification}.
+     *
+     * @param filters criteria to convert
+     * @return combined specification applying all filters with AND semantics
+     */
+    public static <T> Specification<T> fromFilters(List<FilterCriteria> filters) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            for (FilterCriteria fc : filters) {
+                Path<?> path = root.get(fc.field());
+                Object value = convertValue(fc.value(), path.getJavaType());
+                switch (fc.operator()) {
+                    case EQ -> predicates.add(cb.equal(path, value));
+                    case NE -> predicates.add(cb.notEqual(path, value));
+                    case GT -> predicates.add(cb.greaterThan(path.as(Comparable.class), (Comparable) value));
+                    case GTE -> predicates.add(cb.greaterThanOrEqualTo(path.as(Comparable.class), (Comparable) value));
+                    case LT -> predicates.add(cb.lessThan(path.as(Comparable.class), (Comparable) value));
+                    case LTE -> predicates.add(cb.lessThanOrEqualTo(path.as(Comparable.class), (Comparable) value));
+                    case LIKE -> predicates.add(cb.like(path.as(String.class), "%" + value + "%"));
+                }
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static Object convertValue(String raw, Class<?> type) {
+        if (raw == null) {
+            return null;
+        }
+        if (Long.class.isAssignableFrom(type) || long.class.isAssignableFrom(type)) {
+            return Long.valueOf(raw);
+        }
+        if (Integer.class.isAssignableFrom(type) || int.class.isAssignableFrom(type)) {
+            return Integer.valueOf(raw);
+        }
+        if (Double.class.isAssignableFrom(type) || double.class.isAssignableFrom(type)) {
+            return Double.valueOf(raw);
+        }
+        if (BigDecimal.class.isAssignableFrom(type)) {
+            return new BigDecimal(raw);
+        }
+        if (Boolean.class.isAssignableFrom(type) || boolean.class.isAssignableFrom(type)) {
+            return Boolean.valueOf(raw);
+        }
+        return raw;
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/util/SpecificationUtilsTest.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/util/SpecificationUtilsTest.java
@@ -1,0 +1,68 @@
+package org.open4goods.nudgerfrontapi.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.filter.FilterCriteria;
+import org.open4goods.nudgerfrontapi.dto.filter.FilterOperator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.domain.Specification;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@DataJpaTest
+class SpecificationUtilsTest {
+
+    @Entity
+    static class Product {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        Long id;
+        double price;
+        String name;
+    }
+
+    interface ProductRepo extends JpaRepository<Product, Long> {
+        List<Product> findAll(Specification<Product> spec);
+    }
+
+    @Autowired
+    private ProductRepo repo;
+
+    @Test
+    void specificationFiltersResults() {
+        Product p1 = new Product();
+        p1.price = 10.0;
+        p1.name = "apple";
+        repo.save(p1);
+        Product p2 = new Product();
+        p2.price = 30.0;
+        p2.name = "banana";
+        repo.save(p2);
+
+        List<FilterCriteria> filters = List.of(new FilterCriteria("price", FilterOperator.LT, "20"));
+        Specification<Product> spec = SpecificationUtils.fromFilters(filters);
+        List<Product> results = repo.findAll(spec);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).name).isEqualTo("apple");
+    }
+
+    @Test
+    void parserConvertsParameters() {
+        Map<String, String[]> params = Map.of("filter[price_lt]", new String[]{"5"});
+        List<FilterCriteria> criteria = FilterCriteriaParser.parse(params);
+        assertThat(criteria).hasSize(1);
+        assertThat(criteria.get(0).field()).isEqualTo("price");
+        assertThat(criteria.get(0).operator()).isEqualTo(FilterOperator.LT);
+        assertThat(criteria.get(0).value()).isEqualTo("5");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FilterCriteria` and `FilterOperator`
- add `FilterCriteriaParser` utility
- add `SpecificationUtils` to create JPA `Specification`
- include tests using an in-memory repository
- enable `spring-boot-starter-data-jpa` and H2 in front API module

## Testing
- `mvn -pl nudger-front-api -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685be40d57e8833394dd67e226163810