### PR TITLE
Implement locale resolution in Nudger Front API

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleConfig.java
@@ -1,0 +1,36 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.open4goods.nudgerfrontapi.interceptor.XLocaleHeaderInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Configuration for locale resolution and interceptor registration.
+ */
+@Configuration
+public class LocaleConfig implements WebMvcConfigurer {
+
+    private final XLocaleHeaderInterceptor xLocaleHeaderInterceptor;
+
+    public LocaleConfig(XLocaleHeaderInterceptor xLocaleHeaderInterceptor) {
+        this.xLocaleHeaderInterceptor = xLocaleHeaderInterceptor;
+    }
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        return new UserPreferenceLocaleResolver();
+    }
+
+    @Bean
+    public XLocaleHeaderInterceptor xLocaleHeaderInterceptor(LocaleResolver localeResolver) {
+        return new XLocaleHeaderInterceptor(localeResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(xLocaleHeaderInterceptor);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/UserPreferenceLocaleResolver.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/UserPreferenceLocaleResolver.java
@@ -1,0 +1,53 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Resolves the locale based on a user preference stored in a cookie or JWT
+ * claim, falling back to the request {@code Accept-Language} header.
+ */
+public class UserPreferenceLocaleResolver extends AcceptHeaderLocaleResolver {
+
+    private static final String COOKIE_NAME = "locale";
+    private static final String CLAIM_NAME = "locale";
+
+    @Override
+    public Locale resolveLocale(HttpServletRequest request) {
+        if (request == null) {
+            return Locale.getDefault();
+        }
+
+        // Check cookie preference
+        if (request.getCookies() != null) {
+            Optional<String> cookie = Arrays.stream(request.getCookies())
+                    .filter(c -> COOKIE_NAME.equals(c.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst();
+            if (cookie.isPresent()) {
+                return Locale.forLanguageTag(cookie.get());
+            }
+        }
+
+        // Check JWT claim
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof JwtAuthenticationToken token) {
+            Object claim = token.getToken().getClaim(CLAIM_NAME);
+            if (claim != null) {
+                return Locale.forLanguageTag(claim.toString());
+            }
+        }
+
+        // Fallback to Accept-Language
+        return request.getLocale();
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.LocaleResolver;
 
 @Configuration
 @EnableWebSecurity
@@ -23,8 +24,9 @@ import org.springframework.security.web.SecurityFilterChain;
 public class WebSecurityConfig {
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LocaleResolver localeResolver) throws Exception {
         http
+            .setSharedObject(LocaleResolver.class, localeResolver)
             .authorizeHttpRequests(auth -> auth
                     .requestMatchers("/", "/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/auth/**").permitAll()
                     .anyRequest().authenticated())

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/XLocaleHeaderInterceptor.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/XLocaleHeaderInterceptor.java
@@ -1,0 +1,30 @@
+package org.open4goods.nudgerfrontapi.interceptor;
+
+import java.util.Locale;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.LocaleResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Interceptor adding the resolved locale to the {@code X-Locale} response
+ * header so the Nuxt frontend can pick it up.
+ */
+public class XLocaleHeaderInterceptor implements HandlerInterceptor {
+
+    private final LocaleResolver localeResolver;
+
+    public XLocaleHeaderInterceptor(LocaleResolver localeResolver) {
+        this.localeResolver = localeResolver;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        Locale locale = localeResolver.resolveLocale(request);
+        response.setHeader("X-Locale", locale.toLanguageTag());
+        return true;
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -46,9 +46,12 @@ class ProductControllerIT {
         long gtin = 123L;
         given(service.getReviews(any())).willReturn(List.of(new ProductReviewDto("fr", new AiReview(), 1L)));
 
-        mockMvc.perform(get("/product/{gtin}/reviews", gtin).with(jwt()))
+        mockMvc.perform(get("/product/{gtin}/reviews", gtin)
+                .header("Accept-Language", "de")
+                .with(jwt()))
             .andExpect(status().isOk())
-            .andExpect(header().string("Cache-Control", "public, max-age=3600"));
+            .andExpect(header().string("Cache-Control", "public, max-age=3600"))
+            .andExpect(header().string("X-Locale", "de"));
     }
 
 


### PR DESCRIPTION
## Summary
- add `UserPreferenceLocaleResolver` to check cookies, JWTs and Accept-Language
- expose locale through `X-Locale` header via `XLocaleHeaderInterceptor`
- wire resolver and interceptor in new `LocaleConfig`
- register locale resolver in `WebSecurityConfig`
- update `ProductControllerIT` to assert locale header

## Testing
- `mvn -pl nudger-front-api -am test -q` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685be4673bd483339e8a746e4eef38ab