### PR TITLE
Integrate Bucket4j rate limiting

### DIFF
--- a/nudger-front-api/pom.xml
+++ b/nudger-front-api/pom.xml
@@ -71,7 +71,16 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.vladimir-bukhtoyarov</groupId>
+      <artifactId>bucket4j-core</artifactId>
+      <version>8.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.open4goods.nudgerfrontapi.ratelimit.RateLimitException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -12,6 +13,14 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleException(Exception ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         pd.setTitle("Internal Server Error");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(RateLimitException.class)
+    public ProblemDetail handleRateLimit(RateLimitException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.TOO_MANY_REQUESTS);
+        pd.setTitle("Too Many Requests");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
 import org.open4goods.nudgerfrontapi.service.ProductService;
+import org.open4goods.nudgerfrontapi.ratelimit.RateLimit;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -117,6 +118,7 @@ public class ProductController {
                     @ApiResponse(responseCode = "429", description = "Too many concurrent generations")
             }
     )
+    @RateLimit(capacity = 3, refillSeconds = 60)
     public ResponseEntity<Void> generateReview(@PathVariable @Pattern(regexp = "\\d{8,14}") String gtin,
                                                @RequestParam("hcaptchaResponse") String captcha,
                                                HttpServletRequest request) throws Exception {

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimit.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimit.java
@@ -1,0 +1,22 @@
+package org.open4goods.nudgerfrontapi.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to declare rate limited endpoints.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+    /** Maximum bucket capacity */
+    long capacity();
+
+    /** Number of tokens refilled each interval (defaults to capacity). */
+    long refillTokens() default -1;
+
+    /** Interval in seconds after which tokens are refilled. */
+    long refillSeconds();
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimitAspect.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimitAspect.java
@@ -1,0 +1,42 @@
+package org.open4goods.nudgerfrontapi.ratelimit;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Refill;
+
+/**
+ * Aspect implementing rate limiting using Bucket4j.
+ */
+@Aspect
+@Component
+public class RateLimitAspect {
+
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    @Around("@annotation(rateLimit)")
+    public Object rateLimit(ProceedingJoinPoint pjp, RateLimit rateLimit) throws Throwable {
+        String key = pjp.getSignature().toLongString();
+        Bucket bucket = buckets.computeIfAbsent(key, k -> createBucket(rateLimit));
+        if (bucket.tryConsume(1)) {
+            return pjp.proceed();
+        }
+        throw new RateLimitException("Too many requests");
+    }
+
+    private Bucket createBucket(RateLimit rl) {
+        long refillTokens = rl.refillTokens() > 0 ? rl.refillTokens() : rl.capacity();
+        Refill refill = Refill.greedy(refillTokens, Duration.ofSeconds(rl.refillSeconds()));
+        Bandwidth limit = Bandwidth.classic(rl.capacity(), refill);
+        return Bucket4j.builder().addLimit(limit).build();
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimitException.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/ratelimit/RateLimitException.java
@@ -1,0 +1,10 @@
+package org.open4goods.nudgerfrontapi.ratelimit;
+
+/**
+ * Thrown when a request exceeds configured rate limits.
+ */
+public class RateLimitException extends RuntimeException {
+    public RateLimitException(String message) {
+        super(message);
+    }
+}

--- a/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/nudger-front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -20,10 +20,12 @@ import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class ProductControllerIT {
 
     @Autowired
@@ -62,5 +64,21 @@ class ProductControllerIT {
                 .param("hcaptchaResponse", "resp")
                 .with(jwt()))
             .andExpect(status().isAccepted());
+    }
+
+    @Test
+    void postReviewIsRateLimited() throws Exception {
+        long gtin = 123L;
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/product/{gtin}/reviews", gtin)
+                    .param("hcaptchaResponse", "resp")
+                    .with(jwt()))
+                .andExpect(status().isAccepted());
+        }
+
+        mockMvc.perform(post("/product/{gtin}/reviews", gtin)
+                .param("hcaptchaResponse", "resp")
+                .with(jwt()))
+            .andExpect(status().isTooManyRequests());
     }
 }


### PR DESCRIPTION
## Summary
- add Bucket4j and AOP deps
- implement `@RateLimit` and aspect
- expose 429 handling
- limit review generation
- test rate limit behaviour

## Testing
- `mvn -s settings.xml -pl nudger-front-api -am clean install`

------
https://chatgpt.com/codex/tasks/task_e_685be4dd70488333bd414becb306979d