### PR TITLE
Fix locale config circular dependency

### DIFF
--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleBeansConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleBeansConfig.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.open4goods.nudgerfrontapi.interceptor.XLocaleHeaderInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.LocaleResolver;
+
+import org.open4goods.nudgerfrontapi.config.UserPreferenceLocaleResolver;
+
+/**
+ * Beans related to locale resolution.
+ */
+@Configuration
+public class LocaleBeansConfig {
+
+    @Bean
+    public LocaleResolver localeResolver() {
+        return new UserPreferenceLocaleResolver();
+    }
+
+    @Bean
+    public XLocaleHeaderInterceptor xLocaleHeaderInterceptor(LocaleResolver localeResolver) {
+        return new XLocaleHeaderInterceptor(localeResolver);
+    }
+}

--- a/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleConfig.java
+++ b/nudger-front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LocaleConfig.java
@@ -1,9 +1,7 @@
 package org.open4goods.nudgerfrontapi.config;
 
 import org.open4goods.nudgerfrontapi.interceptor.XLocaleHeaderInterceptor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,16 +15,6 @@ public class LocaleConfig implements WebMvcConfigurer {
 
     public LocaleConfig(XLocaleHeaderInterceptor xLocaleHeaderInterceptor) {
         this.xLocaleHeaderInterceptor = xLocaleHeaderInterceptor;
-    }
-
-    @Bean
-    public LocaleResolver localeResolver() {
-        return new UserPreferenceLocaleResolver();
-    }
-
-    @Bean
-    public XLocaleHeaderInterceptor xLocaleHeaderInterceptor(LocaleResolver localeResolver) {
-        return new XLocaleHeaderInterceptor(localeResolver);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid constructor cycle when instantiating locale beans
- register locale-related beans in a dedicated configuration

## Testing
- `mvn -pl nudger-front-api -am test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c02fc22f08333abbeb23a3518ca24