### PR TITLE
Implement HTML bloc retrieval

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -2,35 +2,23 @@ package org.open4goods.nudgerfrontapi.controller.api;
 
 import java.time.Duration;
 import java.util.Locale;
-import java.util.Set;
 
-import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
-import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
-import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
 import org.open4goods.nudgerfrontapi.dto.xwiki.XwikiContentBlocDto;
-import org.open4goods.nudgerfrontapi.service.ProductMappingService;
 import org.open4goods.xwiki.services.XWikiHtmlService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
@@ -43,23 +31,38 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class ContentsController {
 
 
-	// TODO : mutualize constant
+    // TODO : mutualize constant
     private static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
 
+    private final XWikiHtmlService xwikiHtmlService;
 
-	private XWikiHtmlService xwikiHtmlService;
+    public ContentsController(XWikiHtmlService xwikiHtmlService) {
+        this.xwikiHtmlService = xwikiHtmlService;
+    }
 
 
 
     @GetMapping("/{blocId}")
-    public ResponseEntity<XwikiContentBlocDto> contentBloc(@PathVariable @Parameter(allowEmptyValue = false,description = "", example = "", in = ParameterIn.PATH)
-                                                       String blocId,
-                                                       Locale locale){
+    @Operation(
+            summary = "Get content bloc",
+            description = "Return the HTML content of the given XWiki bloc.",
+            parameters = {
+                    @Parameter(name = "blocId", description = "XWiki page path", example = "Main.WebHome", in = ParameterIn.PATH, required = true)
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Bloc found", content = @Content(mediaType = "application/json", schema = @Schema(implementation = XwikiContentBlocDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Bloc not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<XwikiContentBlocDto> contentBloc(@PathVariable String blocId,
+                                                           Locale locale) {
 
-        XwikiContentBlocDto body = new XwikiContentBlocDto();
-        // TODO : implement this method, using xwikiHtmlservice
+        String htmlContent = xwikiHtmlService.html(blocId);
+        String editLink = xwikiHtmlService.getEditPageUrl(blocId);
+        XwikiContentBlocDto body = new XwikiContentBlocDto(blocId, htmlContent, editLink);
 
-		return ResponseEntity.ok()
+        return ResponseEntity.ok()
                 .cacheControl(ONE_HOUR_PUBLIC_CACHE)
                 .body(body);
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
@@ -1,16 +1,11 @@
 package org.open4goods.nudgerfrontapi.dto.xwiki;
 
-import org.open4goods.nudgerfrontapi.dto.AbstractDTO;
+/**
+ * DTO representing HTML content extracted from XWiki.
+ *
+ * @param blocId      identifier of the XWiki page
+ * @param htmlContent HTML representation of the bloc
+ * @param editLink    direct edit link for the page
+ */
+public record XwikiContentBlocDto(String blocId, String htmlContent, String editLink) {}
 
-// TODO : Document (javadoc, spring doc, comments, ...)
-// TODO : convert to record
-
-public class XwikiContentBlocDto extends AbstractDTO{
-
-	private String blocId;
-	private String htmlContent;
-	private String editLink;
-
-
-
-}


### PR DESCRIPTION
## Summary
- wire `XWikiHtmlService` into `ContentsController`
- fetch HTML bloc via service and return DTO
- convert `XwikiContentBlocDto` to record

## Testing
- `mvn -pl front-api -am clean install` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_685da91ba1d48333b0407471317679ba