### PR TITLE
Propagate not found exception

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.open4goods.model.exceptions.ResourceNotFoundException;
 
 @RestControllerAdvice
 /**
@@ -18,9 +19,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleException(Exception ex) {
-    	log.error("Unhandled exception", ex);
+        log.error("Unhandled exception", ex);
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         pd.setTitle("Internal Server Error");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ProblemDetail handleNotFound(ResourceNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Not Found");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
@@ -181,7 +181,7 @@ public class ProductsControllers {
                                                        Long gtin,
                                                        @RequestParam(required = false)
                                                        Set<String> include,
-                                                       Locale locale){
+                                                       Locale locale) throws ResourceNotFoundException {
 
         ProductDto body = service.getProduct(gtin, locale, include);
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -44,17 +44,12 @@ public class ProductMappingService {
      * @param includes
      * @return
      */
-    public ProductDto getProduct(long gtin, Locale local, Set<String> includes)  {
-        Product p = null;
-		try {
-			p = repository.getById(gtin);
-		} catch (ResourceNotFoundException e) {
-			// TODO Make 404 back to the controller, through standard spring method
-			e.printStackTrace();
-		}
+    public ProductDto getProduct(long gtin, Locale local, Set<String> includes)
+            throws ResourceNotFoundException {
+        Product p = repository.getById(gtin);
 
-    	ProductDto pdto = mapProduct(p,local, includes);
-    	return pdto;
+        ProductDto pdto = mapProduct(p, local, includes);
+        return pdto;
     }
 
 	private ProductDto mapProduct(  Product p, Locale local, Set<String> includes) {

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -25,6 +25,7 @@ import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.RequestMetadata;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
+import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -79,6 +80,16 @@ class ProductControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.gtin").value(gtin))
                 .andExpect(jsonPath("$.metadatas").doesNotExist());
+    }
+
+    @Test
+    void productEndpointReturns404WhenServiceThrows() throws Exception {
+        long gtin = 999L;
+        given(service.getProduct(anyLong(), any(Locale.class), anySet()))
+                .willThrow(new ResourceNotFoundException());
+
+        mockMvc.perform(get("/products/{gtin}", gtin).with(jwt()))
+                .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- propagate `ResourceNotFoundException` from `ProductMappingService#getProduct`
- update controller signature and global handler to return 404
- extend integration tests to verify 404 response

## Testing
- `mvn -q -pl front-api -am test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_685da93f3f8c833389abfdcc7892e7e0