### PR TITLE
Validate sort and include params

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
@@ -101,27 +101,23 @@ public class ProductsControllers {
 		/// Surface control
 		/////////////////////
 
-		// Validating sort field
-		page.getSort().stream().forEach(s -> {
-			if (!ProductDtoSortableFields.fromText(s.getProperty()).isPresent()) {
+                // Validating sort field
+                page.getSort().forEach(s -> {
+                        if (!ProductDtoSortableFields.fromText(s.getProperty()).isPresent()) {
+                                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid sort field");
+                        }
+                });
 
-				// TODO : HAndle this invalid value, raise approriate http code and
-				// problemdetail to the client.
-				return;
-			}
-		});
-
-		// Validating requested components
-		if (null != include) {
-			include.forEach(i -> {
-				if (null == ProductDtoComponent.valueOf(i)) {
-					// TODO : Handle this invalid value, raise approriate http code and
-					// problemdetail to the client.
-					return;
-				}
-
-			});
-		}
+                // Validating requested components
+                if (null != include) {
+                        include.forEach(i -> {
+                                try {
+                                        ProductDtoComponent.valueOf(i);
+                                } catch (IllegalArgumentException ex) {
+                                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid sort field");
+                                }
+                        });
+                }
 
 
 		////////////////////////

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -93,6 +93,22 @@ class ProductControllerIT {
                 .andExpect(jsonPath("$.page.number").value(0));
     }
 
+    @Test
+    void productsEndpointReturnsBadRequestForInvalidSort() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("sort", "bad,asc")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void productsEndpointReturnsBadRequestForInvalidInclude() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("include", "unknown")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest());
+    }
+
 
 
 


### PR DESCRIPTION
## Summary
- handle invalid `sort` parameters in `ProductsControllers`
- handle invalid `include` values in `ProductsControllers`
- add integration tests for invalid `sort` and `include` parameters

## Testing
- `mvn -pl front-api -am clean install` *(fails: dependencies missing)*
- `mvn -pl front-api -am test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685da904f4108333a7934c2bdf4c2426