### PR TITLE
Switch XwikiContentBlocDto to record

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -56,7 +56,7 @@ public class ContentsController {
                                                        String blocId,
                                                        Locale locale){
 
-        XwikiContentBlocDto body = new XwikiContentBlocDto();
+        XwikiContentBlocDto body = new XwikiContentBlocDto(blocId, null, null);
         // TODO : implement this method, using xwikiHtmlservice
 
 		return ResponseEntity.ok()

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
@@ -1,16 +1,17 @@
 package org.open4goods.nudgerfrontapi.dto.xwiki;
 
-import org.open4goods.nudgerfrontapi.dto.AbstractDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-// TODO : Document (javadoc, spring doc, comments, ...)
-// TODO : convert to record
+/**
+ * DTO exposing an XWiki content block with its edit link.
+ */
+public record XwikiContentBlocDto(
+        @Schema(description = "Identifier of the XWiki content block")
+        String blocId,
 
-public class XwikiContentBlocDto extends AbstractDTO{
+        @Schema(description = "Rendered HTML content of the block")
+        String htmlContent,
 
-	private String blocId;
-	private String htmlContent;
-	private String editLink;
-
-
-
+        @Schema(description = "URL to edit the block in XWiki")
+        String editLink) {
 }


### PR DESCRIPTION
## Summary
- refactor `XwikiContentBlocDto` to be a record with `blocId`, `htmlContent` and `editLink`
- update controller to instantiate new record

## Testing
- `mvn clean install` *(fails: Could not resolve Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685da946f39c833388822a9f2586a3d9