### PR TITLE
Enable CORS in front-api for local development

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -12,6 +12,9 @@ The application runs on **port 8082** by default (`server.port` in `application.
 
 Security is enabled by default using JWT authentication. For local testing it can be disabled by setting
 `front.security.enabled=false` in `application.yml` or via an environment variable.
+To allow the Nuxt frontend running on a different host during development, configure the list of allowed
+CORS origins using the `front.security.cors-allowed-hosts` property. By default it permits requests from
+`http://localhost:8082`.
 
 ## Building
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
@@ -2,6 +2,8 @@ package org.open4goods.nudgerfrontapi.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Configuration properties to enable or disable Spring Security for the
@@ -16,11 +18,24 @@ public class SecurityProperties {
      */
     private boolean enabled = true;
 
+    /**
+     * List of origins allowed for CORS requests.
+     */
+    private List<String> corsAllowedHosts = new ArrayList<>();
+
     public boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public List<String> getCorsAllowedHosts() {
+        return corsAllowedHosts;
+    }
+
+    public void setCorsAllowedHosts(List<String> corsAllowedHosts) {
+        this.corsAllowedHosts = corsAllowedHosts;
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -16,6 +16,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.LocaleResolver;
+import java.util.Arrays;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import org.open4goods.nudgerfrontapi.config.SecurityProperties;
 
@@ -39,6 +43,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http, LocaleResolver localeResolver) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
+            .cors(Customizer.withDefaults())
             .setSharedObject(LocaleResolver.class, localeResolver);
 
         if (securityProperties.isEnabled()) {
@@ -72,5 +77,17 @@ public class WebSecurityConfig {
         AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
         builder.userDetailsService(uds);
         return builder.build();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(securityProperties.getCorsAllowedHosts());
+        configuration.setAllowedMethods(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -18,6 +18,8 @@ springdoc:
 front:
   security:
     enabled: false
+    cors-allowed-hosts:
+      - "http://localhost:8082"
     
 xwiki:
     username: nudger


### PR DESCRIPTION
## Summary
- allow configuring allowed CORS hosts in `SecurityProperties`
- expose global CORS configuration in `WebSecurityConfig`
- document the new property in the module README
- default to allowing localhost in `application.yml`

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_685db52321bc8333a4b8883ab62c5f8a