### PR TITLE
Clarify local API usage

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -16,6 +16,20 @@ To allow the Nuxt frontend running on a different host during development, confi
 CORS origins using the `front.security.cors-allowed-hosts` property. By default it permits requests from
 `http://localhost:8082`.
 
+## Local development tips
+
+When starting the application locally you may be tempted to call the beta API
+(`https://beta.front-api.nudger.fr`). That server does not set CORS headers for
+`http://localhost:8082`, which leads the browser to reject the requests. Ensure
+your frontend uses the local API base URL instead:
+
+```bash
+export API_URL=http://localhost:8082
+```
+
+With this configuration all calls stay on the same origin and the built-in CORS
+rules apply correctly.
+
 ## Building
 
 From this directory run:

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
@@ -9,10 +9,11 @@ import io.swagger.v3.oas.annotations.servers.Server;
 
 @SpringBootApplication(scanBasePackages = "org.open4goods")
 @OpenAPIDefinition(
-		  servers = {
-		    @Server(url = "https://beta.front-api.nudger.fr", description = "Public beta HTTPS API")
-		  }
-		)
+        servers = {
+            @Server(url = "http://localhost:8082", description = "Local development API"),
+            @Server(url = "https://beta.front-api.nudger.fr", description = "Public beta HTTPS API")
+        }
+)
 @EnableCaching
 public class NudgerFrontApiApplication {
 


### PR DESCRIPTION
## Summary
- document that using the beta API causes CORS errors
- list `localhost` server in the OpenAPI definition

## Testing
- `mvn -pl front-api -am clean install -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685db87bdf148333bcce09246d9611ab