### PR TITLE
Add blog posts endpoint

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -43,6 +43,12 @@
 
     <dependency>
       <groupId>org.open4goods</groupId>
+      <artifactId>blog</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.open4goods</groupId>
       <artifactId>captcha</artifactId>
       <version>${global.version}</version>
     </dependency>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -1,6 +1,9 @@
 package org.open4goods.nudgerfrontapi.config;
 
 import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.services.blog.config.BlogConfiguration;
+import org.open4goods.services.blog.service.BlogService;
+import org.open4goods.xwiki.services.XwikiFacadeService;
 import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +28,11 @@ public class AppConfig {
     @Bean
     ProductRepository productRepository() {
         return new ProductRepository();
+    }
+
+    @Bean
+    BlogService blogService(XwikiFacadeService xwikiFacadeService) {
+        return new BlogService(xwikiFacadeService, new BlogConfiguration(), null);
     }
 
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -1,0 +1,123 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+
+import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
+import org.open4goods.services.blog.model.BlogPost;
+import org.open4goods.services.blog.service.BlogService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rometools.rome.io.FeedException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing blog posts coming from XWiki.
+ */
+@RestController
+@RequestMapping("/contents/posts")
+@Validated
+@Tag(name = "Content", description = "Expose nudger Xwiki based CMS content")
+public class PostsController {
+
+    private static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+
+    private final BlogService blogService;
+
+    public PostsController(BlogService blogService) {
+        this.blogService = blogService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "List blog posts",
+            description = "Return all blog posts optionally filtered by tag.",
+            parameters = {
+                    @Parameter(name = "tag", in = ParameterIn.QUERY, description = "Category/tag to filter on")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Posts returned",
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = BlogPostDto.class))))
+            }
+    )
+    public ResponseEntity<List<BlogPostDto>> posts(@RequestParam(name = "tag", required = false) String tag) {
+        List<BlogPostDto> body = blogService.getPosts(tag).stream()
+                .map(this::map)
+                .toList();
+        return ResponseEntity.ok()
+                .cacheControl(ONE_HOUR_PUBLIC_CACHE)
+                .body(body);
+    }
+
+    @GetMapping("/{slug}")
+    @Operation(
+            summary = "Get blog post",
+            description = "Return a single blog post identified by its slug.",
+            parameters = {
+                    @Parameter(name = "slug", in = ParameterIn.PATH, required = true, description = "Post slug")
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Post found",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = BlogPostDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Post not found")
+            }
+    )
+    public ResponseEntity<BlogPostDto> post(@PathVariable String slug) {
+        BlogPost post = blogService.getPostsByUrl().get(slug);
+        if (post == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .cacheControl(ONE_HOUR_PUBLIC_CACHE)
+                .body(map(post));
+    }
+
+    @GetMapping(value = "/rss", produces = "application/rss+xml")
+    @Operation(
+            summary = "Blog RSS feed",
+            description = "Return an RSS feed for all blog posts.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Feed returned",
+                            content = @Content(mediaType = "application/rss+xml"))
+            }
+    )
+    public ResponseEntity<String> rss(Locale locale) throws FeedException {
+        String feed = blogService.rss(locale == null ? Locale.getDefault().getLanguage() : locale.getLanguage());
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(feed);
+    }
+
+    private BlogPostDto map(BlogPost post) {
+        return new BlogPostDto(
+                post.getUrl(),
+                post.getTitle(),
+                post.getAuthor(),
+                post.getSummary(),
+                post.getBody(),
+                post.getCategory(),
+                post.getImage(),
+                post.getEditLink(),
+                post.getCreated() == null ? null : post.getCreated().getTime(),
+                post.getModified() == null ? null : post.getModified().getTime()
+        );
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/blog/BlogPostDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/blog/BlogPostDto.java
@@ -1,0 +1,31 @@
+package org.open4goods.nudgerfrontapi.dto.blog;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing blog post information for the frontend API.
+ */
+public record BlogPostDto(
+        @Schema(description = "URL slug identifying the post", example = "my-first-post")
+        String url,
+        @Schema(description = "Post title", example = "My first post")
+        String title,
+        @Schema(description = "Author full name", example = "John Doe", nullable = true)
+        String author,
+        @Schema(description = "Post summary", example = "Short introduction", nullable = true)
+        String summary,
+        @Schema(description = "HTML body", nullable = true)
+        String body,
+        @Schema(description = "Post categories", example = "[\"eco\"]", nullable = true)
+        List<String> category,
+        @Schema(description = "Cover image URL", example = "/blog/Post/image.jpg", nullable = true)
+        String image,
+        @Schema(description = "Direct edit link", example = "https://wiki/edit/Blog/Post", nullable = true)
+        String editLink,
+        @Schema(description = "Creation timestamp ms", example = "1690972800000", nullable = true)
+        Long createdMs,
+        @Schema(description = "Modification timestamp ms", example = "1690972900000", nullable = true)
+        Long modifiedMs
+) {}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -1,0 +1,70 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.controller.api.PostsController;
+import org.open4goods.services.blog.model.BlogPost;
+import org.open4goods.services.blog.service.BlogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostsControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PostsController controller;
+
+    @MockBean
+    private BlogService blogService;
+
+    @Test
+    void postsEndpointReturnsList() throws Exception {
+        BlogPost post = new BlogPost();
+        post.setTitle("Title");
+        post.setUrl("slug");
+        given(blogService.getPosts(any())).willReturn(List.of(post));
+
+        mockMvc.perform(get("/contents/posts").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("Title"));
+    }
+
+    @Test
+    void postEndpointReturns404WhenMissing() throws Exception {
+        given(blogService.getPostsByUrl()).willReturn(Map.of());
+
+        mockMvc.perform(get("/contents/posts/{slug}", "missing").with(jwt()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void postEndpointReturnsData() throws Exception {
+        BlogPost post = new BlogPost();
+        post.setTitle("Title");
+        post.setUrl("slug");
+        post.setCreated(new Date(1L));
+        given(blogService.getPostsByUrl()).willReturn(Map.of("slug", post));
+
+        mockMvc.perform(get("/contents/posts/{slug}", "slug").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.url").value("slug"))
+                .andExpect(jsonPath("$.title").value("Title"));
+    }
+}


### PR DESCRIPTION
## Summary
- add BlogService dependency to front-api
- expose `/contents/posts` REST API using BlogService
- provide `BlogPostDto` to serialise blog posts
- configure BlogService bean
- test PostsController

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dd2365c008333b781dfe2acf29400