### PR TITLE
Add blog tags endpoint

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -3,6 +3,8 @@ package org.open4goods.nudgerfrontapi.controller.api;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -10,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 
 import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
+import org.open4goods.nudgerfrontapi.dto.blog.BlogTagDto;
 import org.open4goods.services.blog.model.BlogPost;
 import org.open4goods.services.blog.service.BlogService;
 import org.springframework.http.CacheControl;
@@ -104,6 +107,26 @@ public class PostsController {
         return ResponseEntity.ok()
                 .cacheControl(ONE_HOUR_PUBLIC_CACHE)
                 .body(map(post));
+    }
+
+    @GetMapping("/blog/tags")
+    @Operation(
+            summary = "List blog tags",
+            description = "Return the list of available blog tags with post counts.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Tags returned",
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = BlogTagDto.class))))
+            }
+    )
+    public ResponseEntity<List<BlogTagDto>> tags() {
+        List<BlogTagDto> body = blogService.getTags().entrySet().stream()
+                .map(e -> new BlogTagDto(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok()
+                .cacheControl(ONE_HOUR_PUBLIC_CACHE)
+                .body(body);
     }
 
     @GetMapping(value = "/rss", produces = "application/rss+xml")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/blog/BlogTagDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/blog/BlogTagDto.java
@@ -1,0 +1,13 @@
+package org.open4goods.nudgerfrontapi.dto.blog;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO representing a blog tag and the number of posts associated with it.
+ */
+public record BlogTagDto(
+        @Schema(description = "Tag name", example = "eco")
+        String name,
+        @Schema(description = "Number of posts having this tag", example = "5", minimum = "0")
+        int count
+) {}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 import org.junit.jupiter.api.Test;
 import org.open4goods.nudgerfrontapi.controller.api.PostsController;
@@ -66,5 +67,17 @@ class PostsControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.url").value("slug"))
                 .andExpect(jsonPath("$.title").value("Title"));
+    }
+
+    @Test
+    void tagsEndpointReturnsMap() throws Exception {
+        Map<String, Integer> tags = new LinkedHashMap<>();
+        tags.put("eco", 2);
+        given(blogService.getTags()).willReturn(tags);
+
+        mockMvc.perform(get("/blog/tags").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("eco"))
+                .andExpect(jsonPath("$[0].count").value(2));
     }
 }


### PR DESCRIPTION
## Summary
- expose `BlogTagDto` to represent tag name and count
- add `/blog/tags` endpoint returning blog tags
- test tags endpoint

## Testing
- `mvn -pl front-api -am test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e9bfc9a8883339f6a00edeb05cc8c