### PR TITLE
Implement modular product facets

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiTextsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiTextsDto.java
@@ -1,0 +1,11 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * AI generated descriptions facet.
+ */
+public record ProductAiTextsDto(
+        @Schema(description = "AI description")
+        String description
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import org.open4goods.model.product.ExternalIds;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Basic product metadata facet.
+ */
+public record ProductBaseDto(
+        @Schema(description = "Product GTIN", example = "7612345678901")
+        long gtin,
+        @Schema(description = "Creation timestamp", example = "1693000000000")
+        long creationDate,
+        @Schema(description = "Last change timestamp", example = "1693590000000")
+        long lastChange,
+        @Schema(description = "Associated vertical", example = "electronics")
+        String vertical,
+        @Schema(description = "External identifiers")
+        ExternalIds externalIds,
+        @Schema(description = "Google taxonomy identifier", example = "123")
+        Integer googleTaxonomyId
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -14,9 +14,14 @@ public class ProductDto extends AbstractDTO {
 	/**
 	 * Available facets on ProductsDto
 	 */
-	public enum ProductDtoComponent {
-		aiReview, offers, images
-	}
+        public enum ProductDtoComponent {
+                base,
+                names,
+                resources,
+                aiTexts,
+                aiReview,
+                offers
+        }
 
 	/**
 	 * Allowed sort values on Products. (must exactly match elastic mapping)
@@ -54,11 +59,17 @@ public class ProductDto extends AbstractDTO {
 	@Schema(description = "Product GTIN, it is the unique identifier", example = "7612345678901")
 	long gtin;
 
-	private ProductAiReviewDto aiReview;
+        private ProductBaseDto base;
 
-	private ProductOffersDto offers;
+        private ProductNamesDto names;
 
-	private ProductImagesDto images;
+        private ProductResourcesDto resources;
+
+        private ProductAiTextsDto aiTexts;
+
+        private ProductAiReviewDto aiReview;
+
+        private ProductOffersDto offers;
 
 	public long getGtin() {
 		return gtin;
@@ -68,28 +79,52 @@ public class ProductDto extends AbstractDTO {
 		this.gtin = gtin;
 	}
 
-	public ProductAiReviewDto getAiReview() {
-		return aiReview;
-	}
+        public ProductBaseDto getBase() {
+                return base;
+        }
 
-	public void setAiReview(ProductAiReviewDto aiReview) {
-		this.aiReview = aiReview;
-	}
+        public void setBase(ProductBaseDto base) {
+                this.base = base;
+        }
 
-	public ProductOffersDto getOffers() {
-		return offers;
-	}
+        public ProductNamesDto getNames() {
+                return names;
+        }
 
-	public void setOffers(ProductOffersDto offers) {
-		this.offers = offers;
-	}
+        public void setNames(ProductNamesDto names) {
+                this.names = names;
+        }
 
-	public ProductImagesDto getImages() {
-		return images;
-	}
+        public ProductResourcesDto getResources() {
+                return resources;
+        }
 
-	public void setImages(ProductImagesDto images) {
-		this.images = images;
-	}
+        public void setResources(ProductResourcesDto resources) {
+                this.resources = resources;
+        }
+
+        public ProductAiTextsDto getAiTexts() {
+                return aiTexts;
+        }
+
+        public void setAiTexts(ProductAiTextsDto aiTexts) {
+                this.aiTexts = aiTexts;
+        }
+
+        public ProductAiReviewDto getAiReview() {
+                return aiReview;
+        }
+
+        public void setAiReview(ProductAiReviewDto aiReview) {
+                this.aiReview = aiReview;
+        }
+
+        public ProductOffersDto getOffers() {
+                return offers;
+        }
+
+        public void setOffers(ProductOffersDto offers) {
+                this.offers = offers;
+        }
 
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductImagesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductImagesDto.java
@@ -1,5 +1,0 @@
-package org.open4goods.nudgerfrontapi.dto.product;
-
-public class ProductImagesDto {
-
-}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -1,0 +1,21 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Localised textual information.
+ */
+public record ProductNamesDto(
+        @Schema(description = "H1 title")
+        String h1Title,
+        @Schema(description = "Meta description")
+        String metaDescription,
+        @Schema(description = "OpenGraph title")
+        String ogTitle,
+        @Schema(description = "OpenGraph description")
+        String ogDescription,
+        @Schema(description = "Twitter title")
+        String twitterTitle,
+        @Schema(description = "Twitter description")
+        String twitterDescription
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
@@ -1,0 +1,19 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Media resources associated with a product.
+ */
+public record ProductResourcesDto(
+        @Schema(description = "Image URLs", type = "array")
+        List<String> images,
+        @Schema(description = "Video URLs", type = "array")
+        List<String> videos,
+        @Schema(description = "PDF URLs", type = "array")
+        List<String> pdfs,
+        @Schema(description = "Cover image URL")
+        String coverPath
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -11,7 +11,10 @@ import org.open4goods.model.product.Product;
 import org.open4goods.nudgerfrontapi.dto.product.ProductAiReviewDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
-import org.open4goods.nudgerfrontapi.dto.product.ProductImagesDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductBaseDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductNamesDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductResourcesDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAiTextsDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductOffersDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -66,31 +69,66 @@ public class ProductMappingService {
 
     	if (null != includes) {
 
-    		for (String include : includes) {
-	    		ProductDtoComponent component = ProductDtoComponent.valueOf(include);
+                for (String include : includes) {
+                        ProductDtoComponent component = ProductDtoComponent.valueOf(include);
 
-	    		 switch (component) {
-					case aiReview -> pdto.setAiReview(mapAiReview(p, local));
-					case offers -> pdto.setOffers(mapOffers(p, local));
-					case images -> pdto.setImages(mapImages(p, local));
-
-					default -> throw new IllegalArgumentException("Missing component mapper for: " + include);
-	    	    }
-	    	}
+                        switch (component) {
+                                case base -> pdto.setBase(mapBase(p));
+                                case names -> pdto.setNames(mapNames(p, local));
+                                case resources -> pdto.setResources(mapResources(p));
+                                case aiTexts -> pdto.setAiTexts(mapAiTexts(p, local));
+                                case aiReview -> pdto.setAiReview(mapAiReview(p, local));
+                                case offers -> pdto.setOffers(mapOffers(p, local));
+                                default -> throw new IllegalArgumentException("Missing component mapper for: " + include);
+                        }
+                }
     	}
 		return pdto;
 	}
 
 
     private ProductOffersDto mapOffers(Product p, Locale local) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+                return null;
+        }
 
-	private ProductImagesDto mapImages(Product p, Locale local) {
-		// TODO Auto-generated method stub
-		return null;
-	}
+        private ProductBaseDto mapBase(Product p) {
+                return new ProductBaseDto(
+                                p.getId(),
+                                p.getCreationDate(),
+                                p.getLastChange(),
+                                p.getVertical(),
+                                p.getExternalIds(),
+                                p.getGoogleTaxonomyId());
+        }
+
+        private ProductNamesDto mapNames(Product p, Locale local) {
+                if (p.getNames() == null) {
+                        return null;
+                }
+                return new ProductNamesDto(
+                                p.getNames().getH1Title().i18n(local.getLanguage()),
+                                p.getNames().getMetaDescription().i18n(local.getLanguage()),
+                                p.getNames().getProductMetaOpenGraphTitle().i18n(local.getLanguage()),
+                                p.getNames().getProductMetaOpenGraphDescription().i18n(local.getLanguage()),
+                                p.getNames().getProductMetaTwitterTitle().i18n(local.getLanguage()),
+                                p.getNames().getProductMetaTwitterDescription().i18n(local.getLanguage()));
+        }
+
+        private ProductResourcesDto mapResources(Product p) {
+                return new ProductResourcesDto(
+                                p.unprocessedImagesUrl(),
+                                p.videos().stream().map(r -> r.getUrl()).toList(),
+                                p.pdfs().stream().map(r -> r.getUrl()).toList(),
+                                p.externalCover());
+        }
+
+        private ProductAiTextsDto mapAiTexts(Product p, Locale local) {
+                if (p.getGenaiTexts() == null) {
+                        return null;
+                }
+                var ai = p.getGenaiTexts().i18n(local.getLanguage());
+                return ai == null ? null : new ProductAiTextsDto(ai.description());
+        }
 
 	/**
      * AI Review component mapping

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -53,6 +53,21 @@ class ProductMappingServiceTest {
         assertThat(dto.getAiReview().review()).isEqualTo(holder.getReview());
     }
 
+    @Test
+    void getProductReturnsDtoWithBase() throws Exception {
+        long gtin = 321L;
+        Product product = new Product(gtin);
+        product.setCreationDate(1L);
+        product.setLastChange(2L);
+
+        when(repository.getById(gtin)).thenReturn(product);
+
+        ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("base"));
+
+        assertThat(dto.getBase()).isNotNull();
+        assertThat(dto.getBase().gtin()).isEqualTo(gtin);
+    }
+
 
 
     @Test


### PR DESCRIPTION
## Summary
- extend `ProductDto` with selectable facets (base info, names, resources, ai texts)
- map new facets in `ProductMappingService`
- provide DTOs for each facet
- remove obsolete `ProductImagesDto`
- cover `base` mapping with unit tests

## Testing
- `mvn -q -pl front-api -am test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5bd5ecc8333bac84173d12bfe37