### PR TITLE
Enable remote team config

### DIFF
--- a/team/team.yml
+++ b/team/team.yml
@@ -1,0 +1,51 @@
+cores:
+  - name: Goulven Furet
+    title: CEO / CTO
+    linkedInUrl: https://www.linkedin.com/in/goulven-furet-b448b582/
+    imageUrl: /assets/img/team/Goulven.jpeg
+
+  - name: Bérangère Leven
+    title: Communication et pilotage
+    linkedInUrl: https://www.linkedin.com/in/b%C3%A9rang%C3%A8re-leven/
+    imageUrl: /assets/img/team/Berangere.jpeg
+
+  - name: Thomas Vandewalle
+    title: Stratégie SEO & contenus
+    linkedInUrl: https://www.linkedin.com/in/thomas-vandewalle-fr001/
+    imageUrl: /assets/img/team/Thomas.jpeg
+
+  - name: Louis-Marie Toudoire
+    title: Développeur Backend
+    linkedInUrl: https://www.linkedin.com/in/scezen/?originalSubdomain=fr
+    imageUrl: /assets/img/team/Louis-Marie.jpeg
+
+  - name: Laurent Blondel
+    title: Développeur & intégrateur frontend
+    linkedInUrl: https://www.linkedin.com/in/laurent-blondel-33543532/
+    imageUrl: /assets/img/team/Laurent.jpeg
+
+  - name: Max Ziliani
+    title: Identité visuelle et artistique
+    linkedInUrl: https://www.linkedin.com/in/maxziliani/
+    imageUrl: /assets/img/team/Max.jpeg
+
+  - name: Candide Chérel
+    title: Gestion et conduite de projet
+    linkedInUrl: https://www.linkedin.com/in/candide-cherel/?originalSubdomain=fr
+    imageUrl: /assets/img/team/Candide.jpeg
+
+contributors:
+  - name: Thierry Ledan
+    title: Développements backend
+    linkedInUrl: https://www.linkedin.com/in/thierry-ledan-43650a183/
+    imageUrl: /assets/img/team/Thierry.jpeg
+
+  - name: Nicolas Bonamy
+    title: Dev backend & infra
+    linkedInUrl: https://www.linkedin.com/in/nicolas-bonamy-827b63a3/
+    imageUrl: /assets/img/team/Nicolas.jpeg
+
+  - name: Stephane Castrec
+    title: Developpements
+    linkedInUrl: https://www.linkedin.com/in/scastrec/
+    imageUrl: /assets/img/team/Stephane.jpeg

--- a/ui/src/main/resources/application.yml
+++ b/ui/src/main/resources/application.yml
@@ -179,59 +179,7 @@ fun-facts:
 
     
       
-team-config:
-  cores:
-  - name: Goulven Furet
-    title: CEO / CTO
-    linkedInUrl: https://www.linkedin.com/in/goulven-furet-b448b582/
-    imageUrl: /assets/img/team/Goulven.jpeg
-
-  - name: Bérangère Leven
-    title: Communication et pilotage
-    linkedInUrl: https://www.linkedin.com/in/b%C3%A9rang%C3%A8re-leven/
-    imageUrl: /assets/img/team/Berangere.jpeg
-
-  - name: Thomas Vandewalle
-    title: Stratégie SEO & contenus
-    linkedInUrl: https://www.linkedin.com/in/thomas-vandewalle-fr001/
-    imageUrl: /assets/img/team/Thomas.jpeg
-
-  - name: Louis-Marie Toudoire
-    title: Développeur Backend
-    linkedInUrl: https://www.linkedin.com/in/scezen/?originalSubdomain=fr
-    imageUrl: /assets/img/team/Louis-Marie.jpeg
-
-  - name: Laurent Blondel
-    title: Développeur & intégrateur frontend
-    linkedInUrl: https://www.linkedin.com/in/laurent-blondel-33543532/
-    imageUrl: /assets/img/team/Laurent.jpeg
-
-  - name: Max Ziliani
-    title: Identité visuelle et artistique
-    linkedInUrl: https://www.linkedin.com/in/maxziliani/
-    imageUrl: /assets/img/team/Max.jpeg
-
-  - name: Candide Chérel
-    title: Gestion et conduite de projet
-    linkedInUrl: https://www.linkedin.com/in/candide-cherel/?originalSubdomain=fr
-    imageUrl: /assets/img/team/Candide.jpeg
-        
-  contributors:
-  - name: Thierry Ledan
-    title: Développements backend
-    linkedInUrl: https://www.linkedin.com/in/thierry-ledan-43650a183/
-    imageUrl: /assets/img/team/Thierry.jpeg
-
-
-  - name: Nicolas Bonamy
-    title: Dev backend & infra
-    linkedInUrl: https://www.linkedin.com/in/nicolas-bonamy-827b63a3/
-    imageUrl: /assets/img/team/Nicolas.jpeg
-
-  - name: Stephane Castrec
-    title: Developpements
-    linkedInUrl: https://www.linkedin.com/in/scastrec/
-    imageUrl: /assets/img/team/Stephane.jpeg
+teamConfigUrl: https://raw.githubusercontent.com/open4good/open4goods/main/team/team.yml
     
 
 


### PR DESCRIPTION
## Summary
- fetch Team configuration from a YAML file hosted on GitHub
- load TeamConfig using the new `teamConfigUrl` property
- store team members YAML at `team/team.yml`

## Testing
- `mvn -pl ui -am clean install -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685eb6a404f08333b431168e743652ef