### PR TITLE
Add initial controller test

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,36 @@
+# API Module
+
+This module exposes the REST endpoints for the open4goods platform.
+
+## Build
+
+From the repository root run:
+
+```bash
+mvn -pl api -am clean install
+```
+
+Or from this directory:
+
+```bash
+mvn clean install
+```
+
+## Run
+
+After building, start the application with:
+
+```bash
+java -Dspring.profiles.active=dev -jar target/api-<version>.jar
+```
+
+The API listens on port `8081` by default.
+
+## Test
+
+Execute the test suite only for this module with:
+
+```bash
+mvn -pl api test
+```
+

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 
         <!-- The API is also a crawler, with a local access to the store -->

--- a/api/src/test/java/org/open4goods/api/controller/api/ProductControllerTest.java
+++ b/api/src/test/java/org/open4goods/api/controller/api/ProductControllerTest.java
@@ -1,0 +1,53 @@
+package org.open4goods.api.controller.api;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.product.Product;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.commons.services.ProductNameSelectionService;
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProductController.class)
+@AutoConfigureMockMvc
+class ProductControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProductRepository repository;
+    @MockBean
+    private VerticalsConfigService configService;
+    @MockBean
+    private ProductNameSelectionService nameService;
+
+    @Test
+    @WithMockUser(authorities = "ROLE_ADMIN")
+    void getBestNameReturnsValue() throws Exception {
+        Product product = new Product();
+        product.setId(42L);
+        product.setOfferNames(Set.of("Name1", "BestName"));
+
+        when(repository.getById(42L)).thenReturn(product);
+        when(nameService.selectBestNameIndustrial(anyList())).thenReturn(Optional.of("BestName"));
+
+        mockMvc.perform(get("/product/bestname").param("gtin", "42"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("BestName"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add README for the API module
- add a Spring MVC test for `ProductController`
- enable `spring-security-test` for API tests

## Testing
- `mvn -pl api test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb5c43f0833384ef8cd76ac6f33c