### PR TITLE
Refactor API search DTOs to Java records

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -48,6 +48,10 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson</groupId>
+            <artifactId>jackson-modules-java21</artifactId>
+        </dependency>
 
     <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/api/src/main/java/org/open4goods/api/model/SearchResponse.java
+++ b/api/src/main/java/org/open4goods/api/model/SearchResponse.java
@@ -1,52 +1,13 @@
 package org.open4goods.api.model;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.open4goods.model.attribute.ReferentielKey;
-import org.open4goods.model.datafragment.DataFragment;
-
-public class SearchResponse {
-
-
-	private List<SearchResult> results = new ArrayList<>();
-
-	private Long recordsTotal = 0L;
-	private Long recordsFiltered = 0L;
-
-	public void add(final DataFragment p) {
-		final SearchResult r = new SearchResult();
-		r.setBrand(p.getReferentielAttributes().get(ReferentielKey.BRAND) );
-		r.setBrandUid(p.getReferentielAttributes().get(ReferentielKey.MODEL) );
-		r.setDateIndexed(p.getLastIndexationDate());
-		r.setPrice(p.getPrice());
-		r.setUrl(getAffiliatedUrl(p));
-		results.add(r);
-	}
-
-
-
-	private String getAffiliatedUrl(final DataFragment p) {
-		return p.affiliatedUrlIfPossible();
-	}
-
-	public List<SearchResult> getResults() {
-		return results;
-	}
-	public void setResults(final List<SearchResult> results) {
-		this.results = results;
-	}
-	public Long getRecordsTotal() {
-		return recordsTotal;
-	}
-	public void setRecordsTotal(final Long recordsTotal) {
-		this.recordsTotal = recordsTotal;
-	}
-	public Long getRecordsFiltered() {
-		return recordsFiltered;
-	}
-	public void setRecordsFiltered(final Long recordsFiltered) {
-		this.recordsFiltered = recordsFiltered;
-	}
-
+/**
+ * Search response wrapper used by experimental endpoints.
+ */
+public record SearchResponse(
+        List<SearchResult> results,
+        Long recordsTotal,
+        Long recordsFiltered) {
 }
+

--- a/api/src/main/java/org/open4goods/api/model/SearchResult.java
+++ b/api/src/main/java/org/open4goods/api/model/SearchResult.java
@@ -2,44 +2,14 @@ package org.open4goods.api.model;
 
 import org.open4goods.model.price.Price;
 
-public class SearchResult {
-	private String brand;
-	private String brandUid;
-	private Long dateIndexed;
-	private Price price;
-	private String url;
-	public String getBrand() {
-		return brand;
-	}
-	public void setBrand(final String brand) {
-		this.brand = brand;
-	}
-	public String getBrandUid() {
-		return brandUid;
-	}
-	public void setBrandUid(final String brandUid) {
-		this.brandUid = brandUid;
-	}
-
-	public Long getDateIndexed() {
-		return dateIndexed;
-	}
-	public void setDateIndexed(final Long dateIndexed) {
-		this.dateIndexed = dateIndexed;
-	}
-	public Price getPrice() {
-		return price;
-	}
-	public void setPrice(final Price price) {
-		this.price = price;
-	}
-	public String getUrl() {
-		return url;
-	}
-	public void setUrl(final String url) {
-		this.url = url;
-	}
-
-
-
+/**
+ * Search result item returned by various endpoints.
+ */
+public record SearchResult(
+        String brand,
+        String brandUid,
+        Long dateIndexed,
+        Price price,
+        String url) {
 }
+


### PR DESCRIPTION
## Summary
- refactor `SearchResult` and `SearchResponse` DTOs into Java records
- include Jackson Java 21 module for record serialization

## Testing
- `mvn -pl api -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb57c96c8333ad3484db3522971d