### PR TITLE
Fix duplicate plugin in API pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -177,26 +177,11 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
                 <configuration>
                     <layers>
                         <enabled>true</enabled>
                     </layers>
                 </configuration>
-
-
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- clean up the `spring-boot-maven-plugin` configuration to avoid duplication in `api/pom.xml`

## Testing
- `mvn -pl api -am clean package` *(fails: could not resolve artifacts because repo1.maven.org was unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb545b1c833397140dd487faf85f