### PR TITLE
Refactor XWiki mapping to share ObjectMapper

### DIFF
--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/XWikiServiceConfiguration.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/XWikiServiceConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.web.client.RestTemplate;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * This Configuration class handles :
@@ -51,9 +53,14 @@ public class XWikiServiceConfiguration {
 	RestTemplateBuilder localRestTemplateBuilder;
 	
 	
-	public XWikiServiceConfiguration(XWikiServiceProperties xWikiProps) {
-		this.xWikiProperties = xWikiProps;
-	}
+        public XWikiServiceConfiguration(XWikiServiceProperties xWikiProps) {
+                this.xWikiProperties = xWikiProps;
+        }
+
+       @Bean
+       ObjectMapper xwikiObjectMapper() {
+               return new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+       }
 
 	
 
@@ -145,13 +152,14 @@ public class XWikiServiceConfiguration {
 	 * @return
 	 */
 	@Bean( "mappingService" )
-	XwikiMappingService getMappingervice( 
-			@Qualifier("restTemplateService") RestTemplateService restTemplateService
-			) {
+       XwikiMappingService getMappingervice(
+                       @Qualifier("restTemplateService") RestTemplateService restTemplateService,
+                       ObjectMapper xwikiObjectMapper
+                       ) {
 		
 		XwikiMappingService mappingService = null;
-		try {
-			mappingService = new XwikiMappingService(restTemplateService, xWikiProperties);
+               try {
+                       mappingService = new XwikiMappingService(restTemplateService, xWikiProperties, xwikiObjectMapper);
 		} catch(Exception e) {
 			  logger.error("Unable to create MappingService as bean. error message {}", e.getMessage());
 		}

--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/services/XwikiMappingService.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/services/XwikiMappingService.java
@@ -44,15 +44,17 @@ public class XwikiMappingService {
 
 	private static Logger logger = LoggerFactory.getLogger(XwikiMappingService.class);
 
-	RestTemplateService restTemplateService;
-	XWikiServiceProperties properties;
-	private UrlManagementHelper urlHelper;
+       RestTemplateService restTemplateService;
+       XWikiServiceProperties properties;
+       private UrlManagementHelper urlHelper;
+       private final ObjectMapper mapper;
 	
-	public XwikiMappingService(RestTemplateService restTemplateService, XWikiServiceProperties properties){
-		this.restTemplateService = restTemplateService;
-		this.properties = properties;
-		this.urlHelper = new UrlManagementHelper(properties);
-	}
+       public XwikiMappingService(RestTemplateService restTemplateService, XWikiServiceProperties properties, ObjectMapper mapper){
+               this.restTemplateService = restTemplateService;
+               this.properties = properties;
+               this.urlHelper = new UrlManagementHelper(properties);
+               this.mapper = mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+       }
 	
 	/**
 	 * Map 'Page' object from json response endpoint
@@ -361,9 +363,8 @@ public class XwikiMappingService {
 	private Objects deserializeObjects(ResponseEntity<String> response) {
 
 		Objects objects = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			objects = mapper.readValue(response.getBody(),new TypeReference<Objects>(){});
+                try {
+                        objects = mapper.readValue(response.getBody(),new TypeReference<Objects>(){});
 			logger.debug("Object 'Objects' mapped correctly}");
 		}
 		catch(Exception e) {
@@ -380,9 +381,8 @@ public class XwikiMappingService {
 	private Attachments deserializeAttachments(ResponseEntity<String> response) {
 
 		Attachments attachments = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			attachments = mapper.readValue(response.getBody(),new TypeReference<Attachments>(){});
+                try {
+                        attachments = mapper.readValue(response.getBody(),new TypeReference<Attachments>(){});
 			logger.debug("Object 'Attachments' mapped correctly}");
 		}
 		catch(Exception e) {
@@ -400,10 +400,8 @@ public class XwikiMappingService {
 	private Page deserializePage(ResponseEntity<String> response) {
 
 		Page page = null;
-		try {
-			// TODO(p1,perf) : Do not re instanciate
-			ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-			page = mapper.readValue(response.getBody(),new TypeReference<Page>(){});
+                try {
+                        page = mapper.readValue(response.getBody(),new TypeReference<Page>(){});
 			logger.debug("Object 'Page' mapped correctly}");
 		}
 		catch(Exception e) {
@@ -420,9 +418,8 @@ public class XwikiMappingService {
 	public SearchResults deserializeSearchResults(ResponseEntity<String> response) {
 
 		SearchResults results = null;	
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			results = mapper.readValue(response.getBody(), new TypeReference<SearchResults>() {});
+                try {
+                        results = mapper.readValue(response.getBody(), new TypeReference<SearchResults>() {});
 		} catch( Exception e ) {
 			ManageMappingExceptions(e, "SearchResults", response.getBody());
 		}
@@ -437,9 +434,8 @@ public class XwikiMappingService {
 	public SearchResult deserializeSearchResult(ResponseEntity<String> response) {
 
 		SearchResult result = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			result = mapper.readValue(response.getBody(), new TypeReference<SearchResult>() {});
+                try {
+                        result = mapper.readValue(response.getBody(), new TypeReference<SearchResult>() {});
 		} catch( Exception e ) {
 			ManageMappingExceptions(e, "SearchResult", response.getBody());
 		}
@@ -454,9 +450,8 @@ public class XwikiMappingService {
 	public Pages deserializePages(ResponseEntity<String> response) {
 
 		Pages pages = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			pages = mapper.readValue(response.getBody(),new TypeReference<Pages>(){});
+                try {
+                        pages = mapper.readValue(response.getBody(),new TypeReference<Pages>(){});
 			logger.debug("Object 'Pages' mapped correctly}");
 		}
 		catch(Exception e) {
@@ -474,9 +469,8 @@ public class XwikiMappingService {
 
 		Properties properties = null;
 		if( response != null ) {
-			try {
-				ObjectMapper mapper = new ObjectMapper();
-				properties = mapper.readValue(response.getBody(),new TypeReference<Properties>(){});
+                        try {
+                                properties = mapper.readValue(response.getBody(),new TypeReference<Properties>(){});
 				logger.debug("Object 'Map<String,String>' mapped correctly}");
 			}
 			catch(Exception e) {
@@ -494,9 +488,8 @@ public class XwikiMappingService {
 	public Xwiki deserializeXwiki(ResponseEntity<String> response) {
 
 		Xwiki xWiki = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			xWiki = mapper.readValue(response.getBody(),new TypeReference<Xwiki>(){});
+                try {
+                        xWiki = mapper.readValue(response.getBody(),new TypeReference<Xwiki>(){});
 			logger.debug("Object 'Xwiki' mapped correctly}");
 		}	
 		catch(Exception e) {
@@ -513,9 +506,8 @@ public class XwikiMappingService {
 	public Wikis deserializeWikis(ResponseEntity<String> response) {
 
 		Wikis wikis = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			wikis = mapper.readValue(response.getBody(),new TypeReference<Wikis>(){});
+                try {
+                        wikis = mapper.readValue(response.getBody(),new TypeReference<Wikis>(){});
 			logger.debug("Object 'Wikis' mapped correctly}");
 		}
 		catch(Exception e) {
@@ -532,9 +524,8 @@ public class XwikiMappingService {
 	public Wiki deserializeWiki(ResponseEntity<String> response) {
 
 		Wiki wikis = null;
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			wikis = mapper.readValue(response.getBody(),new TypeReference<Wiki>(){});
+                try {
+                        wikis = mapper.readValue(response.getBody(),new TypeReference<Wiki>(){});
 			logger.debug("Object 'Wiki' mapped correctly}");
 		}
 		catch(Exception e) {

--- a/services/xwiki-spring-boot-starter/src/test/java/org/open4goods/xwiki/services/XwikiMappingServiceTest.java
+++ b/services/xwiki-spring-boot-starter/src/test/java/org/open4goods/xwiki/services/XwikiMappingServiceTest.java
@@ -1,0 +1,79 @@
+package org.open4goods.xwiki.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.open4goods.xwiki.config.XWikiServiceProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.xwiki.rest.model.jaxb.Attachments;
+import org.xwiki.rest.model.jaxb.Link;
+import org.xwiki.rest.model.jaxb.Objects;
+import org.xwiki.rest.model.jaxb.Page;
+
+class XwikiMappingServiceTest {
+
+    @Mock
+    private RestTemplateService restTemplateService;
+
+    private XwikiMappingService mappingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        XWikiServiceProperties props = new XWikiServiceProperties();
+        props.setBaseUrl("http://localhost");
+        props.setUsername("user");
+        props.setPassword("pass");
+        props.setHttpsOnly(false);
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mappingService = new XwikiMappingService(restTemplateService, props, mapper);
+    }
+
+    @Test
+    void mapPageDeserializesCorrectly() {
+        String json = "{\"name\":\"WebHome\",\"fullName\":\"Main.WebHome\",\"wiki\":\"xwiki\",\"space\":\"Main\"}";
+        ResponseEntity<String> resp = new ResponseEntity<>(json, HttpStatus.OK);
+        when(restTemplateService.getRestResponse(anyString())).thenReturn(resp);
+
+        Page page = mappingService.mapPage("dummy");
+
+        assertThat(page.getName()).isEqualTo("WebHome");
+        assertThat(page.getWiki()).isEqualTo("xwiki");
+    }
+
+    @Test
+    void getObjectsDeserializesCorrectly() {
+        String json = "{\"objectSummaries\":[{\"className\":\"XWiki.MyClass\",\"number\":0}]}";
+        ResponseEntity<String> resp = new ResponseEntity<>(json, HttpStatus.OK);
+        when(restTemplateService.getRestResponse(anyString())).thenReturn(resp);
+
+        Objects objects = mappingService.getObjects("dummy");
+
+        assertThat(objects.getObjectSummaries()).hasSize(1);
+        assertThat(objects.getObjectSummaries().get(0).getClassName()).isEqualTo("XWiki.MyClass");
+    }
+
+    @Test
+    void getAttachmentsDeserializesCorrectly() {
+        String json = "{\"attachments\":[{\"id\":\"A1\",\"name\":\"file.txt\"}]}";
+        ResponseEntity<String> resp = new ResponseEntity<>(json, HttpStatus.OK);
+        when(restTemplateService.getRestResponse(anyString())).thenReturn(resp);
+
+        Page page = new Page().withLinks(new Link().withHref("http://example.com/page").withRel("self"));
+
+        Attachments attachments = mappingService.getAttachments(page);
+
+        assertThat(attachments.getAttachments()).hasSize(1);
+        assertThat(attachments.getAttachments().get(0).getName()).isEqualTo("file.txt");
+    }
+}


### PR DESCRIPTION
## Summary
- centralize an `ObjectMapper` bean in `XWikiServiceConfiguration`
- inject this mapper into `XwikiMappingService`
- use the shared mapper for all deserialisation
- cover page, object and attachment mapping with tests

## Testing
- `mvn -pl services/xwiki-spring-boot-starter -am clean install` *(fails: Non-resolvable import POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb325f14833393e78245f0def9ed