### PR TITLE
Make front cache path configurable

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -6,6 +6,8 @@ import org.open4goods.services.blog.service.BlogService;
 import org.open4goods.xwiki.services.XwikiFacadeService;
 import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+
+import org.open4goods.nudgerfrontapi.config.CacheProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
@@ -20,8 +22,9 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 public class AppConfig {
 
     @Bean
-    RemoteFileCachingService remoteFileCachingService(RemoteFileCachingProperties props) {
-        return new RemoteFileCachingService("./cache", props);
+    RemoteFileCachingService remoteFileCachingService(CacheProperties cacheProperties,
+                                                     RemoteFileCachingProperties props) {
+        return new RemoteFileCachingService(cacheProperties.getPath(), props);
     }
 
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheProperties.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for front cache settings.
+ */
+@Component
+@ConfigurationProperties(prefix = "front.cache")
+public class CacheProperties {
+
+    /** Path used to store cached files. */
+    private String path = "./cache";
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,9 +1,16 @@
 {
-  "groups": [{
-    "name": "front.security",
-    "type": "org.open4goods.nudgerfrontapi.config.SecurityProperties",
-    "sourceType": "org.open4goods.nudgerfrontapi.config.SecurityProperties"
-  }],
+  "groups": [
+    {
+      "name": "front.security",
+      "type": "org.open4goods.nudgerfrontapi.config.SecurityProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.SecurityProperties"
+    },
+    {
+      "name": "front.cache",
+      "type": "org.open4goods.nudgerfrontapi.config.CacheProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.CacheProperties"
+    }
+  ],
   "properties": [
     {
       "name": "front.security.enabled",
@@ -15,6 +22,12 @@
       "name": "front.security.cors-allowed-hosts",
       "type": "java.lang.String",
       "description": "A description for 'front.security.cors-allowed-hosts'"
+    },
+    {
+      "name": "front.cache.path",
+      "type": "java.lang.String",
+      "description": "Path used to store cached files.",
+      "defaultValue": "./cache"
     }
   ]
 }

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -16,9 +16,11 @@ springdoc:
     use-root-path: true
 
 front:
+  cache:
+    path: ./cache
   security:
     enabled: false
-    cors-allowed-hosts: 
+    cors-allowed-hosts:
       "http://localhost:8082"
     
 xwiki:

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplicationTests.java
@@ -3,7 +3,7 @@ package org.open4goods.nudgerfrontapi;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "front.cache.path=${java.io.tmpdir}")
 class NudgerFrontApiApplicationTests {
 
     @Test

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = "front.cache.path=${java.io.tmpdir}")
 @AutoConfigureMockMvc
 class PostsControllerIT {
 

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -33,7 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = "front.cache.path=${java.io.tmpdir}")
 @AutoConfigureMockMvc
 class ProductControllerIT {
 

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = "front.cache.path=${java.io.tmpdir}")
 @AutoConfigureMockMvc
 class OpenApiDocsIT {
 


### PR DESCRIPTION
## Summary
- add `CacheProperties` for `front.cache.path`
- inject cache path into `RemoteFileCachingService`
- document new property in `additional-spring-configuration-metadata.json`
- set default value in `application.yml`
- use temporary cache path for test contexts

## Testing
- `mvn -q -DskipTests install` *(fails: Could not download Spring dependencies)*
- `mvn -q test` *(fails: Could not download Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb13f5d883338bebdbfc0047e583