### PR TITLE
Add Javadoc and rename product controller

### DIFF
--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -5,6 +5,7 @@ Provide a **clear and fully documented REST API** for the Nuxt 3 frontend, using
 The OpenAPI contract is generated directly from the annotated controllers and DTOs.
 
 ---
+Main product endpoints are implemented by `ProductController`.
 
 ## 2. Architecture (hexagonal + cache)
 ~~~text
@@ -48,6 +49,14 @@ mvn test
 # From the repo root
 mvn -pl nudger-front-api -am clean install
 ~~~
+
+### Configuration properties
+
+The module exposes configurable security settings via
+`front.security.*` mapped by `SecurityProperties`:
+
+- `front.security.enabled` – toggle Spring Security.
+- `front.security.cors-allowed-hosts` – list of allowed CORS origins.
 
 ---
 

--- a/front-api/README.md
+++ b/front-api/README.md
@@ -2,6 +2,7 @@
 
 This module provides the REST endpoints used by the Nuxt 3 frontend. It exposes data aggregated by other open4goods modules and is secured with JWT tokens.
 The former `/api/v1/search` endpoint was removed from this module.
+The main REST endpoints are provided by the `ProductController` class.
 Use the main `api` service for search operations.
 
 ## Default Port

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
@@ -15,6 +15,9 @@ import io.swagger.v3.oas.annotations.servers.Server;
         }
 )
 @EnableCaching
+/**
+ * Spring Boot application entry point for the frontend API.
+ */
 public class NudgerFrontApiApplication {
 
     public static void main(String[] args) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -17,6 +17,9 @@ import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
 @Configuration
+/**
+ * Beans providing core infrastructure services for the frontend API.
+ */
 public class AppConfig {
 
     @Bean

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
@@ -5,6 +5,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+/**
+ * SpringDoc configuration exposing only the frontend endpoints.
+ */
 public class OpenApiConfig {
 
     @Bean

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
@@ -8,6 +8,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 
 @Configuration
+/**
+ * Customises Spring MVC pageable parameter names for the API.
+ */
 public class PageableConfig implements WebMvcConfigurer {
 
     @Override

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -45,14 +45,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequestMapping("/products")
 @Validated
 @Tag(name = "Product", description = "Read product data, offers, impact score and reviews; trigger AI review generation.")
-public class ProductsControllers {
+public class ProductController {
 
 	// TODO : mutualize constant
     private static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
 
     private final ProductMappingService service;
 
-    public ProductsControllers(ProductMappingService service) {
+    public ProductController(ProductMappingService service) {
         this.service = service;
     }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -29,6 +29,11 @@ import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * Maps {@link Product} domain entities to DTOs consumed by the frontend API.
+ * Handles localisation and filtering of the returned fields.
+ */
+
 @Service
 public class ProductMappingService {
 

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -20,7 +20,7 @@ import org.springframework.data.domain.Pageable;
 
 import org.junit.jupiter.api.Test;
 import org.open4goods.model.ai.AiReview;
-import org.open4goods.nudgerfrontapi.controller.api.ProductsControllers;
+import org.open4goods.nudgerfrontapi.controller.api.ProductController;
 import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.RequestMetadata;
@@ -41,7 +41,7 @@ class ProductControllerIT {
     private MockMvc mockMvc;
 
     @Autowired
-    private ProductsControllers controller;
+    private ProductController controller;
 
     @MockBean
     private ProductMappingService service;


### PR DESCRIPTION
## Summary
- document public classes like `ProductMappingService` and config beans
- rename `ProductsControllers` to `ProductController`
- mention new class and configuration properties in docs

## Testing
- `mvn -q -pl front-api -am test` *(fails: Non-resolvable import POM)*
- `mvn -q -DskipTests install` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb11aed8833383da7ad85a8253c2