### PR TITLE
Refactor ProductDto as record

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -51,3 +51,10 @@ Execute the tests with:
 ```bash
 mvn test
 ```
+
+## Migration notes
+
+DTO classes such as `ProductDto` are now implemented using Java records. This
+means all fields are immutable and accessed via record accessors
+(e.g. `dto.base()`). Ensure any custom code or tests no longer rely on
+setters.

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -5,11 +5,27 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.open4goods.nudgerfrontapi.dto.AbstractDTO;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public class ProductDto extends AbstractDTO {
+/**
+ * DTO representing a product view returned by the API.
+ */
+public record ProductDto(
+        @Schema(description = "Product GTIN, it is the unique identifier", example = "7612345678901")
+        long gtin,
+        @Schema(description = "Basic product metadata")
+        ProductBaseDto base,
+        @Schema(description = "Localised textual information")
+        ProductNamesDto names,
+        @Schema(description = "Associated media resources")
+        ProductResourcesDto resources,
+        @Schema(description = "AI generated texts")
+        ProductAiTextsDto aiTexts,
+        @Schema(description = "AI-generated review")
+        ProductAiReviewDto aiReview,
+        @Schema(description = "Product offers")
+        ProductOffersDto offers
+) {
 
 	/**
 	 * Available facets on ProductsDto
@@ -25,9 +41,9 @@ public class ProductDto extends AbstractDTO {
 	/**
 	 * Allowed sort values on Products. (must exactly match elastic mapping)
 	 */
-	public enum ProductDtoSortableFields {
-		price("price.minPrice.price"),
-		offersCount("offersCount");
+        public enum ProductDtoSortableFields {
+                price("price.minPrice.price"),
+                offersCount("offersCount");
 
 		private final String text;
 
@@ -49,81 +65,9 @@ public class ProductDto extends AbstractDTO {
 		 */
 		private static final Map<String, ProductDtoSortableFields> LOOKUP = Arrays.stream(values()).collect(Collectors.toMap(ProductDtoSortableFields::getText, e -> e));
 
-		public static Optional<ProductDtoSortableFields> fromText(String text) {
-			return Optional.ofNullable(LOOKUP.get(text));
-		}
+                public static Optional<ProductDtoSortableFields> fromText(String text) {
+                        return Optional.ofNullable(LOOKUP.get(text));
+                }
 
-	}
-
-	@Schema(description = "Product GTIN, it is the unique identifier", example = "7612345678901")
-	long gtin;
-
-        private ProductBaseDto base;
-
-        private ProductNamesDto names;
-
-        private ProductResourcesDto resources;
-
-        private ProductAiTextsDto aiTexts;
-
-        private ProductAiReviewDto aiReview;
-
-        private ProductOffersDto offers;
-
-	public long getGtin() {
-		return gtin;
-	}
-
-	public void setGtin(long gtin) {
-		this.gtin = gtin;
-	}
-
-        public ProductBaseDto getBase() {
-                return base;
         }
-
-        public void setBase(ProductBaseDto base) {
-                this.base = base;
-        }
-
-        public ProductNamesDto getNames() {
-                return names;
-        }
-
-        public void setNames(ProductNamesDto names) {
-                this.names = names;
-        }
-
-        public ProductResourcesDto getResources() {
-                return resources;
-        }
-
-        public void setResources(ProductResourcesDto resources) {
-                this.resources = resources;
-        }
-
-        public ProductAiTextsDto getAiTexts() {
-                return aiTexts;
-        }
-
-        public void setAiTexts(ProductAiTextsDto aiTexts) {
-                this.aiTexts = aiTexts;
-        }
-
-        public ProductAiReviewDto getAiReview() {
-                return aiReview;
-        }
-
-        public void setAiReview(ProductAiReviewDto aiReview) {
-                this.aiReview = aiReview;
-        }
-
-        public ProductOffersDto getOffers() {
-                return offers;
-        }
-
-        public void setOffers(ProductOffersDto offers) {
-                this.offers = offers;
-        }
-
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -56,34 +56,37 @@ public class ProductMappingService {
     }
 
 	private ProductDto mapProduct(  Product p, Locale local, Set<String> includes) {
-		ProductDto pdto = new ProductDto();
+        ProductBaseDto base = null;
+        ProductNamesDto names = null;
+        ProductResourcesDto resources = null;
+        ProductAiTextsDto aiTexts = null;
+        ProductAiReviewDto aiReview = null;
+        ProductOffersDto offers = null;
 
-    	/////////////////////////////////////////////
-    	// Handling global / high level attributes
-    	/////////////////////////////////////////////
-    	pdto.setGtin(p.getId());
-
-    	/////////////////////////////////////////////
-    	// Handling requested components
-    	/////////////////////////////////////////////
-
-    	if (null != includes) {
-
+        if (null != includes) {
                 for (String include : includes) {
                         ProductDtoComponent component = ProductDtoComponent.valueOf(include);
 
                         switch (component) {
-                                case base -> pdto.setBase(mapBase(p));
-                                case names -> pdto.setNames(mapNames(p, local));
-                                case resources -> pdto.setResources(mapResources(p));
-                                case aiReview -> pdto.setAiReview(mapAiReview(p, local));
-                                case offers -> pdto.setOffers(mapOffers(p, local));
+                                case base -> base = mapBase(p);
+                                case names -> names = mapNames(p, local);
+                                case resources -> resources = mapResources(p);
+                                case aiReview -> aiReview = mapAiReview(p, local);
+                                case offers -> offers = mapOffers(p, local);
                                 default -> throw new IllegalArgumentException("Missing component mapper for: " + include);
                         }
                 }
-    	}
-		return pdto;
-	}
+        }
+
+        return new ProductDto(
+                p.getId(),
+                base,
+                names,
+                resources,
+                aiTexts,
+                aiReview,
+                offers);
+        }
 
 
     private ProductOffersDto mapOffers(Product p, Locale local) {

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -72,7 +72,7 @@ class ProductControllerIT {
     @Test
     void includeParameterFiltersFields() throws Exception {
         long gtin = 321L;
-        given(service.getProduct(anyLong(), Locale.ENGLISH, anySet())).willReturn(new ProductDto());
+        given(service.getProduct(anyLong(), Locale.ENGLISH, anySet())).willReturn(new ProductDto(0L, null, null, null, null, null, null));
 
         mockMvc.perform(get("/products/{gtin}", gtin)
                         .param("include", "gtin")
@@ -94,7 +94,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointReturnsPage() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto()), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet())).willReturn(page);
 
         mockMvc.perform(get("/products")

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -49,8 +49,8 @@ class ProductMappingServiceTest {
 
         ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("aiReview"));
 
-        assertThat(dto.getAiReview()).isNotNull();
-        assertThat(dto.getAiReview().review()).isEqualTo(holder.getReview());
+        assertThat(dto.aiReview()).isNotNull();
+        assertThat(dto.aiReview().review()).isEqualTo(holder.getReview());
     }
 
     @Test
@@ -64,8 +64,8 @@ class ProductMappingServiceTest {
 
         ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("base"));
 
-        assertThat(dto.getBase()).isNotNull();
-        assertThat(dto.getBase().gtin()).isEqualTo(gtin);
+        assertThat(dto.base()).isNotNull();
+        assertThat(dto.base().gtin()).isEqualTo(gtin);
     }
 
 


### PR DESCRIPTION
## Summary
- refactor `ProductDto` into a Java record with `@Schema` for each field
- adapt `ProductMappingService` to build record instances
- update controller and service tests for record accessors
- document DTO immutability in the front-api README

## Testing
- `mvn -pl front-api -am clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb0e77c48333b5ec0df15464b8f0