### PR TITLE
Add parameter validation for ProductsController

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.model.exceptions.InvalidParameterException;
 
 @RestControllerAdvice
 /**
@@ -30,6 +31,14 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleNotFound(ResourceNotFoundException ex) {
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
         pd.setTitle("Not Found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler(InvalidParameterException.class)
+    public ProblemDetail handleInvalidParameter(InvalidParameterException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        pd.setTitle("Bad Request");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.model.exceptions.InvalidParameterException;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
@@ -93,9 +94,9 @@ public class ProductsControllers {
             }
     )
     public ResponseEntity<Page<ProductDto>> products(
-    		@Parameter(hidden = true) @PageableDefault(size = 20) Pageable page,
-    		@RequestParam(required=false) Set<String> include,
-    		  Locale locale) {
+                @Parameter(hidden = true) @PageableDefault(size = 20) Pageable page,
+                @RequestParam(required=false) Set<String> include,
+                  Locale locale) throws InvalidParameterException {
 
 
 		/////////////////////
@@ -103,26 +104,22 @@ public class ProductsControllers {
 		/////////////////////
 
 		// Validating sort field
-		page.getSort().stream().forEach(s -> {
-			if (!ProductDtoSortableFields.fromText(s.getProperty()).isPresent()) {
-
-				// TODO : HAndle this invalid value, raise approriate http code and
-				// problemdetail to the client.
-				return;
-			}
-		});
+                for (var order : page.getSort()) {
+                        if (ProductDtoSortableFields.fromText(order.getProperty()).isEmpty()) {
+                                throw new InvalidParameterException("Invalid sort parameter: " + order.getProperty());
+                        }
+                }
 
 		// Validating requested components
-		if (null != include) {
-			include.forEach(i -> {
-				if (null == ProductDtoComponent.valueOf(i)) {
-					// TODO : Handle this invalid value, raise approriate http code and
-					// problemdetail to the client.
-					return;
-				}
-
-			});
-		}
+                if (include != null) {
+                        for (String i : include) {
+                                try {
+                                        ProductDtoComponent.valueOf(i);
+                                } catch (IllegalArgumentException ex) {
+                                        throw new InvalidParameterException("Invalid include parameter: " + i);
+                                }
+                        }
+                }
 
 
 		////////////////////////

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -104,6 +104,24 @@ class ProductControllerIT {
                 .andExpect(jsonPath("$.page.number").value(0));
     }
 
+    @Test
+    void productsEndpointReturns400ForInvalidSort() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("sort", "unknown,asc")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Bad Request"));
+    }
+
+    @Test
+    void productsEndpointReturns400ForInvalidInclude() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("include", "bad")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Bad Request"));
+    }
+
 
 
 


### PR DESCRIPTION
## Summary
- validate `sort` and `include` parameters in `ProductsControllers`
- handle `InvalidParameterException` in `GlobalExceptionHandler`
- test bad request cases for invalid parameters

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not transfer artifact)*
- `mvn -pl front-api -am test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_685eeaf848288333a97b558b6ccf2c70