### PR TITLE
Introduce pagination properties and cache bean

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheConfig.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+
+/**
+ * Cache related beans reused across controllers.
+ */
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheControl oneHourPublicCache() {
+        return CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+    }
+}
+

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
@@ -7,8 +7,18 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 
+/**
+ * Web MVC configuration for pageable parameters.
+ */
+
 @Configuration
 public class PageableConfig implements WebMvcConfigurer {
+
+    private final PaginationProperties paginationProperties;
+
+    public PageableConfig(PaginationProperties paginationProperties) {
+        this.paginationProperties = paginationProperties;
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -17,8 +27,7 @@ public class PageableConfig implements WebMvcConfigurer {
         pageableResolver.setPageParameterName("page[number]");
         pageableResolver.setSizeParameterName("page[size]");
 
-        // TODO : Document, from conf
-        pageableResolver.setMaxPageSize(50);
+        pageableResolver.setMaxPageSize(paginationProperties.getMaxPageSize());
 
         resolvers.add(pageableResolver);
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PaginationProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PaginationProperties.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for pagination settings.
+ */
+@Component
+@ConfigurationProperties(prefix = "front.pagination")
+public class PaginationProperties {
+
+    /**
+     * Maximum allowed page size for pageable endpoints.
+     */
+    private int maxPageSize = 50;
+
+    public int getMaxPageSize() {
+        return maxPageSize;
+    }
+
+    public void setMaxPageSize(int maxPageSize) {
+        this.maxPageSize = maxPageSize;
+    }
+}
+

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -1,6 +1,5 @@
 package org.open4goods.nudgerfrontapi.controller.api;
 
-import java.time.Duration;
 import java.util.Locale;
 
 import org.open4goods.nudgerfrontapi.dto.xwiki.XwikiContentBlocDto;
@@ -31,13 +30,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class ContentsController {
 
 
-    // TODO : mutualize constant
-    private static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+    private final CacheControl oneHourPublicCache;
 
     private final XWikiHtmlService xwikiHtmlService;
 
-    public ContentsController(XWikiHtmlService xwikiHtmlService) {
+    public ContentsController(XWikiHtmlService xwikiHtmlService,
+                              CacheControl oneHourPublicCache) {
         this.xwikiHtmlService = xwikiHtmlService;
+        this.oneHourPublicCache = oneHourPublicCache;
     }
 
 
@@ -63,7 +63,7 @@ public class ContentsController {
         XwikiContentBlocDto body = new XwikiContentBlocDto(blocId, htmlContent, editLink);
 
         return ResponseEntity.ok()
-                .cacheControl(ONE_HOUR_PUBLIC_CACHE)
+                .cacheControl(oneHourPublicCache)
                 .body(body);
     }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductsControllers.java
@@ -1,6 +1,5 @@
 package org.open4goods.nudgerfrontapi.controller.api;
 
-import java.time.Duration;
 import java.util.Locale;
 import java.util.Set;
 
@@ -47,13 +46,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Product", description = "Read product data, offers, impact score and reviews; trigger AI review generation.")
 public class ProductsControllers {
 
-	// TODO : mutualize constant
-    private static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+    private final CacheControl oneHourPublicCache;
 
     private final ProductMappingService service;
 
-    public ProductsControllers(ProductMappingService service) {
+    public ProductsControllers(ProductMappingService service,
+                               CacheControl oneHourPublicCache) {
         this.service = service;
+        this.oneHourPublicCache = oneHourPublicCache;
     }
 
 
@@ -133,7 +133,7 @@ public class ProductsControllers {
 
 
 
-		return ResponseEntity.ok().cacheControl(ONE_HOUR_PUBLIC_CACHE).body(body);
+                return ResponseEntity.ok().cacheControl(oneHourPublicCache).body(body);
 	}
 
     /**
@@ -189,7 +189,7 @@ public class ProductsControllers {
 
 
         return ResponseEntity.ok()
-                .cacheControl(ONE_HOUR_PUBLIC_CACHE)
+                .cacheControl(oneHourPublicCache)
                 .body(body);
     }
 //

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -3,6 +3,10 @@
     "name": "front.security",
     "type": "org.open4goods.nudgerfrontapi.config.SecurityProperties",
     "sourceType": "org.open4goods.nudgerfrontapi.config.SecurityProperties"
+  }, {
+    "name": "front.pagination",
+    "type": "org.open4goods.nudgerfrontapi.config.PaginationProperties",
+    "sourceType": "org.open4goods.nudgerfrontapi.config.PaginationProperties"
   }],
   "properties": [
     {
@@ -15,6 +19,12 @@
       "name": "front.security.cors-allowed-hosts",
       "type": "java.lang.String",
       "description": "A description for 'front.security.cors-allowed-hosts'"
+    },
+    {
+      "name": "front.pagination.max-page-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum allowed page size for pageable endpoints.",
+      "defaultValue": 50
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `PaginationProperties` with configurable max page size
- wire `PageableConfig` to use the new property
- document `front.pagination.max-page-size` metadata
- share cache settings via new `CacheConfig`
- inject `CacheControl` bean in controllers

## Testing
- `mvn -pl front-api -am test -q` *(fails: Could not transfer artifact spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685eeaee16dc83338cdf5fd1b248085f