### PR TITLE
Refactor blog service post loading

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -100,7 +100,7 @@ public class PostsController {
             }
     )
     public ResponseEntity<BlogPostDto> post(@PathVariable String slug) {
-        BlogPost post = blogService.getPostsByUrl().get(slug);
+        BlogPost post = blogService.getPost(slug);
         if (post == null) {
             return ResponseEntity.notFound().build();
         }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -49,7 +49,7 @@ class PostsControllerIT {
 
     @Test
     void postEndpointReturns404WhenMissing() throws Exception {
-        given(blogService.getPostsByUrl()).willReturn(Map.of());
+        given(blogService.getPost("missing")).willReturn(null);
 
         mockMvc.perform(get("/contents/posts/{slug}", "missing").with(jwt()))
                 .andExpect(status().isNotFound());
@@ -61,7 +61,7 @@ class PostsControllerIT {
         post.setTitle("Title");
         post.setUrl("slug");
         post.setCreated(new Date(1L));
-        given(blogService.getPostsByUrl()).willReturn(Map.of("slug", post));
+        given(blogService.getPost("slug")).willReturn(post);
 
         mockMvc.perform(get("/contents/posts/{slug}", "slug").with(jwt()))
                 .andExpect(status().isOk())

--- a/services/blog/src/main/java/org/open4goods/services/blog/service/BlogService.java
+++ b/services/blog/src/main/java/org/open4goods/services/blog/service/BlogService.java
@@ -19,10 +19,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.open4goods.services.blog.config.BlogConfiguration;
 import org.open4goods.model.Localisable;
-import org.open4goods.model.helper.IdHelper;
 import org.open4goods.services.blog.model.BlogPost;
 import org.open4goods.xwiki.model.FullPage;
 import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.open4goods.xwiki.XWikiServiceConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.Health;
@@ -69,10 +69,9 @@ public class BlogService implements HealthIndicator {
     private final XwikiFacadeService xwikiFacadeService;
     private final Localisable<String, String> baseUrl;
 
-    // Volatile fields to ensure visibility in concurrent access.
-    private volatile List<BlogPost> posts = Collections.emptyList();
-    private volatile Map<String, BlogPost> postsByUrl = Collections.emptyMap();
-    private volatile Map<String, Integer> tags = Collections.emptyMap();
+    // Index of posts keyed by slug -> title. Only slugs are kept to avoid
+    // fetching full pages during the scheduled refresh.
+    private volatile Map<String, String> postIndex = Collections.emptyMap();
 
     // Date formatter for blog publish dates (thread-safe)
     private final DateTimeFormatter blogDateFormatter = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss zzz yyyy", Locale.ENGLISH);
@@ -108,7 +107,7 @@ public class BlogService implements HealthIndicator {
     @Scheduled(initialDelay = 0, fixedDelay = 1000 * 3600 * 2)
     public void refreshPosts() {
         try {
-            updateBlogPosts();
+            updatePostIndex();
         } catch (Exception e) {
             logger.error("Critical error during refreshing posts: {}", e.getMessage(), e);
             // Rethrow to fail fast in a critical situation
@@ -123,197 +122,148 @@ public class BlogService implements HealthIndicator {
      * @return a list of blog posts that contain the specified tag in their category list
      */
     public List<BlogPost> getPosts(String tag) {
-        if (StringUtils.isEmpty(tag)) {
-            return posts; // return all posts if no tag provided
-        }
-        return posts.stream()
-                .filter(post -> post.getCategory() != null && post.getCategory().contains(tag))
-                .collect(Collectors.toList());
+        return postIndex.keySet().stream()
+                .map(this::getPost)
+                .filter(post -> post != null && (StringUtils.isEmpty(tag)
+                        || (post.getCategory() != null && post.getCategory().contains(tag))))
+                .toList();
     }
 
     /**
-     * Updates the blog posts by fetching data from XWiki.
-     * <p>
-     * For thread safety, new collections are built locally and then the internal references
-     * are replaced atomically with unmodifiable collections.
-     * </p>
+     * Retrieve a single blog post using its slug.
+     *
+     * @param slug the XWiki page name
+     * @return the BlogPost or {@code null} if retrieval fails
      */
-    public void updateBlogPosts() {
-        // Prevent concurrent updates
+    @org.springframework.cache.annotation.Cacheable(cacheNames = XWikiServiceConfiguration.ONE_HOUR_LOCAL_CACHE_NAME,
+            key = "'blog:' + #slug")
+    public BlogPost getPost(String slug) {
+        try {
+            FullPage fullPage = xwikiFacadeService.getFullPage("Blog", slug);
+            if (fullPage == null) {
+                return null;
+            }
+
+            // Evict the default blog page with title "Blog"
+            if ("Blog".equals(fullPage.getProperties().get("title"))) {
+                return null;
+            }
+
+            // Skip hidden pages
+            if (fullPage.getWikiPage().isHidden()) {
+                return null;
+            }
+
+            BlogPost post = new BlogPost();
+            post.setWikiPage(fullPage);
+
+            String image = fullPage.getProperties().get("image");
+            if (StringUtils.isNotEmpty(image)) {
+                String fullImage = getBlogImageUrl(
+                        URLEncoder.encode(slug, StandardCharsets.UTF_8),
+                        URLEncoder.encode(image, StandardCharsets.UTF_8));
+                post.setImage(fullImage);
+            }
+
+            String author = fullPage.getWikiPage().getAuthor();
+            if (author != null && author.length() > 6) {
+                post.setAuthor(WordUtils.capitalizeFully(author.substring(6)));
+            } else {
+                post.setAuthor(author);
+            }
+
+            String extract = fullPage.getProperties().get("extract");
+            post.setSummary(extract);
+
+            String category = fullPage.getProperties().get("category");
+            if (category != null) {
+                List<String> categories = Arrays.stream(category.replace("Blog.", "").split("\\|")).filter(StringUtils::isNotEmpty).toList();
+                post.setCategory(categories);
+            } else {
+                post.setCategory(Collections.emptyList());
+            }
+
+            String publishDate = fullPage.getProperties().get("publishDate");
+            if (publishDate != null) {
+                ZonedDateTime zonedDateTime = ZonedDateTime.parse(publishDate, blogDateFormatter);
+                post.setCreated(new Date(zonedDateTime.toInstant().toEpochMilli()));
+            }
+
+            if (fullPage.getWikiPage().getModified() != null) {
+                post.setModified(new Date(fullPage.getWikiPage().getModified().getTimeInMillis()));
+            }
+
+            String title = fullPage.getProperties().get("title");
+            post.setTitle(title);
+            post.setUrl(slug);
+
+            String[] pageIdParts = fullPage.getWikiPage().getId().replace("xwiki:", "").split("\\.");
+            post.setEditLink(xwikiFacadeService.getPathHelper().getEditpath(pageIdParts));
+
+            String html = fullPage.getHtmlContent();
+            int startPos = html.indexOf(XWIKI_BLOGPOST_START_MARKUP);
+            if (startPos != -1) {
+                html = html.substring(startPos);
+            }
+            int stopPos = html.indexOf(XWIKI_BLOGPOST_STOP_MARKUP);
+            if (stopPos != -1) {
+                html = html.substring(0, stopPos);
+            }
+            html = Jsoup.clean(html, Safelist.basicWithImages());
+            String basePath = '/' + config.getBlogUrl();
+            if (basePath.endsWith("/")) {
+                basePath = basePath.substring(0, basePath.length() - 1);
+            }
+            html = html.replace("\"/bin/download/Blog", "\"" + basePath);
+            post.setBody(html);
+
+            if (post.getBody() != null && post.getSummary() == null && post.getBody().length() > 100) {
+                post.setSummary(post.getBody().substring(0, 100) + " ...");
+            }
+
+            return post;
+        } catch (Exception e) {
+            logger.error("Error while retrieving blog post {}", slug, e);
+            return null;
+        }
+    }
+
+    /**
+     * Updates the blog post index without fetching full pages.
+     */
+    public void updatePostIndex() {
         if (!loading.compareAndSet(false, true)) {
             logger.warn("Blog posts update is already running");
             return;
         }
 
         try {
-            logger.info("Starting update of blog posts from XWiki");
+            logger.info("Updating blog post index from XWiki");
             Pages pages = xwikiFacadeService.getPages("Blog");
             if (pages == null) {
                 logger.error("Received null pages from XWiki service.");
                 throw new IllegalStateException("Pages from XWiki are null");
             }
 
-            // Initialize local counters and collections
-            int localExpectedCount = pages.getPageSummaries().size();
-            int localExceptionsCount = 0;
+            Map<String, String> newIndex = new LinkedHashMap<>();
+            int localExpectedCount = 0;
 
-            List<BlogPost> newPosts = new ArrayList<>();
-            Map<String, BlogPost> newPostsByUrl = new HashMap<>();
-            Map<String, Integer> newTags = new HashMap<>();
-
-            // Process each page summary from XWiki
             for (PageSummary page : pages.getPageSummaries()) {
-                try {
-                    // Discard internal XWiki pages.
-                    if (page.getFullName().endsWith(".WebHome")) {
-                        localExpectedCount--;
-                        continue;
-                    }
-
-                    FullPage fullPage = xwikiFacadeService.getFullPage(page.getSpace(), page.getName());
-
-                    // Evict the default blog page with title "Blog"
-                    if ("Blog".equals(fullPage.getProperties().get("title"))) {
-                        localExpectedCount--;
-                        continue;
-                    }
-
-                    // Skip hidden pages
-                    if (fullPage.getWikiPage().isHidden()) {
-                        localExpectedCount--;
-                        continue;
-                    }
-
-                    BlogPost post = new BlogPost();
-                    post.setWikiPage(fullPage);
-
-                    // Process the image if available
-                    String image = fullPage.getProperties().get("image");
-                    if (StringUtils.isNotEmpty(image)) {
-                        // Use StandardCharsets.UTF_8 for encoding for safety
-                        String fullImage = getBlogImageUrl(
-                                URLEncoder.encode(page.getName(), StandardCharsets.UTF_8),
-                                URLEncoder.encode(image, StandardCharsets.UTF_8));
-                        post.setImage(fullImage);
-                    }
-
-                    // Set the author; remove "XWiki." prefix and capitalize fully
-                    String author = fullPage.getWikiPage().getAuthor();
-                    if (author != null && author.length() > 6) {
-                        post.setAuthor(WordUtils.capitalizeFully(author.substring(6)));
-                    } else {
-                        post.setAuthor(author);
-                    }
-
-                    // Set summary if available
-                    String extract = fullPage.getProperties().get("extract");
-                    post.setSummary(extract);
-
-                    // Process category: remove "Blog." prefix and split by '|'
-                    String category = fullPage.getProperties().get("category");
-                    if (category != null) {
-                        List<String> categories = Arrays.stream(category.replace("Blog.", "").split("\\|"))
-                                .filter(StringUtils::isNotEmpty)
-                                .collect(Collectors.toList());
-                        post.setCategory(categories);
-                    } else {
-                        post.setCategory(Collections.emptyList());
-                    }
-
-                    // Parse publish date using blogDateFormatter
-                    String publishDate = fullPage.getProperties().get("publishDate");
-                    if (publishDate != null) {
-                        ZonedDateTime zonedDateTime = ZonedDateTime.parse(publishDate, blogDateFormatter);
-                        post.setCreated(new Date(zonedDateTime.toInstant().toEpochMilli()));
-                    }
-
-                    // Set last modification date
-                    if (fullPage.getWikiPage().getModified() != null) {
-                        post.setModified(new Date(fullPage.getWikiPage().getModified().getTimeInMillis()));
-                    }
-
-                    // Set post title and derive URL from it
-                    String title = fullPage.getProperties().get("title");
-                    post.setTitle(title);
-                    post.setUrl(IdHelper.normalizeFileName(title));
-
-                    // Set the edit link using xwikiFacadeService's path helper
-                    String[] pageIdParts = page.getId().replace("xwiki:", "").split("\\.");
-                    post.setEditLink(xwikiFacadeService.getPathHelper().getEditpath(pageIdParts));
-
-                    // Process HTML content to extract the blog post body
-                    String html = fullPage.getHtmlContent();
-                    int startPos = html.indexOf(XWIKI_BLOGPOST_START_MARKUP);
-                    if (startPos != -1) {
-                        html = html.substring(startPos);
-                    }
-                    int stopPos = html.indexOf(XWIKI_BLOGPOST_STOP_MARKUP);
-                    if (stopPos != -1) {
-                        html = html.substring(0, stopPos);
-                    }
-                    // Sanitize HTML content to avoid XSS
-                    html = Jsoup.clean(html, Safelist.basicWithImages());
-                    // Replace blog attachment links with proxied equivalent links
-                    String basePath = '/' + config.getBlogUrl();
-                    if (basePath.endsWith("/")) {
-                        basePath = basePath.substring(0, basePath.length() - 1);
-                    }
-                    html = html.replace("\"/bin/download/Blog", "\"" + basePath);
-                    post.setBody(html);
-
-                    // Generate a summary if not provided and the body is sufficiently long
-                    if (post.getBody() != null && post.getSummary() == null && post.getBody().length() > 100) {
-                        // TODO (p3,conf): Truncation length should be configurable
-                        post.setSummary(post.getBody().substring(0, 100) + " ...");
-                    }
-
-                    newPosts.add(post);
-                } catch (Exception ex) {
-                    localExceptionsCount++;
-                    // Log detailed error information for the failing page.
-                    logger.error("Error processing blog post for page '{}': {}", page.getFullName(), ex.getMessage(), ex);
-                    // Optionally, rethrow severe exceptions if needed. For now, we continue processing.
+                if (page.getFullName().endsWith(".WebHome")) {
+                    continue;
                 }
+                newIndex.put(page.getName(), page.getTitle());
+                localExpectedCount++;
             }
 
-            // Sort posts by creation date in descending order.
-            newPosts.sort((o1, o2) -> o2.getCreated().compareTo(o1.getCreated()));
-
-            // Build postsByUrl map from the new posts.
-            for (BlogPost post : newPosts) {
-                newPostsByUrl.put(post.getUrl(), post);
-            }
-
-            // Build tags map by counting tag occurrences in each post.
-            for (BlogPost post : newPosts) {
-                List<String> categories = post.getCategory();
-                for (String tag : categories) {
-                    newTags.merge(tag, 1, Integer::sum);
-                }
-            }
-
-            // Atomically replace the internal collections with unmodifiable versions for thread safety.
-            this.posts = Collections.unmodifiableList(newPosts);
-            this.postsByUrl = Collections.unmodifiableMap(newPostsByUrl);
-            this.tags = Collections.unmodifiableMap(newTags);
+            this.postIndex = Collections.unmodifiableMap(newIndex);
             this.expectedBlogPagesCount = localExpectedCount;
-            this.exceptionsCount = localExceptionsCount;
+            this.exceptionsCount = 0;
 
-            // If any exceptions were encountered during processing, rethrow an exception to notify the scheduler.
-            if (localExceptionsCount > 0) {
-                throw new IllegalStateException("Encountered " + localExceptionsCount + " errors during blog posts update");
-            }
-
-            logger.info("Blog posts updated successfully. Total posts: {}", newPosts.size());
+            logger.info("Blog index updated successfully. Total posts: {}", newIndex.size());
         } catch (Exception e) {
-
-        	// TODO : Handle healthchecks / metrics status
-        	logger.error("Error while updating blog posts !",e);
-		}
-
-
-        finally {
-            // Ensure the loading flag is reset even if exceptions occur.
+            logger.error("Error while updating blog index", e);
+        } finally {
             loading.set(false);
         }
     }
@@ -335,8 +285,8 @@ public class BlogService implements HealthIndicator {
         feed.setLink(baseUrl.i18n(lang));
 
         List<SyndEntry> entries = new ArrayList<>();
-        // Iterate over posts in a thread-safe manner.
-        for (BlogPost post : postsByUrl.values()) {
+        for (String slug : postIndex.keySet()) {
+            BlogPost post = getPost(slug);
             SyndEntry entry = new SyndEntryImpl();
             entry.setTitle(post.getTitle());
             entry.setLink(baseUrl.i18n(lang) + config.getBlogUrl() + post.getUrl());
@@ -411,60 +361,29 @@ public class BlogService implements HealthIndicator {
     }
 
     ///////////////////////////////
-    // Getters and Setters
+    // Getters
     ///////////////////////////////
 
     /**
-     * Retrieves the map of blog posts by their URL.
-     *
-     * @return an unmodifiable map of blog posts keyed by URL
+     * Current post index mapping slug to title.
      */
-    public Map<String, BlogPost> getPostsByUrl() {
-        return postsByUrl;
+    public Map<String, String> getPostIndex() {
+        return postIndex;
     }
 
     /**
-     * Sets the map of blog posts by URL.
-     *
-     * @param postsByUrl the new map of blog posts by URL
-     */
-    public void setPostsByUrl(Map<String, BlogPost> postsByUrl) {
-        this.postsByUrl = postsByUrl;
-    }
-
-    /**
-     * Retrieves the list of blog posts.
-     *
-     * @return an unmodifiable list of blog posts
-     */
-    public List<BlogPost> getPosts() {
-        return posts;
-    }
-
-    /**
-     * Sets the list of blog posts.
-     *
-     * @param posts the new list of blog posts
-     */
-    public void setPosts(List<BlogPost> posts) {
-        this.posts = posts;
-    }
-
-    /**
-     * Retrieves the tags map with counts of posts per tag.
-     *
-     * @return an unmodifiable map of tags to post counts
+     * Compute tags counts lazily from loaded posts.
      */
     public Map<String, Integer> getTags() {
-        return tags;
-    }
-
-    /**
-     * Sets the tags map.
-     *
-     * @param tags the new tags map
-     */
-    public void setTags(Map<String, Integer> tags) {
-        this.tags = tags;
+        Map<String, Integer> counts = new HashMap<>();
+        for (String slug : postIndex.keySet()) {
+            BlogPost post = getPost(slug);
+            if (post.getCategory() != null) {
+                for (String cat : post.getCategory()) {
+                    counts.merge(cat, 1, Integer::sum);
+                }
+            }
+        }
+        return counts;
     }
 }

--- a/services/blog/src/test/java/org/open4goods/services/blog/service/BlogServiceTest.java
+++ b/services/blog/src/test/java/org/open4goods/services/blog/service/BlogServiceTest.java
@@ -1,0 +1,95 @@
+package org.open4goods.services.blog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import java.util.Calendar;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.open4goods.model.Localisable;
+import org.open4goods.services.blog.config.BlogConfiguration;
+import org.open4goods.services.blog.model.BlogPost;
+import org.open4goods.xwiki.XWikiServiceConfiguration;
+import org.open4goods.xwiki.model.FullPage;
+import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.xwiki.rest.model.jaxb.Page;
+import org.xwiki.rest.model.jaxb.PageSummary;
+import org.xwiki.rest.model.jaxb.Pages;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = BlogServiceTest.Config.class)
+class BlogServiceTest {
+
+    @Configuration
+    @Import(BlogService.class)
+    static class Config {
+        @Bean
+        BlogConfiguration blogConfiguration() {
+            return new BlogConfiguration();
+        }
+
+        @Bean
+        Localisable<String, String> baseUrl() {
+            return new Localisable<>();
+        }
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager(XWikiServiceConfiguration.ONE_HOUR_LOCAL_CACHE_NAME);
+        }
+    }
+
+    @MockBean
+    XwikiFacadeService xwikiFacadeService;
+
+    @Autowired
+    BlogService blogService;
+
+    @Test
+    void updateIndexDoesNotFetchFullPosts() {
+        Pages pages = new Pages();
+        PageSummary ps = new PageSummary();
+        ps.setName("slug");
+        ps.setTitle("Title");
+        pages.getPageSummaries().add(ps);
+        when(xwikiFacadeService.getPages("Blog")).thenReturn(pages);
+
+        blogService.updatePostIndex();
+
+        verify(xwikiFacadeService).getPages("Blog");
+        verify(xwikiFacadeService, never()).getFullPage(anyString(), anyString());
+        assertThat(blogService.getPostIndex()).containsEntry("slug", "Title");
+    }
+
+    @Test
+    void getPostUsesCache() {
+        FullPage full = new FullPage();
+        Page page = new Page();
+        page.setHidden(false);
+        page.setId("xwiki:Blog.slug");
+        page.setModified(Calendar.getInstance());
+        full.setWikiPage(page);
+        full.setProperties(new HashMap<>());
+        full.getProperties().put("title", "Title");
+        when(xwikiFacadeService.getFullPage("Blog", "slug")).thenReturn(full);
+
+        BlogPost first = blogService.getPost("slug");
+        BlogPost second = blogService.getPost("slug");
+
+        verify(xwikiFacadeService, times(1)).getFullPage("Blog", "slug");
+        assertThat(first.getTitle()).isEqualTo("Title");
+        assertThat(second).isSameAs(first);
+    }
+}

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/BlogController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/pages/BlogController.java
@@ -57,7 +57,7 @@ public class BlogController  implements SitemapExposedController{
 	public ModelAndView blogIndex(final HttpServletRequest request) {
 		ModelAndView model = uiService.defaultModelAndView("blog", request);
 		model.addObject("url",  "/");
-		List<BlogPost> posts = blogService.getPosts();
+                List<BlogPost> posts = blogService.getPosts(null);
 		
 		model.addObject("posts", posts);
 		model.addObject("tags",blogService.getTags());
@@ -75,7 +75,7 @@ public class BlogController  implements SitemapExposedController{
 	public ModelAndView blogIndexByCat(final HttpServletRequest request, @PathVariable String tag) {
 		ModelAndView model = uiService.defaultModelAndView("blog", request);
 		model.addObject("url",  "/");
-		List<BlogPost> posts = blogService.getPosts();
+                List<BlogPost> posts = blogService.getPosts(null);
 		
 		// Filtering by tag
 		if (null != tag) {
@@ -102,7 +102,7 @@ public class BlogController  implements SitemapExposedController{
 	public ModelAndView post(@PathVariable String post, final HttpServletRequest request) {
 		ModelAndView model = uiService.defaultModelAndView("blog-post", request);
 
-		BlogPost blogPost = blogService.getPostsByUrl().get(post);
+                BlogPost blogPost = blogService.getPost(post);
 		
 		if (null == blogPost) {
 			LOGGER.info("Blog post not found : {}", post);

--- a/ui/src/main/java/org/open4goods/ui/services/SitemapGenerationService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/SitemapGenerationService.java
@@ -113,7 +113,7 @@ public class SitemapGenerationService {
 
 
 			// Adding blog posts
-			addBlogPost(blogService.getPosts(),  baseUrl, lang );
+                        addBlogPost(blogService.getPosts(null),  baseUrl, lang );
 
 			// Adding wiki pages
 			addWikiPages( baseUrl, lang);


### PR DESCRIPTION
## Summary
- load blog posts lazily via `getPost` with caching
- keep lightweight post index refreshed periodically
- update API/UI controllers and sitemap generation to use the new methods
- add unit tests for blog service cache and index

## Testing
- `mvn -pl services/blog -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ee825d4548333b760a773c1b86c0e