### PR TITLE
Update frontend CI workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,11 +12,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: '8.15.9'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+        working-directory: frontend
       - run: pnpm lint
+        working-directory: frontend
       - run: pnpm generate
+        working-directory: frontend
       - run: pnpm test run
+        working-directory: frontend
       - name: Verify production build
+        working-directory: frontend
         run: |
           pnpm build
           node .output/server/index.mjs &

--- a/.github/workflows/frontend-deploy-static.yml
+++ b/.github/workflows/frontend-deploy-static.yml
@@ -16,22 +16,31 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: '8.15.9'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        working-directory: frontend
 
       - name: Build Nuxt (GitHub Pages)
         run: NITRO_PRESET=github_pages pnpm generate
+        working-directory: frontend
 
       - name: Build Storybook
         run: pnpm storybook:build -- --output-dir storybook-static
+        working-directory: frontend
 
       - name: Prepare dist/
         run: |
             rm -rf dist
             mkdir -p dist/storybook
-            cp -r .output/public/* dist/
-            cp -r storybook-static/* dist/storybook/
+            cp -r frontend/.output/public/* dist/
+            cp -r frontend/storybook-static/* dist/storybook/
             echo 'static.nudger.fr' > dist/CNAME
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- use `pnpm/action-setup@v4` with version `8.15.9`
- add Node.js 20 setup with pnpm cache
- run all pnpm commands from the `frontend` folder

## Testing
- `mvn clean install` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862d66e3a248333a0c6b1ae1a141427