### PR TITLE
Fix frontend CI paths

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,6 +5,7 @@ on:
       - 'frontend/**'    
     branches: [main]
   pull_request:
+    paths: ['frontend/**']
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- restrict frontend CI to only run on changes in `frontend/`

## Testing
- `mvn clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6862d6744fd08333a91bfc3a652294f3