### PR TITLE
Update frontend CI workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,10 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+        working-directory: frontend
       - run: pnpm lint
+        working-directory: frontend
       - run: pnpm generate
+        working-directory: frontend
       - run: pnpm test run
+        working-directory: frontend
       - name: Verify production build
         run: |
           pnpm build
@@ -26,3 +34,4 @@ jobs:
           for route in / /sitemap.xml; do
             curl -sf "http://localhost:3000$route"
           done
+        working-directory: frontend

--- a/.github/workflows/frontend-deploy-static.yml
+++ b/.github/workflows/frontend-deploy-static.yml
@@ -16,15 +16,22 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        working-directory: frontend
 
       - name: Build Nuxt (GitHub Pages)
         run: NITRO_PRESET=github_pages pnpm generate
+        working-directory: frontend
 
       - name: Build Storybook
         run: pnpm storybook:build -- --output-dir storybook-static
+        working-directory: frontend
 
       - name: Prepare dist/
         run: |
@@ -33,9 +40,11 @@ jobs:
             cp -r .output/public/* dist/
             cp -r storybook-static/* dist/storybook/
             echo 'static.nudger.fr' > dist/CNAME
+        working-directory: frontend
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./frontend/dist
+


### PR DESCRIPTION
## Summary
- ensure Node.js 20 is available for pnpm workflows
- cache pnpm dependencies in Node setup
- run pnpm commands from the `frontend` folder
- deploy static pages from `frontend/dist`

## Testing
- `pnpm lint` *(fails: Parsing error)*
- `pnpm test run`
- `pnpm generate`
- `pnpm storybook -- --smoke-test`
- `pnpm preview` *(manual stop)*
- `mvn -q clean install` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862d686f26c83338f988c6d879223da