### PR TITLE
feat: blog pages and components

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -8,4 +8,6 @@ export default createConfigForNuxt({
   rules: {
     'vue/multi-word-component-names': 'off'
   }
+}).append({
+  ignores: ['src/api/**']
 })

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -1,0 +1,8 @@
+{
+  "blog": {
+    "title": "Blog",
+    "noPosts": "No posts found",
+    "by": "by",
+    "tags": "Tags"
+  }
+}

--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -1,0 +1,8 @@
+{
+  "blog": {
+    "title": "Blog",
+    "noPosts": "Aucun article",
+    "by": "par",
+    "tags": "Étiquettes"
+  }
+}

--- a/frontend/src/components/blog/Author.spec.ts
+++ b/frontend/src/components/blog/Author.spec.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import Author from './Author.vue'
+
+describe('Author', () => {
+  it('renders name', () => {
+    const wrapper = mount(Author, { props: { name: 'Alice' } })
+    expect(wrapper.text()).toContain('Alice')
+  })
+
+  it('computes avatar url', () => {
+    const wrapper = mount(Author, { props: { name: 'Alice Smith' } })
+    expect(wrapper.find('img').attributes('src')).toContain('alice-smith')
+  })
+})

--- a/frontend/src/components/blog/Author.stories.ts
+++ b/frontend/src/components/blog/Author.stories.ts
@@ -1,0 +1,12 @@
+import Author from './Author.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Author> = {
+  component: Author,
+  title: 'Blog/Author'
+}
+export default meta
+
+export const Default: StoryObj<typeof Author> = {
+  args: { name: 'Jane Doe' }
+}

--- a/frontend/src/components/blog/Author.vue
+++ b/frontend/src/components/blog/Author.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="flex items-center gap-2">
+    <img :src="avatar" alt="" class="w-8 h-8 rounded-full">
+    <span>{{ name }}</span>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ name: string }>()
+const avatar = computed(() => `/img/authors/${props.name.toLowerCase().replace(/\s+/g, '-')}.png`)
+</script>

--- a/frontend/src/components/blog/PostContent.spec.ts
+++ b/frontend/src/components/blog/PostContent.spec.ts
@@ -1,0 +1,10 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import PostContent from './PostContent.vue'
+
+describe('PostContent', () => {
+  it('renders HTML body', () => {
+    const wrapper = mount(PostContent, { props: { body: '<p>Hello</p>' } })
+    expect(wrapper.html()).toContain('<p>Hello</p>')
+  })
+})

--- a/frontend/src/components/blog/PostContent.stories.ts
+++ b/frontend/src/components/blog/PostContent.stories.ts
@@ -1,0 +1,12 @@
+import PostContent from './PostContent.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof PostContent> = {
+  component: PostContent,
+  title: 'Blog/PostContent'
+}
+export default meta
+
+export const Default: StoryObj<typeof PostContent> = {
+  render: () => ({ components: { PostContent }, template: '<PostContent body="<p>Body</p>" />' })
+}

--- a/frontend/src/components/blog/PostContent.vue
+++ b/frontend/src/components/blog/PostContent.vue
@@ -1,0 +1,8 @@
+<!-- eslint-disable vue/no-v-html -->
+<template>
+  <div v-html="body" />
+</template>
+
+<script setup lang="ts">
+defineProps<{ body: string }>()
+</script>

--- a/frontend/src/components/blog/PostPreview.spec.ts
+++ b/frontend/src/components/blog/PostPreview.spec.ts
@@ -1,0 +1,13 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import PostPreview from './PostPreview.vue'
+
+const post = { title: 'T', summary: 'S', author: 'A', category: ['tag'] }
+
+describe('PostPreview', () => {
+  it('renders title and summary', () => {
+    const wrapper = mount(PostPreview, { props: { post } })
+    expect(wrapper.text()).toContain('T')
+    expect(wrapper.text()).toContain('S')
+  })
+})

--- a/frontend/src/components/blog/PostPreview.stories.ts
+++ b/frontend/src/components/blog/PostPreview.stories.ts
@@ -1,0 +1,19 @@
+import PostPreview from './PostPreview.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof PostPreview> = {
+  component: PostPreview,
+  title: 'Blog/PostPreview'
+}
+export default meta
+
+export const Default: StoryObj<typeof PostPreview> = {
+  render: (args) => ({
+    components: { PostPreview },
+    setup() { return { args } },
+    template: '<PostPreview :post="args.post" />'
+  }),
+  args: {
+    post: { title: 'Hello', summary: 'Summary', author: 'Jane', category: ['news'] }
+  }
+}

--- a/frontend/src/components/blog/PostPreview.vue
+++ b/frontend/src/components/blog/PostPreview.vue
@@ -1,0 +1,19 @@
+<template>
+  <article class="border rounded p-4 mb-4">
+    <h2 class="text-xl font-bold">{{ post.title }}</h2>
+    <Author :name="post.author" class="mt-2" />
+    <p class="mt-2">{{ post.summary }}</p>
+    <ul v-if="post.category?.length" class="flex gap-2 mt-2">
+      <li v-for="tag in post.category" :key="tag" class="text-sm bg-gray-200 px-2 rounded">
+        {{ tag }}
+      </li>
+    </ul>
+  </article>
+</template>
+
+<script setup lang="ts">
+import Author from './Author.vue'
+import type { BlogPostDto } from '@/api'
+
+defineProps<{ post: BlogPostDto }>()
+</script>

--- a/frontend/src/composables/useBlogApi.ts
+++ b/frontend/src/composables/useBlogApi.ts
@@ -1,0 +1,7 @@
+import { BlogApi, Configuration } from '@/api'
+import { useRuntimeConfig } from '#imports'
+
+export function useBlogApi() {
+  const config = useRuntimeConfig()
+  return new BlogApi(new Configuration({ basePath: config.public.siteUrl }))
+}

--- a/frontend/src/pages/blog/[slug].vue
+++ b/frontend/src/pages/blog/[slug].vue
@@ -1,0 +1,19 @@
+<template>
+  <div v-if="post">
+    <h1>{{ post.title }}</h1>
+    <Author :name="post.author" class="mb-2" />
+    <PostContent :body="post.body || ''" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute, useAsyncData } from '#imports'
+import Author from '@/components/blog/Author.vue'
+import PostContent from '@/components/blog/PostContent.vue'
+import { useBlogApi } from '@/composables/useBlogApi'
+
+const blogApi = useBlogApi()
+const route = useRoute()
+
+const { data: post } = await useAsyncData('post', () => blogApi.post({ slug: route.params.slug as string }))
+</script>

--- a/frontend/src/pages/blog/index.vue
+++ b/frontend/src/pages/blog/index.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <h1>{{ t('blog.title') }}</h1>
+    <div class="my-2">
+      <label class="mr-2">{{ t('blog.tags') }}</label>
+      <select v-model="selectedTag" class="border px-2 py-1">
+        <option value="">All</option>
+        <option v-for="tag in tags" :key="tag.name" :value="tag.name">
+          {{ tag.name }} ({{ tag.count }})
+        </option>
+      </select>
+    </div>
+    <PostPreview v-for="p in posts" :key="p.url" :post="p" />
+    <p v-if="posts.length === 0">{{ t('blog.noPosts') }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { useAsyncData, useI18n } from '#imports'
+import PostPreview from '@/components/blog/PostPreview.vue'
+import { useBlogApi } from '@/composables/useBlogApi'
+
+const { t } = useI18n()
+const route = useRoute()
+const blogApi = useBlogApi()
+const selectedTag = ref<string | undefined>(route.query.tag as string)
+
+const { data: posts } = await useAsyncData('posts', () => blogApi.posts({ tag: selectedTag.value }))
+const { data: tags } = await useAsyncData('tags', () => blogApi.tags())
+
+watch(selectedTag, async () => {
+  posts.value = await blogApi.posts({ tag: selectedTag.value })
+})
+</script>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,7 +9,8 @@ export default defineConfig({
       // Map `@/` to the `src` directory so imports like `@/components` work in tests
       '@': fileURLToPath(new URL('./src', import.meta.url)),
       // Map `#app` to Nuxt's runtime directory to resolve Nuxt internals during tests
-      '#app': fileURLToPath(new URL('./node_modules/nuxt/dist/app', import.meta.url))
+      '#app': fileURLToPath(new URL('./node_modules/nuxt/dist/app', import.meta.url)),
+      '#imports': fileURLToPath(new URL('./node_modules/nuxt/dist/app', import.meta.url))
     }
   },
   test: {


### PR DESCRIPTION
## Summary
- add blog composable with BlogApi
- create Author, PostPreview and PostContent components with tests and stories
- implement blog listing and post pages
- add i18n keys in English and French
- configure Vitest for Nuxt imports

Generated by AI. Estimated 4h.

------
https://chatgpt.com/codex/tasks/task_e_6862d77a81088333ad98f6f5e311628b