### PR TITLE
Improve Renovate setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,5 +119,11 @@ mvn -pl api -am clean install
 
 A predictable, enforced structure lowers cognitive load for humans and gives large-language models a deterministic environment in which to operate. This accelerates onboarding, reduces bugs, and keeps architecture sound as we migrate monolith parts to independent Spring Boot services (see the services/**) .
 
-> **Questions?**  
+## 10  Automated dependency updates
+
+Dependencies for Maven modules, Node projects (`frontend` and `ui`), and GitHub
+Actions workflows are maintained by Renovate. Updates run nightly (after 10pm
+and before 5am) with major Maven upgrades disabled.
+
+> **Questions?**
 > Open a GitHub Discussion or justify any deviation in your PR description.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,15 @@ Our [verticals definitions are totaly open](https://github.com/open4good/open4go
 
 ## Geek it ! 
 
-Contribute to the websites, on the UI, on the content, or on the data aspects. Quiet simple to set-up, you can run open4goods website localy with the below instructions. 
+Contribute to the websites, on the UI, on the content, or on the data aspects. Quiet simple to set-up, you can run open4goods website localy with the below instructions.
 
- 
+
+### Automated dependency updates
+Dependencies across Maven modules, Node projects (`frontend` and `ui`) and GitHub Actions
+are maintained by [Renovate](https://github.com/renovatebot/renovate). Updates run
+nightly (`after 10pm and before 5am`), and major Maven upgrades are disabled by default.
+
+
 # Run in dev mode
 We will see here how to run open4goods frontends and API's on tour computer.
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -152,6 +152,8 @@ export const Primary: Story = {
 ## Documentation
 - Always document produced code
 - Always update existing documentation (for example README.md, AGENTS.md) with features update, architecturals changes or considerations.
+- Dependency updates are handled by Renovate using the configs `renovate.json` at
+  the repository root and `frontend/renovate.json`. Updates run nightly.
 
 
 ## Linting and Formatting

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "schedule": ["after 10pm and before 5am"],
+  "github-actions": { "enabled": true },
+  "dependencyDashboard": false,
+  "packageRules": [
+    {
+      "matchManagers": ["maven"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchPaths": ["frontend/**"],
+      "packageManager": "pnpm"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- configure Renovate to manage Maven, pnpm and GitHub Actions
- add nightly schedule for updates
- document automated dependency updates in AGENTS and README
- note Renovate config in frontend guide

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862deb6e3448333b6883f3398d92564