### PR TITLE
fix: compile frontend with updated openapi clients

### DIFF
--- a/frontend/src/api/apis/BlogApi.ts
+++ b/frontend/src/api/apis/BlogApi.ts
@@ -31,8 +31,8 @@ export interface PostRequest {
 
 export interface PostsRequest {
     tag?: string;
-    UNKNOWN_PARAMETER_NAME?: ;
-    UNKNOWN_PARAMETER_NAME2?: ;
+    pageNumber?: number;
+    pageSize?: number;
 }
 
 /**
@@ -90,12 +90,12 @@ export class BlogApi extends runtime.BaseAPI {
             queryParameters['tag'] = requestParameters['tag'];
         }
 
-        if (requestParameters['UNKNOWN_PARAMETER_NAME'] != null) {
-            queryParameters['page[number]'] = requestParameters['UNKNOWN_PARAMETER_NAME'];
+        if (requestParameters['pageNumber'] != null) {
+            queryParameters['page[number]'] = requestParameters['pageNumber'];
         }
 
-        if (requestParameters['UNKNOWN_PARAMETER_NAME2'] != null) {
-            queryParameters['page[size]'] = requestParameters['UNKNOWN_PARAMETER_NAME2'];
+        if (requestParameters['pageSize'] != null) {
+            queryParameters['page[size]'] = requestParameters['pageSize'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};

--- a/frontend/src/api/apis/ProductApi.ts
+++ b/frontend/src/api/apis/ProductApi.ts
@@ -32,8 +32,8 @@ export interface ProductRequest {
 
 export interface ProductsRequest {
     include?: Array<ProductsIncludeEnum>;
-    UNKNOWN_PARAMETER_NAME?: ;
-    UNKNOWN_PARAMETER_NAME2?: ;
+    pageNumber?: number;
+    pageSize?: number;
     sort?: Array<ProductsSortEnum>;
 }
 
@@ -96,12 +96,12 @@ export class ProductApi extends runtime.BaseAPI {
             queryParameters['include'] = requestParameters['include'];
         }
 
-        if (requestParameters['UNKNOWN_PARAMETER_NAME'] != null) {
-            queryParameters['page[number]'] = requestParameters['UNKNOWN_PARAMETER_NAME'];
+        if (requestParameters['pageNumber'] != null) {
+            queryParameters['page[number]'] = requestParameters['pageNumber'];
         }
 
-        if (requestParameters['UNKNOWN_PARAMETER_NAME2'] != null) {
-            queryParameters['page[size]'] = requestParameters['UNKNOWN_PARAMETER_NAME2'];
+        if (requestParameters['pageSize'] != null) {
+            queryParameters['page[size]'] = requestParameters['pageSize'];
         }
 
         if (requestParameters['sort'] != null) {


### PR DESCRIPTION
## Summary
- patch BlogApi and ProductApi to use valid query param fields
- regenerate query param usage to avoid TypeScript errors

Generated by AI. Estimated time to complete: 30 minutes.

------
https://chatgpt.com/codex/tasks/task_e_6862e097ba008333a2026bf7340c4a42