### PR TITLE
Update pageable param names

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/PageableConfig.java
@@ -17,8 +17,8 @@ public class PageableConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 
         PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
-        pageableResolver.setPageParameterName("page[number]");
-        pageableResolver.setSizeParameterName("page[size]");
+        pageableResolver.setPageParameterName("pageNumber");
+        pageableResolver.setSizeParameterName("pageSize");
 
         // TODO : Document, from conf
         pageableResolver.setMaxPageSize(50);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdvice.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdvice.java
@@ -72,8 +72,8 @@ public class PaginationLinkAdvice implements ResponseBodyAdvice<Object> {
     }
 
     private String buildLink(UriComponentsBuilder builder, long number, int size, String rel) {
-        String uri = builder.replaceQueryParam("page[number]", number)
-                .replaceQueryParam("page[size]", size)
+        String uri = builder.replaceQueryParam("pageNumber", number)
+                .replaceQueryParam("pageSize", size)
                 .toUriString();
         return "<" + uri + ">; rel=\"" + rel + "\"";
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -59,8 +59,8 @@ public class PostsController {
             description = "Return paginated blog posts optionally filtered by tag.",
             parameters = {
                     @Parameter(name = "tag", in = ParameterIn.QUERY, description = "Category/tag to filter on"),
-                    @Parameter(name = "page[number]", in = ParameterIn.QUERY, description = "Zero-based page index"),
-                    @Parameter(name = "page[size]", in = ParameterIn.QUERY, description = "Page size")
+                    @Parameter(name = "pageNumber", in = ParameterIn.QUERY, description = "Zero-based page index"),
+                    @Parameter(name = "pageSize", in = ParameterIn.QUERY, description = "Page size")
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Posts returned",

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -77,8 +77,8 @@ public class ProductController {
                             array = @ArraySchema(
                                     schema = @Schema(implementation = ProductDtoComponent.class)
                             )),
-                    @Parameter(name = "page[number]", in = ParameterIn.QUERY, description = "Zero-based page index"),
-                    @Parameter(name = "page[size]", in = ParameterIn.QUERY, description = "Page size"),
+                    @Parameter(name = "pageNumber", in = ParameterIn.QUERY, description = "Zero-based page index"),
+                    @Parameter(name = "pageSize", in = ParameterIn.QUERY, description = "Page size"),
                     @Parameter(name = "sort", in = ParameterIn.QUERY, description = "Sort criteria in the format: property,(asc|desc). ",array = @ArraySchema(
                             schema = @Schema(implementation = ProductDtoSortableFields.class)
                     )),
@@ -218,8 +218,8 @@ public class ProductController {
 //            parameters = {
 //                    @Parameter(name = "gtin", description = "Global Trade Item Number (8–14 digit numeric code)", example = "00012345600012", required = true),
 //
-//                    @Parameter(name = "page[number]", in = ParameterIn.QUERY, description = "Zero-based page index"),
-//                    @Parameter(name = "page[size]", in = ParameterIn.QUERY, description = "Page size")
+//                    @Parameter(name = "pageNumber", in = ParameterIn.QUERY, description = "Zero-based page index"),
+//                    @Parameter(name = "pageSize", in = ParameterIn.QUERY, description = "Page size")
 //
 //            },
 //            responses = {


### PR DESCRIPTION
## Summary
- rename pageable query parameters to `pageNumber` and `pageSize`
- adapt pagination link builder
- update controller annotations

## Testing
- `mvn -pl front-api -am clean install` *(fails: Non-resolvable import POM)*
- `pnpm exec openapi-generator-cli generate -i http://localhost:8082/v3/api-docs/front -g typescript-fetch -o /tmp/tsclient --skip-validate-spec`

------
https://chatgpt.com/codex/tasks/task_e_6862eaefb78083339b57f969301babba