### PR TITLE
feat(frontend): configure i18n locales

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -36,9 +36,11 @@ export default defineNuxtConfig({
 
   // Internationalization settings
   i18n: {
+    restructureDir: '',
+    langDir: 'locales',
     locales: [
-      { code: 'en', iso: 'en-US', name: 'English' },
-      { code: 'fr', iso: 'fr-FR', name: 'Français' }
+      { code: 'en', iso: 'en-US', name: 'English', file: 'en.json' },
+      { code: 'fr', iso: 'fr-FR', name: 'Français', file: 'fr.json' }
     ],
     defaultLocale: 'fr',
     strategy: 'prefix_except_default',


### PR DESCRIPTION
## Summary
- adjust Nuxt i18n config so translations load from `locales`
- ensure each locale entry specifies its JSON file

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate` *(fails: Could not load locales, prerender errors)*
- `pnpm storybook`
- `pnpm preview` *(prompts for serve package)*

------
https://chatgpt.com/codex/tasks/task_e_6862eb28915483338ebb8bfe93072853