### PR TITLE
fix: ensure blog list defaults

### DIFF
--- a/frontend/src/pages/blog/index.vue
+++ b/frontend/src/pages/blog/index.vue
@@ -27,8 +27,12 @@ const route = useRoute()
 const blogApi = useBlogApi()
 const selectedTag = ref<string | undefined>(route.query.tag as string)
 
-const { data: posts } = await useAsyncData('posts', () => blogApi.posts({ tag: selectedTag.value }))
-const { data: tags } = await useAsyncData('tags', () => blogApi.tags())
+const { data: posts } = await useAsyncData(
+  'posts',
+  () => blogApi.posts({ tag: selectedTag.value }),
+  { default: () => [] }
+)
+const { data: tags } = await useAsyncData('tags', () => blogApi.tags(), { default: () => [] })
 
 watch(selectedTag, async () => {
   posts.value = await blogApi.posts({ tag: selectedTag.value })


### PR DESCRIPTION
## Summary
- default to empty arrays when fetching blog posts and tags

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm generate`
- `pnpm storybook` *(server started)*
- `pnpm preview` *(server started)*

This PR is generated by AI. Estimated time to complete: 15 minutes.

------
https://chatgpt.com/codex/tasks/task_e_6862eb1cf71c833399b2d40f613993b3