### PR TITLE
Fix pnpm version in frontend workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/frontend-deploy-static.yml
+++ b/.github/workflows/frontend-deploy-static.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- specify pnpm version for action setup

## Testing
- `mvn clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm generate` *(fails: Server Error while prerendering)*
- `pnpm test run`
- `pnpm storybook`
- `pnpm preview`

------
https://chatgpt.com/codex/tasks/task_e_6862ec9d31e483339886c54c68d8a0eb