### PR TITLE
fix(front-api): document page params

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -59,8 +59,12 @@ public class PostsController {
             description = "Return paginated blog posts optionally filtered by tag.",
             parameters = {
                     @Parameter(name = "tag", in = ParameterIn.QUERY, description = "Category/tag to filter on"),
-                    @Parameter(name = "page[number]", in = ParameterIn.QUERY, description = "Zero-based page index"),
-                    @Parameter(name = "page[size]", in = ParameterIn.QUERY, description = "Page size")
+                    @Parameter(name = "page[number]", in = ParameterIn.QUERY,
+                            description = "Zero-based page index",
+                            schema = @Schema(type = "integer", minimum = "0")),
+                    @Parameter(name = "page[size]", in = ParameterIn.QUERY,
+                            description = "Page size",
+                            schema = @Schema(type = "integer", minimum = "0"))
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Posts returned",

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -77,8 +77,12 @@ public class ProductController {
                             array = @ArraySchema(
                                     schema = @Schema(implementation = ProductDtoComponent.class)
                             )),
-                    @Parameter(name = "page[number]", in = ParameterIn.QUERY, description = "Zero-based page index"),
-                    @Parameter(name = "page[size]", in = ParameterIn.QUERY, description = "Page size"),
+                    @Parameter(name = "page[number]", in = ParameterIn.QUERY,
+                            description = "Zero-based page index",
+                            schema = @Schema(type = "integer", minimum = "0")),
+                    @Parameter(name = "page[size]", in = ParameterIn.QUERY,
+                            description = "Page size",
+                            schema = @Schema(type = "integer", minimum = "0")),
                     @Parameter(name = "sort", in = ParameterIn.QUERY, description = "Sort criteria in the format: property,(asc|desc). ",array = @ArraySchema(
                             schema = @Schema(implementation = ProductDtoSortableFields.class)
                     )),


### PR DESCRIPTION
## Summary
- annotate pagination query parameters `page[number]` and `page[size]` with integer schema
- regenerate frontend dependencies

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies: Network is unreachable)*
- `pnpm install`
- `pnpm generate:api` *(fails: unable to read remote URL due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc07c2108333b7fcc6049ad81068