### PR TITLE
Add schema rule and CI for Nuxt API contract

### DIFF
--- a/.github/workflows/front-api-contract.yml
+++ b/.github/workflows/front-api-contract.yml
@@ -1,0 +1,61 @@
+name: Front API Contract
+
+on:
+  push:
+    paths:
+      - 'front-api/**'
+    branches: [ main ]
+  pull_request:
+    paths:
+      - 'front-api/**'
+
+jobs:
+  generate-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build front-api
+        run: mvn -pl front-api -am package -DskipTests
+
+      - name: Start front-api
+        run: |
+          java -jar front-api/target/front-api-0.0.1-SNAPSHOT.jar &
+          echo "PID=$!" >> $GITHUB_ENV
+
+      - name: Wait for API docs
+        run: npx wait-on http://localhost:8082/v3/api-docs/front
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Generate client from local API
+        run: pnpm exec openapi-generator-cli generate -i http://localhost:8082/v3/api-docs/front -g typescript-fetch -o tmp-client --skip-validate-spec
+        working-directory: frontend
+
+      - name: Check for unknown parameters
+        run: |
+          if grep -R "UNKNOWN_PARAMETER_NAME" -n tmp-client; then
+            echo 'Unknown parameters found';
+            exit 1;
+          fi
+        working-directory: frontend
+
+      - name: Stop front-api
+        if: always()
+        run: |
+          kill $PID
+

--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -73,6 +73,16 @@ The module exposes configurable security settings via
 | `@SecurityRequirement` | auth or captcha                     |
 | `@Tag`                 | group controllers                   |
 
+> **Rule**: add `schema = @Schema(...)` for every `@Parameter` to specify the type.
+> Missing schemas lead to `UNKNOWN_PARAMETER_NAME` fields in the generated Nuxt client.
+>
+> Example:
+> ```java
+> @Parameter(name = "page[number]", in = ParameterIn.QUERY,
+>     description = "Zero-based page index",
+>     schema = @Schema(type = "integer", minimum = "0"))
+> ```
+
 **Example**
 ~~~java
 @Operation(


### PR DESCRIPTION
## Summary
- document rule in `front-api` AGENTS guide that every `@Parameter` must define a `@Schema`
- add GitHub workflow to generate a Nuxt API client from the local `front-api` server

## Testing
- `mvn -pl front-api -am package -DskipTests`
- `npx wait-on http://localhost:8082/v3/api-docs/front`
- `pnpm exec openapi-generator-cli generate -i http://localhost:8082/v3/api-docs/front -g typescript-fetch -o tmp-client --skip-validate-spec`


------
https://chatgpt.com/codex/tasks/task_e_6862f869998c8333886afa475ba36b63