### PR TITLE
feat(frontend): add blog link on homepage

### DIFF
--- a/frontend/src/pages/index.spec.ts
+++ b/frontend/src/pages/index.spec.ts
@@ -3,7 +3,31 @@ import { mount } from '@vue/test-utils'
 import IndexPage from './index.vue'
 describe('Index page', () => {
   it('renders welcome text', () => {
-    const wrapper = mount(IndexPage)
+    const wrapper = mount(IndexPage, {
+      global: {
+        stubs: {
+          NuxtLink: {
+            template: '<a><slot /></a>',
+            props: ['to']
+          }
+        }
+      }
+    })
     expect(wrapper.text()).toContain('Nudger')
+  })
+
+  it('links to blog page', () => {
+    const wrapper = mount(IndexPage, {
+      global: {
+        stubs: {
+          NuxtLink: {
+            template: '<a><slot /></a>',
+            props: ['to']
+          }
+        }
+      }
+    })
+    const link = wrapper.get('a')
+    expect(link.text()).toContain('Blog')
   })
 })

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
   <Card>Welcome to Nudger Next gen !</Card>
+  <NuxtLink to="/blog" class="text-blue-600 underline">Blog</NuxtLink>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- add a NuxtLink on the front page so users can reach the blog
- test the presence of the blog link

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate` *(fails: Transform failed with esbuild error)*
- `pnpm storybook --smoke-test`
- `pnpm preview --port 4000` *(fails: Cannot find nitro.json)*
- `mvn -q clean install` *(fails: missing dependencies)*

---
*This PR was generated by an AI assistant. Estimated time to complete: 20 minutes.*

------
https://chatgpt.com/codex/tasks/task_e_6863a6a5a3c883338322fe7c2ea36eee