### PR TITLE
Improve GitHub project automation

### DIFF
--- a/.github/workflows/label-to-project-dispatch.yml
+++ b/.github/workflows/label-to-project-dispatch.yml
@@ -1,0 +1,72 @@
+name: Backfill Issues to GitHub Projects V2
+
+# Manual workflow to reapply project assignment rules to all open issues.
+on:
+  workflow_dispatch:
+
+env:
+  ORG_NAME: open4good
+  PROJECT_ID_MAPPING: |
+    squad:ux=PVT_kwDOBOJOp84A2ZRZ
+    squad:backend=PVT_kwDOBOJOp84A8xdZ
+    squad:exposition=PVT_kwDOBOJOp84A8xdy
+    squad:pmo=PVT_kwDOBOJOp84A8tDc
+    EPIC=PVT_kwDOBOJOp84A8tDc
+  PMO_PROJECT_ID: PVT_kwDOBOJOp84A8tDc
+  PMO_STATUS_FIELD_ID: ${{ secrets.PMO_STATUS_FIELD_ID }}
+  PMO_TRIAGE_OPTION_ID: ${{ secrets.PMO_TRIAGE_OPTION_ID }}
+
+jobs:
+  reassign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_PAT }}
+          script: |
+            const mapping = Object.fromEntries(
+              process.env.PROJECT_ID_MAPPING
+                .trim()
+                .split('\n')
+                .map(line => line.trim().split('='))
+            );
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            for (const issue of issues) {
+              const labels = issue.labels.map(l => l.name);
+              const hasSquad = labels.some(n => n.startsWith('squad:'));
+              const hasEpic = labels.includes('EPIC');
+              for (const label of labels) {
+                if (mapping[label]) {
+                  try {
+                    await github.graphql(
+                      `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`,
+                      { projectId: mapping[label], contentId: issue.node_id }
+                    );
+                  } catch (e) {
+                    console.log(`Skip project add: ${e.message}`);
+                  }
+                }
+              }
+              if (!hasSquad || hasEpic) {
+                const addRes = await github.graphql(
+                  `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`,
+                  { projectId: process.env.PMO_PROJECT_ID, contentId: issue.node_id }
+                );
+                const itemId = addRes.addProjectV2ItemById.item.id;
+                await github.graphql(
+                  `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { item { id } } }`,
+                  {
+                    projectId: process.env.PMO_PROJECT_ID,
+                    itemId,
+                    fieldId: process.env.PMO_STATUS_FIELD_ID,
+                    optionId: process.env.PMO_TRIAGE_OPTION_ID,
+                  }
+                );
+              }
+            }
+

--- a/.github/workflows/label-to-project.yml
+++ b/.github/workflows/label-to-project.yml
@@ -1,8 +1,13 @@
 name: Assign Issues to GitHub Projects V2
 
+# Automatically routes issues to the appropriate GitHub Project V2 board
+# based on their labels. Issues without a `squad:*` label or with the
+# `EPIC` label are added to the PMO board and placed in the `Triage`
+# column. Triggered for newly opened issues and whenever labels are added.
+
 on:
   issues:
-    types: [labeled]
+    types: [opened, labeled]
 
 env:
   ORG_NAME: open4good
@@ -12,10 +17,12 @@ env:
     squad:exposition=PVT_kwDOBOJOp84A8xdy
     squad:pmo=PVT_kwDOBOJOp84A8tDc
     EPIC=PVT_kwDOBOJOp84A8tDc
+  PMO_PROJECT_ID: PVT_kwDOBOJOp84A8tDc
+  PMO_STATUS_FIELD_ID: ${{ secrets.PMO_STATUS_FIELD_ID }}
+  PMO_TRIAGE_OPTION_ID: ${{ secrets.PMO_TRIAGE_OPTION_ID }}
 
 jobs:
   assign-to-project:
-    if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -28,20 +35,42 @@ jobs:
                 .split('\n')
                 .map(line => line.trim().split('='))
             );
-            const labelName = context.payload.label.name;
-            const projectId = mapping[labelName];
-            if (!projectId) {
-              console.log(`No project configured for label '${labelName}', skipping.`);
-              return;
-            }
-            await github.graphql(
-              `
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-                  item { id }
-                }
+
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(l => l.name);
+            const hasSquad = labels.some(n => n.startsWith('squad:'));
+            const hasEpic = labels.includes('EPIC');
+            const labelName = context.payload.action === 'labeled' ? context.payload.label.name : null;
+
+            if (labelName && mapping[labelName]) {
+              const projectId = mapping[labelName];
+              try {
+                await github.graphql(
+                  `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`,
+                  { projectId, contentId: issue.node_id }
+                );
+                console.log(`Issue #${issue.number} added to project ID ${projectId}.`);
+              } catch (e) {
+                console.log(`Unable to add to project ${projectId}: ${e.message}`);
               }
-              `,
-              { projectId, contentId: context.payload.issue.node_id }
-            );
-            console.log(`Issue #${context.payload.issue.number} added to project ID ${projectId}.`);
+            }
+
+            if (!hasSquad || hasEpic) {
+              const projectId = process.env.PMO_PROJECT_ID;
+              const addRes = await github.graphql(
+                `mutation($projectId: ID!, $contentId: ID!) { addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) { item { id } } }`,
+                { projectId, contentId: issue.node_id }
+              );
+              const itemId = addRes.addProjectV2ItemById.item.id;
+              await github.graphql(
+                `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) { updateProjectV2ItemFieldValue(input: { projectId: $projectId, itemId: $itemId, fieldId: $fieldId, value: { singleSelectOptionId: $optionId } }) { item { id } } }`,
+                {
+                  projectId,
+                  itemId,
+                  fieldId: process.env.PMO_STATUS_FIELD_ID,
+                  optionId: process.env.PMO_TRIAGE_OPTION_ID,
+                }
+              );
+              console.log(`Issue #${issue.number} routed to PMO project.`);
+            }
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Dependencies across Maven modules, Node projects (`frontend` and `ui`) and GitHu
 are maintained by [Renovate](https://github.com/renovatebot/renovate). Updates run
 nightly (`after 10pm and before 5am`), and major Maven upgrades are disabled by default.
 
+### Project management automation
+Issues are organised using GitHub Projects V2. The workflow
+[label-to-project.yml](.github/workflows/label-to-project.yml) automatically
+assigns newly opened issues to the right project board based on their labels.
+If an issue has no `squad:*` label or carries the `EPIC` label, it is routed to
+the PMO board and placed in the `Triage` column. A manual workflow named
+[label-to-project-dispatch.yml](.github/workflows/label-to-project-dispatch.yml)
+can be triggered to reapply these rules to existing issues.
+
 
 # Run in dev mode
 We will see here how to run open4goods frontends and API's on tour computer.


### PR DESCRIPTION
## Summary
- route issues without a `squad:` label or with `EPIC` to the PMO board
- document project management automation in README
- add manual workflow for backfilling issues

## Testing
- `mvn clean install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863afc2e72c8333a1c6ac04045adfa9