### PR TITLE
Introduce generic PageDto

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdvice.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdvice.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.open4goods.nudgerfrontapi.dto.PageDto;
+import org.open4goods.nudgerfrontapi.dto.PageMetaDto;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
@@ -61,14 +64,8 @@ public class PaginationLinkAdvice implements ResponseBodyAdvice<Object> {
             response.getHeaders().add(HttpHeaders.LINK, String.join(", ", links));
         }
 
-        Map<String, Object> meta = Map.of(
-                "number", pageNumber,
-                "size", pageSize,
-                "totalElements", page.getTotalElements(),
-                "totalPages", totalPages);
-        return Map.of(
-                "page", meta,
-                "data", page.getContent());
+        PageMetaDto meta = new PageMetaDto(pageNumber, pageSize, page.getTotalElements(), totalPages);
+        return new PageDto<>(meta, page.getContent());
     }
 
     private String buildLink(UriComponentsBuilder builder, long number, int size, String rel) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 
 import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
 import org.open4goods.nudgerfrontapi.dto.blog.BlogTagDto;
+import org.open4goods.nudgerfrontapi.dto.PageDto;
 import org.open4goods.services.blog.model.BlogPost;
 import org.open4goods.services.blog.service.BlogService;
 import org.springframework.http.CacheControl;
@@ -70,7 +71,7 @@ public class PostsController {
                     @ApiResponse(responseCode = "200", description = "Posts returned",
                             headers = @Header(name = "Link", description = "Pagination links as defined by RFC 8288"),
                             content = @Content(mediaType = "application/json",
-                                    array = @ArraySchema(schema = @Schema(implementation = BlogPostDto.class))))
+                                    schema = @Schema(implementation = PageDto.class)))
             }
     )
     public ResponseEntity<Page<BlogPostDto>> posts(

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -8,6 +8,7 @@ import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
+import org.open4goods.nudgerfrontapi.dto.PageDto;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -90,7 +91,7 @@ public class ProductController {
             responses = {
                     @ApiResponse(responseCode = "200", description = "Products returned",
                             headers = @Header(name = "Link", description = "Pagination links as defined by RFC 8288"),
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductDto.class, type = "array"))),
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageDto.class))),
                     @ApiResponse(responseCode = "401", description = "Authentication required"),
                     @ApiResponse(responseCode = "403", description = "Access forbidden"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PageDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PageDto.java
@@ -1,0 +1,15 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Generic page wrapper.
+ */
+public record PageDto<T>(
+        @Schema(description = "Pagination metadata")
+        PageMetaDto page,
+        @Schema(description = "Current page content")
+        List<T> data) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PageMetaDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/PageMetaDto.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Pagination metadata.
+ */
+public record PageMetaDto(
+        @Schema(description = "Zero-based page index")
+        int number,
+        @Schema(description = "Requested page size")
+        int size,
+        @Schema(description = "Total number of elements")
+        long totalElements,
+        @Schema(description = "Total number of pages")
+        long totalPages) {
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -44,7 +44,8 @@ class PostsControllerIT {
 
         mockMvc.perform(get("/contents/posts").with(jwt()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].title").value("Title"));
+                .andExpect(jsonPath("$.page.number").value(0))
+                .andExpect(jsonPath("$.data[0].title").value("Title"));
     }
 
     @Test

--- a/frontend/src/pages/blog/index.vue
+++ b/frontend/src/pages/blog/index.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAsyncData, useI18n } from '#imports'
 import PostPreview from '@/components/blog/PostPreview.vue'
@@ -27,14 +27,15 @@ const route = useRoute()
 const blogApi = useBlogApi()
 const selectedTag = ref<string | undefined>(route.query.tag as string)
 
-const { data: posts } = await useAsyncData(
+const { data: page } = await useAsyncData(
   'posts',
   () => blogApi.posts({ tag: selectedTag.value }),
-  { default: () => [] }
+  { default: () => ({ data: [] }) }
 )
+const posts = computed(() => page.value?.data ?? [])
 const { data: tags } = await useAsyncData('tags', () => blogApi.tags(), { default: () => [] })
 
 watch(selectedTag, async () => {
-  posts.value = await blogApi.posts({ tag: selectedTag.value })
+  page.value = await blogApi.posts({ tag: selectedTag.value })
 })
 </script>


### PR DESCRIPTION
## Summary
- add generic PageDto and PageMetaDto records
- adapt `PaginationLinkAdvice` to return PageDto
- reference PageDto in PostsController and ProductController
- update integration tests for paged blog posts
- regenerate frontend API client (fails due to network) and update blog page

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `mvn clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6863aed3d3bc8333aedb96ae33477eb6