### PR TITLE
Fix CORS host configuration

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -14,15 +14,17 @@ The application runs on **port 8082** by default (`server.port` in `application.
 Security is enabled by default using JWT authentication. For local testing it can be disabled by setting
 `front.security.enabled=false` in `application.yml` or via an environment variable.
 To allow the Nuxt frontend running on a different host during development, configure the list of allowed
-CORS origins using the `front.security.cors-allowed-hosts` property. By default it permits requests from
+CORS origins using the `front.security.cors-allowed-hosts` property. You can override the default value
+via the `FRONT_SECURITY_CORS_ALLOWED_HOSTS` environment variable. By default it permits requests from
 `http://localhost:8082`.
 
 ## Local development tips
 
 When starting the application locally you may be tempted to call the beta API
 (`https://beta.front-api.nudger.fr`). That server does not set CORS headers for
-`http://localhost:8082`, which leads the browser to reject the requests. Ensure
-your frontend uses the local API base URL instead:
+`http://localhost:8082`, which leads the browser to reject the requests. Either
+set `FRONT_SECURITY_CORS_ALLOWED_HOSTS=http://localhost:3000` on the API server
+or keep your frontend pointed to the local API base URL:
 
 ```bash
 export API_URL=http://localhost:8082

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -21,7 +21,8 @@
     {
       "name": "front.security.cors-allowed-hosts",
       "type": "java.lang.String",
-      "description": "A description for 'front.security.cors-allowed-hosts'"
+      "description": "Comma-separated list of origins allowed for CORS requests.",
+      "defaultValue": "http://localhost:8082"
     },
     {
       "name": "front.cache.path",

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -20,8 +20,7 @@ front:
     path: ./cache
   security:
     enabled: false
-    cors-allowed-hosts:
-      "http://localhost:8082"
+    cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
     
 xwiki:
     username: nudger


### PR DESCRIPTION
## Summary
- allow overriding CORS hosts in front-api via env variable
- document how to change allowed hosts for local dev

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863bcd42848833388f409c68bdf6bc5