### PR TITLE
Fix Vitest ESM support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "generate": "nuxt generate",
     "lint": "eslint .",
     "format": "prettier --check .",
-    "test": "vitest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules vitest run",
     "storybook": "pnpm exec storybook dev -p 6006 --no-open",
     "storybook:build": "pnpm exec storybook build",
     "generate:api": "openapi-generator-cli generate -i https://beta.front-api.nudger.fr/v3/api-docs/front -g typescript-fetch -o src/api --skip-validate-spec",


### PR DESCRIPTION
## Summary
- run Vitest with NODE_OPTIONS so it loads ESM correctly

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm generate`
- `pnpm storybook` *(fails: process kept running so was aborted)*
- `pnpm preview` *(failed: needed to install serve)*
- `mvn -DskipTests install` *(failed: couldn't resolve dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_686437b01d2083338548d0228b5bd408