### PR TITLE
Add optional aggregations to product list

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -8,9 +8,9 @@ import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
-import org.open4goods.nudgerfrontapi.dto.PageDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
+import org.open4goods.nudgerfrontapi.dto.product.ProductPageAggsDto;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.CacheControl;
@@ -87,20 +87,26 @@ public class ProductController {
                     @Parameter(name = "sort", in = ParameterIn.QUERY, description = "Sort criteria in the format: property,(asc|desc). ",array = @ArraySchema(
                             schema = @Schema(implementation = ProductDtoSortableFields.class)
                     )),
+                    @Parameter(name = "withAggs", in = ParameterIn.QUERY, description = "Fields to aggregate on",
+                            array = @ArraySchema(schema = @Schema(implementation = ProductDtoAggregatableFields.class))),
+                    @Parameter(name = "withSubAggs", in = ParameterIn.QUERY, description = "Sub aggregation fields",
+                            array = @ArraySchema(schema = @Schema(implementation = ProductDtoAggregatableFields.class)))
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Products returned",
                             headers = @Header(name = "Link", description = "Pagination links as defined by RFC 8288"),
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = PageDto.class))),
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductPageAggsDto.class))),
                     @ApiResponse(responseCode = "401", description = "Authentication required"),
                     @ApiResponse(responseCode = "403", description = "Access forbidden"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
-    public ResponseEntity<Page<ProductDto>> products(
-    		@Parameter(hidden = true) @PageableDefault(size = 20) Pageable page,
-    		@RequestParam(required=false) Set<String> include,
-    		  Locale locale) {
+    public ResponseEntity<ProductPageAggsDto> products(
+                @Parameter(hidden = true) @PageableDefault(size = 20) Pageable page,
+                @RequestParam(required=false) Set<String> include,
+                @RequestParam(name = "withAggs", required = false) Set<String> aggs,
+                @RequestParam(name = "withSubAggs", required = false) Set<String> subAggs,
+                  Locale locale) {
 
 
 		/////////////////////
@@ -134,12 +140,28 @@ public class ProductController {
 		// Transforming product to DTO
 		///////////////////////
 
-		Page<ProductDto> body = service.getProducts(page, locale, include == null ? Set.of() : include);
+                if (aggs != null) {
+                        aggs.forEach(a -> {
+                                if (ProductDtoAggregatableFields.fromText(a).isEmpty()) {
+                                        return;
+                                }
+                        });
+                }
 
+                if (subAggs != null) {
+                        subAggs.forEach(a -> {
+                                if (ProductDtoAggregatableFields.fromText(a).isEmpty()) {
+                                        return;
+                                }
+                        });
+                }
 
+                ProductPageAggsDto body = service.getProducts(page, locale,
+                                include == null ? Set.of() : include,
+                                aggs, subAggs);
 
-		return ResponseEntity.ok().cacheControl(ONE_HOUR_PUBLIC_CACHE).body(body);
-	}
+                return ResponseEntity.ok().cacheControl(ONE_HOUR_PUBLIC_CACHE).body(body);
+        }
 
     /**
      * Return high level information for a product.

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -71,3 +71,35 @@ public record ProductDto(
 
         }
 }
+
+        /**
+         * Allowed aggregation fields.
+         */
+        public enum ProductDtoAggregatableFields {
+                vertical("vertical"),
+                taxonomy("googleTaxonomyId"),
+                country("gtinInfos.country");
+
+                private final String text;
+
+                ProductDtoAggregatableFields(String text) {
+                        this.text = text;
+                }
+
+                public String getText() {
+                        return text;
+                }
+
+                @Override
+                public String toString() {
+                        return text;
+                }
+
+                private static final Map<String, ProductDtoAggregatableFields> LOOKUP =
+                        Arrays.stream(values()).collect(Collectors.toMap(ProductDtoAggregatableFields::getText, e -> e));
+
+                public static Optional<ProductDtoAggregatableFields> fromText(String text) {
+                        return Optional.ofNullable(LOOKUP.get(text));
+                }
+        }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPageAggsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPageAggsDto.java
@@ -1,0 +1,19 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Wrapper around the paginated product list with optional aggregations.
+ */
+public record ProductPageAggsDto(
+        @Schema(description = "Page of products")
+        Page<ProductDto> page,
+        @Schema(description = "Aggregations keyed by field name")
+        Map<String, @ArraySchema(schema = @Schema(implementation = TermsBucketDto.class)) List<TermsBucketDto>> aggs) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/TermsBucketDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/TermsBucketDto.java
@@ -1,0 +1,13 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Represents a single bucket returned by an Elastic terms aggregation.
+ */
+public record TermsBucketDto(
+        @Schema(description = "Bucket key", example = "electronics")
+        String key,
+        @Schema(description = "Number of matching documents", example = "42")
+        long count) {
+}


### PR DESCRIPTION
## Summary
- add `ProductDtoAggregatableFields` enum
- introduce `ProductPageAggsDto` and `TermsBucketDto`
- implement aggregation query support in `ProductRepository`
- expose `withAggs` and `withSubAggs` parameters in `ProductController`
- map aggregations in `ProductMappingService`

## Testing
- `mvn -pl front-api -am test -q` *(fails: Could not transfer artifact spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68646b6cee208333972b80aa0bb6ea5a