### PR TITLE
feat(frontend): add blog pagination

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -3,6 +3,8 @@
     "title": "Blog",
     "noPosts": "No posts found",
     "by": "by",
-    "tags": "Tags"
+    "tags": "Tags",
+    "previous": "Previous",
+    "next": "Next"
   }
 }

--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -3,6 +3,8 @@
     "title": "Blog",
     "noPosts": "Aucun article",
     "by": "par",
-    "tags": "Étiquettes"
+    "tags": "Étiquettes",
+    "previous": "Précédent",
+    "next": "Suivant"
   }
 }

--- a/frontend/src/components/Pagination.spec.ts
+++ b/frontend/src/components/Pagination.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('#imports', () => ({
+  useI18n: () => ({ t: (key: string) => key })
+}))
+import Pagination from './Pagination.vue'
+
+const meta = { number: 0, size: 10, totalElements: 20, totalPages: 2 }
+
+describe('Pagination', () => {
+  it('emits change event when next page clicked', async () => {
+    const wrapper = mount(Pagination, { props: { meta } })
+    await wrapper.findAll('button')[1].trigger('click')
+    expect(wrapper.emitted('change')?.[0]).toEqual([1])
+  })
+
+  it('disables previous button on first page', () => {
+    const wrapper = mount(Pagination, { props: { meta } })
+    expect(wrapper.findAll('button')[0].attributes()).toHaveProperty('disabled')
+  })
+})

--- a/frontend/src/components/Pagination.stories.ts
+++ b/frontend/src/components/Pagination.stories.ts
@@ -1,0 +1,21 @@
+import Pagination from './Pagination.vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+
+const meta: Meta<typeof Pagination> = {
+  component: Pagination,
+  title: 'Pagination'
+}
+export default meta
+
+export const Default: StoryObj<typeof Pagination> = {
+  render: (args) => ({
+    components: { Pagination },
+    setup() {
+      return { args }
+    },
+    template: '<Pagination :meta="args.meta" />'
+  }),
+  args: {
+    meta: { number: 0, size: 10, totalElements: 20, totalPages: 2 }
+  }
+}

--- a/frontend/src/components/Pagination.vue
+++ b/frontend/src/components/Pagination.vue
@@ -1,0 +1,35 @@
+<template>
+  <nav v-if="meta" class="flex justify-center mt-4 items-center gap-2">
+    <button
+      class="px-3 py-1 border rounded disabled:opacity-50"
+      :disabled="meta.number === 0"
+      @click="change(meta.number - 1)"
+    >
+      {{ t('blog.previous') }}
+    </button>
+    <span class="px-2">{{ meta.number + 1 }} / {{ meta.totalPages }}</span>
+    <button
+      class="px-3 py-1 border rounded disabled:opacity-50"
+      :disabled="meta.number + 1 >= meta.totalPages"
+      @click="change(meta.number + 1)"
+    >
+      {{ t('blog.next') }}
+    </button>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from '#imports'
+import type { PageMetaDto } from '@/api'
+
+defineProps<{ meta: PageMetaDto }>()
+const emit = defineEmits<{
+  (e: 'change', page: number): void
+}>()
+
+const { t } = useI18n()
+
+function change(page: number) {
+  emit('change', page)
+}
+</script>

--- a/frontend/src/pages/blog/index.vue
+++ b/frontend/src/pages/blog/index.vue
@@ -12,30 +12,47 @@
     </div>
     <PostPreview v-for="p in posts" :key="p.url" :post="p" />
     <p v-if="posts.length === 0">{{ t('blog.noPosts') }}</p>
+    <Pagination v-if="meta.totalPages > 1" :meta="meta" @change="pageNumber = $event" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useAsyncData, useI18n } from '#imports'
 import PostPreview from '@/components/blog/PostPreview.vue'
+import Pagination from '@/components/Pagination.vue'
 import { useBlogApi } from '@/composables/useBlogApi'
 
 const { t } = useI18n()
 const route = useRoute()
+const router = useRouter()
 const blogApi = useBlogApi()
 const selectedTag = ref<string | undefined>(route.query.tag as string)
+const pageNumber = ref<number>(route.query.page ? Number(route.query.page) : 0)
+
+const defaultPage = { page: { number: 0, size: 10, totalElements: 0, totalPages: 0 }, data: [] }
 
 const { data: page } = await useAsyncData(
   'posts',
-  () => blogApi.posts({ tag: selectedTag.value }),
-  { default: () => ({ data: [] }) }
+  () => blogApi.posts({ tag: selectedTag.value, pageNumber: pageNumber.value }),
+  { default: () => defaultPage }
 )
 const posts = computed(() => page.value?.data ?? [])
+const meta = computed(() => page.value?.page ?? defaultPage.page)
 const { data: tags } = await useAsyncData('tags', () => blogApi.tags(), { default: () => [] })
 
+async function load() {
+  page.value = await blogApi.posts({ tag: selectedTag.value, pageNumber: pageNumber.value })
+  router.replace({ query: { tag: selectedTag.value, page: pageNumber.value.toString() } })
+}
+
 watch(selectedTag, async () => {
-  page.value = await blogApi.posts({ tag: selectedTag.value })
+  pageNumber.value = 0
+  await load()
+})
+
+watch(pageNumber, async () => {
+  await load()
 })
 </script>


### PR DESCRIPTION
## Summary
- add new Pagination component
- paginate blog posts using backend pageable structure
- translate pagination labels
- test Pagination component

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm generate`
- `pnpm storybook`
- `pnpm preview` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68653113ad708333bdba61fed25f973d