### PR TITLE
Fix Nuxt config import

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,4 +1,4 @@
-import type { NuxtConfig } from '@nuxt/schema'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   // Enable server-side rendering
@@ -96,4 +96,4 @@ export default defineNuxtConfig({
     preset: process.env.NITRO_PRESET === 'github_pages' ? 'github-pages' : undefined
   }
 
-} satisfies NuxtConfig)
+})


### PR DESCRIPTION
## Summary
- update Nuxt config file to use `defineNuxtConfig` import

## Testing
- `pnpm lint`
- `pnpm exec vitest run`
- `pnpm generate`
- `pnpm storybook:build`
- `pnpm preview --port 4000`
- `mvn -q -DskipTests install` *(failed: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866757e632c8333871f6a7b31ff7bde