### PR TITLE
Expose available product fields

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -3,11 +3,14 @@ package org.open4goods.nudgerfrontapi.controller.api;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Set;
+import java.util.Arrays;
+import java.util.List;
 
 import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
 import org.open4goods.nudgerfrontapi.dto.PageDto;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
 import org.springframework.data.domain.Page;
@@ -55,6 +58,66 @@ public class ProductController {
 
     public ProductController(ProductMappingService service) {
         this.service = service;
+    }
+
+    /**
+     * List allowed component names that can be requested via the {@code include} parameter.
+     */
+    @GetMapping("/fields/components")
+    @Operation(
+            summary = "Get available components",
+            description = "Return the list of components that can be included in product responses.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Components returned",
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(type = "string"))))
+            }
+    )
+    public ResponseEntity<List<String>> components() {
+        List<String> body = Arrays.stream(ProductDtoComponent.values())
+                .map(Enum::name)
+                .toList();
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * List product fields that can be used for sorting.
+     */
+    @GetMapping("/fields/sortable")
+    @Operation(
+            summary = "Get sortable fields",
+            description = "Return the list of fields accepted by the sort parameter.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Fields returned",
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(type = "string"))))
+            }
+    )
+    public ResponseEntity<List<String>> sortableFields() {
+        List<String> body = Arrays.stream(ProductDtoSortableFields.values())
+                .map(ProductDtoSortableFields::getText)
+                .toList();
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * List product fields that support aggregation queries.
+     */
+    @GetMapping("/fields/aggregatable")
+    @Operation(
+            summary = "Get aggregatable fields",
+            description = "Return the list of fields available for aggregation.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Fields returned",
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(type = "string"))))
+            }
+    )
+    public ResponseEntity<List<String>> aggregatableFields() {
+        List<String> body = Arrays.stream(ProductDtoAggregatableFields.values())
+                .map(ProductDtoAggregatableFields::getText)
+                .toList();
+        return ResponseEntity.ok(body);
     }
 
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -70,4 +70,35 @@ public record ProductDto(
                 }
 
         }
+
+        /**
+         * Allowed aggregation fields on Products. (must match elastic mapping)
+         */
+        public enum ProductDtoAggregatableFields {
+                price("price.minPrice.price"),
+                offersCount("offersCount");
+
+                private final String text;
+
+                ProductDtoAggregatableFields(String text) {
+                        this.text = text;
+                }
+
+                public String getText() {
+                        return text;
+                }
+
+                @Override
+                public String toString() {
+                        return text;
+                }
+
+                private static final Map<String, ProductDtoAggregatableFields> LOOKUP =
+                        Arrays.stream(values()).collect(Collectors.toMap(ProductDtoAggregatableFields::getText, e -> e));
+
+                public static Optional<ProductDtoAggregatableFields> fromText(String text) {
+                        return Optional.ofNullable(LOOKUP.get(text));
+                }
+
+        }
 }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -104,6 +104,27 @@ class ProductControllerIT {
                 .andExpect(jsonPath("$.page.number").value(0));
     }
 
+    @Test
+    void sortableFieldsEndpointReturnsList() throws Exception {
+        mockMvc.perform(get("/products/fields/sortable").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void componentsEndpointReturnsList() throws Exception {
+        mockMvc.perform(get("/products/fields/components").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void aggregatableFieldsEndpointReturnsList() throws Exception {
+        mockMvc.perform(get("/products/fields/aggregatable").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
 
 
 


### PR DESCRIPTION
## Summary
- expose new ProductDtoAggregatableFields enum
- add endpoints to list product components, sortable and aggregatable fields
- test new endpoints in ProductControllerIT

## Testing
- `mvn -pl front-api -am test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4193c488333b89ab519b3714adc