### PR TITLE
Add auto lint-fix to frontend build

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -15,6 +15,7 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
    - `NUXT_PUBLIC_SITE_URL`, etc.
 5. **Run Dev Server**: `pnpm dev` → http://localhost:3000
 6. **Production Build**: `pnpm build` then `pnpm preview`
+   - The `build` script automatically runs `pnpm lint --fix` before invoking Nuxt, ensuring lint issues are corrected during CI.
 7. **Static Generation**: `pnpm generate`
 8. **Helper Scripts**:
    - `pnpm lint`
@@ -186,4 +187,6 @@ Before issueing a PR, systematically validate and check global non regession usi
 - pnpm generate
 - pnpm storybook, check all components have an associated storybook 
 - pnpm preview, then tests URLS are HTTP 200 or act as expected
+
+The `pnpm build` script runs `pnpm lint --fix` automatically before building to enforce consistent formatting.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "nuxt dev",
-    "build": "nuxt build",
-    "build:ssr": "NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
+    "build": "pnpm lint --fix && nuxt build",
+    "build:ssr": "pnpm lint --fix && NODE_OPTIONS='--max-old-space-size=8192' nuxt build",
     "preview": "nuxt preview",
     "generate": "nuxt generate",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- run `pnpm lint --fix` automatically in the frontend build script
- document automatic lint-fix step in `frontend/AGENTS.md`

## Testing
- `mvn clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*
- `pnpm install --frozen-lockfile`
- `pnpm lint --fix`
- `pnpm test run`
- `pnpm generate`
- `pnpm storybook:build`
- `pnpm build`
- `pnpm preview` *(checked HTTP 200 for `/` and `/sitemap.xml`)*

------
https://chatgpt.com/codex/tasks/task_e_6866e0ece9a88333bdb1b735545d6a9e