### PR TITLE
Update frontend pre-push checks

### DIFF
--- a/frontend/.husky/pre-push
+++ b/frontend/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-#TODO : Renable, but whereas pnpm is installed, eclipse / giit fail, indicating "pnpm not found"
-#pnpm lint && pnpm test --run && pnpm build
+pnpm lint && pnpm test --run && pnpm build

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -162,7 +162,7 @@ export const Primary: Story = {
 - Prettier integrated via ESLint
 - Run: `pnpm lint`, `pnpm lint --fix`
 - Run: `pnpm format` to check formatting
-- Husky hooks enforce checks on commits
+- Husky hooks enforce checks on commits and pushes. The `pre-push` hook runs `pnpm lint && pnpm test --run && pnpm build`.
 
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -121,7 +121,7 @@ src/
 - `.storybook/` – Storybook configuration files
 - `nudger-api.json` – OpenAPI specification used by `generate:api`
 - `.env.example` – example environment variables
-- `.husky/` – Git hooks executed on commit
+- `.husky/` – Git hooks executed on commit and push (pre-push runs `pnpm lint && pnpm test --run && pnpm build`)
 
 ## Vue 3 & Nuxt 3 Conventions
 


### PR DESCRIPTION
## Summary
- enable husky pre-push hook again
- document new hook behaviour

## Testing
- `pnpm lint --fix`
- `pnpm vitest run`
- `pnpm generate`
- `pnpm storybook --smoke-test`
- `pnpm preview` *(fails: need to install serve)*
- `mvn clean install -DskipTests` *(fails: could not transfer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866e85c6b9c8333885c31d399883a84