### PR TITLE
Add pre-commit hook to frontend

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm lint
+pnpm format

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -323,7 +323,8 @@ We welcome pull requests! To contribute:
 1. Fork this repository and create a feature branch.
 2. Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 3. Run `pnpm lint`, `pnpm generate`, and `pnpm test` before committing.
-4. Open a pull request against the `main` branch.
+4. A Husky **pre-commit hook** automatically runs `pnpm lint` and `pnpm format`.
+5. Open a pull request against the `main` branch.
 
 ## Semantic Commit Examples
 


### PR DESCRIPTION
## Summary
- add a Husky pre-commit script running `pnpm lint` and `pnpm format`
- document the hook in the frontend README

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm exec vitest run`
- `pnpm generate`
- `pnpm storybook:build`
- `pnpm preview` *(fails: requires serve)*

------
https://chatgpt.com/codex/tasks/task_e_6866e85b83c88333bd0c0b3c826a4504