### PR TITLE
Remove frontend dist symlink

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 !/.husky/pre-push
 !/.husky/pre-commit
 !/.husky/
+dist/

--- a/frontend/dist
+++ b/frontend/dist
@@ -1,1 +1,0 @@
-/home/goulven/git/open4goods/frontend/.output/public


### PR DESCRIPTION
## Summary
- drop the `frontend/dist` symlink from version control
- ignore build output directory in `frontend/.gitignore`

## Testing
- `pnpm lint --fix` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm test` *(fails: vitest not found)*
- `pnpm generate` *(fails: nuxt not found)*
- `pnpm storybook` *(fails: command "storybook" not found)*
- `mvn clean install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866e85a24388333b0c804664ae86243