### PR TITLE
Add service READMEs

### DIFF
--- a/services/blog/README.md
+++ b/services/blog/README.md
@@ -1,0 +1,37 @@
+# Blog Service
+
+This microservice fetches blog posts from XWiki and exposes them as an RSS feed.
+Scheduled refresh keeps posts up to date and a Spring Boot health indicator
+reports loading issues.
+
+## Features
+
+- Retrieves posts via `XwikiFacadeService`.
+- Generates an RSS feed with Rome.
+- Periodically refreshes posts using `@Scheduled`.
+- Provides health status through Spring Boot Actuator.
+
+## Configuration
+
+Configuration properties (example `application.yml`):
+
+```yaml
+blog:
+  feedType: "rss_2.0"
+  blogUrl: "blog/"
+  feedUrl: "blog/rss/"
+  feedTitle: { en: "Open4goods", fr: "Open4goods" }
+  feedDescription: { en: "Latest news", fr: "Dernières nouvelles" }
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for details.
+This module is released under the [AGPL v3 license](../../LICENSE).

--- a/services/captcha/README.md
+++ b/services/captcha/README.md
@@ -1,0 +1,30 @@
+# Captcha Service
+
+Validates hCaptcha challenges and assigns a Spring Security role on success.
+
+## Features
+
+- Verifies tokens against the hCaptcha API.
+- Assigns the configured role to the authenticated user.
+- Exposes a health indicator via Spring Boot Actuator.
+
+## Configuration
+
+```yaml
+captcha:
+  key: "site-key"
+  secretKey: "secret-key"
+  validRole: "ROLE_HUMAN"
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for more information.
+This module is distributed under the [AGPL v3 license](../../LICENSE).

--- a/services/favicon/README.md
+++ b/services/favicon/README.md
@@ -1,0 +1,37 @@
+# Favicon Service
+
+Retrieves and caches website favicons. Provides a REST API to query and
+fetch icons with optional fallback mechanisms.
+
+## Features
+
+- Resolve favicon URLs from HTML pages or direct mappings.
+- Cache icons in memory and on disk via `RemoteFileCachingService`.
+- Exposes metrics and health status.
+- REST endpoints:
+  - `GET /favicon/exists?url=...` – check if a favicon is available.
+  - `GET /favicon?url=...` – retrieve the favicon bytes.
+  - `DELETE /favicon/cache` – clear the cache.
+
+## Configuration
+
+```yaml
+favicon:
+  cacheFolder: "/opt/open4goods/.cached/"
+  urlTimeout: 5000
+  fallbackUrl: "https://t3.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url={url}&size=64"
+  domainMapping:
+    example.com: "http://www.example.com/favicon.ico"
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for details.
+This module is licensed under the [AGPL v3](../../LICENSE).

--- a/services/github-feedback/README.md
+++ b/services/github-feedback/README.md
@@ -1,0 +1,36 @@
+# GitHub Feedback Service
+
+Publishes feedback issues to GitHub and manages per‑IP voting quotas.
+
+## Features
+
+- Create "bug" or "idea" issues through the GitHub API.
+- Limit votes per IP and store total votes via comments.
+- Health indicator checks repository connectivity.
+
+## Configuration
+
+```yaml
+feedback:
+  github:
+    accessToken: "your-token"
+    organization: "open4good"
+    repo: "open4goods"
+    user: "bot-user"
+  voting:
+    maxVotesPerIpPerDay: 5
+    requiredLabel: "votable"
+    defaultVotable: true
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for more information.
+This module is released under the [AGPL v3 license](../../LICENSE).

--- a/services/icecat/README.md
+++ b/services/icecat/README.md
@@ -1,0 +1,36 @@
+# Icecat Service
+
+Loads Icecat XML data (features, categories, languages) and exposes helper
+methods for product enrichment.
+
+## Features
+
+- Downloads and caches Icecat XML files through `RemoteFileCachingService`.
+- Parses languages, brands, feature groups and categories.
+- Provides utilities to resolve Icecat feature names.
+
+## Configuration
+
+```yaml
+icecat:
+  featuresListFileUri: "https://.../features_list.xml.gz"
+  categoryFeatureListFileUri: "https://.../category_features.xml.gz"
+  languageListFileUri: "https://.../language_list.xml.gz"
+  brandsListFileUri: "https://.../brands_list.xml.gz"
+  categoriesListFileUri: "https://.../categories_list.xml.gz"
+  featureGroupsFileUri: "https://.../feature_groups.xml.gz"
+  user: "myuser"
+  password: "secret"
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for details.
+This module is licensed under the [AGPL v3](../../LICENSE).

--- a/services/remotefilecaching/README.md
+++ b/services/remotefilecaching/README.md
@@ -1,0 +1,30 @@
+# Remote File Caching Service
+
+Utility for downloading remote resources with local caching and optional
+archive extraction.
+
+## Features
+
+- Download files with configurable timeouts.
+- Refresh files based on a configurable period.
+- Supports GZIP decompression when retrieving archives.
+
+## Configuration
+
+```yaml
+remote-file-caching:
+  connectionTimeout: 30000
+  readTimeout: 30000
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for details.
+This module is released under the [AGPL v3 license](../../LICENSE).

--- a/services/review-generation/README.md
+++ b/services/review-generation/README.md
@@ -1,0 +1,38 @@
+# Review Generation Service
+
+Generates AI-assisted product reviews using OpenAI. It searches the web
+for sources, fetches content, and composes prompts either in realtime or
+via the batch API.
+
+## Features
+
+- Google search integration to build context.
+- URL fetching with concurrency control.
+- Realtime and batch review generation flows.
+- Scheduled processing of batch jobs.
+- Exposes health metrics.
+
+## Configuration
+
+```yaml
+review:
+  generation:
+    batchFolder: "/opt/open4goods/batch-ids/"
+    threadPoolSize: 10
+    maxQueueSize: 1000
+    maxSearch: 5
+    regenerationDelayDays: 30
+    retryDelayDays: 7
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for details.
+This module is provided under the [AGPL v3 license](../../LICENSE).

--- a/services/urlfetching/README.md
+++ b/services/urlfetching/README.md
@@ -1,0 +1,39 @@
+# URL Fetching Service
+
+Provides asynchronous URL retrieval with domain-specific strategies. Can
+record responses for testing and supports HTTP, proxified and Selenium
+based fetchers.
+
+## Features
+
+- Configurable fetching strategy per domain.
+- Optional response recording for mock generation.
+- Metrics and health indicators.
+
+## Configuration
+
+```yaml
+urlfetcher:
+  threadPoolSize: 10
+  domains:
+    example.com:
+      userAgent: "Mozilla/5.0"
+      strategy: SELENIUM
+    another.com:
+      strategy: PROXIFIED
+  record:
+    enabled: false
+    destinationFolder: "src/test/resources/urlfetching/mocks"
+```
+
+## Build & Test
+
+```bash
+mvn clean install
+mvn test
+```
+
+## Project Links
+
+See the [main open4goods project](../../README.md) for more details.
+This module is licensed under the [AGPL v3](../../LICENSE).


### PR DESCRIPTION
## Summary
- add missing READMEs for Blog, Captcha, Favicon, GitHub Feedback, Icecat, Remote File Caching, Review Generation and URL Fetching services
- explain key features, configuration and build/test steps for each module

## Testing
- `mvn clean install` *(fails: transfer failed)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb84378883339677d626cab0f445