### PR TITLE
Enhance service READMEs

### DIFF
--- a/services/evaluation/README.md
+++ b/services/evaluation/README.md
@@ -51,12 +51,24 @@ evaluation:
 
 This property controls whether Thymeleaf template caching is enabled. IDE metadata is provided for enhanced Spring configuration support.
 
-## How to Build
+## Build & Test
 
-Use Maven to build the project:
+Build the module from this folder:
 
 ```bash
 mvn clean install
+```
+
+Run the tests only:
+
+```bash
+mvn test
+```
+
+You can also build it from the repository root:
+
+```bash
+mvn -pl services/evaluation -am clean install
 ```
 
 ## Running
@@ -129,3 +141,6 @@ Critical failures in SpEL and Thymeleaf evaluations are logged at the `ERROR` le
 ## Contributing
 
 Contributions are welcome. Please ensure that any new code is accompanied by appropriate unit tests and documentation.
+
+For project-wide information see the [main README](../../README.md).
+

--- a/services/googlesearch/README.md
+++ b/services/googlesearch/README.md
@@ -59,14 +59,29 @@ googlesearch:
 
 A sample unit test is provided in `src/test/java/org/open4goods/googlesearch/GoogleSearchServiceTest.java`. The test configuration is bootstrapped using an `application-test.yml`.
 
-## Maven Build
+## Build & Test
 
-The Maven POM is configured with the necessary dependencies and plugins. To build the service, run:
+Build the module from this directory:
 
 ```bash
 mvn clean install
 ```
 
+Run tests only:
+
+```bash
+mvn test
+```
+
+You can also build from the repository root:
+
+```bash
+mvn -pl services/googlesearch -am clean install
+```
+
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).
+
+For project-wide information see the [main README](../../README.md).
+

--- a/services/image-processing/README.md
+++ b/services/image-processing/README.md
@@ -1,15 +1,45 @@
 # Image Processing Service
 
-This module provides utilities for generating images using OpenAI and basic image manipulation with ImageMagick.
+This service is part of the [open4goods](https://github.com/open4good/open4goods) project. It provides simple image generation through OpenAI and utilities around ImageMagick.
 
-## Features
+## Overview
 
-- Generate images through the OpenAI API.
-- Convert and resize images via ImageMagick command line tools.
-- Simple image analysis utilities.
+Main responsibilities:
 
-Build with Maven:
+- Convert images to PNG format and create thumbnails.
+- Analyse basic image metadata such as size or type.
+- Optionally generate images via OpenAI.
+
+## Configuration
+
+The service does not expose configuration properties. All parameters are supplied directly to the service methods.
+
+## Usage Example
+
+```java
+ImageMagickService service = new ImageMagickService();
+service.convertToPng(new File("src.jpg"), new File("target.png"));
+service.generateThumbnail(new File("target.png"), new File("thumb.png"), 120);
+```
+
+## Build & Test
+
+Build from this directory:
 
 ```bash
 mvn clean install
 ```
+
+Run tests only:
+
+```bash
+mvn test
+```
+
+You can also build it from the repository root:
+
+```bash
+mvn -pl services/image-processing -am clean install
+```
+
+For project-wide information see the [main README](../../README.md).

--- a/services/product-repository/README.md
+++ b/services/product-repository/README.md
@@ -1,131 +1,61 @@
-# Evaluation Microservice
+# Product Repository Service
 
-This microservice provides evaluation functionality for products using Spring Expression Language (SpEL) and Thymeleaf templates.
+This service is part of the [open4goods](https://github.com/open4good/open4goods) project. It stores and retrieves aggregated product data from Elasticsearch.
 
-## Features
+## Overview
 
-- **SpEL Evaluations:** Validate and compute product properties using trusted SpEL expressions.
-- **Thymeleaf Template Evaluations:** Generate dynamic strings based on product data with Thymeleaf templates.
-- **Configuration Driven:** Template caching is configurable via YAML with Spring IDE metadata for auto-completion.
-- **Robust Error Handling:** Critical failures in SpEL and template evaluations are logged at the ERROR level, and unresolved template variables raise a custom exception.
-- **Unit Testing:** Tests are written with Mockito and bootstrapped with a dedicated test configuration.
+Main responsibilities:
 
-## Directory Structure
-
-```
-.
-├── pom.xml
-├── src
-│   ├── main
-│   │   ├── java
-│   │   │   └── org
-│   │   │       └── open4goods
-│   │   │           └── evaluation
-│   │   │               ├── config
-│   │   │               │   └── EvaluationProperties.java
-│   │   │               ├── exception
-│   │   │               │   └── TemplateEvaluationException.java
-│   │   │               └── service
-│   │   │                   └── EvaluationService.java
-│   │   └── resources
-│   └── test
-│       ├── java
-│       │   └── org
-│       │       └── open4goods
-│       │           └── evaluation
-│       │               └── service
-│       │                   └── EvaluationServiceTest.java
-│       └── resources
-│           └── application-test.yml
-```
+- Persist `Product` documents and perform search queries.
+- Export and stream results for other modules.
+- Handle asynchronous indexation through worker threads.
 
 ## Configuration
 
-The microservice reads its configuration from YAML files. In particular, the template caching property is configured via:
+Indexation parameters are provided by `IndexationConfig`:
 
-```yaml
-evaluation:
-  template:
-    cacheable: true
+| Property | Default | Description |
+| --- | --- | --- |
+| `productsQueueMaxSize` | 5000 | Queue size for full products. |
+| `partialProductsQueueMaxSize` | 5000 | Queue size for partial updates. |
+| `datafragmentQueueMaxSize` | 20000 | Queue size for data fragments. |
+| `productsbulkPageSize` | 200 | Bulk size for full products. |
+| `partialProductsbulkPageSize` | 300 | Bulk size for partial products. |
+| `dataFragmentbulkPageSize` | 200 | Bulk size for data fragments. |
+| `productWorkers` | 2 | Number of worker threads for full products. |
+| `partialProductWorkers` | 2 | Worker threads for partial updates. |
+| `dataFragmentworkers` | 2 | Worker threads for data fragment aggregation. |
+| `pauseDuration` | 4000 | Pause duration (ms) when queues are empty. |
+
+## Usage Example
+
+```java
+@Autowired
+private ProductRepository productRepository;
+
+public Product loadProduct(long id) throws ResourceNotFoundException {
+    return productRepository.getById(id);
+}
 ```
 
-This property controls whether Thymeleaf template caching is enabled. IDE metadata is provided for enhanced Spring configuration support.
+## Build & Test
 
-## How to Build
-
-Use Maven to build the project:
+Build from this folder:
 
 ```bash
 mvn clean install
 ```
 
-## Running
-
-Run the microservice as a Spring Boot application using your preferred method.
-
-## How to Use
-
-The `EvaluationService` is a Spring-managed service that can be injected into your controllers or other services. Here are some example usages:
-
-```java
-import org.open4goods.services.evaluation.service.EvaluationService;
-import org.open4goods.services.evaluation.exception.TemplateEvaluationException;
-import org.open4goods.model.product.Product;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-@Service
-public class ProductController {
-
-    private final EvaluationService evaluationService;
-
-    @Autowired
-    public ProductController(EvaluationService evaluationService) {
-        this.evaluationService = evaluationService;
-    }
-
-    public void evaluateProduct(Product product) {
-        // Evaluate a condition using SpEL (e.g., check if the product price is greater than 100)
-        boolean isValid = evaluationService.spelEval(product, "p.price > 100");
-        System.out.println("Product valid: " + isValid);
-
-        // Compute a string value using SpEL (e.g., generate a product identifier)
-        String computedId = evaluationService.spelCompute(product, "'Product-' + p.id");
-        System.out.println("Computed Product ID: " + computedId);
-
-        // Evaluate a Thymeleaf template using product data
-        try {
-            String evaluatedTemplate = evaluationService.thymeleafEval(product, "Product Name: [[${p.name}]]");
-            System.out.println(evaluatedTemplate);
-        } catch (TemplateEvaluationException ex) {
-            // Handle unresolved variable exception
-            System.err.println("Error evaluating template: " + ex.getMessage());
-        }
-    }
-}
-```
-
-You can also pass a map of additional parameters to the Thymeleaf evaluation:
-
-```java
-Map<String, Object> params = new HashMap<>();
-params.put("customMessage", "Welcome to our product service!");
-String result = evaluationService.thymeleafEval(params, "Message: [[${customMessage}]]");
-System.out.println(result);
-```
-
-## Testing
-
-Unit tests are provided in the `src/test` directory. To run tests, execute:
+Run tests:
 
 ```bash
 mvn test
 ```
 
-## Logging
+You can also build from the project root:
 
-Critical failures in SpEL and Thymeleaf evaluations are logged at the `ERROR` level for better traceability.
+```bash
+mvn -pl services/product-repository -am clean install
+```
 
-## Contributing
-
-Contributions are welcome. Please ensure that any new code is accompanied by appropriate unit tests and documentation.
+For project-wide information see the [main README](../../README.md).

--- a/services/prompt/README.md
+++ b/services/prompt/README.md
@@ -11,7 +11,7 @@ The **Prompt Service** is part of the [open4goods](https://github.com/open4good/
 
 ## Requirements
 
-- Java 11 or higher
+- Java 21
 - Maven 3.6+
 - Spring Boot
 
@@ -23,6 +23,20 @@ Clone the repository and build using Maven:
 git clone https://github.com/open4good/open4goods.git
 cd open4goods/services/prompt
 mvn clean install
+```
+
+## Build & Test
+
+Run the tests only:
+
+```bash
+mvn test
+```
+
+You can also build from the project root:
+
+```bash
+mvn -pl services/prompt -am clean install
 ```
 
 ## Usage
@@ -237,3 +251,6 @@ Contributions are welcome! Please submit a pull request or open an issue for any
 ## License
 
 This project is licensed under the MIT License.
+
+For project-wide information see the [main README](../../README.md).
+

--- a/services/serialisation/README.md
+++ b/services/serialisation/README.md
@@ -57,11 +57,21 @@ This module is part of the [Open4Goods project](https://github.com/open4good/ope
    The module uses an `application-test.yml` for test-specific configurations.
 
 
-## Building the Project
+## Build & Test
 
-Ensure you have Java 11+ installed and then run:
+Build from this directory:
 ```bash
 mvn clean install
+```
+
+Run tests only:
+```bash
+mvn test
+```
+
+You can also build from the repository root:
+```bash
+mvn -pl services/serialisation -am clean install
 ```
 
 ## Additional Information
@@ -71,3 +81,6 @@ For more details, refer to the Javadoc comments in the source code and the unit 
 ---
 
 Happy coding!
+
+For project-wide information see the [main README](../../README.md).
+

--- a/services/xwiki-spring-boot-starter/README.md
+++ b/services/xwiki-spring-boot-starter/README.md
@@ -64,8 +64,22 @@ public void loadPage() {
 }
 ```
 
-Build the module with:
+## Build & Test
 
+Build from this directory:
+```bash
+mvn clean install
+```
+
+Run the tests:
+```bash
+mvn test
+```
+
+You can also build from the repository root:
 ```bash
 mvn -pl services/xwiki-spring-boot-starter -am clean install
 ```
+
+For project-wide information see the [main README](../../README.md).
+


### PR DESCRIPTION
## Summary
- update Evaluation README with build & test section
- expand GoogleSearch README instructions
- rewrite Image Processing README for clarity
- replace Product Repository README with accurate content
- update Prompt README Java requirement and add build section
- tweak Serialisation README build instructions
- add build steps to XWiki Spring Boot starter doc

## Testing
- `mvn -q -pl services/evaluation -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb8849b083338392e39a2883d8d0