### PR TITLE
Remove Strapi integration from frontend

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -10,8 +10,6 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
 2. **Clone the Repository**: `git clone https://github.com/your-org/nudger-nuxt-front.git`
 3. **Install Dependencies**: `pnpm install`
 4. **Environment Variables**:
-   - `STRAPI_URL`: e.g. `http://localhost:1337`
-   - `STRAPI_TOKEN`: read-only token
    - `NUXT_PUBLIC_SITE_URL`, etc.
 5. **Run Dev Server**: `pnpm dev` → http://localhost:3000
 6. **Production Build**: `pnpm build` then `pnpm preview`
@@ -111,19 +109,6 @@ Workflow:
 
 ---
 
-## Content from Strapi CMS
-
-- Env vars: `STRAPI_URL`, `STRAPI_TOKEN`
-- Fetch using `useFetch`
-```ts
-const { data } = await useFetch(`${config.public.strapiUrl}/api/pages`, {
-  headers: { Authorization: `Bearer ${config.strapiToken}` },
-});
-```
-- Handle nested `data[].attributes`
-- Consider `useStrapiContent()` composable abstraction
-
----
 
 ## Testing with Vitest
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -19,7 +19,7 @@ Experience Nudger frontend online:
 
 **Welcome** to the Nudger front-end project. This guide is a comprehensive overview of the Nudger UI application structure, coding conventions, and tooling.
 
-The Nudger front-end is a Nuxt 3 app (Vue 3) that interfaces with a Strapi headless CMS for content and uses an OpenAPI-described backend for core application data. We employ modern frameworks and best practices – from Tailwind CSS and Pinia, to Vitest and Storybook – to maintain a robust, scalable codebase.
+The Nudger front-end is a Nuxt 3 app (Vue 3) that relies on an OpenAPI-described backend for application data. We employ modern frameworks and best practices – from Tailwind CSS and Pinia, to Vitest and Storybook – to maintain a robust, scalable codebase.
 
 Use this document as the bible for:
 
@@ -50,8 +50,6 @@ To get the project up and running locally, follow these steps:
 
 4. **Environment Variables**:  
    Copy `.env.example` to `.env` and set the following:
-   - `STRAPI_URL`: Base URL of the Strapi CMS (e.g. `http://localhost:1337`)
-   - `STRAPI_TOKEN`: API access token for Strapi (read-only)
    - `BASE_URL`: Base path for the Nuxt app (default `/`)
    - Other optional variables: `NUXT_PUBLIC_SITE_URL`, etc.
      These are declared in `nuxt.config.ts` under `runtimeConfig`.
@@ -224,18 +222,6 @@ const cart = useCartStore();
   const response = await api.listVersionsv2()
   ```
 
-## Fetching Content from Strapi
-
-```ts
-const config = useRuntimeConfig();
-const { data: postRes } = await useFetch(`${config.public.strapiUrl}/api/posts`, {
-  params: { filters: { slug } },
-  headers: {
-    Authorization: `Bearer ${config.strapiToken}`
-  }
-});
-const post = postRes.value?.data[0]?.attributes;
-```
 
 ## Vitest (Testing)
 

--- a/frontend/nuxt.config.mts
+++ b/frontend/nuxt.config.mts
@@ -50,9 +50,7 @@ export default defineNuxtConfig({
   },
   // Runtime configuration available on both client and server
   runtimeConfig: {
-    strapiToken: process.env.STRAPI_TOKEN, // private token for Strapi CMS
     public: {
-      strapiUrl: process.env.STRAPI_URL || 'http://localhost:1337', // Strapi base URL
       plausibleDomain: process.env.NUXT_PUBLIC_PLAUSIBLE_DOMAIN, // Plausible domain
       siteUrl: process.env.NUXT_PUBLIC_SITE_URL // Public site URL
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@nuxtjs/robots": "^5.2.11",
     "@nuxtjs/seo": "^3.0.3",
     "@nuxtjs/sitemap": "^7.4.3",
-    "@nuxtjs/strapi": "^2.0.0",
     "@nuxtjs/tailwindcss": "7.0.0-beta.0",
     "@pinia/nuxt": "^0.11.1",
     "@semantic-release/changelog": "^6.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@nuxtjs/sitemap':
         specifier: ^7.4.3
         version: 7.4.3(h3@1.15.3)(vite@6.3.5)(vue@3.5.17)
-      '@nuxtjs/strapi':
-        specifier: ^2.0.0
-        version: 2.1.1
       '@nuxtjs/tailwindcss':
         specifier: 7.0.0-beta.0
         version: 7.0.0-beta.0(vite@6.3.5)
@@ -3344,18 +3341,6 @@ packages:
       - magicast
       - vite
       - vue
-    dev: true
-
-  /@nuxtjs/strapi@2.1.1:
-    resolution: {integrity: sha512-CNcsEqkhto4P5SEA4ZuRrGdfOT7swsZp/hvR7SNG3OW3J8eHJythE68P1LaszCq5uvYlg7j90Iue534sEdedtQ==}
-    dependencies:
-      '@nuxt/kit': 3.17.5
-      defu: 6.1.4
-      graphql: 16.11.0
-      qs: 6.14.0
-      ufo: 1.6.1
-    transitivePeerDependencies:
-      - magicast
     dev: true
 
   /@nuxtjs/tailwindcss@7.0.0-beta.0(vite@6.3.5):
@@ -10108,11 +10093,6 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-    dev: true
-
-  /graphql@16.11.0:
-    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: true
 
   /gzip-size@7.0.0:


### PR DESCRIPTION
## Summary
- purge Strapi references from docs and config
- drop `@nuxtjs/strapi` dependency

## Testing
- `pnpm lint --fix`
- `pnpm test run`
- `pnpm generate`
- `pnpm storybook` *(fails: killed after start)*
- `pnpm preview` *(failed to run)*
- `mvn -q clean install -DskipTests` *(failed to resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1027d808333bd16ec4c74e43d5d