### PR TITLE
Add XWiki full page endpoint

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -5,6 +5,11 @@ The former `/api/v1/search` endpoint was removed from this module.
 The main REST endpoints are provided by the `ProductController` class.
 Use the main `api` service for search operations.
 
+### Content endpoints
+
+- `GET /blocs/{blocId}` – return a small HTML bloc from XWiki.
+- `GET /pages/{xwikiPageId}` – return a rendered XWiki page with metadata.
+
 ## Default Port
 
 The application runs on **port 8082** by default (`server.port` in `application.yml`). This keeps it separate from the main API on port 8081.


### PR DESCRIPTION
## Summary
- expose a new `/pages/{xwikiPageId}` endpoint in `ContentsController`
- document content endpoints in the module README

## Testing
- `mvn -pl front-api -am clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68670edead0883338ac2f2efb8ddf2c6