### PR TITLE
fix(frontend): update nitro compatibility date

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes will be documented in this file.
 
 ## [Unreleased]
 - Initial setup
+- Set Nitro `compatibilityDate` to 2025-07-04

--- a/frontend/nuxt.config.mts
+++ b/frontend/nuxt.config.mts
@@ -93,7 +93,7 @@ export default defineNuxtConfig({
   nitro: {
     logLevel: 3,
     //externals: { inline: ['vue'] },
-    compatibilityDate: '2025-06-15',
+    compatibilityDate: '2025-07-04',
     preset: process.env.NITRO_PRESET === 'github_pages' ? 'github-pages' : undefined
   }
 


### PR DESCRIPTION
## Summary
- update Nitro compatibilityDate to resolve dev warning
- document compatibilityDate update in the CHANGELOG

Generated by AI, based on user request. Estimated time spent: 20 minutes.

------
https://chatgpt.com/codex/tasks/task_e_686723ff611483339f030d828f27d6f7