### PR TITLE
feat(frontend): merge Figma token sets

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -89,6 +89,8 @@ Design tokens are configured in `tokens.config.json`. Replace the
 (e.g. `https://www.figma.com/file/<FILE_ID>/...`) and provide a
 `FIGMA_TOKEN` environment variable. After setting these values, run
 your design token generation command to pull the latest tokens.
+Then run `pnpm run tokens:build` to merge the token sets and generate
+the corresponding CSS and SCSS files in `styles/`.
 
 ## Project Structure
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",
-    "tokens:build": "style-dictionary build --config style-dictionary/config.json",
+    "tokens:merge": "node scripts/merge-tokens.cjs",
+    "tokens:build": "pnpm run tokens:merge && cd style-dictionary && style-dictionary build --config config.json",
     "preview": "nuxt preview",
     "generate": "nuxt generate",
     "lint": "eslint .",
@@ -58,7 +59,8 @@
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",
     "semantic-release": "^24.2.5",
-    "storybook": "8.6.14"
+    "storybook": "8.6.14",
+    "style-dictionary": "^5.0.1"
   },
   "packageManager": "pnpm@8.15.9",
   "engines": {

--- a/frontend/scripts/merge-tokens.cjs
+++ b/frontend/scripts/merge-tokens.cjs
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const tokensPath = path.join(__dirname, '..', 'design-tokens', 'tokens.json');
+const tokens = JSON.parse(fs.readFileSync(tokensPath, 'utf8'));
+
+const mergedSets = Object.assign({}, tokens.global, tokens.scss, tokens.css);
+
+const grouped = {};
+for (const [name, token] of Object.entries(mergedSets)) {
+  const type = token.type || 'other';
+  if (!grouped[type]) grouped[type] = {};
+  grouped[type][name] = { "$value": token.value, "$type": type };
+  if (token.description) grouped[type][name].description = token.description;
+}
+
+const outputPath = path.join(__dirname, '..', 'design-tokens', 'merged-tokens.json');
+fs.writeFileSync(outputPath, JSON.stringify(grouped, null, 2));
+console.log(`Merged tokens written to ${outputPath}`);
+

--- a/frontend/style-dictionary/config.json
+++ b/frontend/style-dictionary/config.json
@@ -1,5 +1,5 @@
 {
-  "source": ["../design-tokens/**/*.json"],
+  "source": ["../design-tokens/merged-tokens.json"],
   "platforms": {
     "css": {
       "transformGroup": "css",

--- a/frontend/styles/_variables.scss
+++ b/frontend/styles/_variables.scss
@@ -1,0 +1,8 @@
+
+// Do not edit directly, this file was auto-generated.
+
+$sizing-size-1: 25;
+$asset-ass1: url("ass1value");
+$color-color: #e25050;
+$color-color2: #b35959;
+$color-css-color1: #2b8f5d;

--- a/frontend/styles/variables.css
+++ b/frontend/styles/variables.css
@@ -1,0 +1,11 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --sizing-size-1: 25;
+  --asset-ass1: url("ass1value");
+  --color-color: #e25050;
+  --color-color2: #b35959;
+  --color-css-color1: #2b8f5d;
+}


### PR DESCRIPTION
## Summary
- add merge-tokens script
- use merged token file in Style Dictionary
- generate CSS/SCSS variables from tokens
- document design token build step

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest not found)*
- `pnpm generate` *(fails: network errors fetching fonts)*
- `pnpm storybook` *(fails: missing Storybook configuration)*
- `pnpm preview` *(fails: could not fetch font metadata)*
- `pnpm run tokens:build`

------
https://chatgpt.com/codex/tasks/task_e_686a2f5128f48333b8d3baf2ceea0408