### PR TITLE
fix(frontend): ensure style dictionary reads merged tokens

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -35,3 +35,8 @@ node_modules/
 !/.husky/pre-push
 !/.husky/pre-commit
 !/.husky/
+# Design token outputs
+styles/variables.css
+styles/_variables.scss
+design-tokens/merged-tokens.json
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -89,6 +89,8 @@ Design tokens are configured in `tokens.config.json`. Replace the
 (e.g. `https://www.figma.com/file/<FILE_ID>/...`) and provide a
 `FIGMA_TOKEN` environment variable. After setting these values, run
 your design token generation command to pull the latest tokens.
+Run `pnpm run tokens:build` to merge the exported token sets and
+generate the CSS and SCSS variable files in `styles/`.
 
 ## Project Structure
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",
-    "tokens:build": "style-dictionary build --config style-dictionary/config.json",
+    "tokens:merge": "node scripts/merge-tokens.cjs",
+    "tokens:build": "pnpm run tokens:merge && style-dictionary build --config style-dictionary/config.json",
     "preview": "nuxt preview",
     "generate": "nuxt generate",
     "lint": "eslint .",
@@ -58,7 +59,8 @@
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",
     "semantic-release": "^24.2.5",
-    "storybook": "8.6.14"
+    "storybook": "8.6.14",
+    "style-dictionary": "^5.0.1"
   },
   "packageManager": "pnpm@8.15.9",
   "engines": {

--- a/frontend/scripts/merge-tokens.cjs
+++ b/frontend/scripts/merge-tokens.cjs
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const tokensPath = path.join(__dirname, '..', 'design-tokens', 'tokens.json');
+const tokens = JSON.parse(fs.readFileSync(tokensPath, 'utf8'));
+
+// merge all sets except special keys starting with '$'
+const merged = {};
+for (const [setName, setTokens] of Object.entries(tokens)) {
+  if (!setName.startsWith('$') && typeof setTokens === 'object') {
+    Object.assign(merged, setTokens);
+  }
+}
+
+// group tokens by type for Style Dictionary
+const grouped = {};
+for (const [name, token] of Object.entries(merged)) {
+  const type = token.type || 'other';
+  if (!grouped[type]) grouped[type] = {};
+  grouped[type][name] = { $value: token.value, $type: type };
+  if (token.description) grouped[type][name].description = token.description;
+}
+
+const outPath = path.join(__dirname, '..', 'design-tokens', 'merged-tokens.json');
+fs.writeFileSync(outPath, JSON.stringify(grouped, null, 2));
+console.log(`Merged tokens written to ${outPath}`);
+

--- a/frontend/style-dictionary/config.json
+++ b/frontend/style-dictionary/config.json
@@ -1,9 +1,10 @@
 {
-  "source": ["../design-tokens/**/*.json"],
+  "usesDtcg": true,
+  "source": ["design-tokens/merged-tokens.json"],
   "platforms": {
     "css": {
       "transformGroup": "css",
-      "buildPath": "../styles/",
+      "buildPath": "styles/",
       "files": [
         {
           "destination": "variables.css",
@@ -13,7 +14,7 @@
     },
     "scss": {
       "transformGroup": "scss",
-      "buildPath": "../styles/",
+      "buildPath": "styles/",
       "files": [
         {
           "destination": "_variables.scss",


### PR DESCRIPTION
## Summary
- configure Style Dictionary to use DTCG format

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest not found)*
- `pnpm generate` *(fails: could not fetch fonts)*
- `pnpm storybook` *(fails: missing configuration)*
- `pnpm preview` *(fails: could not fetch fonts)*
- `pnpm run tokens:build`
- `mvn -q -DskipTests clean install` *(fails: dependency resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a2f5128f48333b8d3baf2ceea0408