### PR TITLE
fix(frontend): build design tokens automatically

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -89,8 +89,10 @@ Design tokens are configured in `tokens.config.json`. Replace the
 (e.g. `https://www.figma.com/file/<FILE_ID>/...`) and provide a
 `FIGMA_TOKEN` environment variable. After setting these values, run
 your design token generation command to pull the latest tokens.
-Run `pnpm run tokens:build` to merge the exported token sets and
-generate the CSS and SCSS variable files in `styles/`.
+Design token styles are generated automatically during `pnpm install`,
+`pnpm dev`, `pnpm build` and `pnpm generate`. You can also run
+`pnpm run tokens:build` manually to update `styles/variables.css` and
+`styles/_variables.scss`.
 
 ## Project Structure
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,10 @@
     "build": "nuxt build",
     "tokens:merge": "node scripts/merge-tokens.cjs",
     "tokens:build": "pnpm run tokens:merge && style-dictionary build --config style-dictionary/config.json",
+    "predev": "pnpm run tokens:build",
+    "prebuild": "pnpm run tokens:build",
+    "pregenerate": "pnpm run tokens:build",
+    "prepreview": "pnpm run tokens:build",
     "preview": "nuxt preview",
     "generate": "nuxt generate",
     "lint": "eslint .",
@@ -16,7 +20,7 @@
     "storybook:build": "pnpm exec storybook build",
     "generate:api": "openapi-generator-cli generate -i https://beta.front-api.nudger.fr/v3/api-docs/front -g typescript-fetch -o src/api --skip-validate-spec",
     "semantic-release": "semantic-release",
-    "postinstall": "nuxt prepare"
+    "postinstall": "pnpm run tokens:build && nuxt prepare"
   },
   "dependencies": {
     "@nuxt/fonts": "0.11.4",

--- a/frontend/styles/_variables.scss
+++ b/frontend/styles/_variables.scss
@@ -1,5 +1,8 @@
 
-// Do not edit directly
-// Generated on Sun, 06 Jul 2025 09:28:51 GMT
+// Do not edit directly, this file was auto-generated.
 
-
+$sizing-size-1: 25;
+$asset-ass1: url("ass1value");
+$color-color: #e25050;
+$color-color2: #b35959;
+$color-css-color1: #2b8f5d;

--- a/frontend/styles/variables.css
+++ b/frontend/styles/variables.css
@@ -1,8 +1,11 @@
 /**
- * Do not edit directly
- * Generated on Sun, 06 Jul 2025 09:28:51 GMT
+ * Do not edit directly, this file was auto-generated.
  */
 
 :root {
-
+  --sizing-size-1: 25;
+  --asset-ass1: url("ass1value");
+  --color-color: #e25050;
+  --color-color2: #b35959;
+  --color-css-color1: #2b8f5d;
 }


### PR DESCRIPTION
## Summary
- generate CSS/SCSS token files on install and before dev/build commands
- document new automatic design token generation
- regenerate token output

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest not found)*
- `pnpm generate` *(fails: network errors fetching fonts)*
- `pnpm storybook` *(fails: configuration missing)*
- `pnpm preview` *(fails: network errors fetching fonts)*
- `mvn clean install` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a42b0864083339069e0e318083157