### PR TITLE
Fix swagger annotations version clash

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -146,6 +146,19 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.9</version>
+            <exclusions>
+                <!-- Avoid pulling the old swagger-annotations variant -->
+                <exclusion>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Force usage of the jakarta annotations variant -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+            <version>2.2.30</version>
         </dependency>
         <dependency>
             <groupId>org.open4goods</groupId>


### PR DESCRIPTION
## Summary
- exclude old swagger annotations from springdoc
- add jakarta swagger annotations dependency

## Testing
- `mvn -pl api -am clean install -DskipTests` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a228d608333b73ff10356fbc5b9