### PR TITLE
Fix pnpm generate with Node 22

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -10,6 +10,16 @@ export default defineNuxtConfig({
     define: {
       __VUE_PROD_DEVTOOLS__: false,
     },
+    build: {
+      commonjsOptions: {
+        requireReturnsDefault: false,
+      },
+    },
+    resolve: {
+      alias: {
+        vue: './scripts/vue-default.mjs',
+      },
+    },
   },
 
   modules: [
@@ -42,6 +52,15 @@ export default defineNuxtConfig({
     },
     vuetifyOptions: {
       /* vuetify options */
+    },
+  },
+  nitro: {
+    rollupConfig: {
+      plugins: {
+        commonjs: {
+          requireReturnsDefault: 'namespace',
+        },
+      },
     },
   },
 })

--- a/frontend/scripts/vue-default.mjs
+++ b/frontend/scripts/vue-default.mjs
@@ -1,0 +1,3 @@
+import * as Vue from 'vue'
+export default {}
+export * from 'vue'


### PR DESCRIPTION
## Summary
- add an alias providing a `default` export for Vue when running under Node 22
- configure Vite to use the alias

## Testing
- `pnpm generate` *(fails: Could not initialize providers)*

------
https://chatgpt.com/codex/tasks/task_e_686affb97b808333b9ac49bd0ca55e24