### PR TITLE
Update Node to v22 in frontend workflows

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 8.15.9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
         working-directory: frontend
       - run: pnpm lint

--- a/.github/workflows/frontend-deploy-static.yml
+++ b/.github/workflows/frontend-deploy-static.yml
@@ -18,6 +18,10 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 8.15.9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/frontend-release.yml
+++ b/.github/workflows/frontend-release.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: corepack prepare pnpm@10.12.1 --activate
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- use Node 22 for frontend release workflow
- pin Node 22 in CI and deploy workflows

## Testing
- `mvn clean install -q` *(fails: transfer failed for spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bf090a01c83338a90910a30597998