### PR TITLE
Add basic frontend testing setup

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: frontend
       - run: pnpm generate
         working-directory: frontend
-      - run: pnpm test run
+      - run: pnpm test
         working-directory: frontend
       - name: Verify production build
         run: |

--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -197,7 +197,7 @@ export const Primary: Story = {
 Before issueing a PR, systematically validate and check global non regession using
 
 - pnpm lint
-- pnpm test run
+- pnpm test
 - pnpm generate
 - pnpm storybook, check all components have an associated storybook
 - pnpm preview, then tests URLS are HTTP 200 or act as expected

--- a/frontend/stores/__tests__/useAppStore.spec.ts
+++ b/frontend/stores/__tests__/useAppStore.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAppStore } from '../useAppStore'
+
+describe('useAppStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('initializes with empty state', () => {
+    const store = useAppStore()
+    expect(store.$state).toEqual({})
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+})


### PR DESCRIPTION
## Summary
- add Vitest config for Nuxt frontend
- create initial test for `useAppStore`
- run `pnpm test` in CI workflow
- update AGENT instructions for the test command

## Testing
- `pnpm lint`
- `pnpm test` *(fails: vitest not installed)*
- `pnpm generate` *(fails: network unreachable during prerender)*
- `pnpm storybook` *(fails: configuration missing)*
- `pnpm preview` *(fails: external fonts unreachable)*
- `mvn clean install` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bf0862c148333b55dcccc839355eb