### PR TITLE
Fix husky pre-push script

### DIFF
--- a/frontend/.husky/pre-push
+++ b/frontend/.husky/pre-push
@@ -1,5 +1,3 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-#TODO : Renable, but whereas pnpm is installed, eclipse / giit fail, indicating "pnpm not found"
-#pnpm lint && pnpm test --run && pnpm build
+pnpm lint && pnpm test && pnpm build


### PR DESCRIPTION
## Summary
- update pre-push hook to run lint, tests and build
- mark the hook as executable

## Testing
- `mvn -q clean install` *(fails: missing dependencies)*
- `pnpm lint` *(fails: cannot find @nuxt/eslint-config)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm build` *(fails: style-dictionary not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf08b99fc8333a069395436ecc706