### PR TITLE
fix(frontend): alias vue esm bundler

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -10,6 +10,11 @@ export default defineNuxtConfig({
     define: {
       __VUE_PROD_DEVTOOLS__: false,
     },
+    resolve: {
+      alias: {
+        vue: 'vue/dist/vue.esm-bundler.js',
+      },
+    },
   },
 
   modules: [


### PR DESCRIPTION
## Summary
- fix nuxt build error by resolving vue to its ESM bundler build

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm generate` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d96d3509883339ddf65a5943d7370