### PR TITLE
Remove Storybook from frontend

### DIFF
--- a/.github/workflows/frontend-deploy-static.yml
+++ b/.github/workflows/frontend-deploy-static.yml
@@ -27,16 +27,10 @@ jobs:
         run: NITRO_PRESET=github_pages pnpm generate
         working-directory: frontend
 
-      - name: Build Storybook
-        run: pnpm storybook:build -- --output-dir storybook-static
-        working-directory: frontend
-
       - name: Prepare dist/
         run: |
             rm -rf dist
-            mkdir -p dist/storybook
             cp -r .output/public/* dist/
-            cp -r storybook-static/* dist/storybook/
             echo 'static.nudger.fr' > dist/CNAME
         working-directory: frontend
 

--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -31,7 +31,6 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
    - `pnpm format`
    - `pnpm test`
    - `pnpm generate:api`
-   - `pnpm storybook:build`
 ---
 
 ## Project Structure and Directories
@@ -148,19 +147,7 @@ const { data } = await useFetch(`${config.public.strapiUrl}/api/pages`, {
 
 ---
 
-## Storybook for UI Components
 
-- Run `pnpm storybook` → http://localhost:6006
-- Co-locate stories next to components
-```ts
-export const Primary: Story = {
-  args: { label: 'Primary Button' }
-};
-```
-- Update stories with component changes
-- Use Addon Essentials for docs
----
----
 
 
 ## Documentation
@@ -198,7 +185,6 @@ Before issueing a PR, systematically validate and check global non regession usi
 - pnpm lint
 - pnpm test run
 - pnpm generate
-- pnpm storybook, check all components have an associated storybook
 - pnpm preview, then tests URLS are HTTP 200 or act as expected
 
 # Best practices for Nuxt3 project

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -272,10 +272,8 @@ describe('Button', () => {
   - Vercel/Netlify (with Nitro adapter)
 - Static generation (if suitable): `pnpm generate`
 
-- Production deployments are served from **GitHub Pages** at
-  [https://static.nudger.fr](https://static.nudger.fr). The Storybook is
-  published alongside the site under
-  [https://static.nudger.fr/storybook/](https://static.nudger.fr/storybook/).
+  - Production deployments are served from **GitHub Pages** at
+  [https://static.nudger.fr](https://static.nudger.fr).
 
 - CI likely includes:
   - Tests and lint on PRs


### PR DESCRIPTION
## Summary
- drop Storybook build step from the GitHub Actions workflow
- remove Storybook mentions from the frontend README and AGENT guide

## Testing
- `pnpm lint` *(fails: 10 errors, 12 warnings)*
- `pnpm test` *(fails: process waiting for file changes)*
- `pnpm generate` *(fails: TypeScript error)*
- `pnpm preview` *(fails: missing nitro build)*
- `mvn -q clean install -DskipTests` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68758240ae50833392a0689eb2eb17d0