### PR TITLE
fix(frontend): disable devtools in prod

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -64,6 +64,9 @@ To get the project up and running locally, follow these steps:
    pnpm build && pnpm preview
    ```
 
+   Les outils de développement Nuxt sont automatiquement désactivés lorsque
+   `NODE_ENV` vaut `production`.
+
 7. **Static Generation (optional)**:
 
    ```bash

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -4,7 +4,7 @@ import { transformAssetUrls } from 'vite-plugin-vuetify'
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
-  devtools: { enabled: true },
+  devtools: { enabled: process.env.NODE_ENV !== 'production' },
   typescript: {
     typeCheck: true,
     tsConfig: {


### PR DESCRIPTION
## Summary
- disable Nuxt devtools in production
- document this behaviour in README

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68759b9f19a88333be17b18bd97a9b5b