### PR TITLE
fix(frontend): correct override for FetchError

### DIFF
--- a/frontend/src/api/runtime.ts
+++ b/frontend/src/api/runtime.ts
@@ -266,7 +266,7 @@ export class ResponseError extends Error {
 
 export class FetchError extends Error {
     override name: "FetchError" = "FetchError";
-    constructor(public cause: Error, msg?: string) {
+    constructor(public override cause: Error, msg?: string) {
         super(msg);
     }
 }


### PR DESCRIPTION
## Summary
- fix the constructor in `FetchError` to properly override Error's `cause`

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate`
- `mvn -q -DskipTests clean install` *(fails: Could not resolve dependencies)*
- `pnpm preview` *(fails: needs to install serve)*

------
https://chatgpt.com/codex/tasks/task_e_687626fc15ec83338b43aada474fe7a4