### PR TITLE
Add HTTP security headers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -272,6 +272,10 @@ describe('Button', () => {
   - Vercel/Netlify (with Nitro adapter)
 - Static generation (if suitable): `pnpm generate`
 
+  Security headers such as `Content-Security-Policy` are configured in
+  `public/_headers`.  Netlify and similar static hosts read this file to
+  apply HTTP response headers on all routes.
+
   - Production deployments are served from **GitHub Pages** at
   [https://static.nudger.fr](https://static.nudger.fr).
 

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,2 +1,7 @@
 /*
   Cache-Control: public, max-age=31536000, immutable
+  Content-Security-Policy: default-src 'self'; img-src 'self' https:; script-src 'self'; style-src 'self' 'unsafe-inline'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: same-origin
+  Permissions-Policy: interest-cohort=()


### PR DESCRIPTION
## Summary
- enhance public/_headers with security directives
- document headers in frontend README

## Testing
- `pnpm lint`
- `pnpm test -- --run`
- `pnpm generate` *(fails: TS4115 override error)*
- `pnpm build` *(fails: TS4115 override error)*
- `pnpm preview` *(fails: missing nitro.json)*
- `mvn -q -DskipTests install` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68759ba3676c833388e4fef9e3797202