### PR TITLE
Add beta SSR deployment

### DIFF
--- a/.github/workflows/frontend-deploy-ssr.yml
+++ b/.github/workflows/frontend-deploy-ssr.yml
@@ -1,0 +1,46 @@
+name: Deploy SSR frontend to Beta
+
+on:
+  push:
+    paths:
+      - 'frontend/**'
+    branches:
+      - main
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Build Nuxt (Node SSR)
+        run: pnpm build
+        working-directory: frontend
+
+      - name: Deploy SSR output to Beta server
+        uses: easingthemes/ssh-deploy@main
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          ARGS: "-rltgoDzvO --delete"
+          SOURCE: "/frontend/.output"
+          REMOTE_HOST: ${{ secrets.REMOTE_BETA_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_BETA_USER }}
+          TARGET: "/opt/open4goods/bin/latest/frontend-ssr"
+
+      - name: Publish frontend
+        uses: appleboy/ssh-action@v1.2.2
+        with:
+          host: ${{ secrets.REMOTE_BETA_HOST }}
+          username: ${{ secrets.REMOTE_BETA_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: sh /opt/open4goods/bin/publish-frontend.sh beta

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -298,6 +298,8 @@ describe('Button', () => {
 - CI likely includes:
   - Tests and lint on PRs
   - Semantic release (automated versioning via commit messages)
+  - Node SSR deployed to the beta server via
+    `.github/workflows/frontend-deploy-ssr.yml`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- deploy Nuxt SSR to beta using SSH
- document the beta SSR deployment in the frontend README

## Testing
- `mvn clean install` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876448207e48333ac320b67f857c34c