### PR TITLE
Add frontend SSR service

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Elastic, kibana and Redis should be available on :
 * Kibana : [http://localhost:5601](http://localhost:5601)
 * Redis : [http://localhost:6379](http://localhost:6379)
 
+The compose file also defines a `frontend-ssr` service. During the CI/CD
+deployment, the Nuxt build directory (`.output`) is copied to
+`/opt/open4goods/bin/latest/frontend-ssr` on the server. The container mounts
+this path and runs `node .output/server/index.mjs` to serve the production
+frontend.
+
 > Before running the docker compose check that the value of 'vm.max_map_count' is higher or equal to 262144. If not, you will have to raise your max map  args to be able to rune the Elastic image, see the [Hint's section](https://github.com/open4good/open4goods?tab=readme-ov-file#elastic-max-map-count)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:9.0.3
     container_name: kibana
-    depends_on: 
+    depends_on:
       - elastic
     ports:
       - "5601:5601"
@@ -71,6 +71,19 @@ services:
 
     networks:
       - o4g-network
+
+  frontend-ssr:
+    image: node:20
+    container_name: frontend-ssr
+    working_dir: /usr/src/app
+    volumes:
+      - /opt/open4goods/bin/latest/frontend-ssr:/usr/src/app
+    command: ["node", ".output/server/index.mjs"]
+    restart: unless-stopped
+    networks:
+      - o4g-network
+    ports:
+      - "3000:3000"
 
     
 volumes:


### PR DESCRIPTION
## Summary
- extend docker-compose with frontend-ssr Node service
- document how the Nuxt build is deployed and served

## Testing
- `mvn clean install -q` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68765161f5ec83339e4e2ab6a5234ea5