### PR TITLE
Add job-level concurrency

### DIFF
--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -20,9 +20,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: test-github-pages
-      url: ${{ steps.deployment.outputs.page_url }} 
+      url: ${{ steps.deployment.outputs.page_url }}
     name: prod-release-deploy
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: true
     steps:
 
       ############################################

--- a/.github/workflows/testAndPublishBeta.yml
+++ b/.github/workflows/testAndPublishBeta.yml
@@ -12,6 +12,9 @@ jobs:
   deploy:
     name: Beta Test, Build, and Publish
     runs-on: self-hosted
+    concurrency:
+      group: deploy-beta
+      cancel-in-progress: true
 
     steps:
 


### PR DESCRIPTION
## Summary
- prevent concurrent beta deployments
- prevent concurrent prod deployments

## Testing
- `mvn -q -ntp clean install` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877b45ef84883338dbd9261045ee198