### PR TITLE
Update pnpm version to 10.12.1

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 8.15.9
+          version: 10.12.1
       - run: pnpm install --frozen-lockfile
         working-directory: frontend
       - run: pnpm lint

--- a/.github/workflows/frontend-deploy-ssr.yml
+++ b/.github/workflows/frontend-deploy-ssr.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.15.9
+          version: 10.12.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,7 +17,7 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
 
 ## Getting Started: Installation & Setup
 
-1. **Prerequisites**: Node.js 20+, `pnpm` (`npm install -g pnpm`)
+1. **Prerequisites**: Node.js 20+, `pnpm@10.12.1` (`npm install -g pnpm@10.12.1`)
 2. **Clone the Repository**: `git clone https://github.com/your-org/nudger-nuxt-front.git`
 3. **Install Dependencies**: `pnpm install`
 4. **Environment Variables**:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,10 +26,10 @@ Use this document as the bible for:
 To get the project up and running locally, follow these steps:
 
 1. **Prerequisites**:
-   Ensure you have Node.js `>=20` and `pnpm 8.15+` installed. Install it globally via:
+   Ensure you have Node.js `>=20` and `pnpm 10.12.1` installed. Install it globally via:
 
    ```bash
-   npm install -g pnpm
+   npm install -g pnpm@10.12.1
    ```
 
 2. **Clone the Repository**:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
     "vue-tsc": "^3.0.1",
     "vuetify": "^3.7.3"
   },
-  "packageManager": "pnpm@8.15.9",
+  "packageManager": "pnpm@10.12.1",
   "engines": {
     "node": ">=20.x"
   },


### PR DESCRIPTION
## Summary
- use pnpm 10.12.1 in CI and deploy workflows
- document pnpm 10.12.1 in README and AGENTS files
- set packageManager to pnpm 10.12.1

## Testing
- `mvn clean install -q` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877b44c21b48333b9155f403a64b341