### PR TITLE
Extract Maven build workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -11,33 +11,7 @@ on:
 jobs:
   test:
     name: PR Check - Maven Build
-    runs-on: self-hosted
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-      - name: Build and Test
-        run: mvn --batch-mode --update-snapshots install
+    uses: ./.github/workflows/maven-build.yml
+    with:
+      goals: install
+    secrets: inherit

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,48 @@
+name: Maven Build
+
+on:
+  workflow_call:
+    inputs:
+      goals:
+        description: "Maven goals to run"
+        required: false
+        default: "install"
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Set up Maven Repositories
+        uses: s4u/maven-settings-action@v3.1.0
+        with:
+          repositories: |
+            [
+              {
+                "id": "xwiki-releases",
+                "name": "xwiki-releases",
+                "url": "https://maven.xwiki.org/releases/",
+                "snapshots": { "enabled": false }
+              }
+            ]
+
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots ${{ inputs.goals }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-build
+          path: |
+            **/target/*.jar
+            target/staging/**

--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -1,4 +1,4 @@
-name: 🚀 Release
+name: "🚀 Release"
 on:
   push:
     tags:
@@ -16,13 +16,20 @@ concurrency:
   cancel-in-progress: false
   
 jobs:
+  build:
+    uses: ./.github/workflows/maven-build.yml
+    with:
+      goals: "clean install site site:stage"
+    secrets: inherit
+
   release:
     if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: test-github-pages
-      url: ${{ steps.deployment.outputs.page_url }} 
+      url: ${{ steps.deployment.outputs.page_url }}
     name: prod-release-deploy
     runs-on: ubuntu-latest
+    needs: build
     steps:
 
       ############################################
@@ -45,41 +52,13 @@ jobs:
 
 
       ############################################
-      # Set up JDK 21 and Maven Cache
+      # Download Maven build artifacts
       ###########################################
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'  # Link this to the previously cached maven dependencies
-
-      ############################################
-      # Set up Maven Repositories
-      ###########################################
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-            
-     
-
-      ############################################
-      # Build Maven site and Artifacts
-      ###########################################
-      - name: Build Maven Site
-        run: mvn --batch-mode clean install site site:stage
+          name: maven-build
+          path: .
 
       ############################################
       # Create the Release Changelog

--- a/.github/workflows/testAndPublishBeta.yml
+++ b/.github/workflows/testAndPublishBeta.yml
@@ -9,57 +9,28 @@ on:
 name: 🔘 Beta - Build, Test, and Publish
 
 jobs:
+  build:
+    uses: ./.github/workflows/maven-build.yml
+    with:
+      goals: install
+    secrets: inherit
+
   deploy:
     name: Beta Test, Build, and Publish
     runs-on: self-hosted
-
+    needs: build
     steps:
-
-      ############################################
-      # 1. Checkout the Main Repository
-      ############################################
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      ############################################
-      # 2. Set up JDK 21 (avec cache Maven intégré)
-      ############################################
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
+          name: maven-build
+          path: .
 
-      ############################################
-      # 3. Set up Maven Repositories
-      ############################################
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-      ############################################
-      # 4. Maven Dependency Tree Submission
-      ############################################      
       - name: Maven Dependency Submission
         uses: advanced-security/maven-dependency-submission-action@v5.0.0
-
-      ############################################
-      # 5. Build and Test with Maven
-      ############################################    
-      - name: Build and Test with Maven
-        run: mvn --batch-mode --update-snapshots install
 
       ############################################
       # 6. Deploy JAR Files to Qualification Environment


### PR DESCRIPTION
## Summary
- add reusable `maven-build.yml` workflow that sets up the JDK and runs Maven
- reuse it in `ci-pr.yml`
- reuse it for beta deployment
- reuse it for production releases

## Testing
- `mvn -q clean install` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6877b417c1388333a9c5ccd9750f373f