### PR TITLE
feat: add blog pagination

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -133,6 +133,14 @@ const { data } = await useFetch(`${config.public.strapiUrl}/api/pages`, {
 - Handle nested `data[].attributes`
 - Consider `useStrapiContent()` composable abstraction
 
+## Blog pagination and infinite scroll
+
+- Blog article lists use `v-infinite-scroll` to load pages incrementally.
+- The `useBlog` composable exposes `fetchArticles` and `loadMoreArticles` for
+  pagination handling.
+- Code under `src/api/` and `server/api/blog/` is generated from the backend
+  OpenAPI contract. Do not edit these files manually.
+
 ---
 
 ## Testing with Vitest

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -239,6 +239,12 @@ const { data: postRes } = await useFetch(
 const post = postRes.value?.data[0]?.attributes
 ```
 
+## Blog pagination
+
+The list of articles uses an infinite scroll component (`v-infinite-scroll`).
+Pages are fetched using `pageNumber` and `pageSize` query parameters and the
+current page index is synchronised with the `page` URL query.
+
 ## Vitest (Testing)
 
 - Colocate tests as `Component.spec.ts`

--- a/frontend/components/domains/blog/TheArticles.vue
+++ b/frontend/components/domains/blog/TheArticles.vue
@@ -1,6 +1,18 @@
 <script setup lang="ts">
 import { useBlog } from '~/composables/blog/useBlog'
-const { articles, loading, error, fetchArticles } = useBlog()
+import { useRoute, useRouter } from '#imports'
+
+const route = useRoute()
+const router = useRouter()
+const {
+  articles,
+  loading,
+  error,
+  fetchArticles,
+  loadMoreArticles,
+  currentPage,
+  hasMore,
+} = useBlog()
 
 // Format date helper
 const formatDate = (timestamp: number) => {
@@ -10,9 +22,11 @@ const formatDate = (timestamp: number) => {
 // Debug mode - use environment variable or default to false
 const debugMode = ref(false)
 
-// Fetch articles on component mount
-onMounted(() => {
-  fetchArticles()
+const initialPage = Number(route.query.page || 0)
+await fetchArticles(initialPage)
+
+watch(currentPage, value => {
+  router.replace({ query: { page: value } })
 })
 </script>
 
@@ -52,15 +66,16 @@ onMounted(() => {
     </div>
 
     <div v-else class="articles">
-      <v-row>
-        <v-col
-          v-for="article in articles"
-          :key="article.url"
-          cols="12"
-          sm="6"
-          md="4"
-          lg="4"
-        >
+      <v-infinite-scroll @load="loadMoreArticles" :disabled="!hasMore">
+        <v-row>
+          <v-col
+            v-for="article in articles"
+            :key="article.url"
+            cols="12"
+            sm="6"
+            md="4"
+            lg="4"
+          >
           <v-card class="article-card" elevation="6" hover>
             <!-- Image de l'article -->
             <v-img
@@ -122,7 +137,8 @@ onMounted(() => {
             </v-card-actions>
           </v-card>
         </v-col>
-      </v-row>
+        </v-row>
+      </v-infinite-scroll>
     </div>
   </div>
 </template>

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -13,12 +13,21 @@ export class BlogService {
 
   /**
    * Fetch paginated blog articles
+   *
+   * @param pageNumber - zero based page index
+   * @param pageSize - page size
    * @returns Promise<PaginatedBlogResponse>
    */
-  async getArticles(): Promise<PaginatedBlogResponse> {
+  async getArticles(
+    pageNumber = 0,
+    pageSize = 10
+  ): Promise<PaginatedBlogResponse> {
     try {
       const response = await $fetch<PaginatedBlogResponse>(
-        `${this.baseUrl}${this.blogEndpoint}`
+        `${this.baseUrl}${this.blogEndpoint}`,
+        {
+          params: { pageNumber, pageSize },
+        }
       )
       return response
     } catch (error) {


### PR DESCRIPTION
## Summary
- implement paginated blog service
- extend `useBlog` composable with pagination state and helpers
- update articles component to use infinite scroll
- adapt tests for new behaviour
- document blog pagination in README and AGENTS

## Testing
- `pnpm lint`
- `pnpm test --run`
- `pnpm generate`
- `pnpm preview`
- `mvn clean install -q -DskipTests` *(failed: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878141eb2408333a50ff9be8240bb72