### PR TITLE
Create reusable Maven build workflow

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -11,33 +11,6 @@ on:
 jobs:
   test:
     name: PR Check - Maven Build
-    runs-on: self-hosted
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-      - name: Build and Test
-        run: mvn --batch-mode --update-snapshots install
+    uses: ./.github/workflows/maven-build.yml
+    with:
+      runner: self-hosted

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,45 @@
+name: Maven Build
+on:
+  workflow_call:
+    inputs:
+      goals:
+        description: "Maven goals to run"
+        required: false
+        default: "install"
+        type: string
+      runner:
+        description: "Runner label"
+        required: false
+        default: "self-hosted"
+        type: string
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Set up Maven Repositories
+        uses: s4u/maven-settings-action@v3.1.0
+        with:
+          repositories: |
+            [
+              {
+                "id": "xwiki-releases",
+                "name": "xwiki-releases",
+                "url": "https://maven.xwiki.org/releases/",
+                "snapshots": {
+                  "enabled": false
+                }
+              }
+            ]
+
+      - name: Maven Build
+        run: mvn --batch-mode --update-snapshots ${{ inputs.goals }}

--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -44,45 +44,14 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
-
-
       ############################################
-      # Set up JDK 21 and Maven Cache
+      # Maven Build
       ###########################################
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - uses: ./.github/workflows/maven-build.yml
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'  # Link this to the previously cached maven dependencies
+          runner: ubuntu-latest
+          goals: "clean install site site:stage"
 
-      ############################################
-      # Set up Maven Repositories
-      ###########################################
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-            
-     
-
-      ############################################
-      # Build Maven site and Artifacts
-      ###########################################
-      - name: Build Maven Site
-        run: mvn --batch-mode clean install site site:stage
 
       ############################################
       # Create the Release Changelog

--- a/.github/workflows/testAndPublishBeta.yml
+++ b/.github/workflows/testAndPublishBeta.yml
@@ -25,44 +25,17 @@ jobs:
         uses: actions/checkout@v4
 
       ############################################
-      # 2. Set up JDK 21 (avec cache Maven intégré)
+      # 2. Maven Build
       ############################################
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - uses: ./.github/workflows/maven-build.yml
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
+          runner: self-hosted
 
       ############################################
-      # 3. Set up Maven Repositories
+      # 3. Maven Dependency Tree Submission
       ############################################
-      - name: Set up Maven Repositories
-        uses: s4u/maven-settings-action@v3.1.0
-        with:
-          repositories: |
-            [
-              {
-                "id": "xwiki-releases",
-                "name": "xwiki-releases",
-                "url": "https://maven.xwiki.org/releases/",
-                "snapshots": {
-                  "enabled": false
-                }
-              }
-            ]
-
-      ############################################
-      # 4. Maven Dependency Tree Submission
-      ############################################      
       - name: Maven Dependency Submission
         uses: advanced-security/maven-dependency-submission-action@v5.0.0
-
-      ############################################
-      # 5. Build and Test with Maven
-      ############################################    
-      - name: Build and Test with Maven
-        run: mvn --batch-mode --update-snapshots install
 
       ############################################
       # 6. Deploy JAR Files to Qualification Environment


### PR DESCRIPTION
## Summary
- add reusable workflow for Maven builds
- call Maven workflow in PR, Beta and release CI files

## Testing
- `mvn -q -DskipTests install` *(fails: dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68820032e32c8333904dc4a1f88ed822