### PR TITLE
Update blog runtime doc

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -217,28 +217,22 @@ const cart = useCartStore();
   pnpm generate:api
   ```
 - Generated files under `src/api/`
-- Example usage:
+- Example usage with the blog client:
   ```ts
-  import { DefaultApi } from '@/api'
-  const api = new DefaultApi()
-  const response = await api.listVersionsv2()
+  import { BlogApi, Configuration } from '@/api'
+  const config = useRuntimeConfig()
+  const api = new BlogApi(new Configuration({ basePath: config.public.blogUrl }))
+  const { data } = await api.posts({ pageNumber: 1 })
   ```
 
 ## Fetching Content from blog
 
 ```ts
+import { BlogApi, Configuration } from '@/api'
 const config = useRuntimeConfig()
-const { data: postRes } = await useFetch(
-  `${config.public.blogUrl}/blog/posts`,
-  {
-    params: { filters: { slug } },
-    // TODO: provisoirement desactivé 
-    // headers: {
-    //   Authorization: `Bearer ${BLOG token}`,
-    // },
-  },
-)
-const post = postRes.value?.data[0]?.attributes
+const api = new BlogApi(new Configuration({ basePath: config.public.blogUrl }))
+const { data: page } = await api.posts({ pageNumber: 1 })
+const posts = page.items
 ```
 
 ## Vitest (Testing)

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -2,13 +2,18 @@ import type {
   BlogArticleData,
   PaginatedBlogResponse,
 } from '~/server/api/blog/types/blog.models'
+import { useRuntimeConfig } from '#imports'
 
 /**
  * Blog service for handling blog-related API calls
  */
 export class BlogService {
-  private readonly baseUrl =
-    process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  /**
+   * Base URL is derived from Nuxt runtime configuration so it works in every environment.
+   */
+  private get baseUrl(): string {
+    return useRuntimeConfig().public.blogUrl
+  }
   private readonly blogEndpoint = '/blog/posts'
 
   /**


### PR DESCRIPTION
## Summary
- document BlogApi usage and runtime config
- use useRuntimeConfig in blog service

## Testing
- `pnpm --offline lint`
- `pnpm --offline test --run`
- `pnpm --offline generate` *(partially executed)*

------
https://chatgpt.com/codex/tasks/task_e_688765e4b29c8333bb1d18125d514f08