### PR TITLE
Add blog service and API endpoint tests

### DIFF
--- a/frontend/server/api/blog/__tests__/handlers.spec.ts
+++ b/frontend/server/api/blog/__tests__/handlers.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Provide minimal implementations for Nitro helpers used in the handlers
+;(global as any).defineEventHandler = (fn: any) => fn
+;(global as any).setResponseHeader = (event: any, name: string, value: string) => {
+  event.node.res.setHeader(name, value)
+}
+;(global as any).createError = ({ statusCode, statusMessage }: any) => {
+  const err = new Error(statusMessage) as any
+  err.statusCode = statusCode
+  return err
+}
+;(global as any).getRouterParam = (event: any, name: string) => event.context?.params?.[name]
+
+vi.mock('~/services/blog.services', () => ({
+  blogService: {
+    getArticles: vi.fn(),
+    getArticleById: vi.fn(),
+  },
+}))
+
+import articlesHandler from '../articles'
+import articleHandler from '../articles/[id]'
+import { blogService } from '~/services/blog.services'
+
+const createEvent = (params: Record<string, string> = {}) => ({
+  context: { params },
+  node: { res: { setHeader: vi.fn() } },
+}) as any
+
+describe('blog proxy endpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns articles and sets cache header', async () => {
+    const event = createEvent()
+    ;(blogService.getArticles as any).mockResolvedValue({ data: [] })
+
+    const result = await articlesHandler(event)
+    expect(blogService.getArticles).toHaveBeenCalled()
+    expect(event.node.res.setHeader).toHaveBeenCalledWith(
+      'Cache-Control',
+      'public, max-age=3600, s-maxage=3600'
+    )
+    expect(result).toEqual({ data: [] })
+  })
+
+  it('propagates service error as 500', async () => {
+    const event = createEvent()
+    ;(blogService.getArticles as any).mockRejectedValue(new Error('fail'))
+
+    await expect(articlesHandler(event)).rejects.toHaveProperty('statusCode', 500)
+  })
+
+  it('returns 400 when id missing', async () => {
+    const event = createEvent()
+    await expect(articleHandler(event)).rejects.toHaveProperty('statusCode', 400)
+  })
+
+  it('returns article from service', async () => {
+    const event = createEvent({ id: '1' })
+    ;(blogService.getArticleById as any).mockResolvedValue({ id: '1' })
+
+    const result = await articleHandler(event)
+    expect(blogService.getArticleById).toHaveBeenCalledWith('1')
+    expect(result).toEqual({ id: '1' })
+  })
+
+  it('propagates article service error as 500', async () => {
+    const event = createEvent({ id: '2' })
+    ;(blogService.getArticleById as any).mockRejectedValue(new Error('fail'))
+
+    await expect(articleHandler(event)).rejects.toHaveProperty('statusCode', 500)
+  })
+})

--- a/frontend/services/__tests__/blog.service.spec.ts
+++ b/frontend/services/__tests__/blog.service.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BlogService } from '../blog.services'
+import type { BlogApi } from '~/src/api/apis/BlogApi'
+
+describe('BlogService', () => {
+  const mockApi = {
+    posts: vi.fn(),
+    post: vi.fn(),
+  } as unknown as BlogApi
+  let service: BlogService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new BlogService(mockApi)
+  })
+
+  it('fetches articles from BlogApi', async () => {
+    const data = { page: { number: 0 }, data: [] } as any
+    ;(mockApi.posts as any).mockResolvedValue(data)
+    const result = await service.getArticles()
+    expect(mockApi.posts).toHaveBeenCalledTimes(1)
+    expect(result).toEqual(data)
+  })
+
+  it('fetches article by id', async () => {
+    const article = { title: 'Test' } as any
+    ;(mockApi.post as any).mockResolvedValue(article)
+    const result = await service.getArticleById('slug')
+    expect(mockApi.post).toHaveBeenCalledWith({ slug: 'slug' })
+    expect(result).toEqual(article)
+  })
+
+  it('throws when posts request fails', async () => {
+    ;(mockApi.posts as any).mockRejectedValue(new Error('fail'))
+    await expect(service.getArticles()).rejects.toThrow('Failed to fetch blog articles')
+  })
+
+  it('throws when post request fails', async () => {
+    ;(mockApi.post as any).mockRejectedValue(new Error('fail'))
+    await expect(service.getArticleById('slug')).rejects.toThrow('Failed to fetch blog article slug')
+  })
+})

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -2,14 +2,23 @@ import type {
   BlogArticleData,
   PaginatedBlogResponse,
 } from '~/server/api/blog/types/blog.models'
+import { BlogApi, Configuration } from '~/src/api'
 
 /**
  * Blog service for handling blog-related API calls
  */
 export class BlogService {
-  private readonly baseUrl =
-    process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  private readonly blogEndpoint = '/blog/posts'
+  private readonly api: BlogApi
+
+  constructor(api?: BlogApi) {
+    if (api) {
+      this.api = api
+    } else {
+      const baseUrl =
+        process.env.BLOG_URL || 'https://beta.front-api.nudger.fr'
+      this.api = new BlogApi(new Configuration({ basePath: baseUrl }))
+    }
+  }
 
   /**
    * Fetch paginated blog articles
@@ -17,10 +26,8 @@ export class BlogService {
    */
   async getArticles(): Promise<PaginatedBlogResponse> {
     try {
-      const response = await $fetch<PaginatedBlogResponse>(
-        `${this.baseUrl}${this.blogEndpoint}`
-      )
-      return response
+      const response = await this.api.posts()
+      return response as unknown as PaginatedBlogResponse
     } catch (error) {
       console.error('Error fetching blog articles:', error)
       throw new Error('Failed to fetch blog articles')
@@ -34,10 +41,8 @@ export class BlogService {
    */
   async getArticleById(id: string): Promise<BlogArticleData> {
     try {
-      const response = await $fetch<BlogArticleData>(
-        `${this.baseUrl}${this.blogEndpoint}/${id}`
-      )
-      return response
+      const response = await this.api.post({ slug: id })
+      return response as unknown as BlogArticleData
     } catch (error) {
       console.error(`Error fetching blog article ${id}:`, error)
       throw new Error(`Failed to fetch blog article ${id}`)


### PR DESCRIPTION
## Summary
- update `BlogService` to use the generated BlogApi client
- add unit tests for the service with a mocked BlogApi
- add tests for blog server endpoints using mocked service

## Testing
- `pnpm --offline lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm --offline test` *(fails: vitest not found)*
- `pnpm --offline generate` *(fails: nuxt not found)*
- `pnpm --offline preview` *(fails: nuxt not found)*

------
https://chatgpt.com/codex/tasks/task_e_688765dfea1c8333993d338340a8e7c2