### PR TITLE
Fix blog API handlers

### DIFF
--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,12 +1,13 @@
 import { blogService } from '~/services/blog.services'
-import type { PaginatedBlogResponse } from './types/blog.models'
+import type { PageDto } from '~/src/api'
+import { _handleError } from '~/utils/server/_handdleErrors'
 
 /**
  * Blog articles API endpoint
  * Handles GET requests for blog articles with caching
  */
 export default defineEventHandler(
-  async (event): Promise<PaginatedBlogResponse> => {
+  async (event): Promise<PageDto> => {
     // Set cache headers for 1 hour
     setResponseHeader(
       event,
@@ -15,19 +16,10 @@ export default defineEventHandler(
     )
 
     try {
-      // Use the service to fetch articles
       const response = await blogService.getArticles()
       return response
     } catch (error) {
-      // Log the error for debugging
-      console.error('Error fetching blog articles:', error)
-
-      // Throw a proper HTTP error
-      throw createError({
-        statusCode: 500,
-        statusMessage: 'Failed to fetch blog articles',
-        cause: error,
-      })
+      _handleError(error, 'Failed to fetch blog articles')
     }
   }
 )

--- a/frontend/server/api/blog/articles/[id].ts
+++ b/frontend/server/api/blog/articles/[id].ts
@@ -1,11 +1,12 @@
 import { blogService } from '~/services/blog.services'
-import type { BlogArticleData } from '../types/blog.models'
+import type { BlogPostDto } from '~/src/api'
+import { _handleError } from '~/utils/server/_handdleErrors'
 
 /**
  * Blog article by ID API endpoint
  * Handles GET requests for a single blog article
  */
-export default defineEventHandler(async (event): Promise<BlogArticleData> => {
+export default defineEventHandler(async (event): Promise<BlogPostDto> => {
   const id = getRouterParam(event, 'id')
 
   if (!id) {
@@ -16,16 +17,9 @@ export default defineEventHandler(async (event): Promise<BlogArticleData> => {
   }
 
   try {
-    // Use the service to fetch the article
     const response = await blogService.getArticleById(id)
     return response
   } catch (error) {
-    console.error('Error fetching blog article:', error)
-
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Failed to fetch blog article',
-      cause: error,
-    })
+    _handleError(error, 'Failed to fetch blog article')
   }
 })

--- a/frontend/utils/server/_handdleErrors.ts
+++ b/frontend/utils/server/_handdleErrors.ts
@@ -1,4 +1,4 @@
-//Ici, créer une fonction qui va gérer les erreurs de façon plus globale
+// Helper to throw consistent server errors
 export function _handleError(error: unknown, message: string) {
   console.error(message, error)
   throw createError({


### PR DESCRIPTION
## Summary
- translate server utils comment to English
- reuse handleError helper in blog article APIs
- return OpenAPI types from blog APIs

## Testing
- `pnpm --offline lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm --offline test` *(fails: vitest not found)*
- `pnpm --offline generate` *(fails: nuxt not found)*
- `mvn --offline -DskipTests clean install` *(fails: missing dependencies in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_688765d70cf08333ae21fbe24935e59c