### PR TITLE
docs(frontend): translate project docs to english

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -57,7 +57,7 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
 - Use `@/` or `~/` aliases
 - Component structure: separate logic/UI
 - Nuxt page features: `definePageMeta`, `useFetch`, `useAsyncData`
-- les noms de fonctions utilitaires commenceront par un underscore : exemple _sanitizeHtml
+- Utility function names should start with an underscore: for example `_sanitizeHtml`.
 
 ---
 
@@ -109,15 +109,15 @@ export const useCartStore = defineStore('cart', {
 
 ## OpenAPI Client Generation & Integration
 
-Le dossier `src/api` est **entièrement généré** à partir de la spécification exposée par `front-api` (`/v3/api-docs/front`).
+The `src/api` folder is **fully generated** from the specification exposed by `front-api` (`/v3/api-docs/front`).
 
 Workflow:
-1. Modifier les contrôleurs ou DTOs du projet `front-api` pour faire évoluer l’API.
-2. Construire `front-api` (`mvn -pl nudger-front-api -am clean install`) pour publier le nouveau contrat.
-3. Dans ce module, exécuter `pnpm --offline generate:api` pour mettre à jour `src/api/`.
-4. Utiliser les nouvelles classes générées.
+1. Modify controllers or DTOs in the `front-api` project to evolve the API.
+2. Build `front-api` (`mvn -pl nudger-front-api -am clean install`) to publish the new contract.
+3. In this module, run `pnpm --offline generate:api` to update `src/api/`.
+4. Use the newly generated classes.
 
-Ne jamais éditer les fichiers générés à la main.
+Never edit the generated files manually.
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -66,8 +66,8 @@ To get the project up and running locally, follow these steps:
    pnpm build && pnpm preview
    ```
 
-   Les outils de développement Nuxt sont automatiquement désactivés lorsque
-   `NODE_ENV` vaut `production`.
+   Nuxt's development tools are automatically disabled when
+   `NODE_ENV` is set to `production`.
 
 7. **Static Generation (optional)**:
 
@@ -232,7 +232,7 @@ const { data: postRes } = await useFetch(
   `${config.public.blogUrl}/blog/posts`,
   {
     params: { filters: { slug } },
-    // TODO: provisoirement desactivé 
+    // TODO: temporarily disabled
     // headers: {
     //   Authorization: `Bearer ${BLOG token}`,
     // },

--- a/frontend/i18n/AIDE.md
+++ b/frontend/i18n/AIDE.md
@@ -1,7 +1,7 @@
-# Traduction avec bard:
+# Translation with Bard:
 
-- traduit moi ce fichier json en allemand > suivi du fichier tout simplement
+- Translate this JSON file into German and output only the file content.
 
-* penser à modifier le fichier de config > locales/i18n.config.js
+* Remember to update the configuration file > `locales/i18n.config.js`.
 
-* Tous laisser dans le même fichier (plus simple à traduire)
+* Keep everything in the same file (easier to translate).


### PR DESCRIPTION
## Summary
- translate French sections of README
- translate OpenAPI generation guide in `AGENTS.md`
- translate instructions in `i18n/AIDE.md`

## Testing
- `pnpm --offline lint`
- `pnpm vitest run`
- `pnpm --offline generate` *(aborted after build)*
- `pnpm --offline preview` *(started then terminated)*
- `mvn --offline clean install -DskipTests` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68875572e1648333aa355078b9da35b6