### PR TITLE
Switch OpenAPI client generator to Axios

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -109,12 +109,12 @@ export const useCartStore = defineStore('cart', {
 
 ## OpenAPI Client Generation & Integration
 
-Le dossier `src/api` est **entièrement généré** à partir de la spécification exposée par `front-api` (`/v3/api-docs/front`).
+Le dossier `src/api` est **entièrement généré** à partir de la spécification exposée par `front-api` (`/v3/api-docs/front`). Le client est généré avec le générateur `typescript-axios` (Axios au lieu de Fetch).
 
 Workflow:
 1. Modifier les contrôleurs ou DTOs du projet `front-api` pour faire évoluer l’API.
 2. Construire `front-api` (`mvn -pl nudger-front-api -am clean install`) pour publier le nouveau contrat.
-3. Dans ce module, exécuter `pnpm --offline generate:api` pour mettre à jour `src/api/`.
+3. Dans ce module, exécuter `pnpm --offline generate:api` pour mettre à jour `src/api/`. Ce script utilise désormais Axios via `typescript-axios`.
 4. Utiliser les nouvelles classes générées.
 
 Ne jamais éditer les fichiers générés à la main.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ To get the project up and running locally, follow these steps:
    - `pnpm lint` – run ESLint
    - `pnpm format` – check formatting
    - `pnpm test` – run tests with Vitest
-   - `pnpm generate:api` – regenerate the OpenAPI fetch client
+   - `pnpm generate:api` – regenerate the OpenAPI axios client
    - `pnpm preview` – serve the production build locally
    - `pnpm build:ssr` – build with increased memory
 
@@ -212,7 +212,7 @@ const cart = useCartStore();
 
 ## OpenAPI Integration
 
-- We use `@openapitools/openapi-generator-cli` with the `typescript-fetch` generator:
+- We use `@openapitools/openapi-generator-cli` with the `typescript-axios` generator:
   ```bash
   pnpm generate:api
   ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest",
-    "generate:api": "openapi-generator-cli generate -i https://beta.front-api.nudger.fr/v3/api-docs/front -g typescript-fetch -o src/api --skip-validate-spec",
+    "generate:api": "openapi-generator-cli generate -i https://beta.front-api.nudger.fr/v3/api-docs/front -g typescript-axios -o src/api --skip-validate-spec",
     "semantic-release": "semantic-release",
     "postinstall": "nuxt prepare",
     "prepare": "husky"
@@ -34,6 +34,7 @@
     "nuxt-device": "^2.1.0",
     "pinia": "^3.0.3",
     "sass-loader": "^16.0.2",
+    "axios": "^1.6.1",
     "unhead": "^2.0.0",
     "vue": "^3.5.17",
     "vue-router": "^4.5.1"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@vueuse/nuxt':
         specifier: ^13.0.0
         version: 13.5.0(magicast@0.3.5)(nuxt@3.17.7(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(db0@0.3.2)(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rollup@4.45.1)(sass@1.89.2)(terser@5.43.1)(typescript@5.8.3)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))
+      axios:
+        specifier: ^1.6.1
+        version: 1.11.0
       dompurify:
         specifier: ^3.2.6
         version: 3.2.6


### PR DESCRIPTION
## Summary
- use `typescript-axios` generator for the frontend API client
- add axios dependency
- document the change in AGENTS and README

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `pnpm --offline preview` *(fails: cannot start preview)*
- `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_688774a0193083339bc9e051535928d6