### PR TITLE
Use OpenAPI types in blog API handlers

### DIFF
--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,33 +1,31 @@
 import { blogService } from '~/services/blog.services'
-import type { PaginatedBlogResponse } from './types/blog.models'
+import type { PageDto } from '@/api/models'
 
 /**
  * Blog articles API endpoint
  * Handles GET requests for blog articles with caching
  */
-export default defineEventHandler(
-  async (event): Promise<PaginatedBlogResponse> => {
-    // Set cache headers for 1 hour
-    setResponseHeader(
-      event,
-      'Cache-Control',
-      'public, max-age=3600, s-maxage=3600'
-    )
+export default defineEventHandler(async (event): Promise<PageDto> => {
+  // Set cache headers for 1 hour
+  setResponseHeader(
+    event,
+    'Cache-Control',
+    'public, max-age=3600, s-maxage=3600'
+  )
 
-    try {
-      // Use the service to fetch articles
-      const response = await blogService.getArticles()
-      return response
-    } catch (error) {
-      // Log the error for debugging
-      console.error('Error fetching blog articles:', error)
+  try {
+    // Use the service to fetch articles
+    const response = await blogService.getArticles()
+    return response
+  } catch (error) {
+    // Log the error for debugging
+    console.error('Error fetching blog articles:', error)
 
-      // Throw a proper HTTP error
-      throw createError({
-        statusCode: 500,
-        statusMessage: 'Failed to fetch blog articles',
-        cause: error,
-      })
-    }
+    // Throw a proper HTTP error
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch blog articles',
+      cause: error,
+    })
   }
-)
+})

--- a/frontend/server/api/blog/articles/[id].ts
+++ b/frontend/server/api/blog/articles/[id].ts
@@ -1,11 +1,11 @@
 import { blogService } from '~/services/blog.services'
-import type { BlogArticleData } from '../types/blog.models'
+import type { BlogPostDto } from '@/api/models'
 
 /**
  * Blog article by ID API endpoint
  * Handles GET requests for a single blog article
  */
-export default defineEventHandler(async (event): Promise<BlogArticleData> => {
+export default defineEventHandler(async (event): Promise<BlogPostDto> => {
   const id = getRouterParam(event, 'id')
 
   if (!id) {

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -1,26 +1,33 @@
-import type {
-  BlogArticleData,
-  PaginatedBlogResponse,
-} from '~/server/api/blog/types/blog.models'
+import { BlogApi } from '@/api/apis/BlogApi'
+import { Configuration } from '@/api'
+import type { BlogPostDto, BlogTagDto, PageDto } from '@/api/models'
+import { useRuntimeConfig } from '#app'
 
 /**
  * Blog service for handling blog-related API calls
  */
 export class BlogService {
-  private readonly baseUrl =
-    process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  private readonly blogEndpoint = '/blog/posts'
+  private readonly api: BlogApi
+
+  constructor() {
+    const config = useRuntimeConfig()
+    const headers: Record<string, string> = {}
+    if (config.blogToken) {
+      headers['Authorization'] = `Bearer ${config.blogToken}`
+    }
+    const apiConfig = new Configuration({
+      basePath: config.public.blogUrl,
+      headers,
+    })
+    this.api = new BlogApi(apiConfig)
+  }
 
   /**
    * Fetch paginated blog articles
-   * @returns Promise<PaginatedBlogResponse>
    */
-  async getArticles(): Promise<PaginatedBlogResponse> {
+  async getArticles(): Promise<PageDto> {
     try {
-      const response = await $fetch<PaginatedBlogResponse>(
-        `${this.baseUrl}${this.blogEndpoint}`
-      )
-      return response
+      return await this.api.posts()
     } catch (error) {
       console.error('Error fetching blog articles:', error)
       throw new Error('Failed to fetch blog articles')
@@ -28,19 +35,26 @@ export class BlogService {
   }
 
   /**
-   * Fetch a single blog article by ID
-   * @param id - Article ID
-   * @returns Promise<BlogArticleData>
+   * Fetch a single blog article by slug
    */
-  async getArticleById(id: string): Promise<BlogArticleData> {
+  async getArticleById(slug: string): Promise<BlogPostDto> {
     try {
-      const response = await $fetch<BlogArticleData>(
-        `${this.baseUrl}${this.blogEndpoint}/${id}`
-      )
-      return response
+      return await this.api.post({ slug })
     } catch (error) {
-      console.error(`Error fetching blog article ${id}:`, error)
-      throw new Error(`Failed to fetch blog article ${id}`)
+      console.error(`Error fetching blog article ${slug}:`, error)
+      throw new Error(`Failed to fetch blog article ${slug}`)
+    }
+  }
+
+  /**
+   * List available blog tags
+   */
+  async getTags(): Promise<BlogTagDto[]> {
+    try {
+      return await this.api.tags()
+    } catch (error) {
+      console.error('Error fetching blog tags:', error)
+      throw new Error('Failed to fetch blog tags')
     }
   }
 }


### PR DESCRIPTION
## Summary
- use the OpenAPI generated `BlogApi` in `BlogService`
- update blog handlers to rely on `@/api` models

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate` *(fails: Cannot find module 'axios')*
- `pnpm preview` *(fails: Cannot find nitro.json)*
- `mvn clean install` *(fails: could not resolve Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887baf0b494833391e0c8e944ab992f