### PR TITLE
feat: add content bloc component

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -241,6 +241,24 @@ const { data: postRes } = await useFetch(
 const post = postRes.value?.data[0]?.attributes
 ```
 
+## Fetching dynamic content blocs
+
+The generated `ContentApi` client allows retrieval of HTML blocs from the
+`front-api` service. The `<TextContent>` component wraps this logic.
+
+```ts
+import { ContentApi, Configuration } from '@/api'
+const config = useRuntimeConfig()
+const api = new ContentApi(new Configuration({ basePath: config.public.blogUrl }))
+const bloc = await api.contentBloc({ blocId: 'Main.WebHome' })
+```
+
+Example usage in a page:
+
+```vue
+<TextContent blocId="Main.WebHome" />
+```
+
 ## Vitest (Testing)
 
 - Colocate tests as `Component.spec.ts`

--- a/frontend/components/domains/content/TextContent.spec.ts
+++ b/frontend/components/domains/content/TextContent.spec.ts
@@ -1,0 +1,43 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import TextContent from './TextContent.vue'
+
+const mockBloc = {
+  htmlContent: '<p>Hello bloc</p>',
+  editLink: '/edit',
+}
+
+const mockUseContentBloc = {
+  htmlContent: mockBloc.htmlContent,
+  editLink: mockBloc.editLink,
+  loading: false,
+  error: null,
+  fetchBloc: vi.fn(),
+}
+
+vi.mock('~/composables/content/useContentBloc', () => ({
+  useContentBloc: () => mockUseContentBloc,
+}))
+
+describe('TextContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders bloc content and calls fetch on mount', async () => {
+    const wrapper = await mountSuspended(TextContent, {
+      props: { blocId: 'Main.WebHome' },
+    })
+    expect(mockUseContentBloc.fetchBloc).toHaveBeenCalledWith('Main.WebHome')
+    expect(wrapper.html()).toContain(mockBloc.htmlContent)
+  })
+
+  test('shows loader when loading', async () => {
+    mockUseContentBloc.loading = true
+    const wrapper = await mountSuspended(TextContent, {
+      props: { blocId: 'id' },
+    })
+    expect(wrapper.find('.v-progress-circular').exists()).toBe(true)
+    mockUseContentBloc.loading = false
+  })
+})

--- a/frontend/components/domains/content/TextContent.vue
+++ b/frontend/components/domains/content/TextContent.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const props = defineProps<{ blocId: string }>()
+
+const { htmlContent, loading, error, fetchBloc } = useContentBloc()
+
+onMounted(() => {
+  fetchBloc(props.blocId)
+})
+
+watch(
+  () => props.blocId,
+  newId => {
+    if (newId) fetchBloc(newId)
+  }
+)
+</script>
+
+<template>
+  <div class="text-content">
+    <v-progress-circular v-if="loading" indeterminate />
+    <v-alert v-else-if="error" type="error" variant="tonal">{{ error }}</v-alert>
+    <div v-else v-html="htmlContent" />
+  </div>
+</template>
+
+<style scoped>
+.text-content {
+  padding: 1rem 0;
+}
+</style>

--- a/frontend/composables/content/useContentBloc.ts
+++ b/frontend/composables/content/useContentBloc.ts
@@ -1,0 +1,33 @@
+import type { XwikiContentBlocDto } from '~/src/api'
+
+/**
+ * Composable to retrieve dynamic content blocs
+ */
+export const useContentBloc = () => {
+  const htmlContent = ref<string>('')
+  const editLink = ref<string | undefined>(undefined)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const fetchBloc = async (blocId: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      const bloc = await $fetch<XwikiContentBlocDto>(`/api/blocs/${blocId}`)
+      htmlContent.value = bloc.htmlContent ?? ''
+      editLink.value = bloc.editLink
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch content'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    htmlContent: readonly(htmlContent),
+    editLink: readonly(editLink),
+    loading: readonly(loading),
+    error: readonly(error),
+    fetchBloc,
+  }
+}

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -51,6 +51,11 @@
         </v-col>
       </v-row>
     </section>
+
+    <!-- Example content bloc -->
+    <section>
+      <TextContent blocId="Main.WebHome" />
+    </section>
   </v-container>
 </template>
 

--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,0 +1,22 @@
+import { contentService } from '~/services/content.services'
+import type { XwikiContentBlocDto } from '~/src/api'
+
+export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> => {
+  const blocId = getRouterParam(event, 'blocId')
+  if (!blocId) {
+    throw createError({ statusCode: 400, statusMessage: 'Bloc id is required' })
+  }
+
+  // Cache content for 1 hour
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=3600')
+  try {
+    return await contentService.getBloc(blocId)
+  } catch (error) {
+    console.error('Error fetching bloc', error)
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch content bloc',
+      cause: error,
+    })
+  }
+})

--- a/frontend/services/content.services.ts
+++ b/frontend/services/content.services.ts
@@ -1,0 +1,25 @@
+import { ContentApi, Configuration } from '~/src/api'
+import type { XwikiContentBlocDto } from '~/src/api'
+
+/**
+ * Content service for fetching HTML blocs from the backend
+ */
+export class ContentService {
+  private readonly api: ContentApi
+
+  constructor() {
+    const basePath = process.env.API_URL || 'http://localhost:8082'
+    this.api = new ContentApi(new Configuration({ basePath }))
+  }
+
+  /**
+   * Retrieve a content bloc by its identifier
+   * @param blocId - XWiki bloc identifier
+   */
+  async getBloc(blocId: string): Promise<XwikiContentBlocDto> {
+    return await this.api.contentBloc({ blocId })
+  }
+}
+
+// Export singleton instance
+export const contentService = new ContentService()

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -1,2 +1,3 @@
 // Export all services
 export { blogService } from '~/services/blog.services'
+export { contentService } from '~/services/content.services'


### PR DESCRIPTION
## Summary
- implement `contentService` using generated API
- provide `useContentBloc` composable
- add `TextContent` component with tests
- expose server API `/api/blocs/[blocId]`
- demo bloc usage on home page
- document dynamic content retrieval in README

## Testing
- `pnpm --offline lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm --offline test` *(fails: vitest not found)*
- `pnpm --offline generate` *(fails: nuxt not found)*


------
https://chatgpt.com/codex/tasks/task_e_6887d50a85b88333bb7d51b7456ecec5