### PR TITLE
fix frontend error logging

### DIFF
--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,5 +1,6 @@
 import { contentService } from '~/services/content.services'
 import type { XwikiContentBlocDto } from '~/src/api'
+import { _handleError } from '~/utils/server/_handdleErrors'
 
 export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> => {
   const blocId = getRouterParam(event, 'blocId')
@@ -12,11 +13,6 @@ export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> =>
   try {
     return await contentService.getBloc(blocId)
   } catch (error) {
-    console.error('Error fetching bloc', error)
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Failed to fetch content bloc',
-      cause: error,
-    })
+    _handleError(error, 'Failed to fetch content bloc')
   }
 })

--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,5 +1,6 @@
 import { blogService } from '~/services/blog.services'
 import type { PageDto } from '~/src/api'
+import { _handleError } from '~/utils/server/_handdleErrors'
 
 /**
  * Blog articles API endpoint
@@ -19,15 +20,7 @@ export default defineEventHandler(
       const response = await blogService.getArticles()
       return response
     } catch (error) {
-      // Log the error for debugging
-      console.error('Error fetching blog articles:', error)
-
-      // Throw a proper HTTP error
-      throw createError({
-        statusCode: 500,
-        statusMessage: 'Failed to fetch blog articles',
-        cause: error,
-      })
+      _handleError(error, 'Failed to fetch blog articles')
     }
   }
 )

--- a/frontend/server/api/blog/articles/[id].ts
+++ b/frontend/server/api/blog/articles/[id].ts
@@ -1,5 +1,6 @@
 import { blogService } from '~/services/blog.services'
 import type { BlogPostDto } from '~/src/api'
+import { _handleError } from '~/utils/server/_handdleErrors'
 
 /**
  * Blog article by ID API endpoint
@@ -20,12 +21,6 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
     const response = await blogService.getArticleById(slug)
     return response
   } catch (error) {
-    console.error('Error fetching blog article:', error)
-
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Failed to fetch blog article',
-      cause: error,
-    })
+    _handleError(error, 'Failed to fetch blog article')
   }
 })

--- a/frontend/utils/server/_handdleErrors.ts
+++ b/frontend/utils/server/_handdleErrors.ts
@@ -1,8 +1,40 @@
-//Ici, créer une fonction qui va gérer les erreurs de façon plus globale
-export function _handleError(error: unknown, message: string) {
-  console.error(message, error)
+// Helper to centralize error handling in server API routes
+import { FetchError, ResponseError } from '~/src/api'
+
+interface ResponseHolder {
+  response?: { status?: number }
+}
+
+export function _handleError(error: unknown, message: string): never {
+  let status = 500
+
+  if (error instanceof ResponseError) {
+    status = error.response.status
+    console.error(`${message} (status ${status})`, error)
+  } else if (error instanceof FetchError) {
+    const cause = error.cause as ResponseHolder | undefined
+    if (cause?.response?.status) {
+      status = cause.response.status
+      console.error(`${message} (status ${status})`, error)
+    } else {
+      console.error(message, error)
+    }
+  } else if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    (error as ResponseHolder).response?.status
+  ) {
+    const holder = error as ResponseHolder
+    status = holder.response?.status ?? 500
+    console.error(`${message} (status ${status})`, error)
+  } else {
+    console.error(message, error)
+  }
+
   throw createError({
-    statusCode: 500,
+    statusCode: status,
     statusMessage: message,
+    cause: error instanceof Error ? error : undefined,
   })
 }


### PR DESCRIPTION
## Summary
- handle FetchError/ResponseError with status code in helper
- use helper in blog and bloc API routes

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate`
- `pnpm preview` *(fails: module not found)*
- `mvn --offline clean install -DskipTests` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887e837e7908333b8f46bcfb0f6cd37