### PR TITLE
fix: content bloc uses runtime config

### DIFF
--- a/frontend/services/content.services.ts
+++ b/frontend/services/content.services.ts
@@ -8,8 +8,9 @@ export class ContentService {
   private readonly api: ContentApi
 
   constructor() {
-    const basePath = process.env.API_URL || 'http://localhost:8082'
-    this.api = new ContentApi(new Configuration({ basePath }))
+    const config = useRuntimeConfig()
+    const apiConfig = new Configuration({ basePath: config.public.blogUrl })
+    this.api = new ContentApi(apiConfig)
   }
 
   /**


### PR DESCRIPTION
## Summary
- fetch content bloc from runtime-configured API

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate`
- `pnpm preview` *(fails: Cannot find module '/workspace/open4goods/frontend/.output/server/index.mjs')*
- `curl -I http://localhost:3000/200.html` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_6888896604788333bd7759d23c8688aa