### PR TITLE
Unify frontend backend URL handling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -87,17 +87,16 @@ To get the project up and running locally, follow these steps:
    - `pnpm preview` – serve the production build locally
    - `pnpm build:ssr` – build with increased memory
 
-## Blog environment variables
+## API environment variables
 
-The frontend interacts with the blog service using two runtime variables
-declared in `nuxt.config.ts`:
+Runtime configuration only requires the backend API URL and an optional blog
+token. They are declared in `nuxt.config.ts`:
 
-- **`BLOG_URL`** – base URL of the blog API. If not specified, it defaults to
-  `https://beta.front-api.nudger.fr`. This value is part of the public runtime
-  configuration (`config.public.blogUrl`).
+- **`API_URL`** – base URL of the backend API. Defaults to
+  `https://beta.front-api.nudger.fr` and is exposed as
+  `config.public.apiUrl`.
 - **`BLOG_TOKEN`** – authentication token for protected blog endpoints. It is
-  defined as a private runtime key (`config.blogToken`) and is therefore only
-  available on the server side.
+  a private runtime key (`config.blogToken`) available only on the server side.
 
 ## Design Tokens
 
@@ -229,7 +228,7 @@ const cart = useCartStore();
 ```ts
 const config = useRuntimeConfig()
 const { data: postRes } = await useFetch(
-  `${config.public.blogUrl}/blog/posts`,
+  `${config.public.apiUrl}/blog/posts`,
   {
     params: { filters: { slug } },
     // TODO: temporarily disabled
@@ -249,7 +248,7 @@ The generated `ContentApi` client allows retrieval of HTML blocs from the
 ```ts
 import { ContentApi, Configuration } from '@/api'
 const config = useRuntimeConfig()
-const api = new ContentApi(new Configuration({ basePath: config.public.blogUrl }))
+const api = new ContentApi(new Configuration({ basePath: config.public.apiUrl }))
 const bloc = await api.contentBloc({ blocId: 'Main.WebHome' })
 ```
 

--- a/frontend/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/components/domains/blog/TheArticles.spec.ts
@@ -41,7 +41,7 @@ vi.mock('~/composables/blog/useBlog', () => ({
 vi.mock('#app', () => ({
   useRuntimeConfig: () => ({
     public: {
-      blogUrl: 'https://test-api.example.com',
+      apiUrl: 'https://test-api.example.com',
     },
   }),
 }))

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -94,7 +94,7 @@ export default defineNuxtConfig({
 
     // Public keys (exposed to client-side)
     public: {
-      blogUrl: process.env.BLOG_URL || 'https://beta.front-api.nudger.fr',
+      apiUrl: process.env.API_URL || 'https://beta.front-api.nudger.fr',
     }
   },
 })

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -9,7 +9,7 @@ export class BlogService {
 
   constructor() {
     const config = useRuntimeConfig()
-    const apiConfig = new Configuration({ basePath: config.public.blogUrl })
+    const apiConfig = new Configuration({ basePath: config.public.apiUrl })
     this.api = new BlogApi(apiConfig)
   }
 

--- a/frontend/services/content.services.ts
+++ b/frontend/services/content.services.ts
@@ -9,7 +9,7 @@ export class ContentService {
 
   constructor() {
     const config = useRuntimeConfig()
-    const apiConfig = new Configuration({ basePath: config.public.blogUrl })
+    const apiConfig = new Configuration({ basePath: config.public.apiUrl })
     this.api = new ContentApi(apiConfig)
   }
 


### PR DESCRIPTION
## Summary
- introduce `API_URL` runtime key
- update blog and content services to use new base path
- document API environment variable in the frontend README
- update tests for new runtime config

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm generate`
- `pnpm build`
- `pnpm preview`
- `mvn clean install` *(fails: Could not transfer org.springframework.boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888bbe55fa483339b4b3c7a9b9f9b94