### PR TITLE
Fix Vuetify plugin integration

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import * as vuetify from 'vite-plugin-vuetify'
-import { transformAssetUrls } from 'vite-plugin-vuetify'
+import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
@@ -36,7 +35,7 @@ export default defineNuxtConfig({
     (_options, nuxt) => {
       nuxt.hooks.hook('vite:extendConfig', (config) => {
         config.plugins = config.plugins ?? []
-        config.plugins.push(vuetify.default({ autoImport: true }))
+        config.plugins.push(...vuetify({ autoImport: true }))
       })
     },
     "@nuxtjs/i18n",


### PR DESCRIPTION
## Summary
- fix nuxt config for vite-plugin-vuetify integration

## Testing
- `pnpm lint`
- `pnpm test` *(fails: cannot resolve `.nuxt/tsconfig.json`)*
- `pnpm generate`
- `pnpm preview` *(fails to start)*

------
https://chatgpt.com/codex/tasks/task_e_6888ccf37cc483338f724a963bc0c5ee