### PR TITLE
feat(frontend): log backend requests

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -199,6 +199,7 @@ Nuxt 3 Specifics
 - Take advantage of VueUse functiontoenhance reactivity and performan(except for color mode management).
 - Use the Server API (within thserverapi directory) to handlserver-sideoperations like databasinteractions,authentication, oprocessing sensitivedata that must remaiconfidential.
 - use useRuntimeConfig to accesandmanage runtime configuratiovariablesthat differ between environmentandare needed both on the serveandclient sides.
+- The plugin `plugins/fetch-logger.ts` wraps `fetch` on the server to log each backend request to `API_URL`.
 - For SEO use useHead and useSeoMeta.
 - For images use <NuxtImageor<NuxtPicture> component and foIconsuse Nuxt Icons module.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -117,7 +117,7 @@ src/
 ├── layouts/      # Page layout wrappers
 ├── middleware/   # Route guards
 ├── pages/        # File-based routes
-├── plugins/      # Nuxt plugins
+├── plugins/      # Nuxt plugins (e.g. `fetch-logger.ts` logs all backend requests)
 ├── stores/       # Pinia state stores
 ```
 

--- a/frontend/plugins/fetch-logger.ts
+++ b/frontend/plugins/fetch-logger.ts
@@ -1,0 +1,16 @@
+export default defineNuxtPlugin(() => {
+  if (!import.meta.server || (globalThis as { __fetchLoggerInstalled?: boolean }).__fetchLoggerInstalled) {
+    return
+  }
+  const config = useRuntimeConfig()
+  const originalFetch = globalThis.fetch
+  ;(globalThis as { __fetchLoggerInstalled?: boolean }).__fetchLoggerInstalled = true
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+    if (url.startsWith(config.public.apiUrl)) {
+      const method = init?.method ?? 'GET'
+      console.log(`[nuxt] ${method} ${url}`)
+    }
+    return originalFetch(input, init)
+  }
+})


### PR DESCRIPTION
## Summary
- add `fetch-logger` plugin to log full backend URLs when Nuxt makes server-side requests
- document plugin usage in README and AGENTS

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build` *(fails: preview requires nitro.json)*

------
https://chatgpt.com/codex/tasks/task_e_688936ade3e08333bdc47b9b374761bb