### PR TITLE
Fix front-api security default

### DIFF
--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -19,7 +19,7 @@ front:
   cache:
     path: ./cache
   security:
-    enabled: false
+    enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
     
 xwiki:


### PR DESCRIPTION
## Summary
- enable security by default in `application.yml`

## Testing
- `mvn --offline clean install` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68894ba5d1f083338941dafe12a16c55