### PR TITLE
Remove HTTP basic auth from front-api

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -51,7 +51,7 @@ public class WebSecurityConfig {
                     .requestMatchers("/", "/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/auth/**").permitAll()
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .httpBasic(Customizer.withDefaults());
+                .formLogin(Customizer.withDefaults());
         } else {
             http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         }


### PR DESCRIPTION
## Summary
- switch to form login in the front-api security config

## Testing
- `mvn -q -pl front-api -am clean install` *(fails: could not resolve Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68894b9e17a4833388add4c2e721a3ac