### PR TITLE
feat(frontend): add login page and auth composable

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -88,12 +88,19 @@ To get the project up and running locally, follow these steps:
 
 ## API environment variables
 
-Runtime configuration only requires the backend API URL. It is declared in
+Runtime configuration requires a few environment variables declared in
 `nuxt.config.ts`:
 
 - **`API_URL`** – base URL of the backend API. Defaults to
   `http://localhost:8082` and is exposed as
   `config.public.apiUrl`.
+- **`AUTH_COOKIE_DOMAIN`** – optional domain used when setting
+  authentication cookies. Leave empty for localhost.
+
+The `/auth/login` API route stores JWT and refresh tokens in HTTP‑only cookies
+named `jwt` and `refresh_token`. In production these cookies are set with the
+`Secure` attribute and `SameSite=None` so they can be sent on cross‑site
+requests.
 
 ## Design Tokens
 

--- a/frontend/composables/auth/useUserRoles.ts
+++ b/frontend/composables/auth/useUserRoles.ts
@@ -1,0 +1,25 @@
+/**
+ * Decode user roles from the JWT stored in cookies
+ */
+export const useUserRoles = () => {
+  const jwtCookie = useCookie<string | undefined>('jwt')
+  const roles = computed(() => {
+    const token = jwtCookie.value
+    if (!token) {
+      return [] as string[]
+    }
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1] ?? '')) as {
+        roles?: string[]
+      }
+      return payload.roles ?? []
+    } catch (err) {
+      console.error('Failed to decode JWT', err)
+      return [] as string[]
+    }
+  })
+
+  return {
+    roles,
+  }
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -72,7 +72,7 @@ export default defineNuxtConfig({
   ],
   // Runtime configuration for environment variables
   runtimeConfig: {
-
+    authCookieDomain: process.env.AUTH_COOKIE_DOMAIN,
     // Public keys (exposed to client-side)
     public: {
       apiUrl: process.env.API_URL || 'http://localhost:8082',

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-container class="d-flex justify-center">
+    <v-card width="400">
+      <v-card-title>Login</v-card-title>
+      <v-card-text>
+        <v-form @submit.prevent="submit">
+          <v-text-field v-model="username" label="Username" required />
+          <v-text-field
+            v-model="password"
+            label="Password"
+            type="password"
+            required
+          />
+          <v-btn
+            type="submit"
+            color="primary"
+            :loading="loading"
+            class="mt-4"
+            block
+            >Login</v-btn
+          >
+          <v-alert v-if="error" type="error" class="mt-4">{{ error }}</v-alert>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+const router = useRouter()
+const username = ref('')
+const password = ref('')
+const error = ref<string | null>(null)
+const loading = ref(false)
+
+const submit = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    await $fetch('/auth/login', {
+      method: 'POST',
+      body: { username: username.value, password: password.value },
+    })
+    await router.push('/')
+  } catch (err) {
+    error.value = 'Invalid credentials'
+    console.error('Login error', err)
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/server/routes/auth/login.post.ts
+++ b/frontend/server/routes/auth/login.post.ts
@@ -1,0 +1,39 @@
+import { readBody, setCookie } from 'h3'
+
+interface LoginResponse {
+  token: string
+  refreshToken: string
+}
+
+export default defineEventHandler(async event => {
+  const body = await readBody(event)
+  const { username, password } = body as { username: string; password: string }
+  const config = useRuntimeConfig()
+  try {
+    const tokens = await $fetch<LoginResponse>(
+      `${config.public.apiUrl}/auth/login`,
+      {
+        method: 'POST',
+        body: { username, password },
+      }
+    )
+    const secure = process.env.NODE_ENV === 'production'
+    const cookieOptions = {
+      httpOnly: true,
+      path: '/',
+      secure,
+      sameSite: secure ? 'none' : 'lax',
+      domain: config.authCookieDomain as string | undefined,
+    } as const
+    setCookie(event, 'jwt', tokens.token, cookieOptions)
+    setCookie(event, 'refresh_token', tokens.refreshToken, cookieOptions)
+    return { success: true }
+  } catch (err) {
+    console.error('Login error', err)
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Invalid credentials',
+      cause: err,
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- add Nuxt server route for `/auth/login`
- create login page
- provide `useUserRoles` composable
- expose `AUTH_COOKIE_DOMAIN` runtime config
- document env vars and cookie usage

## Testing
- `pnpm --offline lint`
- `pnpm --offline test` *(fails: watch mode ended)*
- `pnpm --offline generate` *(failed: error TS2353)*
- `pnpm --offline preview` *(failed: cannot find nitro.json)*
- `mvn --offline -q -DskipTests clean install` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68894b2d343c8333b7f282f9cf271aa2