### PR TITLE
Add login and refresh token endpoints

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -23,6 +23,12 @@ CORS origins using the `front.security.cors-allowed-hosts` property. You can ove
 via the `FRONT_SECURITY_CORS_ALLOWED_HOSTS` environment variable. By default it permits requests from
 `http://localhost:8082`.
 
+Additional properties configure token generation:
+
+- `front.security.jwt-secret` – secret key used to sign JWT tokens.
+- `front.security.access-token-expiry` – duration before an access token expires (default `PT30M`).
+- `front.security.refresh-token-expiry` – duration before a refresh token expires (default `P7D`).
+
 With this configuration all calls stay on the same origin and the built-in CORS
 rules apply correctly.
 

--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -88,6 +88,24 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.4</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.4</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.8.9</version>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
@@ -2,6 +2,7 @@ package org.open4goods.nudgerfrontapi.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,6 +24,21 @@ public class SecurityProperties {
      */
     private List<String> corsAllowedHosts = new ArrayList<>();
 
+    /**
+     * Secret key used to sign JWT tokens.
+     */
+    private String jwtSecret = "changeMe";
+
+    /**
+     * Access token validity duration.
+     */
+    private Duration accessTokenExpiry = Duration.ofMinutes(30);
+
+    /**
+     * Refresh token validity duration.
+     */
+    private Duration refreshTokenExpiry = Duration.ofDays(7);
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -37,5 +53,29 @@ public class SecurityProperties {
 
     public void setCorsAllowedHosts(List<String> corsAllowedHosts) {
         this.corsAllowedHosts = corsAllowedHosts;
+    }
+
+    public String getJwtSecret() {
+        return jwtSecret;
+    }
+
+    public void setJwtSecret(String jwtSecret) {
+        this.jwtSecret = jwtSecret;
+    }
+
+    public Duration getAccessTokenExpiry() {
+        return accessTokenExpiry;
+    }
+
+    public void setAccessTokenExpiry(Duration accessTokenExpiry) {
+        this.accessTokenExpiry = accessTokenExpiry;
+    }
+
+    public Duration getRefreshTokenExpiry() {
+        return refreshTokenExpiry;
+    }
+
+    public void setRefreshTokenExpiry(Duration refreshTokenExpiry) {
+        this.refreshTokenExpiry = refreshTokenExpiry;
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -9,11 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.servlet.LocaleResolver;
 import java.util.Arrays;
@@ -34,9 +30,12 @@ import org.open4goods.nudgerfrontapi.config.SecurityProperties;
 public class WebSecurityConfig {
 
     private final SecurityProperties securityProperties;
+    private final AuthenticationProvider authenticationProvider;
 
-    public WebSecurityConfig(SecurityProperties securityProperties) {
+    public WebSecurityConfig(SecurityProperties securityProperties,
+                             AuthenticationProvider authenticationProvider) {
         this.securityProperties = securityProperties;
+        this.authenticationProvider = authenticationProvider;
     }
 
     @Bean
@@ -60,22 +59,9 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
-
-    @Bean
-    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
-        return new InMemoryUserDetailsManager(User.withUsername("user")
-                .password(passwordEncoder.encode("password"))
-                .roles("USER")
-                .build());
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http, UserDetailsService uds) throws Exception {
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
         AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
-        builder.userDetailsService(uds);
+        builder.authenticationProvider(authenticationProvider);
         return builder.build();
     }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
@@ -1,0 +1,108 @@
+package org.open4goods.nudgerfrontapi.controller.auth;
+
+import org.open4goods.nudgerfrontapi.dto.auth.AuthTokensDto;
+import org.open4goods.nudgerfrontapi.dto.auth.LoginRequest;
+import org.open4goods.nudgerfrontapi.service.auth.JwtService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Authentication endpoints for the frontend.
+ */
+@RestController
+@RequestMapping("/auth")
+@Tag(name = "Authentication", description = "Login and refresh tokens")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtService jwtService;
+
+    public AuthController(AuthenticationManager authenticationManager, JwtService jwtService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/login")
+    @Operation(
+            summary = "Login with XWiki credentials",
+            description = "Validate credentials against XWiki and return JWT tokens as cookies.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = LoginRequest.class))
+            ),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Authentication success",
+                            content = @Content(schema = @Schema(implementation = AuthTokensDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Authentication failed")
+            }
+    )
+    public ResponseEntity<AuthTokensDto> login(@RequestBody LoginRequest request) {
+        try {
+            Authentication auth = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.username(), request.password()));
+            String access = jwtService.generateAccessToken(auth);
+            String refresh = jwtService.generateRefreshToken(auth);
+
+            ResponseCookie accessCookie = ResponseCookie.from("access-token", access)
+                    .httpOnly(true)
+                    .path("/")
+                    .maxAge(jwtService.getProperties().getAccessTokenExpiry())
+                    .build();
+            ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", refresh)
+                    .httpOnly(true)
+                    .path("/auth/refresh")
+                    .maxAge(jwtService.getProperties().getRefreshTokenExpiry())
+                    .build();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                    .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                    .body(new AuthTokensDto(access, refresh));
+        } catch (AuthenticationException ex) {
+            return ResponseEntity.status(401).build();
+        }
+    }
+
+    @PostMapping("/refresh")
+    @Operation(
+            summary = "Refresh access token",
+            description = "Issue a new access token using the refresh token cookie.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Token refreshed",
+                            content = @Content(schema = @Schema(implementation = AuthTokensDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Invalid refresh token")
+            }
+    )
+    public ResponseEntity<AuthTokensDto> refresh(@jakarta.servlet.http.CookieValue("refresh-token") String refreshToken) {
+        try {
+            String user = jwtService.validateRefreshToken(refreshToken);
+            Authentication auth = new UsernamePasswordAuthenticationToken(user, "N/A");
+            String access = jwtService.generateAccessToken(auth);
+            ResponseCookie accessCookie = ResponseCookie.from("access-token", access)
+                    .httpOnly(true)
+                    .path("/")
+                    .maxAge(jwtService.getProperties().getAccessTokenExpiry())
+                    .build();
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
+                    .body(new AuthTokensDto(access, refreshToken));
+        } catch (Exception ex) {
+            return ResponseEntity.status(401).build();
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/AuthTokensDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/AuthTokensDto.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Tokens returned after successful authentication.
+ */
+public record AuthTokensDto(
+        @Schema(description = "JWT access token")
+        String accessToken,
+        @Schema(description = "JWT refresh token")
+        String refreshToken
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/LoginRequest.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/LoginRequest.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Login request payload.
+ */
+public record LoginRequest(
+        @Schema(description = "XWiki username", example = "john")
+        String username,
+        @Schema(description = "XWiki password", example = "secret")
+        String password
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/auth/JwtService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/auth/JwtService.java
@@ -1,0 +1,74 @@
+package org.open4goods.nudgerfrontapi.service.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.open4goods.nudgerfrontapi.config.SecurityProperties;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+/**
+ * Utility service to issue and validate JWT tokens for the frontend API.
+ */
+@Service
+public class JwtService {
+
+    private final SecurityProperties properties;
+
+    public JwtService(SecurityProperties properties) {
+        this.properties = properties;
+    }
+
+    public SecurityProperties getProperties() {
+        return properties;
+    }
+
+    /**
+     * Generate an access token for the given authentication.
+     */
+    public String generateAccessToken(Authentication auth) {
+        Instant now = Instant.now();
+        Instant exp = now.plus(properties.getAccessTokenExpiry());
+        return Jwts.builder()
+                .setSubject(auth.getName())
+                .claim("roles", auth.getAuthorities().stream()
+                        .map(GrantedAuthority::getAuthority).collect(Collectors.toList()))
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(exp))
+                .signWith(Keys.hmacShaKeyFor(properties.getJwtSecret().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Generate a refresh token for the given authentication.
+     */
+    public String generateRefreshToken(Authentication auth) {
+        Instant now = Instant.now();
+        Instant exp = now.plus(properties.getRefreshTokenExpiry());
+        return Jwts.builder()
+                .setSubject(auth.getName())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(exp))
+                .signWith(Keys.hmacShaKeyFor(properties.getJwtSecret().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * Validate a token and return the authentication subject.
+     */
+    public String validateRefreshToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(properties.getJwtSecret().getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -25,6 +25,24 @@
       "defaultValue": "http://localhost:8082"
     },
     {
+      "name": "front.security.jwt-secret",
+      "type": "java.lang.String",
+      "description": "Secret key used to sign JWT tokens.",
+      "defaultValue": "changeMe"
+    },
+    {
+      "name": "front.security.access-token-expiry",
+      "type": "java.time.Duration",
+      "description": "Access token validity duration.",
+      "defaultValue": "PT30M"
+    },
+    {
+      "name": "front.security.refresh-token-expiry",
+      "type": "java.time.Duration",
+      "description": "Refresh token validity duration.",
+      "defaultValue": "P7D"
+    },
+    {
       "name": "front.cache.path",
       "type": "java.lang.String",
       "description": "Path used to store cached files.",

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
@@ -1,0 +1,63 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.auth.LoginRequest;
+import org.open4goods.nudgerfrontapi.service.auth.JwtService;
+import org.open4goods.xwiki.services.XWikiAuthenticationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest(properties = {
+        "front.cache.path=${java.io.tmpdir}",
+        "front.security.jwt-secret=testsecret"})
+@AutoConfigureMockMvc
+class AuthControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private XWikiAuthenticationService authService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    void loginReturnsCookies() throws Exception {
+        given(authService.login("user", "pass")).willReturn(List.of("XWiki.XWikiUsers"));
+        LoginRequest req = new LoginRequest("user", "pass");
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsBytes(req)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("access-token"))
+                .andExpect(cookie().exists("refresh-token"));
+    }
+
+    @Test
+    void refreshIssuesNewAccessToken() throws Exception {
+        var auth = new UsernamePasswordAuthenticationToken("user", "N/A");
+        String refresh = jwtService.generateRefreshToken(auth);
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(new jakarta.servlet.http.Cookie("refresh-token", refresh)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists("access-token"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JWT dependencies
- implement `AuthController` with `/auth/login` and `/auth/refresh`
- include `JwtService` and DTOs
- extend `SecurityProperties` with JWT secret and expiry settings
- update security configuration for authentication provider
- document new security properties
- test login and refresh endpoints

## Testing
- `mvn -q -pl front-api -am clean install` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68894b7f8a048333ac3b06b42a5dccf0