### PR TITLE
fix(frontend): forward backend error details

### DIFF
--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,33 +1,46 @@
 import { blogService } from '~/services/blog.services'
 import type { PageDto } from '~/src/api'
+import { ResponseError } from '~/src/api'
 
 /**
  * Blog articles API endpoint
  * Handles GET requests for blog articles with caching
  */
-export default defineEventHandler(
-  async (event): Promise<PageDto> => {
-    // Set cache headers for 1 hour
-    setResponseHeader(
-      event,
-      'Cache-Control',
-      'public, max-age=3600, s-maxage=3600'
-    )
+export default defineEventHandler(async (event): Promise<PageDto> => {
+  // Set cache headers for 1 hour
+  setResponseHeader(
+    event,
+    'Cache-Control',
+    'public, max-age=3600, s-maxage=3600'
+  )
 
-    try {
-      // Use the service to fetch articles
-      const response = await blogService.getArticles()
-      return response
-    } catch (error) {
-      // Log the error for debugging
-      console.error('Error fetching blog articles:', error)
+  try {
+    // Use the service to fetch articles
+    const response = await blogService.getArticles()
+    return response
+  } catch (error) {
+    // Log the error for debugging
+    console.error('Error fetching blog articles:', error)
 
-      // Throw a proper HTTP error
+    if (error instanceof ResponseError) {
+      const message = await error.response.text().catch(() => undefined)
+
+      // Forward backend status code and message
       throw createError({
-        statusCode: 500,
-        statusMessage: 'Failed to fetch blog articles',
+        statusCode: error.response.status,
+        statusMessage: message || error.response.statusText,
         cause: error,
       })
     }
+
+    // Fallback generic error
+    throw createError({
+      statusCode: 500,
+      statusMessage:
+        error instanceof Error
+          ? error.message
+          : 'Failed to fetch blog articles',
+      cause: error,
+    })
   }
-)
+})

--- a/frontend/server/api/blog/articles/[id].ts
+++ b/frontend/server/api/blog/articles/[id].ts
@@ -1,5 +1,6 @@
 import { blogService } from '~/services/blog.services'
 import type { BlogPostDto } from '~/src/api'
+import { ResponseError } from '~/src/api'
 
 /**
  * Blog article by ID API endpoint
@@ -22,9 +23,22 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
   } catch (error) {
     console.error('Error fetching blog article:', error)
 
+    if (error instanceof ResponseError) {
+      const message = await error.response.text().catch(() => undefined)
+
+      // Forward backend status code and message
+      throw createError({
+        statusCode: error.response.status,
+        statusMessage: message || error.response.statusText,
+        cause: error,
+      })
+    }
+
+    // Fallback generic error
     throw createError({
       statusCode: 500,
-      statusMessage: 'Failed to fetch blog article',
+      statusMessage:
+        error instanceof Error ? error.message : 'Failed to fetch blog article',
       cause: error,
     })
   }

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -19,16 +19,19 @@ export class BlogService {
    * Fetch paginated blog articles
    * @returns Promise<PageDto>
    */
-  async getArticles(params: {
-    tag?: string
-    pageNumber?: number
-    pageSize?: number
-  } = {}): Promise<PageDto> {
+  async getArticles(
+    params: {
+      tag?: string
+      pageNumber?: number
+      pageSize?: number
+    } = {}
+  ): Promise<PageDto> {
     try {
       return await this.api.posts(params)
     } catch (error) {
       console.error('Error fetching blog articles:', error)
-      throw new Error('Failed to fetch blog articles')
+      // Rethrow original error so callers can access status and message
+      throw error
     }
   }
 
@@ -42,7 +45,8 @@ export class BlogService {
       return await this.api.post({ slug })
     } catch (error) {
       console.error(`Error fetching blog article ${slug}:`, error)
-      throw new Error(`Failed to fetch blog article ${slug}`)
+      // Preserve original error details for upstream handlers
+      throw error
     }
   }
 }


### PR DESCRIPTION
## Summary
- propagate backend HTTP status and message in blog article endpoints
- rethrow original API errors to preserve status details

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `pnpm --offline preview`
- `mvn --offline clean install` *(fails: missing dependencies while offline)*

---
PR generated by AI agent. Estimated time: 1h 15m.

------
https://chatgpt.com/codex/tasks/task_e_688e0e5226948333b3778296e3b7866d