### PR TITLE
Validate query parameters in ProductController

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -180,26 +180,32 @@ public class ProductController {
 		/////////////////////
 
 		// Validating sort field
-		page.getSort().stream().forEach(s -> {
-			if (!ProductDtoSortableFields.fromText(s.getProperty()).isPresent()) {
+                for (var order : page.getSort()) {
+                        if (ProductDtoSortableFields.fromText(order.getProperty()).isEmpty()) {
+                                ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+                                pd.setTitle("Invalid sort parameter");
+                                pd.setDetail("Unknown sort field: " + order.getProperty());
+                                @SuppressWarnings({"unchecked", "rawtypes"})
+                                ResponseEntity<Page<ProductDto>> response = (ResponseEntity) ResponseEntity.badRequest().body(pd);
+                                return response;
+                        }
+                }
+                // Validating requested components
 
-				// TODO : HAndle this invalid value, raise approriate http code and
-				// problemdetail to the client.
-				return;
-			}
-		});
-
-		// Validating requested components
-		if (null != include) {
-			include.forEach(i -> {
-				if (null == ProductDtoComponent.valueOf(i)) {
-					// TODO : Handle this invalid value, raise approriate http code and
-					// problemdetail to the client.
-					return;
-				}
-
-			});
-		}
+                if (include != null) {
+                        for (String i : include) {
+                                try {
+                                        ProductDtoComponent.valueOf(i);
+                                } catch (IllegalArgumentException ex) {
+                                        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+                                        pd.setTitle("Invalid include parameter");
+                                        pd.setDetail("Unknown component: " + i);
+                                        @SuppressWarnings({"unchecked", "rawtypes"})
+                                        ResponseEntity<Page<ProductDto>> response = (ResponseEntity) ResponseEntity.badRequest().body(pd);
+                                        return response;
+                                }
+                        }
+                }
 
 
 		////////////////////////

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -117,6 +117,22 @@ class ProductControllerIT {
     }
 
     @Test
+    void productsEndpointReturns400OnInvalidSort() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("sort", "invalid,asc")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void productsEndpointReturns400OnInvalidInclude() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("include", "wrong")
+                        .with(jwt()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void sortableFieldsEndpointReturnsList() throws Exception {
         mockMvc.perform(get("/products/fields/sortable").with(jwt()))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- validate `sort` and `include` query parameters
- test that invalid values return HTTP 400 with Problem-Detail

## Testing
- `mvn --offline -pl front-api -am clean install` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_68894b8e20ec8333be1c2e3e623b21e8