### PR TITLE
Secure Swagger endpoints with basic authentication

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -47,10 +47,11 @@ public class WebSecurityConfig {
 
         if (securityProperties.isEnabled()) {
             http.authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/", "/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/auth/**").permitAll()
+                    .requestMatchers("/", "/auth/**").permitAll()
                     .anyRequest().authenticated())
                 .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
-                .formLogin(Customizer.withDefaults());
+                .formLogin(Customizer.withDefaults())
+                .httpBasic(Customizer.withDefaults());
         } else {
             http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         }


### PR DESCRIPTION
## Summary
- restrict public endpoints to `/` and `/auth/**`, protecting Swagger and API docs
- enable HTTP Basic login in addition to form login so Swagger UI prompts for credentials

## Testing
- `mvn -pl front-api -am clean install` *(fails: Non-resolvable import POM; network is unreachable)*
- `mvn -pl front-api -am spring-boot:run` *(fails: Non-resolvable import POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e733f98dc833385a9d1860996904b