### PR TITLE
feat(front-api): add global bearer auth to Swagger

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/OpenApiConfig.java
@@ -3,6 +3,10 @@ package org.open4goods.nudgerfrontapi.config;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 /**
@@ -16,5 +20,19 @@ public class OpenApiConfig {
                 .group("front")
                 .pathsToMatch("/**")
                 .build();
+    }
+
+    @Bean
+    OpenAPI openAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 }


### PR DESCRIPTION
## Summary
- secure swagger docs with a global Bearer JWT scheme

## Testing
- `mvn -Djava.net.preferIPv4Stack=true -pl front-api -am clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.4: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_688e7348edec8333bd52cfe2a7766d38