### PR TITLE
docs(front-api): secure swagger docs

### DIFF
--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -137,8 +137,8 @@ public record OfferDto(
 ---
 
 ## 7. Validation checklist
-1. `mvn spring-boot:run`  
-2. Open `/swagger-ui.html`  
+1. `mvn spring-boot:run`
+2. Open `/swagger-ui.html` (requires XWiki credentials via Basic auth)
 3. Verify:  
    - all endpoints are listed  
    - each DTO field has description & example  
@@ -172,8 +172,8 @@ Follow java / spring documentation best practices :
 
 | Action          | URL / Command        |
 |-----------------|----------------------|
-| Raw spec        | `GET /v3/api-docs`   |
-| Swagger UI      | `GET /swagger-ui.html` |
+| Raw spec        | `GET /v3/api-docs` (Basic auth)  |
+| Swagger UI      | `GET /swagger-ui.html` (Basic auth) |
 | Build module    | `mvn --offline clean install`  |
 | Tests only      | `mvn --offline test`           |
 

--- a/front-api/README.md
+++ b/front-api/README.md
@@ -32,6 +32,29 @@ Additional properties configure token generation:
 With this configuration all calls stay on the same origin and the built-in CORS
 rules apply correctly.
 
+## API documentation
+
+Access to the Swagger UI (`/swagger-ui.html`) and the raw OpenAPI specification
+(`/v3/api-docs`) requires valid XWiki credentials. Use HTTP Basic
+authentication when requesting these endpoints. Example commands:
+
+```bash
+curl -u XWIKI_USER:XWIKI_PASS http://localhost:8082/swagger-ui.html
+curl -u XWIKI_USER:XWIKI_PASS http://localhost:8082/v3/api-docs
+```
+
+To call secured REST endpoints you must obtain a JWT by authenticating with the
+same credentials:
+
+```bash
+curl -X POST http://localhost:8082/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"XWIKI_USER","password":"XWIKI_PASS"}'
+```
+
+The response returns `accessToken` and `refreshToken`; include the access token
+in subsequent requests using the `Authorization: Bearer <token>` header.
+
 ## Building
 
 From this directory run:


### PR DESCRIPTION
## Summary
- document that Swagger UI and raw OpenAPI spec require XWiki credentials
- show curl examples for basic auth and JWT retrieval
- note credential requirement in developer AGENTS guide

## Testing
- `mvn --offline -pl front-api -am clean install` *(fails: 'dependencies.dependency.version' missing)*
- `mvn -pl front-api -am clean install` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e73579d788333b568911bad972425