### PR TITLE
test: secure openapi docs access

### DIFF
--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
@@ -3,12 +3,17 @@ package org.open4goods.nudgerfrontapi.docs;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
+import java.util.List;
+import org.open4goods.xwiki.services.XWikiAuthenticationService;
 
 @SpringBootTest(properties = "front.cache.path=${java.io.tmpdir}")
 @AutoConfigureMockMvc
@@ -17,10 +22,20 @@ class OpenApiDocsIT {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private XWikiAuthenticationService authService;
+
     @Test
-    void apiDocsAreExposed() throws Exception {
+    void unauthenticatedRequestIsRejected() throws Exception {
         mockMvc.perform(get("/v3/api-docs"))
-               .andExpect(status().isOk())
-               .andExpect(jsonPath("$.openapi").exists());
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void apiDocsAccessibleWithBasicAuth() throws Exception {
+        given(authService.login("user", "pass")).willReturn(List.of("XWiki.XWikiUsers"));
+        mockMvc.perform(get("/v3/api-docs").with(httpBasic("user", "pass")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists());
     }
 }


### PR DESCRIPTION
## Summary
- ensure OpenAPI docs endpoint enforces authentication
- verify unauthenticated requests are rejected and authenticated ones succeed

## Testing
- `mvn -q -pl front-api -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e735336888333a38d8e72457ccd6c