### PR TITLE
feat(front-api): issue and validate jwt locally

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -92,18 +92,6 @@
       <artifactId>jjwt-api</artifactId>
       <version>0.12.6</version>
     </dependency>
-    <dependency>
-      <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt-impl</artifactId>
-      <version>0.12.6</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt-jackson</artifactId>
-      <version>0.12.6</version>
-      <scope>runtime</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.springdoc</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -1,23 +1,32 @@
 package org.open4goods.nudgerfrontapi.config;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import javax.crypto.SecretKey;
+
+import org.open4goods.nudgerfrontapi.config.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.servlet.LocaleResolver;
-import java.util.Arrays;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.LocaleResolver;
 
-import org.open4goods.nudgerfrontapi.config.SecurityProperties;
+import io.jsonwebtoken.security.Keys;
 
 /**
  * Web security configuration for the frontend API.
@@ -36,6 +45,24 @@ public class WebSecurityConfig {
                              AuthenticationProvider authenticationProvider) {
         this.securityProperties = securityProperties;
         this.authenticationProvider = authenticationProvider;
+    }
+
+    @Bean
+    /**
+     * JWT encoder backed by the shared secret.
+     */
+    JwtEncoder jwtEncoder() {
+        SecretKey key = Keys.hmacShaKeyFor(securityProperties.getJwtSecret().getBytes(StandardCharsets.UTF_8));
+        return NimbusJwtEncoder.withSecretKey(key).build();
+    }
+
+    @Bean
+    /**
+     * JWT decoder using the same shared secret.
+     */
+    JwtDecoder jwtDecoder() {
+        SecretKey key = Keys.hmacShaKeyFor(securityProperties.getJwtSecret().getBytes(StandardCharsets.UTF_8));
+        return NimbusJwtDecoder.withSecretKey(key).build();
     }
 
     @Bean

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: https://auth.example.com/issuer
+          secret-key: ${front.security.jwt-secret}
 
 springdoc:
   api-docs:
@@ -21,6 +21,7 @@ front:
   security:
     enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
+    jwt-secret: ${FRONT_SECURITY_JWT_SECRET:CHANGE_ME_TO_A_LONG_SECRET_VALUE_32_BYTES_MIN}
     
 xwiki:
     username: nudger

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest(properties = {
         "front.cache.path=${java.io.tmpdir}",
-        "front.security.jwt-secret=testsecret"})
+        "front.security.jwt-secret=0123456789ABCDEF0123456789ABCDEF"})
 @AutoConfigureMockMvc
 class AuthControllerIT {
 


### PR DESCRIPTION
## Summary
- use shared secret for Spring Security resource server
- encode and decode JWTs with Nimbus and shared key
- test login flow with updated secret length

## Testing
- `mvn -pl front-api -am clean install` *(fails: Could not resolve org.springframework.boot:spring-boot-dependencies due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e8a6b2b908333908df2ef7e99c8a0