### PR TITLE
Add missing JJWT runtime dependencies

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -94,6 +94,19 @@
     </dependency>
 
     <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
       <version>2.8.9</version>

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfigTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfigTest.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * Unit tests for {@link WebSecurityConfig}.
+ */
+class WebSecurityConfigTest {
+
+    @Test
+    void shouldCreateJwtDecoder() {
+        SecurityProperties properties = new SecurityProperties();
+        properties.setJwtSecret("0123456789012345678901234567890123456789012345678901234567890123");
+        AuthenticationProvider authProvider = mock(AuthenticationProvider.class);
+
+        JwtDecoder decoder = new WebSecurityConfig(properties, authProvider).jwtDecoder();
+
+        assertThat(decoder).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- include jjwt-impl and jjwt-jackson runtime dependencies so JWT decoder can initialize
- add unit test for WebSecurityConfig.jwtDecoder

## Testing
- `mvn -q clean test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:3.5.4 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e9cb55fe4833395307dd3f52ba0d3