### PR TITLE
feat: handle refresh token rotation

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
@@ -33,7 +33,7 @@ public class SecurityProperties {
     /**
      * Access token validity duration.
      */
-    private Duration accessTokenExpiry = Duration.ofMinutes(30);
+    private Duration accessTokenExpiry = Duration.ofMinutes(15);
 
     /**
      * Refresh token validity duration.

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
@@ -94,14 +94,23 @@ public class AuthController {
             String user = jwtService.validateRefreshToken(refreshToken);
             Authentication auth = new UsernamePasswordAuthenticationToken(user, "N/A");
             String access = jwtService.generateAccessToken(auth);
+            String newRefresh = jwtService.generateRefreshToken(auth);
+
             ResponseCookie accessCookie = ResponseCookie.from("access-token", access)
                     .httpOnly(true)
                     .path("/")
                     .maxAge(jwtService.getProperties().getAccessTokenExpiry())
                     .build();
+            ResponseCookie refreshCookie = ResponseCookie.from("refresh-token", newRefresh)
+                    .httpOnly(true)
+                    .path("/auth/refresh")
+                    .maxAge(jwtService.getProperties().getRefreshTokenExpiry())
+                    .build();
+
             return ResponseEntity.ok()
                     .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
-                    .body(new AuthTokensDto(access, refreshToken));
+                    .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
+                    .body(new AuthTokensDto(access, newRefresh));
         } catch (Exception ex) {
             return ResponseEntity.status(401).build();
         }

--- a/frontend/plugins/auth-refresh.client.ts
+++ b/frontend/plugins/auth-refresh.client.ts
@@ -1,0 +1,25 @@
+import { jwtDecode } from 'jwt-decode'
+import { authService } from '~/services/auth.services'
+
+/**
+ * Periodically checks the access token and refreshes it when expired.
+ */
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+  const token = useCookie<string | null>(config.tokenCookieName)
+
+  const checkExpiration = async () => {
+    if (!token.value) return
+    try {
+      const { exp } = jwtDecode<{ exp?: number }>(token.value)
+      if (exp && exp * 1000 < Date.now()) {
+        await authService.refresh()
+      }
+    } catch (err) {
+      console.error('Failed to decode JWT', err)
+    }
+  }
+
+  checkExpiration()
+  setInterval(checkExpiration, 60_000)
+})

--- a/frontend/server/routes/auth/refresh.post.ts
+++ b/frontend/server/routes/auth/refresh.post.ts
@@ -1,0 +1,37 @@
+import type { H3Event } from 'h3'
+import type { CookieSerializeOptions } from 'cookie-es'
+
+/**
+ * Proxy endpoint to renew access and refresh tokens using the backend API.
+ */
+interface RefreshResponse { accessToken: string; refreshToken: string }
+
+export default defineEventHandler(async (event: H3Event) => {
+  const config = useRuntimeConfig()
+  const refreshToken = getCookie(event, config.refreshCookieName)
+  if (!refreshToken) {
+    throw createError({ statusCode: 401, statusMessage: 'Missing refresh token' })
+  }
+
+  try {
+    const tokens = await $fetch<RefreshResponse>(`${config.public.apiUrl}/auth/refresh`, {
+      method: 'POST',
+      headers: { cookie: `${config.refreshCookieName}=${refreshToken}` },
+    })
+
+    const secure = process.env.NODE_ENV === 'production'
+    const sameSite: 'lax' | 'none' = secure ? 'none' : 'lax'
+    const cookieOptions: CookieSerializeOptions = {
+      httpOnly: true,
+      sameSite,
+      secure,
+      path: '/',
+    }
+    setCookie(event, config.tokenCookieName, tokens.accessToken, cookieOptions)
+    setCookie(event, config.refreshCookieName, tokens.refreshToken, cookieOptions)
+    return { success: true }
+  } catch (err) {
+    console.error('Refresh error', err)
+    throw createError({ statusCode: 401, statusMessage: 'Refresh failed' })
+  }
+})

--- a/frontend/services/auth.services.ts
+++ b/frontend/services/auth.services.ts
@@ -1,8 +1,22 @@
+/**
+ * Authentication service handling login and token refresh calls.
+ */
 export class AuthService {
   async login(username: string, password: string) {
     return await $fetch('/auth/login', {
       method: 'POST',
       body: { username, password },
+      credentials: 'include',
+    })
+  }
+
+  /**
+   * Request a new access token using the refresh token cookie.
+   */
+  async refresh() {
+    return await $fetch('/auth/refresh', {
+      method: 'POST',
+      credentials: 'include',
     })
   }
 }


### PR DESCRIPTION
## Summary
- shorten access token lifetime to 15 minutes
- rotate refresh token and set new cookies at /auth/refresh
- auto-refresh access tokens in frontend and proxy refresh route

## Testing
- `pnpm lint`
- `pnpm test run`
- `mvn -q clean test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f318fbbf08333b0d11a756125e15f