### PR TITLE
feat(front-api): add basic rate limiting

### DIFF
--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -58,6 +58,12 @@ The module exposes configurable security settings via
 - `front.security.enabled` – toggle Spring Security.
 - `front.security.cors-allowed-hosts` – list of allowed CORS origins.
 
+Rate limiting is configured via `front.rate-limit.*` mapped by
+`RateLimitProperties`:
+
+- `front.rate-limit.anonymous` – requests per minute for unauthenticated users.
+- `front.rate-limit.authenticated` – requests per minute for authenticated users.
+
 ---
 
 ## 6. SpringDoc Rules

--- a/front-api/README.md
+++ b/front-api/README.md
@@ -32,6 +32,16 @@ Additional properties configure token generation:
 With this configuration all calls stay on the same origin and the built-in CORS
 rules apply correctly.
 
+## Rate limiting
+
+Requests are limited using an in-memory token bucket. Defaults can be changed in
+`application.yml`:
+
+- `front.rate-limit.anonymous` – requests per minute allowed for unauthenticated users.
+- `front.rate-limit.authenticated` – requests per minute allowed for authenticated users.
+
+When limits are exceeded the API responds with HTTP `429 Too Many Requests`.
+
 ## API documentation
 
 Access to the Swagger UI (`/swagger-ui.html`) and the raw OpenAPI specification

--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -54,6 +54,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>commons</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
+    <dependency>
         <groupId>org.open4goods</groupId>
         <artifactId>xwiki-spring-boot-starter</artifactId>
         <version>0.0.1</version>
@@ -92,6 +98,7 @@
       <artifactId>jjwt-api</artifactId>
       <version>0.12.6</version>
     </dependency>
+
 
     <dependency>
       <groupId>org.springdoc</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/RateLimitConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/RateLimitConfig.java
@@ -1,0 +1,24 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.open4goods.nudgerfrontapi.interceptor.RateLimitingInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers the {@link RateLimitingInterceptor} for all requests.
+ */
+@Configuration
+public class RateLimitConfig implements WebMvcConfigurer {
+
+    private final RateLimitingInterceptor rateLimitingInterceptor;
+
+    public RateLimitConfig(RateLimitingInterceptor rateLimitingInterceptor) {
+        this.rateLimitingInterceptor = rateLimitingInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitingInterceptor);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/RateLimitProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/RateLimitProperties.java
@@ -1,0 +1,34 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Configuration properties for request rate limiting.
+ */
+@Component
+@ConfigurationProperties(prefix = "front.rate-limit")
+public class RateLimitProperties {
+
+    /** Maximum requests per minute for anonymous users. */
+    private int anonymous = 100;
+
+    /** Maximum requests per minute for authenticated users. */
+    private int authenticated = 1000;
+
+    public int getAnonymous() {
+        return anonymous;
+    }
+
+    public void setAnonymous(int anonymous) {
+        this.anonymous = anonymous;
+    }
+
+    public int getAuthenticated() {
+        return authenticated;
+    }
+
+    public void setAuthenticated(int authenticated) {
+        this.authenticated = authenticated;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptor.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptor.java
@@ -1,0 +1,65 @@
+package org.open4goods.nudgerfrontapi.interceptor;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.open4goods.commons.helper.IpHelper;
+import org.open4goods.nudgerfrontapi.config.RateLimitProperties;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Interceptor that enforces per-user or per-IP request limits.
+ */
+@Component
+public class RateLimitingInterceptor implements HandlerInterceptor {
+
+    private static class RequestCounter {
+        int count;
+        long windowStart;
+    }
+
+    private final RateLimitProperties properties;
+    private final Map<String, RequestCounter> counters = new ConcurrentHashMap<>();
+
+    public RateLimitingInterceptor(RateLimitProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String key = resolveKey(request);
+        RequestCounter counter = counters.computeIfAbsent(key, k -> {
+            RequestCounter rc = new RequestCounter();
+            rc.windowStart = System.currentTimeMillis();
+            return rc;
+        });
+        int limit = key.startsWith("ip:") ? properties.getAnonymous() : properties.getAuthenticated();
+        synchronized (counter) {
+            long now = System.currentTimeMillis();
+            if (now - counter.windowStart >= 60_000) {
+                counter.count = 0;
+                counter.windowStart = now;
+            }
+            if (counter.count < limit) {
+                counter.count++;
+                return true;
+            }
+        }
+        response.setStatus(HttpServletResponse.SC_TOO_MANY_REQUESTS);
+        return false;
+    }
+
+    private String resolveKey(HttpServletRequest request) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+            return "auth:" + auth.getName();
+        }
+        return "ip:" + IpHelper.getIp(request);
+    }
+}

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -22,6 +22,9 @@ front:
     enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
     jwt-secret: ${FRONT_SECURITY_JWT_SECRET:CHANGE_ME_TO_A_LONG_SECRET_VALUE_32_BYTES_MIN}
+  rate-limit:
+    anonymous: 100
+    authenticated: 1000
     
 xwiki:
     username: nudger

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptorTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptorTest.java
@@ -1,0 +1,48 @@
+package org.open4goods.nudgerfrontapi.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.config.RateLimitProperties;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Tests for {@link RateLimitingInterceptor}.
+ */
+class RateLimitingInterceptorTest {
+
+    private RateLimitingInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setAnonymous(1);
+        props.setAuthenticated(2);
+        interceptor = new RateLimitingInterceptor(props);
+    }
+
+    @Test
+    void anonymousRequestsAreLimited() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void authenticatedRequestsAreLimited() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken("user", "pass", "ROLE_USER"));
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+        assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(429);
+        SecurityContextHolder.clearContext();
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable rate limit properties for anonymous and authenticated calls
- enforce per-IP/token quotas via interceptor
- document rate limiting configuration

## Testing
- `mvn --offline -pl front-api -am clean install` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_688f319a3984833382f6d82871bf90a1