### PR TITLE
feat(front-api): add request logging and metrics

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -77,6 +77,10 @@ Execute the tests with:
 mvn test
 ```
 
+## Observability
+
+Each request is logged with endpoint, status, client IP and user subject. Metrics counters are exposed via Spring Boot Actuator at /actuator/metrics.
+
 ## Migration notes
 
 DTO classes such as `ProductDto` are now implemented using Java records. This

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LoggingConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/LoggingConfig.java
@@ -1,0 +1,24 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.open4goods.nudgerfrontapi.interceptor.LoggingInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers application-wide HTTP logging interceptor.
+ */
+@Configuration
+public class LoggingConfig implements WebMvcConfigurer {
+
+    private final LoggingInterceptor loggingInterceptor;
+
+    public LoggingConfig(LoggingInterceptor loggingInterceptor) {
+        this.loggingInterceptor = loggingInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/LoggingInterceptor.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/interceptor/LoggingInterceptor.java
@@ -1,0 +1,70 @@
+package org.open4goods.nudgerfrontapi.interceptor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Interceptor logging request entry/exit and publishing simple metrics.
+ */
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingInterceptor.class);
+
+    private final MeterRegistry meterRegistry;
+
+    public LoggingInterceptor(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String uri = request.getRequestURI();
+        String ip = request.getRemoteAddr();
+        String user = resolveUser();
+        LOG.info("Entering endpoint={} ip={} user={}", uri, ip, user);
+        Counter.builder("front.api.requests")
+                .tag("uri", uri)
+                .register(meterRegistry)
+                .increment();
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        String uri = request.getRequestURI();
+        String ip = request.getRemoteAddr();
+        String user = resolveUser();
+        int status = response.getStatus();
+        LOG.info("Exiting endpoint={} status={} ip={} user={}", uri, status, ip, user);
+        if (status >= 400) {
+            Counter.builder("front.api.errors")
+                    .tag("uri", uri)
+                    .tag("status", String.valueOf(status))
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+
+    private String resolveUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof JwtAuthenticationToken token) {
+            Object subject = token.getToken().getClaims().get("sub");
+            if (subject != null) {
+                return subject.toString();
+            }
+        }
+        return "anonymous";
+    }
+}
+

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -28,3 +28,9 @@ xwiki:
     password: nudger 
     baseUrl: https://wiki.nudger.fr
         
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/LoggingInterceptorTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/LoggingInterceptorTest.java
@@ -1,0 +1,46 @@
+package org.open4goods.nudgerfrontapi.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Unit tests for {@link LoggingInterceptor}.
+ */
+class LoggingInterceptorTest {
+
+    @Test
+    void preHandleIncrementsRequestCounter() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        LoggingInterceptor interceptor = new LoggingInterceptor(registry);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        interceptor.preHandle(request, response, new Object());
+
+        Counter counter = registry.find("front.api.requests").tag("uri", "/test").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1);
+    }
+
+    @Test
+    void afterCompletionIncrementsErrorCounter() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        LoggingInterceptor interceptor = new LoggingInterceptor(registry);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(500);
+
+        interceptor.afterCompletion(request, response, new Object(), null);
+
+        Counter counter = registry.find("front.api.errors").tag("uri", "/test").tag("status", "500").counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add interceptor to log endpoint, status, IP and user claim
- expose actuator metrics for request rate and errors
- document observability and provide unit tests

## Testing
- `mvn -pl front-api -am clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f3207e1c483339bd159421e68d0e0