### PR TITLE
Use JWT roles for security

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -7,9 +7,11 @@ import org.open4goods.nudgerfrontapi.dto.xwiki.XwikiContentBlocDto;
 import org.open4goods.xwiki.model.FullPage;
 import org.open4goods.xwiki.services.XWikiHtmlService;
 import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.open4goods.commons.model.constants.RolesConstants;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +31,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping
 @Validated
+@PreAuthorize("hasAuthority('" + RolesConstants.ROLE_XWIKI_ALL + "')")
 @Tag(name = "Content", description = "Content blocs")
 public class ContentsController {
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/PostsController.java
@@ -16,9 +16,11 @@ import org.open4goods.nudgerfrontapi.dto.blog.BlogTagDto;
 import org.open4goods.nudgerfrontapi.dto.PageDto;
 import org.open4goods.services.blog.model.BlogPost;
 import org.open4goods.services.blog.service.BlogService;
+import org.open4goods.commons.model.constants.RolesConstants;
 import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,6 +45,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping("/blog")
 @Validated
+@PreAuthorize("hasAuthority('" + RolesConstants.ROLE_XWIKI_ALL + "')")
 @Tag(name = "Blog", description = "Blog posts, tags and RSS feed")
 public class PostsController {
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -14,6 +14,7 @@ import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoSortableFields;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
+import org.open4goods.commons.model.constants.RolesConstants;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -22,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -53,6 +55,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping("/products")
 @Validated
+@PreAuthorize("hasAuthority('" + RolesConstants.ROLE_XWIKI_ALL + "')")
 @Tag(name = "Product", description = "Read product data, offers, impact score and reviews; trigger AI review generation.")
 public class ProductController {
 


### PR DESCRIPTION
## Summary
- read JWT `roles` claim into `Authentication` using a custom `JwtAuthenticationConverter`
- enable method-level security and gate controllers with `@PreAuthorize` on XWiki roles
- rely solely on JWT claims for authorization

## Testing
- `mvn -pl front-api -am clean install` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68906439aa4c8333a66f28a79d046fc1