### PR TITLE
feat(frontend): inject machine token into server requests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -52,6 +52,7 @@ To get the project up and running locally, follow these steps:
      The value is available via `config.public.apiUrl` in `nuxt.config.ts`.
    - `TOKEN_COOKIE_NAME`: Name of the cookie storing the JWT. Defaults to `access_token`.
    - `REFRESH_COOKIE_NAME`: Name of the cookie storing the refresh token. Defaults to `refresh_token`.
+   - `MACHINE_TOKEN`: Shared secret used for server-to-server requests. This value is loaded only on the server and never exposed to the client.
 
 5. **Run the Dev Server**:
 
@@ -99,6 +100,7 @@ Runtime configuration uses the following variables defined in `nuxt.config.ts`:
   `access_token`.
 - **`REFRESH_COOKIE_NAME`** – cookie name for the refresh token. Defaults to
   `refresh_token`.
+- **`MACHINE_TOKEN`** – shared token for server requests. Only available on the server through `config.machineToken` and injected as `X-Shared-Token` when calling `config.public.apiUrl`.
 
 ## Authentication cookies
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -81,6 +81,8 @@ export default defineNuxtConfig({
     tokenCookieName: process.env.TOKEN_COOKIE_NAME || 'access_token',
     // Name of the cookie storing the refresh token
     refreshCookieName: process.env.REFRESH_COOKIE_NAME || 'refresh_token',
+    // Shared token for server-to-server authentication (server-only)
+    machineToken: process.env.MACHINE_TOKEN || '',
 
     // Public keys (exposed to client-side)
     public: {

--- a/frontend/plugins/api-token.server.ts
+++ b/frontend/plugins/api-token.server.ts
@@ -1,0 +1,44 @@
+export default defineNuxtPlugin(() => {
+  const globalObj = globalThis as typeof globalThis & {
+    __apiTokenInstalled?: boolean
+    $fetch?: typeof $fetch
+  }
+  if (globalObj.__apiTokenInstalled) return
+  globalObj.__apiTokenInstalled = true
+
+  const config = useRuntimeConfig()
+  const apiUrl = config.public.apiUrl
+  const token = config.machineToken
+  const originalFetch = globalObj.fetch
+  const toUrl = (input: unknown): string => {
+    if (typeof input === 'string') return input
+    if (input instanceof URL) return input.toString()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (input as any)?.url ?? ''
+  }
+  const withToken = (init: RequestInit = {}): RequestInit => {
+    const headers =
+      init.headers instanceof Headers
+        ? Object.fromEntries(init.headers.entries())
+        : { ...(init.headers as Record<string, string> | undefined) }
+    return { ...init, headers: { ...headers, 'X-Shared-Token': token } }
+  }
+  globalObj.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = toUrl(input)
+    const opts = token && url.startsWith(apiUrl) ? withToken(init) : init
+    return originalFetch(input, opts)
+  }
+
+  const original$fetch = globalObj.$fetch
+  if (original$fetch) {
+    const wrapped = ((input: unknown, init?: RequestInit) => {
+      const url = toUrl(input)
+      const opts = token && url.startsWith(apiUrl) ? withToken(init) : init
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return original$fetch(input as any, opts as any)
+    }) as unknown as typeof $fetch
+    wrapped.raw = original$fetch.raw
+    wrapped.create = original$fetch.create
+    globalObj.$fetch = wrapped
+  }
+})


### PR DESCRIPTION
## Summary
- add server-only `machineToken` to runtime config and docs
- inject `X-Shared-Token` header on server fetch requests
- document `MACHINE_TOKEN` env var

## Details
Added a server-only machineToken to the Nuxt runtime configuration, enabling secure machine-to-machine communication without exposing the token client-side

Introduced a new server plugin that wraps both fetch and $fetch, injecting an X-Shared-Token header for requests targeting the backend API

Documented the MACHINE_TOKEN environment variable in the frontend README, emphasizing its server-only use and linkage to the injected header

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_6890642733088333af342f1c3e13554f