### PR TITLE
feat(front-api): enforce shared token

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SecurityProperties.java
@@ -40,6 +40,11 @@ public class SecurityProperties {
      */
     private Duration refreshTokenExpiry = Duration.ofDays(7);
 
+    /**
+     * Shared token expected in the {@code X-Shared-Token} header for internal calls.
+     */
+    private String sharedToken;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -78,5 +83,13 @@ public class SecurityProperties {
 
     public void setRefreshTokenExpiry(Duration refreshTokenExpiry) {
         this.refreshTokenExpiry = refreshTokenExpiry;
+    }
+
+    public String getSharedToken() {
+        return sharedToken;
+    }
+
+    public void setSharedToken(String sharedToken) {
+        this.sharedToken = sharedToken;
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SharedTokenFilter.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/SharedTokenFilter.java
@@ -1,0 +1,64 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Validates the {@code X-Shared-Token} header against the configured token.
+ */
+@Component
+public class SharedTokenFilter extends OncePerRequestFilter {
+
+    /** Header containing the shared token value. */
+    static final String HEADER_NAME = "X-Shared-Token";
+
+    /** Public endpoints that do not require the shared token. */
+    public static final String[] PUBLIC_ENDPOINTS = {
+        "/",
+        "/auth/**",
+        "/v3/api-docs/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html"
+    };
+
+    private final SecurityProperties securityProperties;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    public SharedTokenFilter(SecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        for (String pattern : PUBLIC_ENDPOINTS) {
+            if (pathMatcher.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!securityProperties.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String header = request.getHeader(HEADER_NAME);
+        if (header == null || !header.equals(securityProperties.getSharedToken())) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/WebSecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -68,7 +69,8 @@ public class WebSecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, LocaleResolver localeResolver) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LocaleResolver localeResolver,
+                                                   SharedTokenFilter sharedTokenFilter) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .cors(Customizer.withDefaults())
@@ -76,8 +78,9 @@ public class WebSecurityConfig {
 
         if (securityProperties.isEnabled()) {
             http.authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/", "/auth/**").permitAll()
+                    .requestMatchers(SharedTokenFilter.PUBLIC_ENDPOINTS).permitAll()
                     .anyRequest().authenticated())
+                .addFilterBefore(sharedTokenFilter, BearerTokenAuthenticationFilter.class)
                 .oauth2ResourceServer(OAuth2ResourceServerConfigurer::jwt)
                 .formLogin(Customizer.withDefaults())
                 .httpBasic(Customizer.withDefaults());

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,6 +31,12 @@
       "defaultValue": "changeMe"
     },
     {
+      "name": "front.security.shared-token",
+      "type": "java.lang.String",
+      "description": "Shared token expected in the X-Shared-Token header.",
+      "defaultValue": "changeMe"
+    },
+    {
       "name": "front.security.access-token-expiry",
       "type": "java.time.Duration",
       "description": "Access token validity duration.",

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -22,6 +22,7 @@ front:
     enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
     jwt-secret: ${FRONT_SECURITY_JWT_SECRET:CHANGE_ME_TO_A_LONG_SECRET_VALUE_32_BYTES_MIN}
+    shared-token: ${FRONT_SECURITY_SHARED_TOKEN:CHANGE_ME}
   rate-limit:
     anonymous: 100
     authenticated: 1000

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/config/SharedTokenFilterTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/config/SharedTokenFilterTest.java
@@ -1,0 +1,45 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Tests for {@link SharedTokenFilter}.
+ */
+class SharedTokenFilterTest {
+
+    @Test
+    void shouldRejectWhenTokenMissing() throws ServletException, IOException {
+        SecurityProperties props = new SecurityProperties();
+        props.setSharedToken("secret");
+        SharedTokenFilter filter = new SharedTokenFilter(props);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/protected");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldAllowWhenTokenMatches() throws ServletException, IOException {
+        SecurityProperties props = new SecurityProperties();
+        props.setSharedToken("secret");
+        SharedTokenFilter filter = new SharedTokenFilter(props);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/protected");
+        request.addHeader(SharedTokenFilter.HEADER_NAME, "secret");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isNotEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
## Summary
- add `front.security.shared-token` property
- enforce shared token header with `SharedTokenFilter`
- register filter before JWT authentication and expose public endpoints

## Testing
- `mvn --offline -pl front-api -am clean install` *(fails: 'dependencies.dependency.version' missing, and import POM unresolved)*
- `mvn -pl front-api -am clean install` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890641a35848333bce7a55e6f61d088