### PR TITLE
Add 403 access denied handler and test in front API

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/advice/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.open4goods.model.exceptions.ResourceNotFoundException;
@@ -15,21 +17,30 @@ import org.open4goods.model.exceptions.ResourceNotFoundException;
  */
 public class GlobalExceptionHandler {
 
-	private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ProblemDetail handleNotFound(ResourceNotFoundException ex) {
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("Not Found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    @ExceptionHandler({AuthorizationDeniedException.class, AccessDeniedException.class})
+    public ProblemDetail handleAccessDenied(Exception ex) {
+        log.warn("Access denied: {}", ex.getMessage(), ex);
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
+        pd.setTitle("Forbidden");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
 
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleException(Exception ex) {
         log.error("Unhandled exception", ex);
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.INTERNAL_SERVER_ERROR);
         pd.setTitle("Internal Server Error");
-        pd.setDetail(ex.getMessage());
-        return pd;
-    }
-
-    @ExceptionHandler(ResourceNotFoundException.class)
-    public ProblemDetail handleNotFound(ResourceNotFoundException ex) {
-        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
-        pd.setTitle("Not Found");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/PostsControllerIT.java
@@ -94,4 +94,14 @@ class PostsControllerIT {
                 .andExpect(jsonPath("$[0].name").value("eco"))
                 .andExpect(jsonPath("$[0].count").value(2));
     }
+
+    @Test
+    void postsEndpointReturns403WhenAccessDenied() throws Exception {
+        mockMvc.perform(get("/blog/posts")
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("Forbidden"))
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.detail").value("Access Denied"));
+    }
 }


### PR DESCRIPTION
## Summary
- handle AuthorizationDeniedException and AccessDeniedException with a 403 ProblemDetail
- verify PreAuthorize-protected endpoint returns 403 ProblemDetail when access is denied

## Testing
- `mvn -pl front-api -am test` *(fails: Non-resolvable import POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68909cce218c8333b785d15be93f14ea