### PR TITLE
feat(frontend): add edit roles runtime config

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -53,6 +53,7 @@ To get the project up and running locally, follow these steps:
    - `TOKEN_COOKIE_NAME`: Name of the cookie storing the JWT. Defaults to `access_token`.
    - `REFRESH_COOKIE_NAME`: Name of the cookie storing the refresh token. Defaults to `refresh_token`.
    - `MACHINE_TOKEN`: Shared secret used for server-to-server requests. This value is loaded only on the server and never exposed to the client.
+   - `EDITOR_ROLES`: Comma-separated roles allowed to edit content blocs. Defaults to `ADMIN` and is exposed as `config.public.editRoles`.
 
 5. **Run the Dev Server**:
 
@@ -101,6 +102,7 @@ Runtime configuration uses the following variables defined in `nuxt.config.ts`:
 - **`REFRESH_COOKIE_NAME`** – cookie name for the refresh token. Defaults to
   `refresh_token`.
 - **`MACHINE_TOKEN`** – shared token for server requests. Only available on the server through `config.machineToken` and injected as `X-Shared-Token` when calling `config.apiUrl`.
+- **`EDITOR_ROLES`** – comma-separated roles that enable edit links on content blocs. Defaults to `ADMIN` and is exposed as `config.public.editRoles`.
 
 ## Authentication cookies
 
@@ -124,6 +126,8 @@ Template example:
 ```vue
 <v-alert v-if="hasRole('ADMIN')">Admin specific content</v-alert>
 ```
+
+Users with any role listed in `config.public.editRoles` will see an edit link on content blocs.
 
 ## Design Tokens
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -88,6 +88,8 @@ export default defineNuxtConfig({
     // Public keys (exposed to client-side)
     public: {
       // Base URL of the backend API
+      // Roles allowed to edit content blocs
+      editRoles: (process.env.EDITOR_ROLES || 'ADMIN').split(','),
     }
   },
 })


### PR DESCRIPTION
## Summary
- expose `editRoles` runtime config from `EDITOR_ROLES`
- document `EDITOR_ROLES` and edit link behavior in README

## Testing
- `pnpm --offline lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm --offline test` *(fails: vitest: not found)*
- `pnpm --offline generate` *(fails: nuxt: not found)*
- `pnpm --offline preview` *(fails: nuxt: not found)*

---
PR generated by AI agent. Estimated time spent by a developer: 15 min.

------
https://chatgpt.com/codex/tasks/task_e_6890d248e974833390fdb045c2040547