### PR TITLE
feat: add edit link to text content

### DIFF
--- a/frontend/components/domains/content/TextContent.spec.ts
+++ b/frontend/components/domains/content/TextContent.spec.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
-import TextContent from './TextContent.vue'
+import { ref } from 'vue'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const mockBloc = {
   htmlContent: '<p>Hello bloc</p>',
@@ -19,6 +19,30 @@ vi.mock('~/composables/content/useContentBloc', () => ({
   useContentBloc: () => mockUseContentBloc,
 }))
 
+// Mock authentication composable
+const mockUseAuth = {
+  isLoggedIn: ref(true),
+  hasRole: vi.fn(() => true),
+}
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => mockUseAuth,
+}))
+
+// Mock runtime configuration with required edit roles
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({
+    public: {
+      editRoles: ['editor'],
+    },
+  }),
+}))
+
+// Dynamically import the component to apply mocks before evaluation
+let TextContent: typeof import('./TextContent.vue')['default']
+beforeAll(async () => {
+  TextContent = (await import('./TextContent.vue')).default
+})
+
 describe('TextContent', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -30,6 +54,26 @@ describe('TextContent', () => {
     })
     expect(mockUseContentBloc.fetchBloc).toHaveBeenCalledWith('Main.WebHome')
     expect(wrapper.html()).toContain(mockBloc.htmlContent)
+    expect(wrapper.find('a.edit-link').exists()).toBe(true)
+  })
+
+  test('shows edit link only for authorized users', async () => {
+    const wrapper = await mountSuspended(TextContent, {
+      props: { blocId: 'Main.WebHome' },
+    })
+    const link = wrapper.find('a.edit-link')
+    expect(link.text()).toBe('Edit')
+    expect(link.attributes('target')).toBe('_blank')
+    expect(link.attributes('rel')).toBe('noopener')
+    expect(wrapper.find('.text-content').classes()).toContain('editable')
+
+    // Simulate user without required role
+    mockUseAuth.hasRole.mockReturnValueOnce(false)
+    const wrapper2 = await mountSuspended(TextContent, {
+      props: { blocId: 'Main.WebHome' },
+    })
+    expect(wrapper2.find('a.edit-link').exists()).toBe(false)
+    expect(wrapper2.find('.text-content').classes()).not.toContain('editable')
   })
 
   test('shows loader when loading', async () => {

--- a/frontend/components/domains/content/TextContent.vue
+++ b/frontend/components/domains/content/TextContent.vue
@@ -1,9 +1,28 @@
 <script setup lang="ts">
+import { unref } from 'vue'
 import { useContentBloc } from '~/composables/content/useContentBloc'
+import { useAuth } from '~/composables/useAuth'
+import { useRuntimeConfig } from '#app'
+
 const props = defineProps<{ blocId: string }>()
 
-const { htmlContent, loading, error, fetchBloc } = useContentBloc()
+// Retrieve bloc content along with its optional edit link
+const { htmlContent, editLink, loading, error, fetchBloc } = useContentBloc()
 
+// Access authentication state and role checker
+const { isLoggedIn, hasRole } = useAuth()
+
+// Runtime configuration contains the roles allowed to edit content
+const config = useRuntimeConfig()
+
+// Determine if the current user can edit the bloc content
+const canEdit = computed(() => {
+  const link = unref(editLink)
+  const roles = (config.public.editRoles as string[]) || []
+  return isLoggedIn.value && !!link && roles.some(role => hasRole(role))
+})
+
+// Fetch the content bloc when the component mounts or when blocId changes
 onMounted(() => {
   fetchBloc(props.blocId)
 })
@@ -17,15 +36,38 @@ watch(
 </script>
 
 <template>
-  <div class="text-content">
+  <!-- Optional border and edit link are displayed only for authorized users -->
+  <div class="text-content" :class="{ editable: canEdit }">
     <v-progress-circular v-if="loading" indeterminate />
     <v-alert v-else-if="error" type="error" variant="tonal">{{ error }}</v-alert>
     <div v-else v-html="htmlContent" />
+    <!-- Edit link opens the bloc in a new tab when user can edit -->
+    <a
+      v-if="canEdit"
+      :href="editLink"
+      target="_blank"
+      rel="noopener"
+      class="edit-link"
+    >
+      Edit
+    </a>
   </div>
 </template>
 
 <style scoped>
 .text-content {
   padding: 1rem 0;
+  position: relative; /* Allow absolute positioning for the edit link */
+}
+
+.text-content.editable {
+  border: 1px solid #ccc; /* Light border indicates editable content */
+}
+
+.edit-link {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.875rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- show edit link and border in TextContent for authorized users
- cover edit controls with tests

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `pnpm --offline preview` *(failed to connect initially; server already listening later)*
- `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_6890d22f51648333a7c4a41581414cae