### PR TITLE
ci(frontend): inject API_URL secrets into deploy workflow

### DIFF
--- a/.github/workflows/frontend-deploy-ssr.yml
+++ b/.github/workflows/frontend-deploy-ssr.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build Nuxt (Node SSR)
         run: pnpm build
         working-directory: frontend
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          MACHINE_TOKEN: ${{ secrets.MACHINE_TOKEN }}
 
       - name: Deploy SSR output to Beta server
         uses: easingthemes/ssh-deploy@main

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -347,7 +347,9 @@ describe('Button', () => {
   - Tests and lint on PRs
   - Semantic release (automated versioning via commit messages)
   - Node SSR deployed to the beta server via
-    `.github/workflows/frontend-deploy-ssr.yml`
+    `.github/workflows/frontend-deploy-ssr.yml`, which injects
+    `API_URL` and `MACHINE_TOKEN` from repository secrets during
+    the build.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- inject `API_URL` and `MACHINE_TOKEN` secrets during SSR build
- document secret-based configuration in frontend README

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `timeout 5 pnpm --offline preview` *(fails: ELIFECYCLE Command failed)*

---
Generated by AI agent; estimated time 0.5h

------
https://chatgpt.com/codex/tasks/task_e_6890d374995083339e96d29ac5bcc823