### PR TITLE
feat(frontend): add category carousel

### DIFF
--- a/frontend/components/domains/categories/CategoryCarousel.spec.ts
+++ b/frontend/components/domains/categories/CategoryCarousel.spec.ts
@@ -1,0 +1,12 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, test } from 'vitest'
+import CategoryCarousel from './CategoryCarousel.vue'
+
+describe('CategoryCarousel', () => {
+  test('renders all categories', async () => {
+    const wrapper = await mountSuspended(CategoryCarousel)
+    const items = wrapper.findAll('.category-item')
+    expect(items).toHaveLength(3)
+    expect(items[0].text()).toContain('Refrigerators')
+  })
+})

--- a/frontend/components/domains/categories/CategoryCarousel.vue
+++ b/frontend/components/domains/categories/CategoryCarousel.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+interface Category {
+  title: string
+  image: string
+  href: string
+}
+
+// Static list of categories for display
+const categories: Category[] = [
+  {
+    title: 'Refrigerators',
+    image: 'https://via.placeholder.com/300x200?text=Refrigerators',
+    href: '/categories/refrigerators',
+  },
+  {
+    title: 'Washing Machines',
+    image: 'https://via.placeholder.com/300x200?text=Washing+Machines',
+    href: '/categories/washing-machines',
+  },
+  {
+    title: 'Dishwashers',
+    image: 'https://via.placeholder.com/300x200?text=Dishwashers',
+    href: '/categories/dishwashers',
+  },
+]
+</script>
+
+<template>
+  <v-carousel class="category-carousel" show-arrows>
+    <v-carousel-item
+      v-for="(category, index) in categories"
+      :key="index"
+      class="category-item"
+    >
+      <NuxtLink :to="category.href" class="d-block h-100">
+        <v-img
+          :src="category.image"
+          :alt="category.title"
+          cover
+          class="fill-height"
+        />
+        <div class="carousel-title">{{ category.title }}</div>
+      </NuxtLink>
+    </v-carousel-item>
+  </v-carousel>
+</template>
+
+<style scoped lang="sass">
+.category-carousel
+  height: 200px
+
+@media (min-width: 600px)
+  .category-carousel
+    height: 300px
+
+.carousel-title
+  position: absolute
+  bottom: 0
+  left: 0
+  right: 0
+  background: rgba(0, 0, 0, 0.5)
+  color: white
+  text-align: center
+  padding: 0.5rem
+</style>

--- a/frontend/pages/test.vue
+++ b/frontend/pages/test.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import CategoryCarousel from '@/components/domains/categories/CategoryCarousel.vue'
+</script>
+
+<template>
+  <CategoryCarousel />
+</template>
+


### PR DESCRIPTION
## Summary
- add `CategoryCarousel` built on `v-carousel`
- wire `CategoryCarousel` into `test.vue`
- add unit test for `CategoryCarousel`

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline preview` *(fails: Cannot find module '/workspace/open4goods/frontend/.output/server/index.mjs')*

---
PR generated by AI agent. Estimated time spent: 30 minutes.


------
https://chatgpt.com/codex/tasks/task_e_6890cf7564348333a95c6e25aa394209