### PR TITLE
feat: add star rating component

### DIFF
--- a/frontend/components/shared/StarRating.spec.ts
+++ b/frontend/components/shared/StarRating.spec.ts
@@ -1,0 +1,16 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, test } from 'vitest'
+import StarRating from './StarRating.vue'
+
+describe('StarRating', () => {
+  test('renders fractional ratings correctly', async () => {
+    const wrapper = await mountSuspended(StarRating, {
+      props: { rating: 3.7 },
+    })
+
+    expect(wrapper.findAll('.star-full')).toHaveLength(3)
+    const partial = wrapper.find('.star-partial .star-front')
+    expect(partial.attributes('style')).toContain('width: 70%')
+    expect(wrapper.findAll('.star-empty')).toHaveLength(1)
+  })
+})

--- a/frontend/components/shared/StarRating.vue
+++ b/frontend/components/shared/StarRating.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="d-flex align-center star-rating">
+    <v-icon
+      v-for="n in fullStars"
+      :key="`full-${n}`"
+      class="star star-full"
+      color="warning"
+      size="24"
+    >mdi-star</v-icon>
+    <div v-if="hasPartialStar" class="partial-star star-partial">
+      <v-icon class="star-outline" color="warning" size="24">mdi-star-outline</v-icon>
+      <v-icon
+        class="star-front"
+        color="warning"
+        size="24"
+        :style="{ width: `${partialWidth}%` }"
+      >mdi-star</v-icon>
+    </div>
+    <v-icon
+      v-for="n in emptyStars"
+      :key="`empty-${n}`"
+      class="star star-empty"
+      color="warning"
+      size="24"
+    >mdi-star-outline</v-icon>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  rating: number
+  max?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  max: 5,
+})
+
+const fullStars = computed(() => Math.floor(props.rating))
+const fraction = computed(() => {
+  const value = props.rating - fullStars.value
+  return value > 0 ? value : 0
+})
+const hasPartialStar = computed(
+  () => fraction.value > 0 && fullStars.value < props.max
+)
+const partialWidth = computed(() => Math.round(fraction.value * 100))
+const emptyStars = computed(
+  () => props.max - fullStars.value - (hasPartialStar.value ? 1 : 0)
+)
+</script>
+
+<style scoped>
+.star-rating .star {
+  line-height: 1;
+}
+.partial-star {
+  position: relative;
+  width: 24px;
+  height: 24px;
+}
+.partial-star .star-outline,
+.partial-star .star-front {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.partial-star .star-front {
+  overflow: hidden;
+}
+</style>

--- a/frontend/test.vue
+++ b/frontend/test.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="p-4">
+    <StarRating :rating="3.7" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import StarRating from '~/components/shared/StarRating.vue'
+</script>


### PR DESCRIPTION
## Summary
- add reusable `StarRating` component rendering full, partial, and empty stars
- cover fractional ratings with unit test
- replace raw rating block in `test.vue` with `StarRating`

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline preview` *(fails: Cannot find module '/workspace/open4goods/frontend/.output/server/index.mjs')*

---
PR generated by AI agent. Estimated developer time: 1 hour.

------
https://chatgpt.com/codex/tasks/task_e_6890cf7993a083338dfa8e780f51cee0