### PR TITLE
feat(frontend): add star rating component

### DIFF
--- a/frontend/components/shared/StarRating.spec.ts
+++ b/frontend/components/shared/StarRating.spec.ts
@@ -1,0 +1,15 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import StarRating from './StarRating.vue'
+
+describe('StarRating', () => {
+  it('renders fractional ratings with a half star', async () => {
+    const wrapper = await mountSuspended(StarRating, {
+      props: { rating: 2.5 },
+    })
+
+    expect(wrapper.findAll('.mdi-star')).toHaveLength(2)
+    expect(wrapper.find('.mdi-star-half-full').exists()).toBe(true)
+    expect(wrapper.findAll('.mdi-star-outline')).toHaveLength(2)
+  })
+})

--- a/frontend/components/shared/StarRating.vue
+++ b/frontend/components/shared/StarRating.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+interface Props {
+  rating: number
+  max?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  max: 5,
+})
+
+// Determine which icon to display for each star position
+const stars = computed(() => {
+  const fullStars = Math.floor(props.rating)
+  const hasFraction = props.rating - fullStars > 0
+
+  return Array.from({ length: props.max }, (_, index) => {
+    if (index < fullStars) {
+      return 'mdi-star'
+    }
+    if (index === fullStars && hasFraction) {
+      return 'mdi-star-half-full'
+    }
+    return 'mdi-star-outline'
+  })
+})
+</script>
+
+<template>
+  <div class="star-rating">
+    <v-icon
+      v-for="(icon, index) in stars"
+      :key="index"
+      :icon="icon"
+      class="mx-1"
+    />
+  </div>
+</template>
+
+<style scoped>
+.star-rating {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/frontend/test.vue
+++ b/frontend/test.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const ratingExample = 3.5
+</script>
+
+<template>
+  <div>
+    <!-- Example usage of StarRating component -->
+    <StarRating :rating="ratingExample" />
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add StarRating component using Vuetify icons with fractional support
- cover half-star rendering with unit test
- demonstrate component usage in test.vue

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline preview` *(fails: Cannot find module '/workspace/open4goods/frontend/.output/server/index.mjs')*
- `mvn --offline -q clean install` *(fails: dependencies missing in offline mode)*
- `mvn -q -DskipTests clean install` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_6890cf85e1688333bf98828f68581e6e