### PR TITLE
refactor(frontend): use service factories

### DIFF
--- a/frontend/pages/auth/login.vue
+++ b/frontend/pages/auth/login.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { authService } from '~/services'
+import { authService } from '~/services/auth.services'
 
 const username = ref('')
 const password = ref('')

--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,4 +1,4 @@
-import { contentService } from '~/services/content.services'
+import { useContentService } from '~/services/content.services'
 import type { XwikiContentBlocDto } from '~/src/api'
 
 export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> => {
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> =>
 
   // Cache content for 1 hour
   setResponseHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=3600')
+  const contentService = useContentService()
   try {
     return await contentService.getBloc(blocId)
   } catch (error) {

--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,4 +1,4 @@
-import { blogService } from '~/services/blog.services'
+import { useBlogService } from '~/services/blog.services'
 import type { PageDto } from '~/src/api'
 import { ResponseError } from '~/src/api'
 
@@ -13,6 +13,8 @@ export default defineEventHandler(async (event): Promise<PageDto> => {
     'Cache-Control',
     'public, max-age=3600, s-maxage=3600'
   )
+
+  const blogService = useBlogService()
 
   try {
     // Use the service to fetch articles

--- a/frontend/server/api/blog/articles/[id].ts
+++ b/frontend/server/api/blog/articles/[id].ts
@@ -1,4 +1,4 @@
-import { blogService } from '~/services/blog.services'
+import { useBlogService } from '~/services/blog.services'
 import type { BlogPostDto } from '~/src/api'
 import { ResponseError } from '~/src/api'
 
@@ -15,6 +15,8 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
       statusMessage: 'Article ID is required',
     })
   }
+
+  const blogService = useBlogService()
 
   try {
     // Use the service to fetch the article

--- a/frontend/server/api/blog/test.ts
+++ b/frontend/server/api/blog/test.ts
@@ -1,9 +1,11 @@
-import { blogService } from '~/services/blog.services'
+import { useBlogService } from '~/services/blog.services'
 
 /**
  * Test endpoint to debug blog data
  */
 export default defineEventHandler(async _event => {
+  const blogService = useBlogService()
+
   try {
     // Get raw data from the external API
     const response = await blogService.getArticles()

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -4,30 +4,26 @@ import type { BlogPostDto, PageDto } from '~/src/api'
 /**
  * Blog service for handling blog-related API calls
  */
-export class BlogService {
-  private readonly api: BlogApi
+export const useBlogService = () => {
+  const config = useRuntimeConfig()
+  const apiConfig = new Configuration({ basePath: config.apiUrl })
+  console.log('[ContentService] baseUrl =', config.apiUrl)
 
-  constructor() {
-    const config = useRuntimeConfig()
-    const apiConfig = new Configuration({ basePath: config.apiUrl })
-    console.log('[ContentService] baseUrl =', config.apiUrl)
-
-    this.api = new BlogApi(apiConfig)
-  }
+  const api = new BlogApi(apiConfig)
 
   /**
    * Fetch paginated blog articles
    * @returns Promise<PageDto>
    */
-  async getArticles(
+  const getArticles = async (
     params: {
       tag?: string
       pageNumber?: number
       pageSize?: number
     } = {}
-  ): Promise<PageDto> {
+  ): Promise<PageDto> => {
     try {
-      return await this.api.posts(params)
+      return await api.posts(params)
     } catch (error) {
       console.error('Error fetching blog articles:', error)
       // Rethrow original error so callers can access status and message
@@ -40,16 +36,15 @@ export class BlogService {
    * @param slug - Article slug
    * @returns Promise<BlogPostDto>
    */
-  async getArticleById(slug: string): Promise<BlogPostDto> {
+  const getArticleById = async (slug: string): Promise<BlogPostDto> => {
     try {
-      return await this.api.post({ slug })
+      return await api.post({ slug })
     } catch (error) {
       console.error(`Error fetching blog article ${slug}:`, error)
       // Preserve original error details for upstream handlers
       throw error
     }
   }
-}
 
-// Export singleton instance
-export const blogService = new BlogService()
+  return { getArticles, getArticleById }
+}

--- a/frontend/services/content.services.ts
+++ b/frontend/services/content.services.ts
@@ -4,23 +4,18 @@ import type { XwikiContentBlocDto } from '~/src/api'
 /**
  * Content service for fetching HTML blocs from the backend
  */
-export class ContentService {
-  private readonly api: ContentApi
-
-  constructor() {
-    const config = useRuntimeConfig()
-    const apiConfig = new Configuration({ basePath: config.apiUrl })
-    this.api = new ContentApi(apiConfig)
-  }
+export const useContentService = () => {
+  const config = useRuntimeConfig()
+  const apiConfig = new Configuration({ basePath: config.apiUrl })
+  const api = new ContentApi(apiConfig)
 
   /**
    * Retrieve a content bloc by its identifier
    * @param blocId - XWiki bloc identifier
    */
-  async getBloc(blocId: string): Promise<XwikiContentBlocDto> {
-    return await this.api.contentBloc({ blocId })
+  const getBloc = async (blocId: string): Promise<XwikiContentBlocDto> => {
+    return await api.contentBloc({ blocId })
   }
-}
 
-// Export singleton instance
-export const contentService = new ContentService()
+  return { getBloc }
+}

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -1,4 +1,4 @@
-// Export all services
-export { blogService } from '~/services/blog.services'
-export { contentService } from '~/services/content.services'
+// Export service factories and singletons
+export { useBlogService } from '~/services/blog.services'
+export { useContentService } from '~/services/content.services'
 export { authService } from '~/services/auth.services'


### PR DESCRIPTION
## Summary
- replace BlogService and ContentService singletons with composable factory functions
- export new factories from services index and update consumers
- import authService directly in login page

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`


------
https://chatgpt.com/codex/tasks/task_e_6891b215be3c8333ba6b326e5642ab55