### PR TITLE
feat(frontend): show username on home page

### DIFF
--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -3,10 +3,11 @@ import { useAuthStore } from '~/stores/useAuthStore'
 
 export const useAuth = () => {
   const authStore = useAuthStore()
-  const { isLoggedIn } = storeToRefs(authStore)
+  const { isLoggedIn, username } = storeToRefs(authStore)
 
   return {
     isLoggedIn,
+    username,
     hasRole: authStore.hasRole,
   }
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -3,16 +3,25 @@
     <!-- Hero section with call to action -->
     <section class="hero d-flex flex-column align-center justify-center">
       <v-img src="/nudger-icon-512x512.png" width="120" class="mb-4" alt="Nudger logo" />
-      <h1 class="text-h3 text-center font-weight-bold mb-2">Welcome to Nudger</h1>
+      <h1 class="text-h3 text-center font-weight-bold mb-2">Welcome {{ isLoggedIn ? username : 'Nudger' }}</h1>
       <p class="text-subtitle-1 mb-6 text-center">
         Compare appliances and make greener choices thanks to our Impact Score
       </p>
-      <router-link to="/blog">
-        <v-btn color="primary" size="large" rounded="pill" class="elevation-2">
-          <v-icon start icon="mdi-book-open" />
-          Read our blog
-        </v-btn>
-      </router-link>
+      <div class="d-flex ga-4">
+        <router-link to="/blog">
+          <v-btn color="primary" size="large" rounded="pill" class="elevation-2">
+            <v-icon start icon="mdi-book-open" />
+            Read our blog
+          </v-btn>
+        </router-link>
+        <!-- Display login button only when the user is not authenticated -->
+        <router-link v-if="!isLoggedIn" to="/auth/login">
+          <v-btn color="secondary" size="large" rounded="pill" class="elevation-2">
+            <v-icon start icon="mdi-login" />
+            Login
+          </v-btn>
+        </router-link>
+      </div>
     </section>
 
     <!-- Key features section -->
@@ -69,7 +78,7 @@
 </template>
 
 <script setup lang="ts">
-const { hasRole } = useAuth()
+const { hasRole, isLoggedIn, username } = useAuth()
 </script>
 
 <style lang="sass" scoped>

--- a/frontend/services/auth.services.ts
+++ b/frontend/services/auth.services.ts
@@ -4,7 +4,11 @@
 import { jwtDecode } from 'jwt-decode'
 import { useAuthStore } from '~/stores/useAuthStore'
 
-interface JwtPayload { roles?: string[] }
+interface JwtPayload {
+  roles?: string[]
+  username?: string
+  sub?: string
+}
 
 export class AuthService {
   private syncAuthState() {
@@ -15,13 +19,17 @@ export class AuthService {
     if (token.value) {
       try {
         const decoded = jwtDecode<JwtPayload>(token.value)
-        authStore.$patch({ roles: decoded.roles ?? [], isLoggedIn: true })
+        authStore.$patch({
+          roles: decoded.roles ?? [],
+          isLoggedIn: true,
+          username: decoded.username ?? decoded.sub ?? null,
+        })
       } catch (err) {
         console.error('Failed to decode JWT', err)
-        authStore.$patch({ roles: [], isLoggedIn: false })
+        authStore.$patch({ roles: [], isLoggedIn: false, username: null })
       }
     } else {
-      authStore.$patch({ roles: [], isLoggedIn: false })
+      authStore.$patch({ roles: [], isLoggedIn: false, username: null })
     }
   }
 

--- a/frontend/stores/useAuthStore.ts
+++ b/frontend/stores/useAuthStore.ts
@@ -3,12 +3,14 @@ import { defineStore } from 'pinia'
 interface AuthState {
   roles: string[]
   isLoggedIn: boolean
+  username: string | null
 }
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     roles: [],
     isLoggedIn: false,
+    username: null,
   }),
   getters: {
     hasRole: (state) => (role: string) => state.roles.includes(role),


### PR DESCRIPTION
## Summary
- display logged in user's name on landing page
- store username in auth store from JWT
- expose username via useAuth composable

## Testing
- `mvn --offline clean install` *(fails: Cannot access central in offline mode)*
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`

---
PR generated by AI agent. Estimated development time: 1h.

------
https://chatgpt.com/codex/tasks/task_e_6891ebb18190833395b69d73610a4377