### PR TITLE
feat: sync auth state on initialization

### DIFF
--- a/frontend/plugins/auth-refresh.client.ts
+++ b/frontend/plugins/auth-refresh.client.ts
@@ -8,6 +8,8 @@ export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig()
   const token = useCookie<string | null>(config.tokenCookieName)
 
+  authService.syncAuthState()
+
   const checkExpiration = async () => {
     if (!token.value) return
     try {

--- a/frontend/services/auth.services.ts
+++ b/frontend/services/auth.services.ts
@@ -11,7 +11,7 @@ interface JwtPayload {
 }
 
 export class AuthService {
-  private syncAuthState() {
+  syncAuthState() {
     const config = useRuntimeConfig()
     const token = useCookie<string | null>(config.tokenCookieName)
     const authStore = useAuthStore()


### PR DESCRIPTION
## Summary
- expose `syncAuthState` on `AuthService`
- initialize auth store in `auth-refresh` plugin so roles and login state persist

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`

---
PR generated by AI agent. Estimated time to complete: 0.5h.

------
https://chatgpt.com/codex/tasks/task_e_6891f00eb8348333a1d3f0bde9bec2da