### PR TITLE
feat: init auth store from token cookie

### DIFF
--- a/frontend/plugins/auth-init.ts
+++ b/frontend/plugins/auth-init.ts
@@ -1,0 +1,21 @@
+import { jwtDecode } from 'jwt-decode'
+import type { JwtPayload } from 'jwt-decode'
+
+/**
+ * Initialize authentication state from the access token cookie
+ */
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+  const token = useCookie<string | null>(config.tokenCookieName)
+  const authStore = useAuthStore()
+
+  if (token.value) {
+    try {
+      const payload = jwtDecode<JwtPayload>(token.value)
+      authStore.setAuth(token.value, payload)
+    } catch (err) {
+      console.error('Failed to decode access token', err)
+      authStore.resetAuth()
+    }
+  }
+})

--- a/frontend/stores/useAuthStore.ts
+++ b/frontend/stores/useAuthStore.ts
@@ -1,0 +1,33 @@
+import { defineStore } from 'pinia'
+import type { JwtPayload } from 'jwt-decode'
+
+interface AuthState {
+  token: string | null
+  payload: JwtPayload | null
+}
+
+export const useAuthStore = defineStore('auth', {
+  state: (): AuthState => ({
+    token: null,
+    payload: null,
+  }),
+  getters: {
+    isAuthenticated: state => !!state.token,
+  },
+  actions: {
+    /**
+     * Save the decoded JWT payload and raw token in store
+     */
+    setAuth(token: string, payload: JwtPayload) {
+      this.token = token
+      this.payload = payload
+    },
+    /**
+     * Clear any authentication information from store
+     */
+    resetAuth() {
+      this.token = null
+      this.payload = null
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- initialize auth store with decoded JWT from cookie
- persist login state across refreshes

## Testing
- `pnpm lint`
- `pnpm test --run`
- `pnpm generate`
- `pnpm build`
- `pnpm preview`


------
https://chatgpt.com/codex/tasks/task_e_68920193ab9883338e754604201da19d