### PR TITLE
fix(frontend): ensure reactive auth state after login

### DIFF
--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -3,11 +3,12 @@ import { useAuthStore } from '~/stores/useAuthStore'
 
 export const useAuth = () => {
   const authStore = useAuthStore()
-  const { isLoggedIn, username } = storeToRefs(authStore)
+  const { isLoggedIn, username, roles } = storeToRefs(authStore)
 
   return {
     isLoggedIn,
     username,
+    roles,
     hasRole: authStore.hasRole,
   }
 }

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -3,9 +3,12 @@
     <!-- Hero section with call to action -->
     <section class="hero d-flex flex-column align-center justify-center">
       <v-img src="/nudger-icon-512x512.png" width="120" class="mb-4" alt="Nudger logo" />
-      <h1 class="text-h3 text-center font-weight-bold mb-2">Welcome {{ isLoggedIn ? 'USER' : 'Nudger' }}</h1>
-      <p class="text-subtitle-1 mb-6 text-center">
+      <h1 class="text-h3 text-center font-weight-bold mb-2">Welcome {{ username || 'Nudger' }}</h1>
+      <p class="text-subtitle-1 mb-4 text-center">
         Compare appliances and make greener choices thanks to our Impact Score
+      </p>
+      <p v-if="isLoggedIn" class="text-subtitle-2 mb-6 text-center">
+        Roles: {{ roles.join(', ') }}
       </p>
       <div class="d-flex ga-4">
         <router-link to="/blog">
@@ -78,7 +81,7 @@
 </template>
 
 <script setup lang="ts">
-const { hasRole, isLoggedIn } = useAuth()
+const { hasRole, isLoggedIn, username, roles } = useAuth()
 </script>
 
 <style lang="sass" scoped>

--- a/frontend/plugins/auth-init.ts
+++ b/frontend/plugins/auth-init.ts
@@ -1,0 +1,8 @@
+import { authService } from '~/services/auth.services'
+
+/**
+ * Hydrates the authentication store on app startup using the token cookie.
+ */
+export default defineNuxtPlugin(() => {
+  authService.syncAuthState()
+})

--- a/frontend/plugins/auth-refresh.client.ts
+++ b/frontend/plugins/auth-refresh.client.ts
@@ -8,8 +8,6 @@ export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig()
   const token = useCookie<string | null>(config.tokenCookieName)
 
-  authService.syncAuthState()
-
   const checkExpiration = async () => {
     if (!token.value) return
     try {

--- a/frontend/server/routes/auth/login.post.ts
+++ b/frontend/server/routes/auth/login.post.ts
@@ -26,7 +26,8 @@ export default defineEventHandler(async (event: H3Event) => {
     }
     setCookie(event, config.tokenCookieName, tokens.accessToken, cookieOptions)
     setCookie(event, config.refreshCookieName, tokens.refreshToken, cookieOptions)
-    return { success: true }
+    // Return tokens so the client can decode and update its state immediately
+    return tokens
   } catch (err) {
     console.error('Login error', err)
     throw createError({ statusCode: 401, statusMessage: 'Invalid credentials' })

--- a/frontend/server/routes/auth/refresh.post.ts
+++ b/frontend/server/routes/auth/refresh.post.ts
@@ -29,7 +29,8 @@ export default defineEventHandler(async (event: H3Event) => {
     }
     setCookie(event, config.tokenCookieName, tokens.accessToken, cookieOptions)
     setCookie(event, config.refreshCookieName, tokens.refreshToken, cookieOptions)
-    return { success: true }
+    // Return tokens to allow the client to update the auth store reactively
+    return tokens
   } catch (err) {
     console.error('Refresh error', err)
     throw createError({ statusCode: 401, statusMessage: 'Refresh failed' })


### PR DESCRIPTION
## Summary
- return JWT tokens from login and refresh API routes
- decode tokens on login/refresh and patch auth store directly
- expose roles in useAuth, show username and roles on index page
- hydrate auth store on startup and simplify refresh plugin

## Testing
- `pnpm --offline lint` *(fails: Cannot find package '@nuxt/eslint-config')*
- `pnpm --offline test` *(fails: vitest: not found)*
- `pnpm --offline generate` *(fails: nuxt: not found)*
- `pnpm --offline build` *(fails: nuxt: not found)*

---
PR generated by AI agent. Estimated time to complete: 2 hours.


------
https://chatgpt.com/codex/tasks/task_e_689222b2abfc83339f514e883fe8df41