### PR TITLE
feat: add blog article page

### DIFF
--- a/frontend/components/domains/blog/TheArticle.spec.ts
+++ b/frontend/components/domains/blog/TheArticle.spec.ts
@@ -1,0 +1,35 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, test } from 'vitest'
+import TheArticle from './TheArticle.vue'
+import type { BlogPostDto } from '~/src/api'
+
+interface BlogArticle extends BlogPostDto {
+  content?: string
+}
+
+describe('TheArticle component', () => {
+  const article: BlogArticle = {
+    title: 'Test Title',
+    author: 'Jane Doe',
+    content: '<p>HTML content</p>',
+    createdMs: 1640995200000,
+  }
+
+  test('renders title, author, date and content', async () => {
+    const wrapper = await mountSuspended(TheArticle, {
+      props: { article },
+    })
+
+    expect(wrapper.find('h1').text()).toBe('Test Title')
+    expect(wrapper.text()).toContain('Jane Doe')
+
+    const formattedDate = new Date(article.createdMs ?? 0).toLocaleDateString('fr-FR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+    expect(wrapper.text()).toContain(formattedDate)
+
+    expect(wrapper.find('.article-content').html()).toContain('HTML content')
+  })
+})

--- a/frontend/components/domains/blog/TheArticle.vue
+++ b/frontend/components/domains/blog/TheArticle.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { BlogPostDto } from '~/src/api'
+
+interface BlogArticle extends BlogPostDto {
+  content?: string
+}
+
+defineProps<{
+  article: BlogArticle
+}>()
+
+// Format a timestamp into a human-readable date in French
+const formatDate = (timestamp: number) =>
+  new Date(timestamp).toLocaleDateString('fr-FR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+</script>
+
+<template>
+  <div>
+    <v-img
+      v-if="article.image"
+      :src="article.image"
+      height="300"
+      class="mb-6"
+      cover
+      rounded
+    />
+
+    <h1 class="text-h4 font-weight-bold mb-2">{{ article.title }}</h1>
+
+    <div class="d-flex align-center text-grey text-subtitle-2 mb-6">
+      <v-icon size="18" class="mr-1" color="primary">mdi-account</v-icon>
+      {{ article.author }}
+      <v-icon size="18" class="ml-4 mr-1" color="grey">mdi-calendar</v-icon>
+      {{ formatDate(article.createdMs ?? 0) }}
+    </div>
+
+    <div class="article-content" v-html="article.content" />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.article-content {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #333;
+
+  p {
+    margin-bottom: 1em;
+  }
+
+  img {
+    max-width: 100%;
+    border-radius: 8px;
+    margin: 1em 0;
+  }
+
+  h2,
+  h3 {
+    margin-top: 2em;
+    margin-bottom: 0.5em;
+    font-weight: 600;
+  }
+
+  ul,
+  ol {
+    margin: 1em 0;
+    padding-left: 1.5em;
+  }
+
+  blockquote {
+    padding: 1em;
+    margin: 1em 0;
+    background: #f9f9f9;
+    border-left: 4px solid #1976d2;
+    font-style: italic;
+    color: #555;
+  }
+}
+</style>

--- a/frontend/composables/blog/useBlog.ts
+++ b/frontend/composables/blog/useBlog.ts
@@ -65,6 +65,29 @@ export const useBlog = () => {
   }
 
   /**
+   * Fetch a single article by URL slug
+   * @param slug - Article URL slug
+   * @returns The fetched article or null if not found
+   */
+  const getArticleByUrl = async (slug: string) => {
+    loading.value = true
+    error.value = null
+
+    try {
+      const article = await $fetch<BlogPostDto>(`/api/blog/articles/${slug}`)
+      currentArticle.value = article
+      return article
+    } catch (err) {
+      error.value =
+        err instanceof Error ? err.message : 'Failed to fetch article'
+      console.error('Error in getArticleByUrl:', err)
+      return null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
    * Clear current article
    */
   const clearCurrentArticle = () => {
@@ -89,6 +112,7 @@ export const useBlog = () => {
     // Actions
     fetchArticles,
     fetchArticleById,
+    getArticleByUrl,
     clearCurrentArticle,
     clearError,
   }

--- a/frontend/pages/blog/[slug].vue
+++ b/frontend/pages/blog/[slug].vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+import { ref, onMounted } from 'vue'
+import { useBlog } from '~/composables/blog/useBlog'
+import type { BlogPostDto } from '~/src/api'
+
+interface BlogArticle extends BlogPostDto {
+  content?: string
+}
+
+const route = useRoute()
+const router = useRouter()
+const { getArticleByUrl } = useBlog()
+
+const article = ref<BlogArticle | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    const data = await getArticleByUrl(route.params.slug as string)
+    if (!data) {
+      error.value = 'Article introuvable.'
+    } else {
+      article.value = data as BlogArticle
+    }
+  } catch {
+    error.value = 'Erreur lors du chargement de l\u2019article.'
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <v-container class="py-10">
+    <v-row justify="center">
+      <v-col cols="12" md="10" lg="8">
+        <v-btn variant="text" @click="router.back()" prepend-icon="mdi-arrow-left">
+          Retour
+        </v-btn>
+
+        <v-skeleton-loader
+          v-if="loading"
+          type="heading, image, paragraph, paragraph"
+          class="mt-4"
+        />
+
+        <v-alert v-else-if="error" type="error" variant="tonal" class="mt-4">
+          {{ error }}
+        </v-alert>
+
+        <TheArticle v-else-if="article" :article="article" />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>


### PR DESCRIPTION
## Summary
- render blog post page with slug route
- expose getArticleByUrl in blog composable
- display posts with reusable TheArticle component

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline build`

---
_This PR was generated by an AI agent. Estimated time to complete manually: 1h._

------
https://chatgpt.com/codex/tasks/task_e_68923dc63fe083339db5b1c4d4a8afe2