### PR TITLE
feat: render XWiki pages and expose edit links

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -78,6 +78,19 @@ public class ContentsController {
                 .body(body);
     }
 
+    @GetMapping("/pages")
+    @Operation(
+            summary = "List XWiki pages",
+            description = "List of pages available for rendering",
+            responses = {
+                    @ApiResponse(responseCode = "501", description = "Not implemented")
+            }
+    )
+    public ResponseEntity<Void> pages() {
+        // TODO: implement listing of pages
+        return ResponseEntity.status(501).build();
+    }
+
     @GetMapping("/pages/{xwikiPageId}")
     @Operation(
             summary = "Get XWiki page",

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -221,5 +221,10 @@ UI and Styling
 - Use Vuetify UI forcomponents and styling.
 - Implement responsive Vuetify approach and mobile-firstapproach.
 
+## Dynamic XWiki pages
+- Full pages are served from the `/pages/{xwikiPageId}` endpoint of `front-api`.
+- Use the `useFullPage` composable and the `pages/pages/[...xwikiPageId].vue` route.
+- Compute edit links on the frontend by replacing `/view/` with `/edit/` and display them only to users with roles listed in `config.public.editRoles`.
+
 # Model error journal
 ## Here are listed all recurring errors of the model.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -292,6 +292,29 @@ Example usage in a page:
 <TextContent blocId="Main.WebHome" />
 ```
 
+## Rendering dynamic pages
+
+Full pages from XWiki can be fetched via the `/pages/{xwikiPageId}` endpoint and
+rendered with the `useFullPage` composable. The page route is automatically
+registered under `/pages/*`.
+
+```vue
+<!-- pages/pages/[...xwikiPageId].vue -->
+<template>
+  <div v-html="htmlContent" />
+</template>
+
+<script setup lang="ts">
+const route = useRoute()
+const { htmlContent, fetchPage } = useFullPage()
+fetchPage(route.params.xwikiPageId as string)
+</script>
+```
+
+The composable also exposes an `editLink` computed by replacing `/view/` with
+`/edit/` on the page's absolute URL. Display this link only for users with roles
+listed in `config.public.editRoles`.
+
 ## Vitest (Testing)
 
 - Colocate tests as `Component.spec.ts`

--- a/frontend/composables/content/useFullPage.spec.ts
+++ b/frontend/composables/content/useFullPage.spec.ts
@@ -1,0 +1,37 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import { useFullPage } from './useFullPage'
+
+const mockPage = {
+  htmlContent: '<p>Hello page</p>',
+  wikiPage: { xwikiAbsoluteUrl: 'https://example.com/bin/view/Main/WebHome' },
+}
+
+describe('useFullPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(mockPage))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('fetchPage retrieves content and edit link', async () => {
+    const { fetchPage, htmlContent, editLink, loading, error } = useFullPage()
+    await fetchPage('Main.WebHome')
+    expect($fetch).toHaveBeenCalledWith('/api/pages/Main.WebHome')
+    expect(htmlContent.value).toBe(mockPage.htmlContent)
+    expect(editLink.value).toBe('https://example.com/bin/edit/Main/WebHome')
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  test('sets error when fetch fails', async () => {
+    const fetchMock = $fetch as unknown as Mock
+    fetchMock.mockRejectedValueOnce(new Error('fail'))
+    const { fetchPage, error, loading } = useFullPage()
+    await fetchPage('id')
+    expect(error.value).toBe('fail')
+    expect(loading.value).toBe(false)
+  })
+})

--- a/frontend/composables/content/useFullPage.ts
+++ b/frontend/composables/content/useFullPage.ts
@@ -1,0 +1,34 @@
+import type { FullPage } from '~/src/api'
+
+/**
+ * Composable to retrieve full XWiki pages
+ */
+export const useFullPage = () => {
+  const htmlContent = ref<string>('')
+  const editLink = ref<string | undefined>(undefined)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const fetchPage = async (xwikiPageId: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      const page = await $fetch<FullPage>(`/api/pages/${xwikiPageId}`)
+      htmlContent.value = page.htmlContent ?? ''
+      const link = page.wikiPage?.xwikiAbsoluteUrl
+      editLink.value = link?.replace('/view/', '/edit/')
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch page'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    htmlContent: readonly(htmlContent),
+    editLink: readonly(editLink),
+    loading: readonly(loading),
+    error: readonly(error),
+    fetchPage,
+  }
+}

--- a/frontend/pages/pages/[...xwikiPageId].vue
+++ b/frontend/pages/pages/[...xwikiPageId].vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { unref } from 'vue'
+import { useFullPage } from '~/composables/content/useFullPage'
+import { useAuth } from '~/composables/useAuth'
+import { useRuntimeConfig } from '#app'
+
+const route = useRoute()
+const param = computed(() => {
+  const p = route.params.xwikiPageId
+  return Array.isArray(p) ? p.join('/') : (p as string) || ''
+})
+
+const { htmlContent, editLink, loading, error, fetchPage } = useFullPage()
+const { isLoggedIn, hasRole } = useAuth()
+const config = useRuntimeConfig()
+
+const canEdit = computed(() => {
+  const link = unref(editLink)
+  const roles = (config.public.editRoles as string[]) || []
+  return isLoggedIn.value && !!link && roles.some(role => hasRole(role))
+})
+
+onMounted(() => {
+  if (param.value) fetchPage(param.value)
+})
+
+watch(param, newId => {
+  if (newId) fetchPage(newId)
+})
+</script>
+
+<template>
+  <div class="page-content" :class="{ editable: canEdit }">
+    <v-progress-circular v-if="loading" indeterminate />
+    <v-alert v-else-if="error" type="error" variant="tonal">{{ error }}</v-alert>
+    <div v-else v-html="htmlContent" />
+    <a
+      v-if="canEdit"
+      :href="editLink"
+      target="_blank"
+      rel="noopener"
+      class="edit-link"
+    >
+      Edit
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.page-content {
+  padding: 1rem 0;
+  position: relative;
+}
+.page-content.editable {
+  border: 1px solid #ccc;
+}
+.edit-link {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.875rem;
+}
+</style>

--- a/frontend/pages/pages/xwikiPageId.spec.ts
+++ b/frontend/pages/pages/xwikiPageId.spec.ts
@@ -1,0 +1,81 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { ref } from 'vue'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockPage = {
+  htmlContent: '<p>Hello page</p>',
+  editLink: '/edit',
+}
+
+const mockUseFullPage = {
+  htmlContent: mockPage.htmlContent,
+  editLink: mockPage.editLink,
+  loading: false,
+  error: null,
+  fetchPage: vi.fn(),
+}
+
+vi.mock('~/composables/content/useFullPage', () => ({
+  useFullPage: () => mockUseFullPage,
+}))
+
+const mockUseAuth = {
+  isLoggedIn: ref(true),
+  hasRole: vi.fn(() => true),
+}
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => mockUseAuth,
+}))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({
+    public: { editRoles: ['editor'] },
+  }),
+}))
+
+let PageComponent: typeof import('./[...xwikiPageId].vue')['default']
+beforeAll(async () => {
+  PageComponent = (await import('./[...xwikiPageId].vue')).default
+})
+
+describe('dynamic page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders page content and calls fetchPage on mount', async () => {
+    const wrapper = await mountSuspended(PageComponent, {
+      route: { params: { xwikiPageId: 'Main.WebHome' } },
+    })
+    expect(mockUseFullPage.fetchPage).toHaveBeenCalledWith('Main.WebHome')
+    expect(wrapper.html()).toContain(mockPage.htmlContent)
+    expect(wrapper.find('a.edit-link').exists()).toBe(true)
+  })
+
+  test('shows edit link only for authorized users', async () => {
+    const wrapper = await mountSuspended(PageComponent, {
+      route: { params: { xwikiPageId: 'Main.WebHome' } },
+    })
+    const link = wrapper.find('a.edit-link')
+    expect(link.text()).toBe('Edit')
+    expect(link.attributes('target')).toBe('_blank')
+    expect(link.attributes('rel')).toBe('noopener')
+    expect(wrapper.find('.page-content').classes()).toContain('editable')
+
+    mockUseAuth.hasRole.mockReturnValueOnce(false)
+    const wrapper2 = await mountSuspended(PageComponent, {
+      route: { params: { xwikiPageId: 'Main.WebHome' } },
+    })
+    expect(wrapper2.find('a.edit-link').exists()).toBe(false)
+    expect(wrapper2.find('.page-content').classes()).not.toContain('editable')
+  })
+
+  test('shows loader when loading', async () => {
+    mockUseFullPage.loading = true
+    const wrapper = await mountSuspended(PageComponent, {
+      route: { params: { xwikiPageId: 'Main.WebHome' } },
+    })
+    expect(wrapper.find('.v-progress-circular').exists()).toBe(true)
+    mockUseFullPage.loading = false
+  })
+})


### PR DESCRIPTION
## Summary
- add stub `/pages` endpoint in ContentsController
- render dynamic XWiki pages on frontend with edit links for authorized roles
- document dynamic page rendering and add tests for composable and page

## Testing
- `pnpm --offline lint`
- `pnpm --offline test --run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `mvn -pl front-api -am clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68923ee5ee6083339bf459f69329e9e5