### PR TITLE
Refactor XwikiFacadeService constructor to use single service instances

### DIFF
--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/XWikiServiceConfiguration.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/XWikiServiceConfiguration.java
@@ -65,14 +65,14 @@ public class XWikiServiceConfiguration {
 	 */
 	@Bean(name = "xwikiFacadeService")
 	
-	XwikiFacadeService xwikiFacadeService(
-										  @Autowired XwikiMappingService mappingService,
-										  @Autowired XWikiReadService xWikiReadService,
-										  @Autowired XWikiHtmlService xWikiHtmlService,
-										  @Autowired XWikiObjectService xWikiObjectService) {
-		logger.info("Creating xwikiFacadeservice");
-		return new XwikiFacadeService(mappingService, xWikiObjectService, xWikiHtmlService, xWikiReadService, xWikiObjectService, xWikiHtmlService, xWikiProperties);
-	}
+XwikiFacadeService xwikiFacadeService(
+                        @Autowired XwikiMappingService mappingService,
+                        @Autowired XWikiReadService xWikiReadService,
+                        @Autowired XWikiHtmlService xWikiHtmlService,
+                        @Autowired XWikiObjectService xWikiObjectService) {
+                logger.info("Creating xwikiFacadeservice");
+                return new XwikiFacadeService(mappingService, xWikiObjectService, xWikiHtmlService, xWikiReadService, xWikiProperties);
+        }
 	
 	/**
 	 * restTemplate dedicated to restful api request

--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/services/XwikiFacadeService.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/services/XwikiFacadeService.java
@@ -39,16 +39,19 @@ public class XwikiFacadeService {
 	private XWikiConstantsResourcesPath pathHelper;
 
 
-	public XwikiFacadeService( XwikiMappingService mappingService, XWikiObjectService xWikiObjectService, XWikiHtmlService xWikiHtmlService,XWikiReadService xWikiReadService, XWikiObjectService xWikiObjectService2, XWikiHtmlService xWikiHtmlService2, XWikiServiceProperties properties) {
-		this.mappingService = mappingService;
-		this.xWikiReadService = xWikiReadService;
-		this.xWikiHtmlService = xWikiHtmlService2;
-		this.xWikiObjectService = xWikiObjectService2;
-		this.properties = properties;
-		this.urlHelper = new UrlManagementHelper(properties);
-		this.pathHelper = new XWikiConstantsResourcesPath(properties.getBaseUrl(), properties.getApiEntrypoint(), properties.getApiWiki());
-
-	}
+        public XwikiFacadeService(XwikiMappingService mappingService,
+                        XWikiObjectService objectService,
+                        XWikiHtmlService htmlService,
+                        XWikiReadService readService,
+                        XWikiServiceProperties properties) {
+                this.mappingService = mappingService;
+                this.xWikiObjectService = objectService;
+                this.xWikiHtmlService = htmlService;
+                this.xWikiReadService = readService;
+                this.properties = properties;
+                this.urlHelper = new UrlManagementHelper(properties);
+                this.pathHelper = new XWikiConstantsResourcesPath(properties.getBaseUrl(), properties.getApiEntrypoint(), properties.getApiWiki());
+        }
 
 	// TODO : I18n
 	// @Cacheable(cacheNames = XWikiServiceProperties.SPRING_CACHE_NAME)


### PR DESCRIPTION
## Summary
- Simplify `XwikiFacadeService` constructor to accept one instance of each XWiki service
- Adjust `XWikiServiceConfiguration` to use the streamlined constructor

## Testing
- `mvn -pl services/xwiki-spring-boot-starter -am clean install` *(fails: Network is unreachable / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6892536c23f483339f7f813ebd857042