### PR TITLE
fix: prefix root selectors

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -5,14 +5,11 @@ export default {
     prefixer({
       prefix: '.xwiki-sandbox',
       transform: (prefix, selector, prefixedSelector) => {
-        if (
-          selector.startsWith('html') ||
-          selector.startsWith('body') ||
-          selector === 'body' ||
-          selector === 'html' ||
-          selector.startsWith(prefix)
-        ) {
+        if (selector.startsWith(prefix)) {
           return selector
+        }
+        if (/^(html|body)/.test(selector)) {
+          return selector.replace(/^(html|body)/, prefix)
         }
         return prefixedSelector
       }


### PR DESCRIPTION
## Summary
- ensure html and body rules in TextContent styles are prefixed
- regenerate prefixed TextContent stylesheet

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`

---
_PR generated by AI agent; estimated 1h of developer time._

------
https://chatgpt.com/codex/tasks/task_e_68935ecd68408333ac15961a057167a1