### PR TITLE
feat: add dynamic wiki page rendering

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/FullPageDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/FullPageDto.java
@@ -1,0 +1,27 @@
+package org.open4goods.nudgerfrontapi.dto.xwiki;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing a rendered XWiki page with metadata.
+ */
+public record FullPageDto(
+        @Schema(description = "HTML meta title", example = "Welcome")
+        String metaTitle,
+
+        @Schema(description = "HTML meta description", example = "Description of the page")
+        String metaDescription,
+
+        @Schema(description = "Page title", example = "Welcome Page")
+        String pageTitle,
+
+        @Schema(description = "Rendered HTML body", example = "<p>Hello</p>")
+        String html,
+
+        @Schema(description = "Suggested page width", example = "full")
+        String width,
+
+        @Schema(description = "Link to open the page in edit mode", example = "https://wiki/edit")
+        String editLink
+) {
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ContentsControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ContentsControllerTest.java
@@ -1,0 +1,68 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.api.ContentsController;
+import org.open4goods.xwiki.model.FullPage;
+import org.open4goods.xwiki.services.XWikiHtmlService;
+import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"front.security.enabled=true", "front.security.shared-token=test-token"})
+@AutoConfigureMockMvc
+class ContentsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ContentsController controller;
+
+    @MockBean
+    private XWikiHtmlService xwikiHtmlService;
+
+    @MockBean
+    private XwikiFacadeService xwikiFacadeService;
+
+    @Test
+    void pagesEndpointReturnsList() throws Exception {
+        mockMvc.perform(get("/pages").with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_FRONTEND)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void pageEndpointReturnsDto() throws Exception {
+        var fp = new FullPage();
+        fp.setHtmlContent("<p>Hi</p>");
+        var props = new HashMap<String, String>();
+        props.put("metaTitle", "title");
+        props.put("metaDescription", "desc");
+        props.put("pageTitle", "page");
+        props.put("width", "full");
+        fp.setProperties(props);
+        given(xwikiFacadeService.getFullPage(anyString())).willReturn(fp);
+        given(xwikiHtmlService.getEditPageUrl(anyString())).willReturn("/edit");
+
+        mockMvc.perform(get("/pages/{id}", "Main.WebHome")
+                        .header("X-Shared-Token", "test-token")
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_FRONTEND)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.metaTitle").value("title"))
+                .andExpect(jsonPath("$.editLink").value("/edit"));
+    }
+}

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -44,6 +44,7 @@ This guide is a comprehensive overview of the Nudger UI project. It covers the N
 - `server/` → API routes for server-side logic
 - `plugins/` → Nuxt plugins
 - `tests/` or `*.spec.ts` → colocated or standalone test files
+- `pages/[...slug].vue` + `composables/wiki/useWikiPage.ts` → dynamic XWiki pages
 
 ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -88,8 +88,8 @@ To get the project up and running locally, follow these steps:
    - `pnpm --offline test` – run tests with Vitest
    - `pnpm --offline generate:api` – regenerate the OpenAPI fetch client
    - `pnpm --offline preprocess:css` – prefix Bootstrap and XWiki styles for `<TextContent>`
-   - `pnpm --offline preview` – serve the production build locally
-   - `pnpm --offline build:ssr` – build with increased memory
+ - `pnpm --offline preview` – serve the production build locally
+  - `pnpm --offline build:ssr` – build with increased memory
 
 ## API environment variables
 
@@ -104,6 +104,10 @@ Runtime configuration uses the following variables defined in `nuxt.config.ts`:
   `refresh_token`.
 - **`MACHINE_TOKEN`** – shared token for server requests. Only available on the server through `config.machineToken` and injected as `X-Shared-Token` when calling `config.apiUrl`.
 - **`EDITOR_ROLES`** – comma-separated roles that enable edit links on content blocs. Defaults to `ROLE_SITEEDITOR,XWIKIADMINGROUP` (roles returned by the backend) and is exposed as `config.public.editRoles`.
+
+## Dynamic wiki pages
+
+The application can render XWiki pages directly. Any path is resolved on demand by the catch‑all page located at `pages/[...slug].vue`, which loads data through the `useWikiPage` composable. Retrieved metadata is injected via `useHead`, and authenticated users with roles listed in `EDITOR_ROLES` see an edit link.
 
 ## Authentication cookies
 

--- a/frontend/composables/wiki/useWikiPage.spec.ts
+++ b/frontend/composables/wiki/useWikiPage.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { useWikiPage } from './useWikiPage'
+
+const mockPage = {
+  metaTitle: 't',
+  metaDescription: 'd',
+  pageTitle: 'p',
+  html: '<p>Hi</p>',
+  width: 'full',
+  editLink: '/edit',
+}
+
+// Mock $fetch
+vi.stubGlobal('$fetch', vi.fn().mockResolvedValue(mockPage))
+const fetchMock = $fetch as unknown as ReturnType<typeof vi.fn>
+
+describe('useWikiPage', () => {
+  beforeEach(() => {
+    fetchMock.mockClear()
+  })
+
+  test('fetches wiki page and exposes data', async () => {
+    const { data, fetchPage, error } = useWikiPage()
+    await fetchPage('Main.WebHome')
+    expect($fetch).toHaveBeenCalledWith('/api/pages/Main.WebHome')
+    expect(data.value).toEqual(mockPage)
+    expect(error.value).toBeNull()
+  })
+
+  test('handles fetch error', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('fail'))
+    const { fetchPage, error } = useWikiPage()
+    await fetchPage('id')
+    expect(error.value).toBe('fail')
+  })
+})

--- a/frontend/composables/wiki/useWikiPage.ts
+++ b/frontend/composables/wiki/useWikiPage.ts
@@ -1,0 +1,36 @@
+interface FullPageDto {
+  metaTitle?: string
+  metaDescription?: string
+  pageTitle?: string
+  html?: string
+  width?: string
+  editLink?: string
+}
+
+/**
+ * Composable to retrieve full XWiki pages
+ */
+export const useWikiPage = () => {
+  const data = ref<FullPageDto | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const fetchPage = async (slug: string) => {
+    loading.value = true
+    error.value = null
+    try {
+      data.value = await $fetch<FullPageDto>(`/api/pages/${slug}`)
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to fetch page'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    data: readonly(data),
+    loading: readonly(loading),
+    error: readonly(error),
+    fetchPage,
+  }
+}

--- a/frontend/pages/[...slug].spec.ts
+++ b/frontend/pages/[...slug].spec.ts
@@ -1,0 +1,49 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { ref } from 'vue'
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mockPage = {
+  metaTitle: 'title',
+  metaDescription: 'desc',
+  html: '<p>Page</p>',
+  editLink: '/edit',
+}
+
+const mockUseWikiPage = {
+  data: ref(mockPage),
+  loading: ref(false),
+  error: ref(null),
+  fetchPage: vi.fn(),
+}
+
+vi.mock('~/composables/wiki/useWikiPage', () => ({
+  useWikiPage: () => mockUseWikiPage,
+}))
+
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({ isLoggedIn: ref(true), hasRole: vi.fn(() => true) }),
+}))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({ public: { editRoles: ['editor'] } }),
+}))
+
+let WikiPage: typeof import('./[...slug].vue')['default']
+beforeAll(async () => {
+  WikiPage = (await import('./[...slug].vue')).default
+})
+
+describe('wiki dynamic page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders page and calls fetch', async () => {
+    const wrapper = await mountSuspended(WikiPage, {
+      route: { params: { slug: ['Main', 'WebHome'] } },
+    })
+    expect(mockUseWikiPage.fetchPage).toHaveBeenCalledWith('Main.WebHome')
+    expect(wrapper.html()).toContain(mockPage.html)
+    expect(wrapper.find('a.edit-link').exists()).toBe(true)
+  })
+})

--- a/frontend/pages/[...slug].vue
+++ b/frontend/pages/[...slug].vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed, unref, watch } from 'vue'
+import { useWikiPage } from '~/composables/wiki/useWikiPage'
+import { useAuth } from '~/composables/useAuth'
+import { useRuntimeConfig } from '#app'
+import '~/assets/css/text-content.css'
+
+const route = useRoute()
+const slugParam = route.params.slug as string[] | string
+const slug = Array.isArray(slugParam) ? slugParam.join('.') : slugParam
+
+const { data, loading, error, fetchPage } = useWikiPage()
+const { isLoggedIn, hasRole } = useAuth()
+const config = useRuntimeConfig()
+
+await fetchPage(slug)
+
+watch(
+  () => route.params.slug,
+  newSlug => {
+    const s = Array.isArray(newSlug) ? newSlug.join('.') : (newSlug as string)
+    fetchPage(s)
+  }
+)
+
+const canEdit = computed(() => {
+  const link = unref(data.value?.editLink)
+  const roles = (config.public.editRoles as string[]) || []
+  return isLoggedIn.value && !!link && roles.some(role => hasRole(role))
+})
+
+useHead(() => ({
+  title: data.value?.metaTitle,
+  meta: [
+    { name: 'description', content: data.value?.metaDescription }
+  ]
+}))
+</script>
+
+<template>
+  <div class="wiki-page" :class="{ editable: canEdit }">
+    <v-progress-circular v-if="loading" indeterminate />
+    <v-alert v-else-if="error" type="error" variant="tonal">{{ error }}</v-alert>
+
+    <div v-else class="xwiki-sandbox" v-html="data?.html" />
+
+    <a
+      v-if="canEdit"
+      :href="data?.editLink"
+      target="_blank"
+      rel="noopener"
+      class="edit-link"
+    >
+      Edit
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.wiki-page {
+  position: relative;
+  padding: 1rem 0;
+}
+
+.wiki-page.editable {
+  border: 1px solid #ccc;
+}
+
+.edit-link {
+  position: absolute;
+  bottom: 0.25rem;
+  right: 0.25rem;
+  font-size: 0.875rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- expose FullPageDto and map XWiki metadata in contents controller
- add Nuxt catch-all page and composable to render wiki pages with edit link
- fetch wiki routes on demand instead of registering them at build time

## Testing
- `mvn -pl front-api -am clean install` (failed: Network is unreachable)
- `pnpm --offline lint` (failed: Cannot find package '@nuxt/eslint-config')
- `pnpm --offline test run` (failed: vitest not found)
- `pnpm --offline generate` (failed: nuxt not found)
- `pnpm --offline build` (failed: postcss not found)
- `pnpm --offline generate:api` (failed: openapi-generator-cli not found)

---
_Pull request generated by AI agent; estimated development time 1 hour._

------
https://chatgpt.com/codex/tasks/task_e_68938934677083338818170a433d3b65