### PR TITLE
fix: delegate blog composable to server API route

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -4,6 +4,8 @@
 - Translate all code comments in english curent language.
 - Never delete code comments without ask to user.
 - Always explain your choices (at least briefly)
+- Composables must call server API routes for backend communication; do not reimplement service logic or talk to backend services directly.
+- When the proper layer is unclear, ask for clarification before coding.
 
 # Global context
 Nudger is a search engine for electronics and household appliances, aggregating energy data from different sources to create an "Impact Score." This allows users to make the best choice of appliance before purchasing.

--- a/frontend/composables/blog/useBlog.ts
+++ b/frontend/composables/blog/useBlog.ts
@@ -44,32 +44,11 @@ export const useBlog = () => {
   }
 
   /**
-   * Fetch a single article by ID
-   * @param id - Article ID
-   */
-  const fetchArticleById = async (id: string) => {
-    loading.value = true
-    error.value = null
-
-    try {
-      // Use our server API as proxy
-      const article = await $fetch<BlogPostDto>(`/api/blog/articles/${id}`)
-      currentArticle.value = article
-    } catch (err) {
-      error.value =
-        err instanceof Error ? err.message : 'Failed to fetch article'
-      console.error('Error in fetchArticleById:', err)
-    } finally {
-      loading.value = false
-    }
-  }
-
-  /**
-   * Fetch a single article by URL slug
-   * @param slug - Article URL slug
+   * Fetch a single article by slug
+   * @param slug - Article slug
    * @returns The fetched article or null if not found
    */
-  const getArticleByUrl = async (slug: string) => {
+  const fetchArticle = async (slug: string) => {
     loading.value = true
     error.value = null
 
@@ -80,7 +59,7 @@ export const useBlog = () => {
     } catch (err) {
       error.value =
         err instanceof Error ? err.message : 'Failed to fetch article'
-      console.error('Error in getArticleByUrl:', err)
+      console.error('Error in fetchArticle:', err)
       return null
     } finally {
       loading.value = false
@@ -111,8 +90,7 @@ export const useBlog = () => {
 
     // Actions
     fetchArticles,
-    fetchArticleById,
-    getArticleByUrl,
+    fetchArticle,
     clearCurrentArticle,
     clearError,
   }

--- a/frontend/pages/blog/[slug].vue
+++ b/frontend/pages/blog/[slug].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import { ref, onMounted } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useBlog } from '~/composables/blog/useBlog'
 import type { BlogPostDto } from '~/src/api'
 
@@ -10,25 +10,15 @@ interface BlogArticle extends BlogPostDto {
 
 const route = useRoute()
 const router = useRouter()
-const { getArticleByUrl } = useBlog()
+const { currentArticle, loading, error, fetchArticle } = useBlog()
 
-const article = ref<BlogArticle | null>(null)
-const loading = ref(true)
-const error = ref<string | null>(null)
+const article = computed(
+  () => currentArticle.value as BlogArticle | null
+)
 
-onMounted(async () => {
-  try {
-    const data = await getArticleByUrl(route.params.slug as string)
-    if (!data) {
-      error.value = 'Article introuvable.'
-    } else {
-      article.value = data as BlogArticle
-    }
-  } catch {
-    error.value = 'Erreur lors du chargement de l\u2019article.'
-  } finally {
-    loading.value = false
-  }
+// Fetch the article when the page loads
+onMounted(() => {
+  fetchArticle(route.params.slug as string)
 })
 </script>
 

--- a/frontend/server/api/blog/articles/[slug].ts
+++ b/frontend/server/api/blog/articles/[slug].ts
@@ -3,16 +3,23 @@ import type { BlogPostDto } from '~/src/api'
 import { ResponseError } from '~/src/api'
 
 /**
- * Blog article by ID API endpoint
+ * Blog article by slug API endpoint
  * Handles GET requests for a single blog article
  */
 export default defineEventHandler(async (event): Promise<BlogPostDto> => {
-  const slug = getRouterParam(event, 'id')
+  // Cache the article for one hour
+  setResponseHeader(
+    event,
+    'Cache-Control',
+    'public, max-age=3600, s-maxage=3600'
+  )
+
+  const slug = getRouterParam(event, 'slug')
 
   if (!slug) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'Article ID is required',
+      statusMessage: 'Article slug is required',
     })
   }
 
@@ -20,7 +27,7 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
 
   try {
     // Use the service to fetch the article
-    const response = await blogService.getArticleById(slug)
+    const response = await blogService.getArticleBySlug(slug)
     return response
   } catch (error) {
     console.error('Error fetching blog article:', error)

--- a/frontend/services/blog.services.ts
+++ b/frontend/services/blog.services.ts
@@ -36,7 +36,7 @@ export const useBlogService = () => {
    * @param slug - Article slug
    * @returns Promise<BlogPostDto>
    */
-  const getArticleById = async (slug: string): Promise<BlogPostDto> => {
+  const getArticleBySlug = async (slug: string): Promise<BlogPostDto> => {
     try {
       return await api.post({ slug })
     } catch (error) {
@@ -46,5 +46,5 @@ export const useBlogService = () => {
     }
   }
 
-  return { getArticles, getArticleById }
+  return { getArticles, getArticleBySlug }
 }


### PR DESCRIPTION
## Summary
- fetch blog posts via server API route using slugs
- add server route for individual blog articles
- clarify composable service usage in AGENTS guidelines

## Testing
- `pnpm --offline lint`
- `pnpm --offline test run`
- `pnpm --offline generate`
- `pnpm --offline build`
- `mvn --offline clean install` *(fails: 'dependencies.dependency.version' missing)*

---
_PR generated by AI agent._
_An average developer would spend around 1 hour on this task._

------
https://chatgpt.com/codex/tasks/task_e_6895c2b6f9588333bd2e31c25f1896ef