### PR TITLE
Fix Swagger annotation dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations-jakarta</artifactId>
-            <version>2.2.35</version>
+            <version>${swagger.core.v3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.open4goods</groupId>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -28,9 +28,15 @@
 
 	<dependencies>
 		<dependency>
-		    <groupId>com.amazon.paapi5</groupId>
-		    <artifactId>paapi5-java-sdk</artifactId>
-		    <version>1.1.0</version>
+			<groupId>com.amazon.paapi5</groupId>
+			<artifactId>paapi5-java-sdk</artifactId>
+			<version>1.1.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.swagger</groupId>
+					<artifactId>swagger-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 		<maven.compiler.target>21</maven.compiler.target>
 		<global.version>0.0.1-SNAPSHOT</global.version>
 		<swagger.version>2.9.2</swagger.version>
+		<swagger.core.v3.version>2.2.35</swagger.core.v3.version>
 		<jacoco.version>0.8.13</jacoco.version>
 		<xwiki.version>11.10.2</xwiki.version>
 
@@ -106,6 +107,11 @@
 				<version>${springboot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-annotations</artifactId>
+				<version>${swagger.core.v3.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary
- exclude the legacy Swagger annotations from the Amazon PAAPI SDK so the crawler module no longer pulls the 1.x jar
- centralize the Swagger Core v3 version in the parent POM and apply it to the jakarta annotations dependency
- pin the classic `swagger-annotations` artifact to the same version in dependency management to avoid loading the outdated 2.2.25 classes

## Testing
- `mvn --offline -pl api -am package` *(fails: requires downloading org.springframework.boot:spring-boot-dependencies which is unavailable offline in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7e0b1adc8333904224bd44ce18f4