### PR TITLE
test: harden blog articles spec guards

### DIFF
--- a/frontend/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/components/domains/blog/TheArticles.spec.ts
@@ -85,6 +85,9 @@ describe('TheArticles Component', () => {
 
     // Check first article content
     const firstCard = articleCards[0]
+    if (!firstCard) {
+      throw new Error('Expected at least one article card')
+    }
     expect(firstCard.find('.article-title').text()).toBe('Test Article 1')
     expect(firstCard.find('.article-summary').text()).toContain(
       'This is a test summary for article 1'
@@ -95,7 +98,11 @@ describe('TheArticles Component', () => {
   test('should handle articles without images', async () => {
     mockUseBlog.loading = false
     mockUseBlog.error = null
-    mockUseBlog.articles = [mockArticles[1]] // Article without image
+    const imagelessArticle = mockArticles.find((article) => !article.image)
+    if (!imagelessArticle) {
+      throw new Error('Expected at least one article without an image')
+    }
+    mockUseBlog.articles = [imagelessArticle]
 
     const wrapper = await mountSuspended(TheArticles)
 


### PR DESCRIPTION
## Summary
- add explicit guard for the first rendered blog article card before asserting its contents
- locate the imageless mock article via a type-safe find guard when preparing the no-image scenario in the spec

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68cd699df140833395bbaffbfcaafc7a