### PR TITLE
fix: rely on vuetify module installation

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -34,6 +34,28 @@ export default defineNuxtConfig({
     "@nuxt/icon",
     "@pinia/nuxt",
   ],
+  vuetify: {
+    vuetifyOptions: {
+      theme: {
+        defaultTheme: 'light',
+        themes: {
+          light: {
+            colors: {
+              primary: '#1976D2',
+              secondary: '#424242',
+              accent: '#82B1FF',
+              error: '#FF5252',
+              info: '#2196F3',
+              success: '#4CAF50',
+              warning: '#FFC107',
+              red: '#F44336',
+              green: '#4CAF50',
+            },
+          },
+        },
+      },
+    },
+  },
   i18n: {
     defaultLocale: 'en-US',
     locales: [

--- a/frontend/plugins/vuetify.ts
+++ b/frontend/plugins/vuetify.ts
@@ -2,28 +2,5 @@
 import '@mdi/font/css/materialdesignicons.css'
 
 import 'vuetify/styles'
-import { createVuetify } from 'vuetify'
 
-export default defineNuxtPlugin(app => {
-  const vuetify = createVuetify({
-    theme: {
-      defaultTheme: 'light',
-      themes: {
-        light: {
-          colors: {
-            primary: '#1976D2',
-            secondary: '#424242',
-            accent: '#82B1FF',
-            error: '#FF5252',
-            info: '#2196F3',
-            success: '#4CAF50',
-            warning: '#FFC107',
-            red: '#F44336',
-            green: '#4CAF50',
-          },
-        },
-      },
-    },
-  })
-  app.vueApp.use(vuetify)
-})
+export default defineNuxtPlugin(() => {})


### PR DESCRIPTION
## Summary
- remove the manual Vuetify plugin setup so the Nuxt module owns installation
- mirror the previous light theme colors through the module `vuetifyOptions`

## Testing
- pnpm dev
- pnpm lint (warnings about existing Vue rules)
- pnpm test -- --run
- pnpm generate
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ce93653554833389df549b94a6fd88