### PR TITLE
Add count method for products with vertical

### DIFF
--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -706,17 +706,23 @@ public class ProductRepository {
 		return elasticsearchOperations.count(Query.findAll(), CURRENT_INDEX);
 	}
 
-	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-	public Long countMainIndexHavingRecentPrices() {
-		CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery());
-		return elasticsearchOperations.count(query, CURRENT_INDEX);
-	}
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexHavingRecentPrices() {
+                CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery());
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
 
-	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-	public Long countMainIndexHavingScore(String scoreName, String vertical) {
-		CriteriaQuery query = new CriteriaQuery(new Criteria("vertical").is(vertical) .and(new Criteria("scores." + scoreName + ".value").exists()));
-		return elasticsearchOperations.count(query, CURRENT_INDEX);
-	}
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexHavingVertical() {
+                CriteriaQuery query = new CriteriaQuery(new Criteria("vertical").exists());
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexHavingScore(String scoreName, String vertical) {
+                CriteriaQuery query = new CriteriaQuery(new Criteria("vertical").is(vertical) .and(new Criteria("scores." + scoreName + ".value").exists()));
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
 
 
 	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)


### PR DESCRIPTION
## Summary
- add a cached repository helper to count products that have a vertical field defined

## Testing
- `mvn --offline -pl services/product-repository -am test` *(fails: missing cached Maven dependencies while offline)*
- `mvn -pl services/product-repository -am test` *(fails: unable to reach Maven Central to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd79fd07883338e15dc87405da748