### PR TITLE
feat(front-api): add categories stats endpoint

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/StatsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/StatsController.java
@@ -1,0 +1,57 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.time.Duration;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.stats.CategoriesStatsDto;
+import org.open4goods.nudgerfrontapi.service.StatsService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing aggregated statistics for the frontend.
+ */
+@RestController
+@RequestMapping("/stats")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Stats", description = "Aggregated catalogue statistics for the frontend UI")
+public class StatsController {
+
+    private static final CacheControl FIVE_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(5)).cachePublic();
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/categories")
+    @Operation(
+            summary = "Get categories statistics",
+            description = "Return aggregated statistics about vertical category mappings.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Statistics returned",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = CategoriesStatsDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<CategoriesStatsDto> categories() {
+        CategoriesStatsDto body = statsService.categories();
+        return ResponseEntity.ok()
+                .cacheControl(FIVE_MINUTES_PUBLIC_CACHE)
+                .body(body);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
@@ -1,0 +1,11 @@
+package org.open4goods.nudgerfrontapi.dto.stats;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing aggregated statistics about vertical categories.
+ */
+public record CategoriesStatsDto(
+        @Schema(description = "Total number of enabled vertical configurations", example = "42")
+        int enabledVerticalConfigs
+) { }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
@@ -1,0 +1,87 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.dto.stats.CategoriesStatsDto;
+import org.open4goods.services.serialisation.exception.SerialisationException;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+
+/**
+ * Service exposing aggregated statistics for the frontend API.
+ */
+@Service
+public class StatsService {
+
+    private static final String CLASSPATH_VERTICALS = "classpath:/verticals/*.yml";
+    private static final String DEFAULT_CONFIG_RESOURCE = "classpath:/verticals/_default.yml";
+    private static final String DEFAULT_CONFIG_FILENAME = "_default.yml";
+
+    private final SerialisationService serialisationService;
+    private final ResourcePatternResolver resourceResolver;
+
+    public StatsService(SerialisationService serialisationService,
+                        ResourcePatternResolver resourceResolver) {
+        this.serialisationService = serialisationService;
+        this.resourceResolver = resourceResolver;
+    }
+
+    /**
+     * Compute statistics about categories mappings.
+     *
+     * @return DTO describing the category statistics used by the frontend.
+     */
+    public CategoriesStatsDto categories() {
+        VerticalConfig defaultConfig = loadDefaultConfig();
+        Resource[] resources = loadVerticalResources();
+
+        long enabledCount = Arrays.stream(resources)
+                .filter(resource -> !Objects.equals(resource.getFilename(), DEFAULT_CONFIG_FILENAME))
+                .map(resource -> loadVerticalConfig(resource, defaultConfig))
+                .filter(Objects::nonNull)
+                .filter(VerticalConfig::isEnabled)
+                .count();
+
+        return new CategoriesStatsDto(Math.toIntExact(enabledCount));
+    }
+
+    private VerticalConfig loadDefaultConfig() {
+        Resource resource = resourceResolver.getResource(DEFAULT_CONFIG_RESOURCE);
+        try (InputStream inputStream = resource.getInputStream()) {
+            return serialisationService.fromYaml(inputStream, VerticalConfig.class);
+        } catch (IOException | SerialisationException e) {
+            throw new IllegalStateException("Cannot load default vertical configuration", e);
+        }
+    }
+
+    private Resource[] loadVerticalResources() {
+        try {
+            return resourceResolver.getResources(CLASSPATH_VERTICALS);
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot list vertical configuration files", e);
+        }
+    }
+
+    private VerticalConfig loadVerticalConfig(Resource resource, VerticalConfig defaultConfig) {
+        try (InputStream inputStream = resource.getInputStream()) {
+            VerticalConfig base = cloneDefault(defaultConfig);
+            ObjectReader reader = serialisationService.getYamlMapper().readerForUpdating(base);
+            return reader.readValue(inputStream);
+        } catch (IOException | SerialisationException e) {
+            throw new IllegalStateException("Cannot load vertical configuration " + resource.getFilename(), e);
+        }
+    }
+
+    private VerticalConfig cloneDefault(VerticalConfig defaultConfig) throws SerialisationException {
+        String yaml = serialisationService.toYaml(defaultConfig);
+        return serialisationService.fromYaml(yaml, VerticalConfig.class);
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/StatsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/StatsControllerIT.java
@@ -1,0 +1,58 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.api.StatsController;
+import org.open4goods.nudgerfrontapi.dto.stats.CategoriesStatsDto;
+import org.open4goods.nudgerfrontapi.service.StatsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"front.cache.path=${java.io.tmpdir}",
+        "front.security.enabled=true",
+        "front.security.shared-token=test-token"})
+@AutoConfigureMockMvc
+class StatsControllerIT {
+
+    private static final String SHARED_TOKEN = "test-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private StatsController controller;
+
+    @MockBean
+    private StatsService statsService;
+
+    @Test
+    void categoriesEndpointReturnsStats() throws Exception {
+        given(statsService.categories()).willReturn(new CategoriesStatsDto(7));
+
+        mockMvc.perform(get("/stats/categories")
+                .header("X-Shared-Token", SHARED_TOKEN)
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabledVerticalConfigs").value(7));
+    }
+
+    @Test
+    void categoriesEndpointReturns403WhenMissingSharedToken() throws Exception {
+        mockMvc.perform(get("/stats/categories")
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.title").value("Forbidden"))
+                .andExpect(jsonPath("$.status").value(403));
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
@@ -1,0 +1,48 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.stats.CategoriesStatsDto;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+class StatsServiceTest {
+
+    private static final String DEFAULT_YAML = "id: default\nenabled: false\n";
+    private static final String ENABLED_YAML = "id: enabled\nenabled: true\n";
+    private static final String DISABLED_YAML = "id: disabled\nenabled: false\n";
+
+    @Test
+    void categoriesCountsEnabledVerticalConfigs() throws Exception {
+        SerialisationService serialisationService = new SerialisationService();
+        ResourcePatternResolver resolver = mock(ResourcePatternResolver.class);
+
+        Resource defaultResource = resource("_default.yml", DEFAULT_YAML);
+        Resource enabledResource = resource("enabled.yml", ENABLED_YAML);
+        Resource disabledResource = resource("disabled.yml", DISABLED_YAML);
+
+        given(resolver.getResource("classpath:/verticals/_default.yml")).willReturn(defaultResource);
+        given(resolver.getResources("classpath:/verticals/*.yml"))
+                .willReturn(new Resource[]{defaultResource, enabledResource, disabledResource});
+
+        StatsService service = new StatsService(serialisationService, resolver);
+
+        CategoriesStatsDto dto = service.categories();
+
+        assertThat(dto.enabledVerticalConfigs()).isEqualTo(1);
+    }
+
+    private Resource resource(String filename, String yaml) {
+        return new ByteArrayResource(yaml.getBytes()) {
+            @Override
+            public String getFilename() {
+                return filename;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a StatsController endpoint at `/stats/categories` returning the count of enabled vertical configurations
- implement a StatsService that loads vertical YAML configs, applies the default, and computes enabled counts
- document the payload with a new CategoriesStatsDto and cover the feature with service and integration tests

## Testing
- `mvn -pl front-api -am clean install` *(fails: missing Spring Boot dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd7bd7c70833393902f80faaa5529