### PR TITLE
feat: support resolved language for XWiki content

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/XwikiContentBlocDto.java
@@ -1,11 +1,26 @@
 package org.open4goods.nudgerfrontapi.dto.xwiki;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * DTO representing HTML content extracted from XWiki.
  *
- * @param blocId      identifier of the XWiki page
- * @param htmlContent HTML representation of the bloc
- * @param editLink    direct edit link for the page
+ * @param blocId          identifier of the XWiki page
+ * @param htmlContent     HTML representation of the bloc
+ * @param editLink        direct edit link for the page
+ * @param resolvedLanguage language finally used to render the bloc
  */
-public record XwikiContentBlocDto(String blocId, String htmlContent, String editLink) {}
+public record XwikiContentBlocDto(
+        @Schema(description = "Identifier of the XWiki bloc", example = "Main.WebHome")
+        String blocId,
+
+        @Schema(description = "Rendered HTML content of the bloc", example = "<p>Translated content</p>")
+        String htmlContent,
+
+        @Schema(description = "Direct XWiki edit URL for the bloc", example = "https://wiki.example.org/bin/edit/Main/WebHome")
+        String editLink,
+
+        @Schema(description = "Language used to serve the bloc", example = "fr")
+        String resolvedLanguage) {
+}
 

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ContentsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ContentsControllerIT.java
@@ -1,0 +1,70 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.xwiki.services.XWikiHtmlService;
+import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"front.cache.path=${java.io.tmpdir}",
+        "front.security.enabled=true",
+        "front.security.shared-token=test-token"})
+@AutoConfigureMockMvc
+class ContentsControllerIT {
+
+    private static final String SHARED_TOKEN = "test-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private XwikiFacadeService xwikiFacadeService;
+
+    @MockBean
+    private XWikiHtmlService xwikiHtmlService;
+
+    @Test
+    void blocEndpointUsesRequestedLanguageWhenAvailable() throws Exception {
+        given(xwikiFacadeService.getLocalizedBloc(eq("Main"), eq("fr"), any(Locale.class)))
+                .willReturn(new XwikiFacadeService.LocalizedHtml("<p>traduction</p>", "fr"));
+        given(xwikiHtmlService.getEditPageUrl("Main")).willReturn("https://wiki/edit/Main");
+
+        mockMvc.perform(get("/blocs/{blocId}", "Main")
+                        .queryParam("lang", "fr")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_FRONTEND)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.htmlContent").value("<p>traduction</p>"))
+                .andExpect(jsonPath("$.resolvedLanguage").value("fr"));
+    }
+
+    @Test
+    void blocEndpointFallsBackToDefaultWhenLangMissing() throws Exception {
+        given(xwikiFacadeService.getLocalizedBloc(eq("Main"), isNull(), any(Locale.class)))
+                .willReturn(new XwikiFacadeService.LocalizedHtml("<p>default</p>", "default"));
+        given(xwikiHtmlService.getEditPageUrl("Main")).willReturn("https://wiki/edit/Main");
+
+        mockMvc.perform(get("/blocs/{blocId}", "Main")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_FRONTEND)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.htmlContent").value("<p>default</p>"))
+                .andExpect(jsonPath("$.resolvedLanguage").value("default"));
+    }
+}

--- a/frontend/src/api/models/XwikiContentBlocDto.ts
+++ b/frontend/src/api/models/XwikiContentBlocDto.ts
@@ -20,23 +20,29 @@ import { mapValues } from '../runtime';
  */
 export interface XwikiContentBlocDto {
     /**
-     * 
+     *
      * @type {string}
      * @memberof XwikiContentBlocDto
      */
     blocId?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof XwikiContentBlocDto
      */
     htmlContent?: string;
     /**
-     * 
+     *
      * @type {string}
      * @memberof XwikiContentBlocDto
      */
     editLink?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof XwikiContentBlocDto
+     */
+    resolvedLanguage?: string;
 }
 
 /**
@@ -59,6 +65,7 @@ export function XwikiContentBlocDtoFromJSONTyped(json: any, ignoreDiscriminator:
         'blocId': json['blocId'] == null ? undefined : json['blocId'],
         'htmlContent': json['htmlContent'] == null ? undefined : json['htmlContent'],
         'editLink': json['editLink'] == null ? undefined : json['editLink'],
+        'resolvedLanguage': json['resolvedLanguage'] == null ? undefined : json['resolvedLanguage'],
     };
 }
 
@@ -76,6 +83,7 @@ export function XwikiContentBlocDtoToJSONTyped(value?: XwikiContentBlocDto | nul
         'blocId': value['blocId'],
         'htmlContent': value['htmlContent'],
         'editLink': value['editLink'],
+        'resolvedLanguage': value['resolvedLanguage'],
     };
 }
 

--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/config/UrlManagementHelper.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/config/UrlManagementHelper.java
@@ -5,6 +5,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -67,11 +68,11 @@ public class UrlManagementHelper {
 	 * @param value
 	 * @return this url with query param key=value if process succedded, null otherwise
 	 */
-	public String addQueryParam(String url, String key, String value) {
+        public String addQueryParam(String url, String key, String value) {
 
-		String uriWithParams = null;
-		try{
-			URI uri = UriComponentsBuilder.fromUriString(url)
+                String uriWithParams = null;
+                try{
+                        URI uri = UriComponentsBuilder.fromUriString(url)
 					.queryParam(key, value)
 					.build()
 					.toUri();
@@ -84,9 +85,16 @@ public class UrlManagementHelper {
 		} catch(Exception e) {
 			logger.warn("Unable to add query params {}={} to uri {}. Error Message:{}",key, value, url, e.getMessage());
 		}       
-		return uriWithParams;
+                return uriWithParams;
 
-	}
+        }
+
+        public String addLanguageQueryParam(String url, String language) {
+                if (!StringUtils.isNotBlank(url) || !StringUtils.isNotBlank(language)) {
+                        return null;
+                }
+                return addQueryParam(url, "language", language);
+        }
 	
 	/**
 	 * Get href link from rel link in 'links'  

--- a/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/model/FullPage.java
+++ b/services/xwiki-spring-boot-starter/src/main/java/org/open4goods/xwiki/model/FullPage.java
@@ -6,12 +6,17 @@ import java.util.Map;
 import org.xwiki.rest.model.jaxb.Objects;
 import org.xwiki.rest.model.jaxb.Page;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public class FullPage {
 
-	private String htmlContent;
-	private Page wikiPage;
-	private Objects objects;
-	private Map<String, String> properties = new HashMap<>();
+        private String htmlContent;
+        private Page wikiPage;
+        private Objects objects;
+        private Map<String, String> properties = new HashMap<>();
+
+        @Schema(description = "Language used to render the page", example = "fr")
+        private String resolvedLanguage;
 	
 	
 	public String getProp(String string) {
@@ -38,12 +43,20 @@ public class FullPage {
 	public void setObjects(Objects objects) {
 		this.objects = objects;
 	}
-	public Map<String, String> getProperties() {
-		return properties;
-	}
-	public void setProperties(Map<String, String> properties) {
-		this.properties = properties;
-	}
+        public Map<String, String> getProperties() {
+                return properties;
+        }
+        public void setProperties(Map<String, String> properties) {
+                this.properties = properties;
+        }
+
+        public String getResolvedLanguage() {
+                return resolvedLanguage;
+        }
+
+        public void setResolvedLanguage(String resolvedLanguage) {
+                this.resolvedLanguage = resolvedLanguage;
+        }
 
 	
 	

--- a/services/xwiki-spring-boot-starter/src/test/java/org/open4goods/xwiki/services/XwikiFacadeServiceTest.java
+++ b/services/xwiki-spring-boot-starter/src/test/java/org/open4goods/xwiki/services/XwikiFacadeServiceTest.java
@@ -1,0 +1,88 @@
+package org.open4goods.xwiki.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.xwiki.config.XWikiServiceProperties;
+import org.open4goods.xwiki.model.FullPage;
+import org.open4goods.xwiki.services.XWikiReadService.PageTranslation;
+import org.xwiki.rest.model.jaxb.Page;
+
+@ExtendWith(MockitoExtension.class)
+class XwikiFacadeServiceTest {
+
+    @Mock
+    private XwikiMappingService mappingService;
+
+    @Mock
+    private XWikiObjectService xWikiObjectService;
+
+    @Mock
+    private XWikiHtmlService xWikiHtmlService;
+
+    @Mock
+    private XWikiReadService xWikiReadService;
+
+    @Mock
+    private XWikiServiceProperties properties;
+
+    private XwikiFacadeService facade;
+
+    @BeforeEach
+    void setUp() {
+        given(properties.getBaseUrl()).willReturn("https://wiki");
+        given(properties.getApiEntrypoint()).willReturn("/rest");
+        given(properties.getApiWiki()).willReturn("xwiki");
+        facade = new XwikiFacadeService(mappingService, xWikiObjectService, xWikiHtmlService, xWikiReadService, properties);
+    }
+
+    @Test
+    void getFullPageReturnsTranslatedContentWhenAvailable() {
+        Page defaultPage = new Page();
+        defaultPage.setLanguage("default");
+        Page translated = new Page();
+        translated.setLanguage("fr");
+
+        given(xWikiReadService.getPage("Main")).willReturn(defaultPage);
+        given(xWikiReadService.getPageTranslation(eq(defaultPage), eq("Main"), eq("fr")))
+                .willReturn(new PageTranslation(translated, "fr"));
+        given(xWikiHtmlService.html("Main", "fr")).willReturn("<p>fr</p>");
+        given(xWikiObjectService.getProperties(translated)).willReturn(Map.of("title", "Titre"));
+
+        FullPage page = facade.getFullPage("Main", "fr", Locale.FRENCH);
+
+        assertThat(page.getHtmlContent()).isEqualTo("<p>fr</p>");
+        assertThat(page.getResolvedLanguage()).isEqualTo("fr");
+        assertThat(page.getProperties()).containsEntry("title", "Titre");
+    }
+
+    @Test
+    void getFullPageFallsBackToDefaultWhenTranslationMissing() {
+        Page defaultPage = new Page();
+        defaultPage.setLanguage("default");
+
+        given(xWikiReadService.getPage("Main")).willReturn(defaultPage);
+        given(xWikiReadService.getPageTranslation(eq(defaultPage), eq("Main"), eq("fr")))
+                .willReturn(null);
+        given(xWikiHtmlService.html("Main", "fr")).willReturn(null);
+        given(xWikiHtmlService.html("Main")).willReturn("<p>default</p>");
+        given(xWikiObjectService.getProperties(defaultPage)).willReturn(Map.of());
+
+        FullPage page = facade.getFullPage("Main", "fr", Locale.FRENCH);
+
+        assertThat(page.getHtmlContent()).isEqualTo("<p>default</p>");
+        assertThat(page.getResolvedLanguage()).isEqualTo("default");
+        verify(xWikiHtmlService).html("Main", "fr");
+        verify(xWikiHtmlService).html("Main");
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit `lang` query support to content endpoints and surface the resolved language in bloc DTOs
- update XWiki facade, read and HTML services to load translations, cache by language and expose the resolved language on FullPage
- refresh the generated TypeScript DTO and add controller and facade tests covering localisation fallback

## Testing
- `mvn --offline -pl front-api,services/xwiki-spring-boot-starter -am test` *(fails: missing cached Maven dependencies in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68cffee67ca88333b7fdc7edf2add266