### PR TITLE
chore(frontend): reorganize postcss config files

### DIFF
--- a/frontend/config/postcss/text-content.config.js
+++ b/frontend/config/postcss/text-content.config.js
@@ -12,7 +12,8 @@ export default {
           return selector.replace(/^(html|body)/, prefix)
         }
         return prefixedSelector
-      }
-    })
-  ]
+      },
+    }),
+  ],
 }
+

--- a/frontend/config/postcss/xwiki-sandbox-prefixer-options.js
+++ b/frontend/config/postcss/xwiki-sandbox-prefixer-options.js
@@ -12,3 +12,4 @@ export const xwikiSandboxPrefixerOptions = {
 }
 
 export default xwikiSandboxPrefixerOptions
+

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
-import xwikiSandboxPrefixerOptions from './xwikiSandboxPrefixerOptions.js'
+import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',

--- a/frontend/scripts/preprocess-css.mjs
+++ b/frontend/scripts/preprocess-css.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import postcss from 'postcss'
 import prefixer from 'postcss-prefix-selector'
-import xwikiSandboxPrefixerOptions from '../xwikiSandboxPrefixerOptions.js'
+import xwikiSandboxPrefixerOptions from '../config/postcss/xwiki-sandbox-prefixer-options.js'
 
 const currentFilePath = fileURLToPath(import.meta.url)
 const projectRoot = path.resolve(path.dirname(currentFilePath), '..')


### PR DESCRIPTION
## Summary
- move text content PostCSS configuration files into frontend/config/postcss with kebab-case names
- update Nuxt configuration and CSS preprocessing script to import the relocated prefixer options

## Testing
- pnpm preprocess:css
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d152e51edc8333bb0fc2a4dda7768d