### PR TITLE
fix(frontend): improve auth fetch error reporting

### DIFF
--- a/frontend/server/routes/auth/login.post.ts
+++ b/frontend/server/routes/auth/login.post.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { CookieSerializeOptions } from 'cookie-es'
+import { FetchError } from 'ofetch'
 
 interface LoginResponse { accessToken: string; refreshToken: string }
 interface LoginBody { username: string; password: string }
@@ -29,7 +30,37 @@ export default defineEventHandler(async (event: H3Event) => {
     // Return tokens so the client can decode and update its state immediately
     return tokens
   } catch (err) {
+    if (err instanceof FetchError) {
+      const fallbackStatusCode = 401
+      const fallbackStatusMessage = 'Invalid credentials'
+      const statusCode = err.response?.status ?? fallbackStatusCode
+      const statusMessage = err.response?.statusText ?? fallbackStatusMessage
+
+      let payload: unknown = err.data
+      if (payload === undefined && err.response) {
+        try {
+          payload = await err.response.text()
+        } catch (payloadReadError) {
+          console.error('Login payload read error', payloadReadError)
+        }
+      }
+
+      const fetchErrorDetails = {
+        statusCode,
+        statusMessage,
+        payload,
+      }
+
+      // Surface backend error metadata so clients and logs stay in sync.
+      console.error('Login fetch error', fetchErrorDetails)
+      throw createError({
+        statusCode,
+        statusMessage,
+        cause: fetchErrorDetails,
+      })
+    }
+
     console.error('Login error', err)
-    throw createError({ statusCode: 401, statusMessage: 'Invalid credentials' })
+    throw createError({ statusCode: 401, statusMessage: 'Invalid credentials', cause: err })
   }
 })

--- a/frontend/server/routes/auth/refresh.post.ts
+++ b/frontend/server/routes/auth/refresh.post.ts
@@ -1,5 +1,6 @@
 import type { H3Event } from 'h3'
 import type { CookieSerializeOptions } from 'cookie-es'
+import { FetchError } from 'ofetch'
 
 /**
  * Proxy endpoint to renew access and refresh tokens using the backend API.
@@ -32,7 +33,37 @@ export default defineEventHandler(async (event: H3Event) => {
     // Return tokens to allow the client to update the auth store reactively
     return tokens
   } catch (err) {
+    if (err instanceof FetchError) {
+      const fallbackStatusCode = 401
+      const fallbackStatusMessage = 'Refresh failed'
+      const statusCode = err.response?.status ?? fallbackStatusCode
+      const statusMessage = err.response?.statusText ?? fallbackStatusMessage
+
+      let payload: unknown = err.data
+      if (payload === undefined && err.response) {
+        try {
+          payload = await err.response.text()
+        } catch (payloadReadError) {
+          console.error('Refresh payload read error', payloadReadError)
+        }
+      }
+
+      const fetchErrorDetails = {
+        statusCode,
+        statusMessage,
+        payload,
+      }
+
+      // Surface backend error metadata so clients and logs stay in sync.
+      console.error('Refresh fetch error', fetchErrorDetails)
+      throw createError({
+        statusCode,
+        statusMessage,
+        cause: fetchErrorDetails,
+      })
+    }
+
     console.error('Refresh error', err)
-    throw createError({ statusCode: 401, statusMessage: 'Refresh failed' })
+    throw createError({ statusCode: 401, statusMessage: 'Refresh failed', cause: err })
   }
 })


### PR DESCRIPTION
## Summary
- capture backend status and payload data when $fetch fails in the login route and propagate it through createError
- mirror the structured fetch error logging and error propagation in the refresh route so clients receive backend diagnostics

## Testing
- pnpm --offline lint
- pnpm --offline test -- --run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d1557bccf083338fab077582070d27