### PR TITLE
feat: improve backend error logging

### DIFF
--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,6 +1,8 @@
 import { useContentService } from '~~/shared/api-client/services/content.services'
 import type { XwikiContentBlocDto } from '~~/shared/api-client'
 
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+
 export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> => {
   const blocId = getRouterParam(event, 'blocId')
   if (!blocId) {
@@ -13,10 +15,12 @@ export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> =>
   try {
     return await contentService.getBloc(blocId)
   } catch (error) {
-    console.error('Error fetching bloc', error)
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error fetching bloc', backendError.logMessage)
+
     throw createError({
-      statusCode: 500,
-      statusMessage: 'Failed to fetch content bloc',
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
       cause: error,
     })
   }

--- a/frontend/server/api/blog/articles/[slug].ts
+++ b/frontend/server/api/blog/articles/[slug].ts
@@ -1,6 +1,7 @@
 import { useBlogService } from '~~/shared/api-client/services/blog.services'
 import type { BlogPostDto } from '~~/shared/api-client'
-import { ResponseError } from '~~/shared/api-client'
+
+import { extractBackendErrorDetails } from '../../../utils/log-backend-error'
 
 /**
  * Blog article by slug API endpoint
@@ -30,24 +31,13 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
     const response = await blogService.getArticleBySlug(slug)
     return response
   } catch (error) {
-    console.error('Error fetching blog article:', error)
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error fetching blog article:', backendError.logMessage)
 
-    if (error instanceof ResponseError) {
-      const message = await error.response.text().catch(() => undefined)
-
-      // Forward backend status code and message
-      throw createError({
-        statusCode: error.response.status,
-        statusMessage: message || error.response.statusText,
-        cause: error,
-      })
-    }
-
-    // Fallback generic error
+    // Forward backend status code and message when available
     throw createError({
-      statusCode: 500,
-      statusMessage:
-        error instanceof Error ? error.message : 'Failed to fetch blog article',
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
       cause: error,
     })
   }

--- a/frontend/server/api/blog/test.ts
+++ b/frontend/server/api/blog/test.ts
@@ -1,5 +1,7 @@
 import { useBlogService } from '~~/shared/api-client/services/blog.services'
 
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+
 /**
  * Test endpoint to debug blog data
  */
@@ -28,12 +30,13 @@ export default defineEventHandler(async _event => {
       },
     }
   } catch (error) {
-    console.error('Error in test endpoint:', error)
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error in test endpoint:', backendError.logMessage)
 
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
-      timestamp: new Date().toISOString(),
-    }
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
   }
 })

--- a/frontend/server/utils/log-backend-error.spec.ts
+++ b/frontend/server/utils/log-backend-error.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { ResponseError } from '~~/shared/api-client'
+
+import { extractBackendErrorDetails } from './log-backend-error'
+
+describe('extractBackendErrorDetails', () => {
+  it('returns backend response details when the error is a ResponseError', async () => {
+    const response = new Response('Backend failure', {
+      status: 502,
+      statusText: 'Bad Gateway',
+    })
+    const error = new ResponseError(response)
+
+    const details = await extractBackendErrorDetails(error)
+
+    expect(details.statusCode).toBe(502)
+    expect(details.statusText).toBe('Bad Gateway')
+    expect(details.bodyText).toBe('Backend failure')
+    expect(details.statusMessage).toBe('Backend failure')
+    expect(details.logMessage).toBe('HTTP 502 - Bad Gateway - Backend failure')
+    expect(details.isResponseError).toBe(true)
+  })
+
+  it('provides a safe fallback for non ResponseError values', async () => {
+    const error = new Error('boom')
+
+    const details = await extractBackendErrorDetails(error)
+
+    expect(details.statusCode).toBe(500)
+    expect(details.statusText).toBe('Internal Server Error')
+    expect(details.bodyText).toBeUndefined()
+    expect(details.statusMessage).toBe('boom')
+    expect(details.logMessage).toBe('HTTP 500 - Internal Server Error - boom')
+    expect(details.isResponseError).toBe(false)
+  })
+})

--- a/frontend/server/utils/log-backend-error.ts
+++ b/frontend/server/utils/log-backend-error.ts
@@ -1,0 +1,80 @@
+import { ResponseError } from '~~/shared/api-client'
+
+export interface BackendErrorDetails {
+  statusCode: number
+  statusText?: string
+  statusMessage: string
+  bodyText?: string
+  isResponseError: boolean
+  logMessage: string
+}
+
+function buildLogMessage({
+  statusCode,
+  statusText,
+  statusMessage,
+}: Pick<BackendErrorDetails, 'statusCode' | 'statusText' | 'statusMessage'>) {
+  const parts = [`HTTP ${statusCode}`]
+
+  if (statusText) {
+    parts.push(statusText)
+  }
+
+  if (statusMessage && statusMessage !== statusText) {
+    parts.push(statusMessage)
+  }
+
+  return parts.join(' - ')
+}
+
+export async function extractBackendErrorDetails(
+  error: unknown
+): Promise<BackendErrorDetails> {
+  if (error instanceof ResponseError) {
+    let bodyText: string | undefined
+    try {
+      bodyText = await error.response.text()
+    } catch {
+      bodyText = undefined
+    }
+
+    const trimmedBody = bodyText?.trim()
+    const statusText = error.response.statusText || undefined
+    const statusMessage =
+      trimmedBody && trimmedBody.length > 0
+        ? trimmedBody
+        : statusText || `HTTP ${error.response.status}`
+
+    return {
+      statusCode: error.response.status,
+      statusText,
+      statusMessage,
+      bodyText: trimmedBody,
+      isResponseError: true,
+      logMessage: buildLogMessage({
+        statusCode: error.response.status,
+        statusText,
+        statusMessage,
+      }),
+    }
+  }
+
+  const fallbackMessage =
+    error instanceof Error ? error.message : 'Unexpected error while calling backend'
+
+  const statusCode = 500
+  const statusText = 'Internal Server Error'
+
+  return {
+    statusCode,
+    statusText,
+    statusMessage: fallbackMessage,
+    bodyText: undefined,
+    isResponseError: false,
+    logMessage: buildLogMessage({
+      statusCode,
+      statusText,
+      statusMessage: fallbackMessage,
+    }),
+  }
+}


### PR DESCRIPTION
## Summary
- add a backend error extraction helper to centralise ResponseError handling
- log response status details and reuse them in server API routes when building h3 errors
- document the helper behaviour with dedicated unit tests

## Testing
- pnpm --offline test run
- pnpm --offline lint
- pnpm --offline build
- pnpm --offline generate

------
https://chatgpt.com/codex/tasks/task_e_68d1557518cc8333ae9800c6e693cec4