### PR TITLE
fix: restore structured backend error logging

### DIFF
--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> =>
     return await contentService.getBloc(blocId)
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
-    console.error('Error fetching bloc', backendError.logMessage)
+    console.error('Error fetching bloc', backendError.logMessage, backendError)
 
     throw createError({
       statusCode: backendError.statusCode,

--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -24,7 +24,11 @@ export default defineEventHandler(async (event): Promise<PageDto> => {
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
     // Log the error for debugging
-    console.error('Error fetching blog articles:', backendError.logMessage)
+    console.error(
+      'Error fetching blog articles:',
+      backendError.logMessage,
+      backendError
+    )
 
     // Forward backend status code and message when available
     throw createError({

--- a/frontend/server/api/blog/articles/[slug].ts
+++ b/frontend/server/api/blog/articles/[slug].ts
@@ -32,7 +32,11 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
     return response
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
-    console.error('Error fetching blog article:', backendError.logMessage)
+    console.error(
+      'Error fetching blog article:',
+      backendError.logMessage,
+      backendError
+    )
 
     // Forward backend status code and message when available
     throw createError({

--- a/frontend/server/api/blog/test.ts
+++ b/frontend/server/api/blog/test.ts
@@ -31,7 +31,11 @@ export default defineEventHandler(async _event => {
     }
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
-    console.error('Error in test endpoint:', backendError.logMessage)
+    console.error(
+      'Error in test endpoint:',
+      backendError.logMessage,
+      backendError
+    )
 
     throw createError({
       statusCode: backendError.statusCode,

--- a/frontend/server/utils/log-backend-error.spec.ts
+++ b/frontend/server/utils/log-backend-error.spec.ts
@@ -19,6 +19,23 @@ describe('extractBackendErrorDetails', () => {
     expect(details.statusMessage).toBe('Backend failure')
     expect(details.logMessage).toBe('HTTP 502 - Bad Gateway - Backend failure')
     expect(details.isResponseError).toBe(true)
+    // Logging contract: the sanitized payload only exposes serialisable primitives
+    expect(Object.keys(details).sort()).toEqual([
+      'bodyText',
+      'isResponseError',
+      'logMessage',
+      'statusCode',
+      'statusMessage',
+      'statusText',
+    ])
+    expect(JSON.parse(JSON.stringify(details))).toMatchObject({
+      statusCode: 502,
+      statusText: 'Bad Gateway',
+      statusMessage: 'Backend failure',
+      bodyText: 'Backend failure',
+      isResponseError: true,
+      logMessage: 'HTTP 502 - Bad Gateway - Backend failure',
+    })
   })
 
   it('provides a safe fallback for non ResponseError values', async () => {
@@ -32,5 +49,21 @@ describe('extractBackendErrorDetails', () => {
     expect(details.statusMessage).toBe('boom')
     expect(details.logMessage).toBe('HTTP 500 - Internal Server Error - boom')
     expect(details.isResponseError).toBe(false)
+    // Logging contract: object can still be stringified for structured logging
+    expect(Object.keys(details).sort()).toEqual([
+      'bodyText',
+      'isResponseError',
+      'logMessage',
+      'statusCode',
+      'statusMessage',
+      'statusText',
+    ])
+    expect(JSON.parse(JSON.stringify(details))).toMatchObject({
+      statusCode: 500,
+      statusText: 'Internal Server Error',
+      statusMessage: 'boom',
+      isResponseError: false,
+      logMessage: 'HTTP 500 - Internal Server Error - boom',
+    })
   })
 })


### PR DESCRIPTION
## Summary
- include the sanitized backend error object in the blog and bloc API route logs so failures retain structured detail
- extend the backend error utility tests to document that the extracted payload remains serialisable for logging

## Testing
- pnpm --offline lint
- pnpm --offline test -- run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d161271294833386b7ba12e74dc6e8