### PR TITLE
feat(frontend): infer i18n locale from hostname

### DIFF
--- a/frontend/app/plugins/i18n-hostname.ts
+++ b/frontend/app/plugins/i18n-hostname.ts
@@ -1,0 +1,79 @@
+import type { Ref } from 'vue'
+
+const DEFAULT_LOCALE = 'en-US' as const
+const HOST_LOCALE_MAP: Record<string, typeof DEFAULT_LOCALE | 'fr-FR'> = {
+  'nudger.com': DEFAULT_LOCALE,
+  'nudger.fr': 'fr-FR',
+  localhost: 'fr-FR',
+  '127.0.0.1': DEFAULT_LOCALE,
+}
+
+const _normalizeHostname = (rawHost: string | undefined | null): string | null => {
+  if (!rawHost) {
+    return null
+  }
+
+  const hostValue = rawHost.split(',')[0]?.trim()
+  if (!hostValue) {
+    return null
+  }
+
+  const hostname = hostValue.split(':')[0]?.toLowerCase()
+  return hostname || null
+}
+
+const _resolveLocale = (hostname: string | null) => {
+  if (!hostname) {
+    return {
+      locale: DEFAULT_LOCALE,
+      matched: false,
+    }
+  }
+
+  const locale = HOST_LOCALE_MAP[hostname]
+
+  if (!locale) {
+    return {
+      locale: DEFAULT_LOCALE,
+      matched: false,
+    }
+  }
+
+  return {
+    locale,
+    matched: true,
+  }
+}
+
+type NuxtI18nInstance = {
+  locale: Ref<string>
+  setLocale: (locale: string) => Promise<void>
+}
+
+export default defineNuxtPlugin(async (nuxtApp) => {
+  const serverContext = nuxtApp.ssrContext
+  const rawServerHost =
+    serverContext?.event.node.req.headers['x-forwarded-host'] ?? serverContext?.event.node.req.headers.host
+  const rawClientHost = import.meta.client ? window.location.host : null
+
+  const rawHost = import.meta.server ? rawServerHost : rawClientHost
+
+  const hostname = _normalizeHostname(Array.isArray(rawHost) ? rawHost[0] : rawHost)
+  const { locale: targetLocale, matched } = _resolveLocale(hostname)
+
+  if (import.meta.server && !matched) {
+    console.warn(
+      `[i18n] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}.`
+    )
+  }
+
+  const i18n = nuxtApp.$i18n as NuxtI18nInstance | undefined
+
+  if (!i18n) {
+    return
+  }
+
+  if (i18n.locale.value !== targetLocale) {
+    await i18n.setLocale(targetLocale)
+  }
+})

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -66,7 +66,8 @@ export default defineNuxtConfig({
       { code: 'fr-FR', name: 'Français' },
       { code: 'en-US', name: 'English' },
     ],
-    strategy: 'prefix_except_default',
+    strategy: 'no_prefix',
+    detectBrowserLanguage: false,
   },
   css: [
     '~/assets/sass/main.sass', // Keep only the main SASS file


### PR DESCRIPTION
## Summary
- disable route prefixes and browser-based language detection so domain-driven locales can take precedence
- introduce a Nuxt plugin that selects locales from hostnames, including localhost overrides and server-side fallback logging

## Testing
- pnpm --offline lint
- pnpm --offline test run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d17184ef9c83338c77191dcba46a6d