### PR TITLE
fix: load i18n locale bundles

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -62,9 +62,10 @@ export default defineNuxtConfig({
     },
   i18n: {
     defaultLocale: 'en-US',
+    langDir: '../i18n/locales',
     locales: [
-      { code: 'fr-FR', name: 'Français' },
-      { code: 'en-US', name: 'English' },
+      { code: 'fr-FR', name: 'Français', file: 'fr-FR.json' },
+      { code: 'en-US', name: 'English', file: 'en-US.json' },
     ],
     strategy: 'no_prefix',
     detectBrowserLanguage: false,


### PR DESCRIPTION
## Summary
- load locale bundles by pointing `@nuxtjs/i18n` to the `i18n/locales` directory
- associate each locale with its JSON file so `/index-v1` renders translated strings

## Testing
- pnpm --offline lint
- pnpm --offline vitest run
- pnpm --offline generate
- pnpm --offline build


------
https://chatgpt.com/codex/tasks/task_e_68d18e8f25488333a3d26ac711f901ca