### PR TITLE
feat: propagate domain language to backend requests

### DIFF
--- a/frontend/app/plugins/i18n-hostname.ts
+++ b/frontend/app/plugins/i18n-hostname.ts
@@ -1,49 +1,5 @@
 import type { Ref } from 'vue'
-
-const DEFAULT_LOCALE = 'en-US' as const
-const HOST_LOCALE_MAP: Record<string, typeof DEFAULT_LOCALE | 'fr-FR'> = {
-  'nudger.com': DEFAULT_LOCALE,
-  'nudger.fr': 'fr-FR',
-  localhost: 'fr-FR',
-  '127.0.0.1': DEFAULT_LOCALE,
-}
-
-const _normalizeHostname = (rawHost: string | undefined | null): string | null => {
-  if (!rawHost) {
-    return null
-  }
-
-  const hostValue = rawHost.split(',')[0]?.trim()
-  if (!hostValue) {
-    return null
-  }
-
-  const hostname = hostValue.split(':')[0]?.toLowerCase()
-  return hostname || null
-}
-
-const _resolveLocale = (hostname: string | null) => {
-  if (!hostname) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  const locale = HOST_LOCALE_MAP[hostname]
-
-  if (!locale) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  return {
-    locale,
-    matched: true,
-  }
-}
+import { resolveDomainResolutionFromHost, warnOnUnknownHostname } from '~~/shared/utils/domain-language'
 
 type NuxtI18nInstance = {
   locale: Ref<string>
@@ -58,13 +14,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   const rawHost = import.meta.server ? rawServerHost : rawClientHost
 
-  const hostname = _normalizeHostname(Array.isArray(rawHost) ? rawHost[0] : rawHost)
-  const { locale: targetLocale, matched } = _resolveLocale(hostname)
+  const resolution = resolveDomainResolutionFromHost(rawHost)
 
-  if (import.meta.server && !matched) {
-    console.warn(
-      `[i18n] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}.`
-    )
+  if (import.meta.server) {
+    warnOnUnknownHostname(resolution)
   }
 
   const i18n = nuxtApp.$i18n as NuxtI18nInstance | undefined
@@ -73,7 +26,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     return
   }
 
-  if (i18n.locale.value !== targetLocale) {
-    await i18n.setLocale(targetLocale)
+  if (i18n.locale.value !== resolution.locale) {
+    await i18n.setLocale(resolution.locale)
   }
 })

--- a/frontend/shared/api-client/services/blog.services.ts
+++ b/frontend/shared/api-client/services/blog.services.ts
@@ -1,13 +1,21 @@
 import { BlogApi, Configuration } from '..'
 import type { BlogPostDto, PageDto } from '..'
+import { resolveDomainResolutionFromRuntime } from '~~/shared/utils/domain-language'
+import { createDomainLanguageMiddleware } from './utils'
 
 /**
  * Blog service for handling blog-related API calls
  */
 export const useBlogService = () => {
   const config = useRuntimeConfig()
-  const apiConfig = new Configuration({ basePath: config.apiUrl })
-  console.log('[ContentService] baseUrl =', config.apiUrl)
+  const resolution = resolveDomainResolutionFromRuntime()
+
+  const normalizedApiUrl = config.apiUrl.replace(/\/+$/, '')
+  const apiConfig = new Configuration({
+    basePath: normalizedApiUrl,
+    middleware: [createDomainLanguageMiddleware(normalizedApiUrl, resolution.domainLanguage)],
+  })
+  console.log('[ContentService] baseUrl =', normalizedApiUrl)
 
   const api = new BlogApi(apiConfig)
 
@@ -48,3 +56,4 @@ export const useBlogService = () => {
 
   return { getArticles, getArticleBySlug }
 }
+

--- a/frontend/shared/api-client/services/content.services.ts
+++ b/frontend/shared/api-client/services/content.services.ts
@@ -1,12 +1,20 @@
 import { ContentApi, Configuration } from '..'
 import type { XwikiContentBlocDto } from '..'
+import { resolveDomainResolutionFromRuntime } from '~~/shared/utils/domain-language'
+import { createDomainLanguageMiddleware } from './utils'
 
 /**
  * Content service for fetching HTML blocs from the backend
  */
 export const useContentService = () => {
   const config = useRuntimeConfig()
-  const apiConfig = new Configuration({ basePath: config.apiUrl })
+  const resolution = resolveDomainResolutionFromRuntime()
+
+  const normalizedApiUrl = config.apiUrl.replace(/\/+$/, '')
+  const apiConfig = new Configuration({
+    basePath: normalizedApiUrl,
+    middleware: [createDomainLanguageMiddleware(normalizedApiUrl, resolution.domainLanguage)],
+  })
   const api = new ContentApi(apiConfig)
 
   /**

--- a/frontend/shared/api-client/services/utils.ts
+++ b/frontend/shared/api-client/services/utils.ts
@@ -1,0 +1,19 @@
+import type { Middleware } from '..'
+import type { DomainLanguage } from '~~/shared/utils/domain-language'
+
+export const createDomainLanguageMiddleware = (
+  apiUrl: string,
+  domainLanguage: DomainLanguage
+): Middleware => ({
+  async pre({ url, init }) {
+    if (!url.startsWith(apiUrl)) {
+      return
+    }
+
+    const targetUrl = new URL(url)
+    if (!targetUrl.searchParams.has('domainLanguage')) {
+      targetUrl.searchParams.set('domainLanguage', domainLanguage)
+      return { url: targetUrl.toString(), init }
+    }
+  },
+})

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -1,0 +1,114 @@
+import { useRequestHeaders } from '#app'
+
+const DEFAULT_LOCALE = 'en-US' as const
+const SUPPORTED_LOCALES = ['en-US', 'fr-FR'] as const
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+export type DomainLanguage = 'en' | 'fr'
+
+const HOST_LOCALE_MAP: Record<string, SupportedLocale> = {
+  'nudger.com': DEFAULT_LOCALE,
+  'nudger.fr': 'fr-FR',
+  localhost: 'fr-FR',
+  '127.0.0.1': DEFAULT_LOCALE,
+}
+
+const LOCALE_DOMAIN_LANGUAGE_MAP: Record<SupportedLocale, DomainLanguage> = {
+  'en-US': 'en',
+  'fr-FR': 'fr',
+}
+
+export const DEFAULT_DOMAIN_LANGUAGE = LOCALE_DOMAIN_LANGUAGE_MAP[DEFAULT_LOCALE]
+
+export interface DomainResolution {
+  hostname: string | null
+  locale: SupportedLocale
+  domainLanguage: DomainLanguage
+  matched: boolean
+}
+
+const formatWarningMessage = (hostname: string | null) =>
+  `[i18n] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}.`
+
+export const warnOnUnknownHostname = (
+  resolution: Pick<DomainResolution, 'matched' | 'hostname'>,
+  logger: (message: string) => void = console.warn
+) => {
+  if (!resolution.matched) {
+    logger(formatWarningMessage(resolution.hostname))
+  }
+}
+
+export const normalizeHostname = (
+  rawHost: string | string[] | undefined | null
+): string | null => {
+  if (!rawHost) {
+    return null
+  }
+
+  const hostValue = Array.isArray(rawHost) ? rawHost[0] : rawHost
+  if (!hostValue) {
+    return null
+  }
+
+  const firstHost = hostValue.split(',')[0]?.trim()
+  if (!firstHost) {
+    return null
+  }
+
+  const hostname = firstHost.split(':')[0]?.toLowerCase()
+  return hostname || null
+}
+
+export const resolveDomainResolutionFromHostname = (
+  hostname: string | null
+): DomainResolution => {
+  const locale = (hostname && HOST_LOCALE_MAP[hostname]) ?? DEFAULT_LOCALE
+  const domainLanguage = LOCALE_DOMAIN_LANGUAGE_MAP[locale]
+  const matched = Boolean(hostname && HOST_LOCALE_MAP[hostname])
+
+  return {
+    hostname,
+    locale,
+    domainLanguage,
+    matched,
+  }
+}
+
+export const resolveDomainResolutionFromHost = (
+  rawHost: string | string[] | undefined | null
+): DomainResolution => {
+  const hostname = normalizeHostname(rawHost)
+  return resolveDomainResolutionFromHostname(hostname)
+}
+
+export const resolveDomainResolutionFromHeaders = (
+  headers: Record<string, string | string[] | undefined>
+): DomainResolution => {
+  const rawHost = headers['x-forwarded-host'] ?? headers.host
+  return resolveDomainResolutionFromHost(rawHost ?? null)
+}
+
+export const resolveDomainResolutionFromRuntime = (): DomainResolution => {
+  let rawHost: string | null = null
+
+  if (import.meta.server) {
+    const headers = useRequestHeaders(['x-forwarded-host', 'host'])
+    rawHost = headers['x-forwarded-host'] ?? headers.host ?? null
+  } else if (typeof window !== 'undefined') {
+    rawHost = window.location.host
+  }
+
+  const resolution = resolveDomainResolutionFromHost(rawHost)
+
+  if (import.meta.server) {
+    warnOnUnknownHostname(resolution)
+  }
+
+  return resolution
+}
+
+export const formatUnknownHostnameWarning = (hostname: string | null) =>
+  formatWarningMessage(hostname)
+
+export { DEFAULT_LOCALE }


### PR DESCRIPTION
## Summary
- centralise hostname to locale and domain language resolution in a shared helper consumed by the i18n plugin and server routes
- inject a request middleware into generated API services so every backend call carries the required `domainLanguage`
- forward the domain language query parameter through the auth Nitro proxies to keep them aligned with the backend contract

## Testing
- pnpm --offline lint *(fails: missing @nuxt/eslint-config because dependencies cannot be installed offline)*
- pnpm --offline test *(fails: vitest binary missing without node_modules)*
- pnpm --offline generate *(fails: nuxt binary missing without node_modules)*
- pnpm --offline build *(fails: postcss package missing without node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d199e2a7f08333a24e3938dab17d93