### PR TITLE
feat(frontend): propagate domain language to backend requests

### DIFF
--- a/frontend/app/plugins/i18n-hostname.ts
+++ b/frontend/app/plugins/i18n-hostname.ts
@@ -1,49 +1,11 @@
 import type { Ref } from 'vue'
-
-const DEFAULT_LOCALE = 'en-US' as const
-const HOST_LOCALE_MAP: Record<string, typeof DEFAULT_LOCALE | 'fr-FR'> = {
-  'nudger.com': DEFAULT_LOCALE,
-  'nudger.fr': 'fr-FR',
-  localhost: 'fr-FR',
-  '127.0.0.1': DEFAULT_LOCALE,
-}
-
-const _normalizeHostname = (rawHost: string | undefined | null): string | null => {
-  if (!rawHost) {
-    return null
-  }
-
-  const hostValue = rawHost.split(',')[0]?.trim()
-  if (!hostValue) {
-    return null
-  }
-
-  const hostname = hostValue.split(':')[0]?.toLowerCase()
-  return hostname || null
-}
-
-const _resolveLocale = (hostname: string | null) => {
-  if (!hostname) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  const locale = HOST_LOCALE_MAP[hostname]
-
-  if (!locale) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  return {
-    locale,
-    matched: true,
-  }
-}
+import {
+  DEFAULT_LOCALE,
+  DEFAULT_DOMAIN_LANGUAGE,
+  getRequestDomainContext,
+  resolveDomainContext,
+  syncDomainLanguageState,
+} from '~~/shared/utils/domain-language'
 
 type NuxtI18nInstance = {
   locale: Ref<string>
@@ -52,20 +14,24 @@ type NuxtI18nInstance = {
 
 export default defineNuxtPlugin(async (nuxtApp) => {
   const serverContext = nuxtApp.ssrContext
-  const rawServerHost =
-    serverContext?.event.node.req.headers['x-forwarded-host'] ?? serverContext?.event.node.req.headers.host
-  const rawClientHost = import.meta.client ? window.location.host : null
+  let resolution = resolveDomainContext(null)
 
-  const rawHost = import.meta.server ? rawServerHost : rawClientHost
+  if (import.meta.server && serverContext?.event) {
+    resolution = getRequestDomainContext(serverContext.event)
+  } else {
+    const rawClientHost = import.meta.client ? window.location.host : null
+    resolution = resolveDomainContext(rawClientHost)
 
-  const hostname = _normalizeHostname(Array.isArray(rawHost) ? rawHost[0] : rawHost)
-  const { locale: targetLocale, matched } = _resolveLocale(hostname)
-
-  if (import.meta.server && !matched) {
-    console.warn(
-      `[i18n] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}.`
-    )
+    if (!resolution.matched) {
+      console.warn(
+        `[i18n] Unknown hostname "${resolution.hostname ?? 'unknown'}" received on client. Falling back to ${DEFAULT_LOCALE}/${DEFAULT_DOMAIN_LANGUAGE}.`
+      )
+    }
   }
+
+  const domainLanguageState = syncDomainLanguageState(resolution.domainLanguage)
+  nuxtApp.vueApp.provide('domainLanguage', domainLanguageState)
+  nuxtApp.provide('domainLanguage', domainLanguageState)
 
   const i18n = nuxtApp.$i18n as NuxtI18nInstance | undefined
 
@@ -73,7 +39,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     return
   }
 
-  if (i18n.locale.value !== targetLocale) {
-    await i18n.setLocale(targetLocale)
+  if (i18n.locale.value !== resolution.locale) {
+    await i18n.setLocale(resolution.locale)
   }
 })

--- a/frontend/server/routes/auth/login.post.ts
+++ b/frontend/server/routes/auth/login.post.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import type { CookieSerializeOptions } from 'cookie-es'
 import { FetchError } from 'ofetch'
+import { getRequestDomainContext } from '~~/shared/utils/domain-language'
 
 interface LoginResponse { accessToken: string; refreshToken: string }
 interface LoginBody { username: string; password: string }
@@ -12,10 +13,12 @@ export default defineEventHandler(async (event: H3Event) => {
   }
 
   const config = useRuntimeConfig()
+  const { domainLanguage } = getRequestDomainContext(event)
   try {
     const tokens = await $fetch<LoginResponse>(`${config.apiUrl}/auth/login`, {
       method: 'POST',
       body,
+      query: { domainLanguage },
     })
     const secure = process.env.NODE_ENV === 'production'
     const sameSite: 'lax' | 'none' = secure ? 'none' : 'lax'

--- a/frontend/server/routes/auth/refresh.post.ts
+++ b/frontend/server/routes/auth/refresh.post.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import type { CookieSerializeOptions } from 'cookie-es'
 import { FetchError } from 'ofetch'
+import { getRequestDomainContext } from '~~/shared/utils/domain-language'
 
 /**
  * Proxy endpoint to renew access and refresh tokens using the backend API.
@@ -14,10 +15,13 @@ export default defineEventHandler(async (event: H3Event) => {
     throw createError({ statusCode: 401, statusMessage: 'Missing refresh token' })
   }
 
+  const { domainLanguage } = getRequestDomainContext(event)
+
   try {
     const tokens = await $fetch<RefreshResponse>(`${config.apiUrl}/auth/refresh`, {
       method: 'POST',
       headers: { cookie: `${config.refreshCookieName}=${refreshToken}` },
+      query: { domainLanguage },
     })
 
     const secure = process.env.NODE_ENV === 'production'

--- a/frontend/shared/api-client/services/blog.services.ts
+++ b/frontend/shared/api-client/services/blog.services.ts
@@ -1,5 +1,6 @@
 import { BlogApi, Configuration } from '..'
 import type { BlogPostDto, PageDto } from '..'
+import { getCurrentDomainLanguage } from '~~/shared/utils/domain-language'
 
 /**
  * Blog service for handling blog-related API calls
@@ -23,7 +24,13 @@ export const useBlogService = () => {
     } = {}
   ): Promise<PageDto> => {
     try {
-      return await api.posts(params)
+      const { tag, pageNumber, pageSize } = params
+      return await api.posts({
+        tag,
+        pageNumber,
+        pageSize,
+        domainLanguage: getCurrentDomainLanguage(),
+      })
     } catch (error) {
       console.error('Error fetching blog articles:', error)
       // Rethrow original error so callers can access status and message
@@ -38,7 +45,10 @@ export const useBlogService = () => {
    */
   const getArticleBySlug = async (slug: string): Promise<BlogPostDto> => {
     try {
-      return await api.post({ slug })
+      return await api.post({
+        slug,
+        domainLanguage: getCurrentDomainLanguage(),
+      })
     } catch (error) {
       console.error(`Error fetching blog article ${slug}:`, error)
       // Preserve original error details for upstream handlers

--- a/frontend/shared/api-client/services/content.services.ts
+++ b/frontend/shared/api-client/services/content.services.ts
@@ -1,5 +1,6 @@
 import { ContentApi, Configuration } from '..'
 import type { XwikiContentBlocDto } from '..'
+import { getCurrentDomainLanguage } from '~~/shared/utils/domain-language'
 
 /**
  * Content service for fetching HTML blocs from the backend
@@ -14,7 +15,10 @@ export const useContentService = () => {
    * @param blocId - XWiki bloc identifier
    */
   const getBloc = async (blocId: string): Promise<XwikiContentBlocDto> => {
-    return await api.contentBloc({ blocId })
+    return await api.contentBloc({
+      blocId,
+      domainLanguage: getCurrentDomainLanguage(),
+    })
   }
 
   return { getBloc }

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -1,0 +1,135 @@
+import type { H3Event } from 'h3'
+import { useRequestEvent, useState } from '#imports'
+
+export type RawHostInput = string | string[] | null | undefined
+
+export type DomainLanguage = 'en' | 'fr'
+
+export const DEFAULT_LOCALE = 'en-US' as const
+export const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'en'
+export const DOMAIN_LANGUAGE_STATE_KEY = 'domain-language'
+
+const HOST_LOCALE_MAP: Record<string, string> = {
+  'nudger.com': DEFAULT_LOCALE,
+  'nudger.fr': 'fr-FR',
+  localhost: 'fr-FR',
+  '127.0.0.1': DEFAULT_LOCALE,
+}
+
+const LOCALE_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
+  'fr-FR': 'fr',
+  'en-US': 'en',
+}
+
+export interface DomainResolution {
+  hostname: string | null
+  locale: string
+  domainLanguage: DomainLanguage
+  matched: boolean
+}
+
+const DOMAIN_CONTEXT_KEY = '__domainLanguageContext'
+
+export const normalizeHostname = (rawHost: RawHostInput): string | null => {
+  if (!rawHost) {
+    return null
+  }
+
+  const firstValue = Array.isArray(rawHost) ? rawHost[0] : rawHost
+  if (!firstValue) {
+    return null
+  }
+
+  const hostValue = firstValue.split(',')[0]?.trim()
+  if (!hostValue) {
+    return null
+  }
+
+  const hostname = hostValue.split(':')[0]?.toLowerCase()
+  return hostname || null
+}
+
+export const resolveLocaleForHostname = (hostname: string | null) => {
+  if (!hostname) {
+    return {
+      locale: DEFAULT_LOCALE,
+      matched: false,
+    }
+  }
+
+  const locale = HOST_LOCALE_MAP[hostname]
+
+  if (!locale) {
+    return {
+      locale: DEFAULT_LOCALE,
+      matched: false,
+    }
+  }
+
+  return {
+    locale,
+    matched: true,
+  }
+}
+
+export const resolveDomainLanguageForLocale = (locale: string): DomainLanguage => {
+  return LOCALE_DOMAIN_LANGUAGE_MAP[locale] ?? DEFAULT_DOMAIN_LANGUAGE
+}
+
+export const resolveDomainContext = (rawHost: RawHostInput): DomainResolution => {
+  const hostname = normalizeHostname(rawHost)
+  const { locale, matched } = resolveLocaleForHostname(hostname)
+  const domainLanguage = resolveDomainLanguageForLocale(locale)
+
+  return {
+    hostname,
+    locale,
+    domainLanguage,
+    matched,
+  }
+}
+
+const logUnknownHostname = (hostname: string | null) => {
+  console.error(
+    `[domain-language] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}/${DEFAULT_DOMAIN_LANGUAGE}.`
+  )
+}
+
+export const getRequestDomainContext = (event: H3Event): DomainResolution => {
+  const context = event.context as Record<string, DomainResolution | undefined>
+  const cached = context[DOMAIN_CONTEXT_KEY]
+  if (cached) {
+    return cached
+  }
+
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const resolution = resolveDomainContext(rawHost)
+
+  if (!resolution.matched) {
+    logUnknownHostname(resolution.hostname)
+  }
+
+  context[DOMAIN_CONTEXT_KEY] = resolution
+  return resolution
+}
+
+export const getCurrentDomainLanguage = (): DomainLanguage => {
+  if (import.meta.server) {
+    const event = useRequestEvent()
+    if (event) {
+      return getRequestDomainContext(event).domainLanguage
+    }
+  }
+
+  return useDomainLanguageState().value
+}
+
+export const useDomainLanguageState = () =>
+  useState<DomainLanguage>(DOMAIN_LANGUAGE_STATE_KEY, () => DEFAULT_DOMAIN_LANGUAGE)
+
+export const syncDomainLanguageState = (domainLanguage: DomainLanguage) => {
+  const state = useDomainLanguageState()
+  state.value = domainLanguage
+  return state
+}


### PR DESCRIPTION
## Summary
- centralize hostname resolution to compute locale/domain language pairs and cache them per request
- sync the i18n hostname plugin with the shared resolver so the resolved domain language is exposed through app state
- append the required domainLanguage parameter to blog/content API clients and auth proxy routes

## Testing
- `pnpm --offline lint` *(fails: missing @nuxt/eslint-config package in offline store)*

------
https://chatgpt.com/codex/tasks/task_e_68d252a5dd0c833384f00c488cf5641a