### PR TITLE
Add categories endpoint backed by vertical configuration

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -27,6 +27,12 @@
 
     <dependency>
       <groupId>org.open4goods</groupId>
+      <artifactId>commons</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.open4goods</groupId>
       <artifactId>serialisation</artifactId>
       <version>${global.version}</version>
     </dependency>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
@@ -1,0 +1,123 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.CategoryMappingService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing metadata about the available vertical categories for the frontend UI.
+ */
+@RestController
+@RequestMapping("/category")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Categories", description = "Retrieve vertical configurations displayed in the catalog navigation.")
+public class CategoriesController {
+
+    private static final CacheControl FIFTEEN_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(15)).cachePublic();
+
+    private final VerticalsConfigService verticalsConfigService;
+    private final CategoryMappingService categoryMappingService;
+
+    public CategoriesController(VerticalsConfigService verticalsConfigService,
+                                CategoryMappingService categoryMappingService) {
+        this.verticalsConfigService = verticalsConfigService;
+        this.categoryMappingService = categoryMappingService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "List categories",
+            description = "Return vertical configurations optionally filtered by their enabled status.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class)),
+                    @Parameter(name = "onlyEnabled", in = ParameterIn.QUERY, required = false,
+                            description = "When true, only return verticals flagged as enabled.",
+                            schema = @Schema(type = "boolean", defaultValue = "true"))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Categories returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = VerticalConfigDto.class)))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<List<VerticalConfigDto>> categories(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+            @RequestParam(name = "onlyEnabled", defaultValue = "true") boolean onlyEnabled) {
+        List<VerticalConfigDto> body = verticalsConfigService.getConfigsWithoutDefault(onlyEnabled).stream()
+                .map(categoryMappingService::toVerticalConfigDto)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return ResponseEntity.ok()
+                .cacheControl(FIFTEEN_MINUTES_PUBLIC_CACHE)
+                .body(body);
+    }
+
+    @GetMapping("/{categoryId}")
+    @Operation(
+            summary = "Get category details",
+            description = "Return the detailed vertical configuration identified by its id.",
+            parameters = {
+                    @Parameter(name = "categoryId", in = ParameterIn.PATH, required = true,
+                            description = "Identifier of the vertical to retrieve.",
+                            schema = @Schema(type = "string", example = "tv")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Category returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = VerticalConfigFullDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Category not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<VerticalConfigFullDto> category(@PathVariable("categoryId") String categoryId,
+                                                          @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        VerticalConfig config = verticalsConfigService.getConfigById(categoryId);
+        if (config == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        VerticalConfigFullDto body = categoryMappingService.toVerticalConfigFullDto(config);
+        return ResponseEntity.ok()
+                .cacheControl(FIFTEEN_MINUTES_PUBLIC_CACHE)
+                .body(body);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigDto.java
@@ -1,0 +1,36 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Summary representation of a vertical configuration exposed to the frontend.
+ */
+public record VerticalConfigDto(
+        @Schema(description = "Unique identifier of the vertical configuration.", example = "tv")
+        String id,
+        @Schema(description = "Indicates whether the vertical is exposed to end-users.", example = "true")
+        boolean enabled,
+        @Schema(description = "Google taxonomy identifier associated with this vertical.", example = "404")
+        Integer googleTaxonomyId,
+        @Schema(description = "Icecat taxonomy identifier associated with this vertical.", example = "1584")
+        Integer icecatTaxonomyId,
+        @Schema(description = "Display order used to render the category list.", example = "1")
+        Integer order,
+        @Schema(description = "Thumbnail image representing the vertical. TODO(front-api): populate when media assets are defined.",
+                nullable = true)
+        String imageThumbnail,
+        @Schema(description = "Primary image for the vertical hero section. TODO(front-api): populate when media assets are defined.",
+                nullable = true)
+        String image,
+        @Schema(description = "Localised singular label for the vertical. TODO(front-api): populate when naming strategy is available.",
+                nullable = true)
+        String singularName,
+        @Schema(description = "Localised plural label for the vertical. TODO(front-api): populate when naming strategy is available.",
+                nullable = true)
+        String pluralName,
+        @Schema(description = "Localised summary texts keyed by IETF BCP 47 language tag.")
+        Map<String, VerticalConfigI18nDto> i18n
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
@@ -1,0 +1,103 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.BarcodeAggregationProperties;
+import org.open4goods.model.vertical.DescriptionsAggregationConfig;
+import org.open4goods.model.vertical.FeatureGroup;
+import org.open4goods.model.vertical.ImpactScoreConfig;
+import org.open4goods.model.vertical.ImpactScoreCriteria;
+import org.open4goods.model.vertical.ProductI18nElements;
+import org.open4goods.model.vertical.RecommandationsConfig;
+import org.open4goods.model.vertical.ResourcesAggregationConfig;
+import org.open4goods.model.vertical.ScoringAggregationConfig;
+import org.open4goods.model.vertical.SiteNaming;
+import org.open4goods.model.vertical.VerticalSubset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Detailed representation of a vertical configuration mirroring the YAML structure consumed by the core services.
+ */
+public record VerticalConfigFullDto(
+        @Schema(description = "Unique identifier of the vertical configuration.", example = "tv")
+        String id,
+        @Schema(description = "Indicates whether the vertical is exposed to end-users.", example = "true")
+        boolean enabled,
+        @Schema(description = "Google taxonomy identifier associated with this vertical.", example = "404")
+        Integer googleTaxonomyId,
+        @Schema(description = "Icecat taxonomy identifier associated with this vertical.", example = "1584")
+        Integer icecatTaxonomyId,
+        @Schema(description = "Display order used to render the category list.", example = "1")
+        Integer order,
+        @Schema(description = "Thumbnail image representing the vertical. TODO(front-api): populate when media assets are defined.",
+                nullable = true)
+        String imageThumbnail,
+        @Schema(description = "Primary image for the vertical hero section. TODO(front-api): populate when media assets are defined.",
+                nullable = true)
+        String image,
+        @Schema(description = "Localised singular label for the vertical. TODO(front-api): populate when naming strategy is available.",
+                nullable = true)
+        String singularName,
+        @Schema(description = "Localised plural label for the vertical. TODO(front-api): populate when naming strategy is available.",
+                nullable = true)
+        String pluralName,
+        @Schema(description = "Localised summary texts keyed by IETF BCP 47 language tag.")
+        Map<String, VerticalConfigI18nDto> i18n,
+        @Schema(description = "Full set of i18n elements as defined in the YAML configuration.")
+        Map<String, ProductI18nElements> rawI18n,
+        @Schema(description = "Eco filters enabled for this vertical.")
+        List<String> ecoFilters,
+        @Schema(description = "Technical filters enabled for this vertical.")
+        List<String> technicalFilters,
+        @Schema(description = "Global technical filters applied across datasources.")
+        List<String> globalTechnicalFilters,
+        @Schema(description = "Mapping of datasource categories to this vertical.")
+        Map<String, Set<String>> matchingCategories,
+        @Schema(description = "Tokens that exclude a product from matching this vertical.")
+        Set<String> excludingTokensFromCategoriesMatching,
+        @Schema(description = "Datasources ignored when computing category matches.")
+        Set<String> generationExcludedFromCategoriesMatching,
+        @Schema(description = "Attributes ignored when computing attribute suggestions.")
+        Set<String> generationExcludedFromAttributesMatching,
+        @Schema(description = "Attributes required for the product to belong to this vertical.")
+        Set<String> requiredAttributes,
+        @Schema(description = "Regenerate URL friendly names even if already generated.")
+        boolean forceNameGeneration,
+        @Schema(description = "Mappings of brand aliases to canonical brand names.")
+        Map<String, String> brandsAlias,
+        @Schema(description = "Brands excluded from this vertical.")
+        Set<String> brandsExclusion,
+        @Schema(description = "Site naming configuration inherited by the UI.")
+        SiteNaming namings,
+        @Schema(description = "Configuration for media aggregation.")
+        ResourcesAggregationConfig resourcesConfig,
+        @Schema(description = "Configuration for attribute aggregation and filters.")
+        AttributesConfig attributesConfig,
+        @Schema(description = "Impact score criteria available for this vertical.")
+        Map<String, ImpactScoreCriteria> availableImpactScoreCriterias,
+        @Schema(description = "Impact score configuration balancing each criterion.")
+        ImpactScoreConfig impactScoreConfig,
+        @Schema(description = "Custom subsets defined for this vertical.")
+        List<VerticalSubset> subsets,
+        @Schema(description = "Subset dedicated to brand exploration.")
+        VerticalSubset brandsSubset,
+        @Schema(description = "Barcode aggregation configuration.")
+        BarcodeAggregationProperties barcodeConfig,
+        @Schema(description = "Recommendation engine configuration.")
+        RecommandationsConfig recommandationsConfig,
+        @Schema(description = "Description aggregation configuration.")
+        DescriptionsAggregationConfig descriptionsAggregationConfig,
+        @Schema(description = "Scoring aggregation configuration.")
+        ScoringAggregationConfig scoringAggregationConfig,
+        @Schema(description = "Feature groups ordering attributes for UI rendering.")
+        List<FeatureGroup> featureGroups,
+        @Schema(description = "Threshold defining how many low scores are considered worsts.")
+        Integer worseLimit,
+        @Schema(description = "Threshold defining how many high scores are considered bests.")
+        Integer bettersLimit
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigI18nDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigI18nDto.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Localised summary texts for a vertical category card.
+ */
+public record VerticalConfigI18nDto(
+        @Schema(description = "Display title for the vertical in the target language.", example = "Téléviseurs")
+        String title,
+        @Schema(description = "Short description shown on the categories listing page.",
+                example = "Découvrez les téléviseurs classés par impact environnemental.")
+        String description,
+        @Schema(description = "Slug used to build the URL of the vertical home page.", example = "televiseurs")
+        String url
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -1,0 +1,118 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.open4goods.model.vertical.ProductI18nElements;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigI18nDto;
+import org.springframework.stereotype.Service;
+
+/**
+ * Mapping utilities converting {@link VerticalConfig} domain objects into transport DTOs.
+ */
+@Service
+public class CategoryMappingService {
+
+    /**
+     * Convert a {@link VerticalConfig} into its summary DTO representation.
+     *
+     * @param verticalConfig domain object loaded from the configuration service
+     * @return DTO exposing the summary view or {@code null} when the source is {@code null}
+     */
+    public VerticalConfigDto toVerticalConfigDto(VerticalConfig verticalConfig) {
+        if (verticalConfig == null) {
+            return null;
+        }
+
+        return new VerticalConfigDto(
+                verticalConfig.getId(),
+                verticalConfig.isEnabled(),
+                verticalConfig.getGoogleTaxonomyId(),
+                verticalConfig.getIcecatTaxonomyId(),
+                verticalConfig.getOrder(),
+                null, // TODO(front-api): populate thumbnail from media catalog once available.
+                null, // TODO(front-api): populate hero image from media catalog once available.
+                null, // TODO(front-api): expose singular label when configuration is extended.
+                null, // TODO(front-api): expose plural label when configuration is extended.
+                mapI18n(verticalConfig.getI18n()));
+    }
+
+    /**
+     * Convert a {@link VerticalConfig} into its detailed DTO representation.
+     *
+     * @param verticalConfig domain object loaded from the configuration service
+     * @return DTO exposing the full vertical configuration or {@code null} when the source is {@code null}
+     */
+    public VerticalConfigFullDto toVerticalConfigFullDto(VerticalConfig verticalConfig) {
+        if (verticalConfig == null) {
+            return null;
+        }
+
+        return new VerticalConfigFullDto(
+                verticalConfig.getId(),
+                verticalConfig.isEnabled(),
+                verticalConfig.getGoogleTaxonomyId(),
+                verticalConfig.getIcecatTaxonomyId(),
+                verticalConfig.getOrder(),
+                null, // TODO(front-api): populate thumbnail from media catalog once available.
+                null, // TODO(front-api): populate hero image from media catalog once available.
+                null, // TODO(front-api): expose singular label when configuration is extended.
+                null, // TODO(front-api): expose plural label when configuration is extended.
+                mapI18n(verticalConfig.getI18n()),
+                defaultMap(verticalConfig.getI18n()),
+                defaultList(verticalConfig.getEcoFilters()),
+                defaultList(verticalConfig.getTechnicalFilters()),
+                defaultList(verticalConfig.getGlobalTechnicalFilters()),
+                defaultMap(verticalConfig.getMatchingCategories()),
+                defaultSet(verticalConfig.getExcludingTokensFromCategoriesMatching()),
+                defaultSet(verticalConfig.getGenerationExcludedFromCategoriesMatching()),
+                defaultSet(verticalConfig.getGenerationExcludedFromAttributesMatching()),
+                defaultSet(verticalConfig.getRequiredAttributes()),
+                verticalConfig.isForceNameGeneration(),
+                defaultMap(verticalConfig.getBrandsAlias()),
+                defaultSet(verticalConfig.getBrandsExclusion()),
+                verticalConfig.getNamings(),
+                verticalConfig.getResourcesConfig(),
+                verticalConfig.getAttributesConfig(),
+                defaultMap(verticalConfig.getAvailableImpactScoreCriterias()),
+                verticalConfig.getImpactScoreConfig(),
+                defaultList(verticalConfig.getSubsets()),
+                verticalConfig.getBrandsSubset(),
+                verticalConfig.getBarcodeConfig(),
+                verticalConfig.getRecommandationsConfig(),
+                verticalConfig.getDescriptionsAggregationConfig(),
+                verticalConfig.getScoringAggregationConfig(),
+                defaultList(verticalConfig.getFeatureGroups()),
+                verticalConfig.getWorseLimit(),
+                verticalConfig.getBettersLimit());
+    }
+
+    private Map<String, VerticalConfigI18nDto> mapI18n(Map<String, ProductI18nElements> i18n) {
+        if (i18n == null || i18n.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return i18n.entrySet().stream()
+                .filter(entry -> Objects.nonNull(entry.getValue()))
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> new VerticalConfigI18nDto(
+                        entry.getValue().getVerticalHomeTitle(),
+                        entry.getValue().getVerticalHomeDescription(),
+                        entry.getValue().getVerticalHomeUrl())));
+    }
+
+    private <T> Map<String, T> defaultMap(Map<String, T> map) {
+        return map == null ? Collections.emptyMap() : map;
+    }
+
+    private <T> java.util.List<T> defaultList(java.util.List<T> list) {
+        return list == null ? Collections.emptyList() : list;
+    }
+
+    private <T> java.util.Set<T> defaultSet(java.util.Set<T> set) {
+        return set == null ? Collections.emptySet() : set;
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoriesControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/CategoriesControllerIT.java
@@ -1,0 +1,139 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.commons.services.VerticalsConfigService;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.BarcodeAggregationProperties;
+import org.open4goods.model.vertical.DescriptionsAggregationConfig;
+import org.open4goods.model.vertical.ImpactScoreConfig;
+import org.open4goods.model.vertical.RecommandationsConfig;
+import org.open4goods.model.vertical.ResourcesAggregationConfig;
+import org.open4goods.model.vertical.ScoringAggregationConfig;
+import org.open4goods.model.vertical.SiteNaming;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.model.vertical.VerticalSubset;
+import org.open4goods.nudgerfrontapi.controller.api.CategoriesController;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
+import org.open4goods.nudgerfrontapi.service.CategoryMappingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"front.cache.path=${java.io.tmpdir}",
+        "front.security.enabled=true",
+        "front.security.shared-token=test-token"})
+@AutoConfigureMockMvc
+class CategoriesControllerIT {
+
+    private static final String SHARED_TOKEN = "test-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CategoriesController controller;
+
+    @MockBean
+    private VerticalsConfigService verticalsConfigService;
+
+    @MockBean
+    private CategoryMappingService categoryMappingService;
+
+    @Test
+    void listCategoriesReturnsDtos() throws Exception {
+        VerticalConfig verticalConfig = new VerticalConfig();
+        verticalConfig.setId("tv");
+
+        given(verticalsConfigService.getConfigsWithoutDefault(true)).willReturn(List.of(verticalConfig));
+
+        VerticalConfigDto dto = new VerticalConfigDto("tv", true, 404, 1584, 1,
+                null, null, null, null, Map.of());
+        given(categoryMappingService.toVerticalConfigDto(verticalConfig)).willReturn(dto);
+
+        mockMvc.perform(get("/category")
+                .param("domainLanguage", "fr")
+                .header("X-Shared-Token", SHARED_TOKEN)
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("tv"));
+    }
+
+    @Test
+    void categoryDetailsReturnDto() throws Exception {
+        VerticalConfig verticalConfig = new VerticalConfig();
+        verticalConfig.setId("tv");
+
+        given(verticalsConfigService.getConfigById("tv")).willReturn(verticalConfig);
+
+        VerticalConfigFullDto fullDto = new VerticalConfigFullDto(
+                "tv",
+                true,
+                404,
+                1584,
+                1,
+                null,
+                null,
+                null,
+                null,
+                Map.of(),
+                Map.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                Map.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                false,
+                Map.of(),
+                Set.of(),
+                new SiteNaming(),
+                new ResourcesAggregationConfig(),
+                new AttributesConfig(),
+                Map.of(),
+                new ImpactScoreConfig(),
+                List.of(),
+                new VerticalSubset(),
+                new BarcodeAggregationProperties(),
+                new RecommandationsConfig(),
+                new DescriptionsAggregationConfig(),
+                new ScoringAggregationConfig(),
+                List.of(),
+                0,
+                0);
+        given(categoryMappingService.toVerticalConfigFullDto(verticalConfig)).willReturn(fullDto);
+
+        mockMvc.perform(get("/category/tv")
+                .param("domainLanguage", "fr")
+                .header("X-Shared-Token", SHARED_TOKEN)
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("tv"));
+    }
+
+    @Test
+    void categoryReturns404WhenMissing() throws Exception {
+        given(verticalsConfigService.getConfigById("missing")).willReturn(null);
+
+        mockMvc.perform(get("/category/missing")
+                .param("domainLanguage", "fr")
+                .header("X-Shared-Token", SHARED_TOKEN)
+                .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceTest.java
@@ -1,0 +1,120 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.vertical.FeatureGroup;
+import org.open4goods.model.vertical.ImpactScoreConfig;
+import org.open4goods.model.vertical.ImpactScoreCriteria;
+import org.open4goods.model.vertical.ProductI18nElements;
+import org.open4goods.model.vertical.ResourcesAggregationConfig;
+import org.open4goods.model.vertical.SiteNaming;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.model.vertical.VerticalSubset;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
+
+class CategoryMappingServiceTest {
+
+    private CategoryMappingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CategoryMappingService();
+    }
+
+    @Test
+    void toVerticalConfigDtoMapsBasicFields() {
+        VerticalConfig config = new VerticalConfig();
+        config.setId("tv");
+        config.setEnabled(true);
+        config.setOrder(1);
+        config.setGoogleTaxonomyId(404);
+        config.setIcecatTaxonomyId(1584);
+
+        ProductI18nElements fr = new ProductI18nElements();
+        fr.setVerticalHomeTitle("Téléviseurs");
+        fr.setVerticalHomeDescription("Desc");
+        fr.setVerticalHomeUrl("televiseurs");
+        config.setI18n(Map.of("fr", fr));
+
+        VerticalConfigDto dto = service.toVerticalConfigDto(config);
+
+        assertThat(dto.id()).isEqualTo("tv");
+        assertThat(dto.enabled()).isTrue();
+        assertThat(dto.googleTaxonomyId()).isEqualTo(404);
+        assertThat(dto.image()).isNull();
+        assertThat(dto.singularName()).isNull();
+        assertThat(dto.i18n()).containsKey("fr");
+        assertThat(dto.i18n().get("fr").title()).isEqualTo("Téléviseurs");
+        assertThat(dto.i18n().get("fr").description()).isEqualTo("Desc");
+        assertThat(dto.i18n().get("fr").url()).isEqualTo("televiseurs");
+    }
+
+    @Test
+    void toVerticalConfigFullDtoMirrorsFields() {
+        VerticalConfig config = new VerticalConfig();
+        config.setId("tv");
+        config.setEnabled(true);
+        config.setOrder(2);
+        config.setGoogleTaxonomyId(404);
+        config.setIcecatTaxonomyId(1584);
+        config.setEcoFilters(List.of("eco"));
+        config.setTechnicalFilters(List.of("tech"));
+        config.setGlobalTechnicalFilters(List.of("global"));
+        config.setMatchingCategories(Map.of("all", Set.of("category")));
+        config.setExcludingTokensFromCategoriesMatching(Set.of("accessoire"));
+        config.setGenerationExcludedFromCategoriesMatching(Set.of("fnac"));
+        config.setGenerationExcludedFromAttributesMatching(Set.of("PRICE"));
+        config.setRequiredAttributes(Set.of("ENERGY_CLASS"));
+        config.setForceNameGeneration(true);
+        config.setBrandsAlias(Map.of("LG ELECTRONICS", "LG"));
+        config.setBrandsExclusion(Set.of("UNKNOWN"));
+        config.setNamings(new SiteNaming());
+        config.setResourcesConfig(new ResourcesAggregationConfig());
+        config.setAvailableImpactScoreCriterias(Map.of("score", new ImpactScoreCriteria()));
+        ImpactScoreConfig impactScoreConfig = new ImpactScoreConfig();
+        config.setImpactScoreConfig(impactScoreConfig);
+        VerticalSubset subset = new VerticalSubset();
+        config.setSubsets(List.of(subset));
+        FeatureGroup featureGroup = new FeatureGroup();
+        config.setFeatureGroups(List.of(featureGroup));
+
+        ProductI18nElements fr = new ProductI18nElements();
+        fr.setVerticalHomeTitle("Téléviseurs");
+        fr.setVerticalHomeDescription("Desc");
+        fr.setVerticalHomeUrl("televiseurs");
+        Map<String, ProductI18nElements> i18n = Map.of("fr", fr);
+        config.setI18n(i18n);
+
+        VerticalConfigFullDto dto = service.toVerticalConfigFullDto(config);
+
+        assertThat(dto.id()).isEqualTo("tv");
+        assertThat(dto.enabled()).isTrue();
+        assertThat(dto.rawI18n()).isSameAs(i18n);
+        assertThat(dto.ecoFilters()).containsExactly("eco");
+        assertThat(dto.technicalFilters()).containsExactly("tech");
+        assertThat(dto.globalTechnicalFilters()).containsExactly("global");
+        assertThat(dto.matchingCategories()).containsKey("all");
+        assertThat(dto.excludingTokensFromCategoriesMatching()).contains("accessoire");
+        assertThat(dto.generationExcludedFromCategoriesMatching()).contains("fnac");
+        assertThat(dto.generationExcludedFromAttributesMatching()).contains("PRICE");
+        assertThat(dto.requiredAttributes()).contains("ENERGY_CLASS");
+        assertThat(dto.forceNameGeneration()).isTrue();
+        assertThat(dto.brandsAlias()).containsEntry("LG ELECTRONICS", "LG");
+        assertThat(dto.brandsExclusion()).contains("UNKNOWN");
+        assertThat(dto.namings()).isNotNull();
+        assertThat(dto.resourcesConfig()).isNotNull();
+        assertThat(dto.availableImpactScoreCriterias()).containsKey("score");
+        assertThat(dto.impactScoreConfig()).isSameAs(impactScoreConfig);
+        assertThat(dto.subsets()).containsExactly(subset);
+        assertThat(dto.featureGroups()).containsExactly(featureGroup);
+        assertThat(dto.imageThumbnail()).isNull();
+        assertThat(dto.singularName()).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add the commons module to the front-api dependencies and register a VerticalsConfigService bean
- expose category summary and detail DTOs with a dedicated mapping service
- provide CategoriesController endpoints with accompanying unit tests for mappings and HTTP contract

## Testing
- mvn -pl front-api -am test *(fails: Network is unreachable when resolving org.springframework.boot:spring-boot-dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d261136804833397cd2062f6a2fa8c