### PR TITLE
feat: align domain language resolution across layers

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -461,10 +461,13 @@ docs: update README with new install steps
 
 ## Frontend internationalisation
 
-The Nuxt 3 frontend picks the visitor's language from the request hostname instead of URL prefixes or browser detection. 
-Production domains map to English (`nudger.com`) and French (`nudger.fr`), while local development can toggle between French (`localhost`) and English (`127.0.0.1`). 
-Unknown domains fall back to English but emit a warning during SSR so misconfigurations can be spotted quickly. 
-Refer to [`/frontend/docs/internationalisation.md`](/frontend/docs/internationalisation.md) for the full workflow and update procedure.
+Hostname-driven language resolution is centralised in [`shared/utils/domain-language.ts`](./shared/utils/domain-language.ts). The helper normalises the incoming host, maps it to a domain language (`'en' | 'fr'`), and exposes the matching Nuxt locale (`'en-US' | 'fr-FR'`).
+
+- The i18n hostname plugin imports the helper so both SSR and CSR pick the same locale for a given domain.
+- Server API routes reuse the helper to read the `x-forwarded-host`/`host` headers and forward the resolved `domainLanguage` to downstream services (e.g. blog and CMS clients).
+- Unknown domains fall back to English and emit a warning on the server so misconfigurations surface in logs without breaking the response.
+
+Refer to [`/frontend/docs/internationalisation.md`](/frontend/docs/internationalisation.md) for the full workflow, current mappings, and update procedure.
 
 ---
 

--- a/frontend/app/plugins/i18n-hostname.ts
+++ b/frontend/app/plugins/i18n-hostname.ts
@@ -1,49 +1,5 @@
 import type { Ref } from 'vue'
-
-const DEFAULT_LOCALE = 'en-US' as const
-const HOST_LOCALE_MAP: Record<string, typeof DEFAULT_LOCALE | 'fr-FR'> = {
-  'nudger.com': DEFAULT_LOCALE,
-  'nudger.fr': 'fr-FR',
-  localhost: 'fr-FR',
-  '127.0.0.1': DEFAULT_LOCALE,
-}
-
-const _normalizeHostname = (rawHost: string | undefined | null): string | null => {
-  if (!rawHost) {
-    return null
-  }
-
-  const hostValue = rawHost.split(',')[0]?.trim()
-  if (!hostValue) {
-    return null
-  }
-
-  const hostname = hostValue.split(':')[0]?.toLowerCase()
-  return hostname || null
-}
-
-const _resolveLocale = (hostname: string | null) => {
-  if (!hostname) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  const locale = HOST_LOCALE_MAP[hostname]
-
-  if (!locale) {
-    return {
-      locale: DEFAULT_LOCALE,
-      matched: false,
-    }
-  }
-
-  return {
-    locale,
-    matched: true,
-  }
-}
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 type NuxtI18nInstance = {
   locale: Ref<string>
@@ -58,14 +14,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
   const rawHost = import.meta.server ? rawServerHost : rawClientHost
 
-  const hostname = _normalizeHostname(Array.isArray(rawHost) ? rawHost[0] : rawHost)
-  const { locale: targetLocale, matched } = _resolveLocale(hostname)
-
-  if (import.meta.server && !matched) {
-    console.warn(
-      `[i18n] Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_LOCALE}.`
-    )
-  }
+  const { locale: targetLocale } = resolveDomainLanguage(rawHost, {
+    logUnknownHost: import.meta.server,
+    logPrefix: '[i18n]',
+  })
 
   const i18n = nuxtApp.$i18n as NuxtI18nInstance | undefined
 

--- a/frontend/docs/internationalisation.md
+++ b/frontend/docs/internationalisation.md
@@ -1,38 +1,44 @@
 # Frontend internationalisation
 
 ## Overview
-The Nuxt 3 frontend determines the active locale on every request by inspecting the incoming hostname. The logic lives in [`app/plugins/i18n-hostname.ts`](../app/plugins/i18n-hostname.ts) and runs during both server-side rendering and client-side navigation, guaranteeing that the page is rendered in the correct language even on the first SSR pass.
+The Nuxt 3 frontend determines the active language on every request by inspecting the incoming hostname. This logic is centralised in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) so that both client and server share the same mapping between hostnames, domain language codes (`'en' | 'fr'`), and Nuxt locales (`'en-US' | 'fr-FR'`).
 
-The i18n module is configured with the `no_prefix` routing strategy. As a consequence, the hostname is the single source of truth: users always see unprefixed paths (for example `/produits`) and the plugin ensures that the locale matches the expected language for the current domain.
+The helper is consumed by:
 
-## Current hostname-to-locale mapping
-| Hostname        | Locale | Notes                                     |
-|-----------------|--------|-------------------------------------------|
-| `nudger.com`    | `en-US`| Default English site.                     |
-| `nudger.fr`     | `fr-FR`| French production domain.                 |
-| `localhost`     | `fr-FR`| Development override for local browsers.  |
-| `127.0.0.1`     | `en-US`| Development override for English testing. |
+- [`app/plugins/i18n-hostname.ts`](../app/plugins/i18n-hostname.ts) to keep SSR and CSR aligned when switching locales.
+- Server API handlers (e.g. [`server/api/blog/articles.ts`](../server/api/blog/articles.ts)) to forward the resolved `domainLanguage` to backend services such as `BlogApi` and `ContentApi`.
+
+The i18n module keeps the `no_prefix` routing strategy. Hostnames remain the single source of truth: users navigate unprefixed paths (for example `/produits`) and the helper ensures that the locale matches the expected language for the current domain on every request.
+
+## Current hostname mapping
+| Hostname        | Domain language | Nuxt locale | Notes                                     |
+|-----------------|-----------------|-------------|-------------------------------------------|
+| `nudger.com`    | `en`            | `en-US`     | Default English site.                     |
+| `nudger.fr`     | `fr`            | `fr-FR`     | French production domain.                 |
+| `localhost`     | `fr`            | `fr-FR`     | Development override for local browsers.  |
+| `127.0.0.1`     | `en`            | `en-US`     | Development override for English testing. |
 
 *IPv6 loopback (`::1`) is intentionally ignored so that dual-stack machines fall back to the default English locale.*
 
-## How the plugin works
-1. **Hostname normalisation** – the plugin extracts the first value from the `x-forwarded-host` header (or `host` as a fallback) on the server, and uses `window.location.host` in the browser. Ports are stripped so that `localhost:3000` still resolves to `localhost`.
-2. **Locale resolution** – the hostname is matched against the static map shown above. When no match is found, the locale falls back to `en-US`.
-3. **SSR observability** – on the server, unmatched hostnames trigger a warning log entry (`console.warn`) before applying the fallback. This makes misconfigurations visible in hosting logs without interrupting the response.
-4. **Locale application** – the plugin compares the resolved locale with the current one provided by `@nuxtjs/i18n` and calls `setLocale` only when a change is required.
+## How the helper works
+1. **Hostname normalisation** – `normalizeHost` extracts the first value from incoming headers (supporting comma-separated `x-forwarded-host` values), strips the port, and lowercases it so that `LOCALHOST:3000` resolves to `localhost`.
+2. **Domain language resolution** – the hostname is matched against `HOST_DOMAIN_LANGUAGE_MAP`. When no match is found the helper falls back to English (`domainLanguage: 'en'`, `locale: 'en-US'`).
+3. **Locale derivation** – `DOMAIN_LANGUAGE_TO_LOCALE_MAP` provides the Nuxt locale string associated with each domain language.
+4. **Observability** – server callers can enable logging (default behaviour) to warn about unknown hostnames. Client-side consumers typically disable it to avoid console noise.
+5. **Application** – the i18n plugin uses `setLocale` only when the resolved locale differs from the current one. Server routes pass the `domainLanguage` to service factories so outbound API calls carry the correct locale context.
 
 ## Updating or extending the mapping
-The mapping is defined in the `HOST_LOCALE_MAP` constant inside [`app/plugins/i18n-hostname.ts`](../app/plugins/i18n-hostname.ts). To add or change domains:
+The mapping lives in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) across two constants: `HOST_DOMAIN_LANGUAGE_MAP` and `DOMAIN_LANGUAGE_TO_LOCALE_MAP`. To add or change domains:
 
-1. Edit the object so that each hostname points to the desired locale code (e.g. `'shop.example.com': 'fr-FR'`).
-2. Keep hostnames lowercase and without protocol or trailing slash.
-3. For development overrides, add entries for raw hostnames only—ports are automatically removed.
+1. Update `HOST_DOMAIN_LANGUAGE_MAP` so that each hostname points to the appropriate domain language (`'en' | 'fr'`).
+2. When introducing a new language, also extend `DOMAIN_LANGUAGE_TO_LOCALE_MAP` with the Nuxt locale string.
+3. Keep hostnames lowercase and without protocol or trailing slash; ports are removed automatically during normalisation.
 4. Restart the Nuxt server if it is already running so the updated map is picked up.
 
 When introducing a new locale, also register it in `nuxt.config.ts` under the `i18n.locales` array so translations can load correctly.
 
 ## Behaviour on unknown domains
-If the application receives a hostname that is not present in `HOST_LOCALE_MAP`, the request falls back to English (`en-US`). During SSR a warning log is emitted describing the unknown hostname so operators can adjust the mapping. Client-side navigation continues without additional logging to avoid noise in the browser console.
+If the application receives a hostname that is not present in `HOST_DOMAIN_LANGUAGE_MAP`, the request falls back to English (`domainLanguage: 'en'`, `locale: 'en-US'`). Server-side callers log a warning describing the unknown hostname so operators can adjust the mapping. Client-side navigation continues without additional logging to avoid noise in the browser console.
 
 ## Relationship with content bundles
-Locale codes correspond to the translation bundles stored under `frontend/i18n/`. Each domain listed above automatically loads the matching bundle; there is no need for query parameters or path prefixes. Manual language switching widgets should respect the hostname contract—if a different behaviour is needed, adjust the plugin first so SSR and CSR remain aligned.
+Locale codes correspond to the translation bundles stored under `frontend/i18n/`. Each domain listed above automatically loads the matching bundle; there is no need for query parameters or path prefixes. Manual language switching widgets should respect the hostname contract—if a different behaviour is needed, adjust the shared helper first so SSR, CSR, and server-to-server calls remain aligned.

--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,5 +1,6 @@
 import { useContentService } from '~~/shared/api-client/services/content.services'
 import type { XwikiContentBlocDto } from '~~/shared/api-client'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 
@@ -11,7 +12,11 @@ export default defineEventHandler(async (event): Promise<XwikiContentBlocDto> =>
 
   // Cache content for 1 hour
   setResponseHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=3600')
-  const contentService = useContentService()
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const contentService = useContentService(domainLanguage)
   try {
     return await contentService.getBloc(blocId)
   } catch (error) {

--- a/frontend/server/api/blog/articles.ts
+++ b/frontend/server/api/blog/articles.ts
@@ -1,5 +1,6 @@
 import { useBlogService } from '~~/shared/api-client/services/blog.services'
 import type { PageDto } from '~~/shared/api-client'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 
@@ -15,7 +16,11 @@ export default defineEventHandler(async (event): Promise<PageDto> => {
     'public, max-age=3600, s-maxage=3600'
   )
 
-  const blogService = useBlogService()
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const blogService = useBlogService(domainLanguage)
 
   try {
     // Use the service to fetch articles

--- a/frontend/server/api/blog/articles/[slug].ts
+++ b/frontend/server/api/blog/articles/[slug].ts
@@ -1,5 +1,6 @@
 import { useBlogService } from '~~/shared/api-client/services/blog.services'
 import type { BlogPostDto } from '~~/shared/api-client'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../../utils/log-backend-error'
 
@@ -24,7 +25,11 @@ export default defineEventHandler(async (event): Promise<BlogPostDto> => {
     })
   }
 
-  const blogService = useBlogService()
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const blogService = useBlogService(domainLanguage)
 
   try {
     // Use the service to fetch the article

--- a/frontend/server/api/blog/test.ts
+++ b/frontend/server/api/blog/test.ts
@@ -1,12 +1,16 @@
 import { useBlogService } from '~~/shared/api-client/services/blog.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 
 /**
  * Test endpoint to debug blog data
  */
-export default defineEventHandler(async _event => {
-  const blogService = useBlogService()
+export default defineEventHandler(async event => {
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+  const blogService = useBlogService(domainLanguage)
 
   try {
     // Get raw data from the external API

--- a/frontend/shared/api-client/services/blog.services.ts
+++ b/frontend/shared/api-client/services/blog.services.ts
@@ -1,10 +1,11 @@
 import { BlogApi, Configuration } from '..'
 import type { BlogPostDto, PageDto } from '..'
+import type { DomainLanguage } from '../../utils/domain-language'
 
 /**
  * Blog service for handling blog-related API calls
  */
-export const useBlogService = () => {
+export const useBlogService = (domainLanguage: DomainLanguage) => {
   const config = useRuntimeConfig()
   const apiConfig = new Configuration({ basePath: config.apiUrl })
   console.log('[ContentService] baseUrl =', config.apiUrl)
@@ -23,7 +24,7 @@ export const useBlogService = () => {
     } = {}
   ): Promise<PageDto> => {
     try {
-      return await api.posts(params)
+      return await api.posts({ ...params, domainLanguage })
     } catch (error) {
       console.error('Error fetching blog articles:', error)
       // Rethrow original error so callers can access status and message
@@ -38,7 +39,7 @@ export const useBlogService = () => {
    */
   const getArticleBySlug = async (slug: string): Promise<BlogPostDto> => {
     try {
-      return await api.post({ slug })
+      return await api.post({ slug, domainLanguage })
     } catch (error) {
       console.error(`Error fetching blog article ${slug}:`, error)
       // Preserve original error details for upstream handlers

--- a/frontend/shared/api-client/services/content.services.ts
+++ b/frontend/shared/api-client/services/content.services.ts
@@ -1,10 +1,11 @@
 import { ContentApi, Configuration } from '..'
 import type { XwikiContentBlocDto } from '..'
+import type { DomainLanguage } from '../../utils/domain-language'
 
 /**
  * Content service for fetching HTML blocs from the backend
  */
-export const useContentService = () => {
+export const useContentService = (domainLanguage: DomainLanguage) => {
   const config = useRuntimeConfig()
   const apiConfig = new Configuration({ basePath: config.apiUrl })
   const api = new ContentApi(apiConfig)
@@ -14,7 +15,7 @@ export const useContentService = () => {
    * @param blocId - XWiki bloc identifier
    */
   const getBloc = async (blocId: string): Promise<XwikiContentBlocDto> => {
-    return await api.contentBloc({ blocId })
+    return await api.contentBloc({ blocId, domainLanguage })
   }
 
   return { getBloc }

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -1,0 +1,117 @@
+export type DomainLanguage = 'en' | 'fr'
+export type NuxtLocale = 'en-US' | 'fr-FR'
+
+const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'en'
+const DEFAULT_NUXT_LOCALE: NuxtLocale = 'en-US'
+
+const HOST_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
+  'nudger.com': 'en',
+  'nudger.fr': 'fr',
+  localhost: 'fr',
+  '127.0.0.1': 'en',
+}
+
+const DOMAIN_LANGUAGE_TO_LOCALE_MAP: Record<DomainLanguage, NuxtLocale> = {
+  en: 'en-US',
+  fr: 'fr-FR',
+}
+
+export interface ResolveDomainLanguageOptions {
+  /**
+   * Whether the helper should log when the incoming host cannot be matched.
+   * Defaults to `true` to surface misconfigurations.
+   */
+  logUnknownHost?: boolean
+  /**
+   * Optional logger implementation. When omitted, the global console is used.
+   */
+  logger?: Pick<Console, 'warn'>
+  /**
+   * Optional prefix injected at the beginning of the warning message.
+   */
+  logPrefix?: string
+}
+
+export interface DomainLanguageResolution {
+  domainLanguage: DomainLanguage
+  locale: NuxtLocale
+  hostname: string | null
+  matched: boolean
+}
+
+export const normalizeHost = (
+  rawHost: string | string[] | undefined | null
+): string | null => {
+  if (!rawHost) {
+    return null
+  }
+
+  const hostValue = Array.isArray(rawHost) ? rawHost[0] : rawHost
+
+  if (!hostValue) {
+    return null
+  }
+
+  const firstHost = hostValue.split(',')[0]?.trim()
+
+  if (!firstHost) {
+    return null
+  }
+
+  const hostname = firstHost.split(':')[0]?.toLowerCase()
+
+  return hostname || null
+}
+
+export const resolveDomainLanguage = (
+  rawHost: string | string[] | undefined | null,
+  options: ResolveDomainLanguageOptions = {}
+): DomainLanguageResolution => {
+  const hostname = normalizeHost(rawHost)
+  const matchedDomainLanguage = hostname
+    ? HOST_DOMAIN_LANGUAGE_MAP[hostname]
+    : undefined
+
+  if (!matchedDomainLanguage) {
+    if (options.logUnknownHost ?? true) {
+      const logger = options.logger ?? console
+      const prefix = options.logPrefix ? `${options.logPrefix} ` : ''
+
+      logger?.warn?.(
+        `${prefix}Unknown hostname "${hostname ?? 'unknown'}" received. Falling back to ${DEFAULT_DOMAIN_LANGUAGE} / ${DEFAULT_NUXT_LOCALE}.`
+      )
+    }
+
+    return {
+      domainLanguage: DEFAULT_DOMAIN_LANGUAGE,
+      locale: DEFAULT_NUXT_LOCALE,
+      hostname,
+      matched: false,
+    }
+  }
+
+  const locale = DOMAIN_LANGUAGE_TO_LOCALE_MAP[matchedDomainLanguage]
+
+  return {
+    domainLanguage: matchedDomainLanguage,
+    locale,
+    hostname,
+    matched: true,
+  }
+}
+
+export const getNuxtLocaleForDomainLanguage = (
+  domainLanguage: DomainLanguage
+): NuxtLocale => DOMAIN_LANGUAGE_TO_LOCALE_MAP[domainLanguage]
+
+export const getDomainLanguageFromHostname = (
+  hostname: string | null
+): DomainLanguageResolution =>
+  resolveDomainLanguage(hostname, { logUnknownHost: false })
+
+export const DEFAULT_DOMAIN_LANGUAGE_RESOLUTION: DomainLanguageResolution = {
+  domainLanguage: DEFAULT_DOMAIN_LANGUAGE,
+  locale: DEFAULT_NUXT_LOCALE,
+  hostname: null,
+  matched: false,
+}


### PR DESCRIPTION
## Summary
- add a shared helper that normalises hosts into domain language and locale pairs with safe logging fallback
- update the i18n hostname plugin and server API routes to reuse the shared resolver
- thread the domain language through blog and content services so downstream API calls receive the correct value
- document the shared hostname-based language resolution in the README and internationalisation guide

## Testing
- pnpm --offline lint *(fails: missing `@nuxt/eslint-config` because dependencies cannot be installed in offline mode)*
- pnpm --offline test *(fails: `vitest` binary unavailable until dependencies can be installed)*
- pnpm --offline generate *(fails: `nuxt` CLI unavailable until dependencies can be installed)*
- pnpm --offline build *(fails: CSS preprocessing step cannot import `postcss` without installed dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68d2670b54088333ac6990341e36aae6