### PR TITLE
feat: allow overriding lorem ipsum length

### DIFF
--- a/frontend/app/components/domains/content/TextContent.spec.ts
+++ b/frontend/app/components/domains/content/TextContent.spec.ts
@@ -117,4 +117,15 @@ describe('TextContent', () => {
     const plainTextLength = sandbox.textContent?.trim().length ?? 0
     expect(plainTextLength).toBeGreaterThanOrEqual(customLength)
   })
+
+  test('prefers ipsumLength over defaultLength for lorem ipsum fallback', async () => {
+    htmlContent.value = ''
+    const ipsumLength = 650
+    const wrapper = await mountSuspended(TextContent, {
+      props: { blocId: 'Main.WebHome', defaultLength: 120, ipsumLength },
+    })
+    const sandbox = wrapper.find('.xwiki-sandbox').element
+    const plainTextLength = sandbox.textContent?.trim().length ?? 0
+    expect(plainTextLength).toBeGreaterThanOrEqual(ipsumLength)
+  })
 })

--- a/frontend/app/components/domains/content/TextContent.vue
+++ b/frontend/app/components/domains/content/TextContent.vue
@@ -8,9 +8,13 @@ import '~/assets/css/text-content.css'
 
 // Props
 
-const props = withDefaults(defineProps<{ blocId: string; defaultLength?: number }>(), {
-  defaultLength: DEFAULT_LOREM_LENGTH,
-})
+const props = withDefaults(
+  defineProps<{ blocId: string; defaultLength?: number; ipsumLength?: number }>(),
+  {
+    defaultLength: DEFAULT_LOREM_LENGTH,
+    ipsumLength: undefined,
+  }
+)
 
 // Composables
 const { htmlContent, editLink, loading, error, fetchBloc } = useContentBloc()
@@ -24,13 +28,15 @@ const canEdit = computed(() => {
   return isLoggedIn.value && !!link && roles.some(role => hasRole(role))
 })
 
+const fallbackLoremLength = computed(() => props.ipsumLength ?? props.defaultLength ?? DEFAULT_LOREM_LENGTH)
+
 const displayHtml = computed(() => {
   const rawContent = (unref(htmlContent) ?? '').trim()
   if (rawContent) {
     return rawContent
   }
 
-  return _generateLoremIpsum(props.defaultLength)
+  return _generateLoremIpsum(fallbackLoremLength.value)
 })
 
 // Watcher / mount


### PR DESCRIPTION
## Summary
- add support for an optional `ipsumLength` prop on `TextContent` while keeping the default lorem length
- prioritize the new prop when generating fallback lorem ipsum content
- add a unit test to ensure the fallback respects the requested `ipsumLength`

## Testing
- pnpm --offline lint
- pnpm --offline test -- --run *(fails: existing Vuetify unit tests require defaults instance)*
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d2871650208333bc872b0b6515569f