### PR TITLE
feat: redesign main footer with legacy content

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooter.vue
+++ b/frontend/app/components/shared/footers/TheMainFooter.vue
@@ -1,9 +1,17 @@
 <script lang="ts" setup></script>
 
 <template>
-  <v-row fluid class="">
-    <v-footer app>
-      <slot name="footer" />
-    </v-footer>
-  </v-row>
+  <v-footer app height="auto" color="secondary" class="main-footer text-white pa-0">
+    <slot name="footer" />
+  </v-footer>
 </template>
+
+<style scoped>
+.main-footer :deep(a) {
+  color: inherit;
+}
+
+.main-footer :deep(a:hover) {
+  text-decoration: underline;
+}
+</style>

--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -1,15 +1,239 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 
+type FooterLink = {
+  label: string
+  href: string
+  target?: string
+  rel?: string
+}
+
 const { t } = useI18n()
+
+const currentYear = computed(() => new Date().getFullYear())
+
+const highlightLinks = computed<FooterLink[]>(() => [
+  {
+    label: t('siteIdentity.footer.highlightLinks.ecoscore'),
+    href: '/ecoscore',
+  },
+  {
+    label: t('siteIdentity.footer.highlightLinks.compensation'),
+    href: '/compensation-ecologique',
+  },
+])
+
+const comparatorLinks = computed<FooterLink[]>(() => [
+  {
+    label: t('siteIdentity.footer.comparator.links.openData'),
+    href: '/opendata',
+  },
+  {
+    label: t('siteIdentity.footer.comparator.links.openSource'),
+    href: '/opensource',
+  },
+  {
+    label: t('siteIdentity.footer.comparator.links.privacy'),
+    href: '/politique-confidentialite',
+  },
+  {
+    label: t('siteIdentity.footer.comparator.links.legal'),
+    href: '/mentions-legales',
+  },
+])
+
+const communityLinks = computed<FooterLink[]>(() => [
+  {
+    label: t('siteIdentity.footer.community.links.team'),
+    href: '/equipe',
+  },
+  {
+    label: t('siteIdentity.footer.community.links.partners'),
+    href: '/partenaires',
+  },
+])
+
+const feedbackLinks = computed<FooterLink[]>(() => [
+  {
+    label: t('siteIdentity.footer.feedback.links.idea'),
+    href: '/feedback/idea',
+  },
+  {
+    label: t('siteIdentity.footer.feedback.links.issue'),
+    href: '/feedback/issue',
+  },
+  {
+    label: t('siteIdentity.footer.feedback.links.contact'),
+    href: '/contact',
+  },
+  {
+    label: t('siteIdentity.footer.feedback.links.linkedin'),
+    href: 'https://www.linkedin.com/company/comparateur-nudger/',
+    target: '_blank',
+    rel: 'nofollow noopener',
+  },
+])
+
+const logoSrc = '/images/nudger-logo-orange.svg'
 </script>
 
 <template>
-  <div class="text-center pa-4">
-    &copy; {{ new Date().getFullYear() }}
-    <a href="https://open4goods.org" target="_blank" rel="noopener">Open4Goods</a>.
-    {{ t('siteIdentity.footer.rightsReserved') }}
-  </div>
+  <v-container class="footer-container py-10" fluid>
+    <h2 id="footer-heading" class="sr-only">
+      {{ t('siteIdentity.footer.accessibleTitle') }}
+    </h2>
+
+    <v-row class="g-8">
+      <v-col cols="12" md="4" class="d-flex flex-column ga-4">
+        <p class="footer-mission text-body-1 mb-0">
+          {{ t('siteIdentity.footer.mission') }}
+        </p>
+
+        <v-btn
+          :href="'/blog'"
+          variant="text"
+          append-icon="mdi-arrow-right"
+          class="footer-link-btn text-white px-0"
+        >
+          {{ t('siteIdentity.footer.blogLink') }}
+        </v-btn>
+      </v-col>
+
+      <v-col cols="12" md="4">
+        <div class="d-flex flex-column ga-2">
+          <v-btn
+            v-for="link in highlightLinks"
+            :key="link.href"
+            :href="link.href"
+            variant="text"
+            append-icon="mdi-arrow-right"
+            class="footer-link-btn text-white px-0"
+          >
+            {{ link.label }}
+          </v-btn>
+        </div>
+
+        <div class="text-subtitle-1 font-weight-medium mt-6">
+          {{ t('siteIdentity.footer.comparator.title') }}
+        </div>
+        <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
+          <v-list-item
+            v-for="link in comparatorLinks"
+            :key="link.href"
+            :href="link.href"
+            class="footer-list-item px-0"
+          >
+            <template #title>
+              <span class="text-body-2">{{ link.label }}</span>
+            </template>
+          </v-list-item>
+        </v-list>
+      </v-col>
+
+      <v-col cols="12" md="4">
+        <div>
+          <div class="text-subtitle-1 font-weight-medium">
+            {{ t('siteIdentity.footer.community.title') }}
+          </div>
+          <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
+            <v-list-item
+              v-for="link in communityLinks"
+              :key="link.href"
+              :href="link.href"
+              class="footer-list-item px-0"
+            >
+              <template #title>
+                <span class="text-body-2">{{ link.label }}</span>
+              </template>
+            </v-list-item>
+          </v-list>
+        </div>
+
+        <div class="text-subtitle-1 font-weight-medium mt-6">
+          {{ t('siteIdentity.footer.feedback.title') }}
+        </div>
+        <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
+          <v-list-item
+            v-for="link in feedbackLinks"
+            :key="link.href"
+            :href="link.href"
+            class="footer-list-item px-0"
+            :target="link.target"
+            :rel="link.rel"
+          >
+            <template #title>
+              <span class="text-body-2">{{ link.label }}</span>
+            </template>
+          </v-list-item>
+        </v-list>
+      </v-col>
+    </v-row>
+
+    <v-divider class="my-8" opacity="0.2" color="white" />
+
+    <v-row class="justify-center text-center">
+      <v-col cols="12" class="d-flex flex-column align-center ga-4">
+        <NuxtLink to="/" class="footer-logo-link d-inline-flex">
+          <v-img
+            :src="logoSrc"
+            :alt="t('siteIdentity.footer.logoAlt')"
+            height="40"
+            class="footer-logo"
+            cover
+          />
+        </NuxtLink>
+        <p class="mb-0 text-body-2">
+          {{ t('siteIdentity.footer.copyright', { year: currentYear }) }}
+        </p>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
-<style lang="postcss" scoped></style>
+<style lang="postcss" scoped>
+.footer-container {
+  max-width: 1200px;
+}
+
+.footer-mission {
+  line-height: 1.6;
+}
+
+.footer-link-btn {
+  justify-content: flex-start;
+  text-transform: none;
+  font-weight: 600;
+}
+
+.footer-list :deep(.v-list-item-title) {
+  color: inherit;
+}
+
+.footer-list-item {
+  min-height: 32px;
+}
+
+.footer-logo {
+  max-width: 160px;
+}
+
+.footer-logo-link {
+  transition: opacity 0.2s ease;
+}
+
+.footer-logo-link:hover {
+  opacity: 0.85;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -16,7 +16,41 @@
       }
     },
     "footer": {
-      "rightsReserved": "All Rights Reserved"
+      "rightsReserved": "All Rights Reserved",
+      "accessibleTitle": "Footer information",
+      "mission": "nudger.fr is an open approach to assess the environmental impact of consumer goods and partially offset the impact of your online purchases.",
+      "blogLink": "Our blog",
+      "highlightLinks": {
+        "ecoscore": "Environmental assessment",
+        "compensation": "Ecological contribution"
+      },
+      "comparator": {
+        "title": "Common good comparator",
+        "links": {
+          "openData": "Open data",
+          "openSource": "Open source",
+          "privacy": "Privacy policy",
+          "legal": "Legal notice"
+        }
+      },
+      "community": {
+        "title": "You are not alone",
+        "links": {
+          "team": "Our team",
+          "partners": "Our partners"
+        }
+      },
+      "feedback": {
+        "title": "Feedback",
+        "links": {
+          "idea": "Have an idea?",
+          "issue": "Found a bug?",
+          "contact": "Contact us",
+          "linkedin": "Follow us"
+        }
+      },
+      "logoAlt": "Nudger orange logo icon",
+      "copyright": "Copyright ©{year} open4goods. Common good product."
     },
     "hero": {
       "mainTitle": "The Comparator That Thinks About Tomorrow",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -16,7 +16,41 @@
       }
     },
     "footer": {
-      "rightsReserved": "Tous droits réservés"
+      "rightsReserved": "Tous droits réservés",
+      "accessibleTitle": "Informations du pied de page",
+      "mission": "nudger.fr est une approche ouverte pour évaluer écologiquement les biens de consommation et compenser partiellement l'impact de vos achats en ligne.",
+      "blogLink": "Notre blog",
+      "highlightLinks": {
+        "ecoscore": "Évaluation environnementale",
+        "compensation": "Contribution écologique"
+      },
+      "comparator": {
+        "title": "Comparateur de bien commun",
+        "links": {
+          "openData": "Open data",
+          "openSource": "Open source",
+          "privacy": "Politique de confidentialité",
+          "legal": "Mentions légales"
+        }
+      },
+      "community": {
+        "title": "Vous n'êtes pas seuls",
+        "links": {
+          "team": "Notre équipe",
+          "partners": "Nos partenaires"
+        }
+      },
+      "feedback": {
+        "title": "Feedback",
+        "links": {
+          "idea": "Une idée ?",
+          "issue": "Un bug ?",
+          "contact": "Nous contacter",
+          "linkedin": "Nous suivre"
+        }
+      },
+      "logoAlt": "Icône Nudger orange",
+      "copyright": "Copyright ©{year} open4goods. Produit de bien commun."
     },
     "hero": {
       "mainTitle": "Le comparateur qui pense à demain",


### PR DESCRIPTION
## Summary
- rebuild TheMainFooter wrapper with a secondary Vuetify footer shell so the slot inherits theme colors
- port the legacy footer layout into TheMainFooterContent using Vuetify rows, columns, lists and buttons
- migrate all footer copy into the i18n dictionaries for both English and French locales

## Testing
- pnpm --offline lint
- pnpm --offline test
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d2e00fa39c8333b34939b40f37c76e