### PR TITLE
fix: hide auth controls when logged out

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -14,13 +14,15 @@
         </v-list-item>
       </v-list>
       <v-btn
+        v-if="isLoggedIn"
         color="secondary"
         rounded="pill"
         class="font-weight-bold"
-        @click="handleAuthAction"
+        data-testid="hero-logout"
+        @click="handleLogout"
       >
-        <v-icon start :icon="authIcon" />
-        {{ authLabel }}
+        <v-icon start icon="mdi-logout" />
+        Logout
       </v-btn>
     </div>
   </menu>
@@ -38,20 +40,17 @@ const route = useRoute();
 const router = useRouter();
 const { isLoggedIn, logout } = useAuth();
 
-const authLabel = computed(() => (isLoggedIn.value ? 'Logout' : 'Login'));
-const authIcon = computed(() => (isLoggedIn.value ? 'mdi-logout' : 'mdi-login'));
-
-const handleAuthAction = async () => {
-  if (isLoggedIn.value) {
-    try {
-      await logout();
-      await router.push('/');
-    } catch (error) {
-      console.error('Logout failed', error);
-    }
+const handleLogout = async () => {
+  if (!isLoggedIn.value) {
     return;
   }
-  router.push('/auth/login');
+
+  try {
+    await logout();
+    await router.push('/');
+  } catch (error) {
+    console.error('Logout failed', error);
+  }
 };
 
 defineEmits<{

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -35,12 +35,17 @@
         </v-list-item-title>
       </v-list-item>
 
-      <v-list-item class="px-6 py-4" @click="handleAuthAction">
+      <v-list-item
+        v-if="isLoggedIn"
+        class="px-6 py-4"
+        data-testid="mobile-logout"
+        @click="handleLogout"
+      >
         <template #prepend>
-          <v-icon :icon="authIcon" class="me-4" />
+          <v-icon icon="mdi-logout" class="me-4" />
         </template>
         <v-list-item-title class="text-body-1">
-          {{ authLabel }}
+          Logout
         </v-list-item-title>
       </v-list-item>
     </v-list>
@@ -65,21 +70,16 @@ const emit = defineEmits<{
 const { isLoggedIn, logout } = useAuth()
 const router = useRouter()
 
-const authLabel = computed(() => (isLoggedIn.value ? 'Logout' : 'Login'))
-const authIcon = computed(() => (isLoggedIn.value ? 'mdi-logout' : 'mdi-login'))
+const handleLogout = async () => {
+  if (!isLoggedIn.value) {
+    return
+  }
 
-const handleAuthAction = async () => {
   try {
-    if (isLoggedIn.value) {
-      await logout()
-      await router.push('/')
-    } else {
-      await router.push('/auth/login')
-    }
+    await logout()
+    await router.push('/')
   } catch (error) {
-    if (isLoggedIn.value) {
-      console.error('Logout failed', error)
-    }
+    console.error('Logout failed', error)
   } finally {
     emit('close')
   }

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -1,0 +1,110 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { reactive, ref } from 'vue'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isLoggedIn = ref(false)
+const logoutMock = vi.fn()
+const routerPush = vi.fn()
+const routerInstance = {
+  push: routerPush,
+}
+const currentRoute = reactive({ path: '/' })
+
+function useRouteMock() {
+  return currentRoute
+}
+
+function useRouterMock() {
+  return routerInstance
+}
+
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({
+    isLoggedIn,
+    logout: logoutMock,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+type NuxtImports = typeof import('#imports')
+
+vi.mock('#imports', async () => {
+  const actual = await vi.importActual<NuxtImports>('#imports')
+
+  return {
+    ...actual,
+    useRoute: useRouteMock,
+    useRouter: useRouterMock,
+  }
+})
+
+vi.mock('#app', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}))
+
+vi.mock('nuxt/app', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}))
+
+let TheHeroMenu: typeof import('./The-hero-menu.vue')['default']
+let TheMobileMenu: typeof import('./The-mobile-menu.vue')['default']
+
+beforeAll(async () => {
+  TheHeroMenu = (await import('./The-hero-menu.vue')).default
+  TheMobileMenu = (await import('./The-mobile-menu.vue')).default
+})
+
+describe('Shared menu authentication controls', () => {
+  beforeEach(() => {
+    isLoggedIn.value = false
+    logoutMock.mockReset()
+    routerPush.mockReset()
+    logoutMock.mockResolvedValue(undefined)
+  })
+
+  it('does not render logout controls when logged out', async () => {
+    const heroWrapper = await mountSuspended(TheHeroMenu)
+    const mobileWrapper = await mountSuspended(TheMobileMenu)
+
+    expect(heroWrapper.find('[data-testid="hero-logout"]').exists()).toBe(false)
+    expect(mobileWrapper.find('[data-testid="mobile-logout"]').exists()).toBe(false)
+  })
+
+  it('logs out and redirects from the hero menu when clicked', async () => {
+    isLoggedIn.value = true
+
+    const wrapper = await mountSuspended(TheHeroMenu)
+    const button = wrapper.get('[data-testid="hero-logout"]')
+
+    await button.trigger('click')
+    await flushPromises()
+
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs out, redirects and closes the drawer from the mobile menu', async () => {
+    isLoggedIn.value = true
+
+    const wrapper = await mountSuspended(TheMobileMenu)
+    const logoutItem = wrapper.get('[data-testid="mobile-logout"]')
+
+    await logoutItem.trigger('click')
+    await flushPromises()
+
+    expect(logoutMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.emitted('close')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- display the hero menu authentication button only while logged in and have it just trigger logout plus a home redirect
- do the same for the mobile drawer menu list item so it only appears for authenticated users and closes after logging out
- add a component test that checks the controls stay hidden when logged out and still trigger logout and drawer closure when authenticated

## Testing
- pnpm --offline lint
- pnpm --offline test run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d2e1099ff483338037632574b73547