### PR TITLE
fix: handle logout without issuing network request

### DIFF
--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -1,6 +1,7 @@
 /**
  * Authentication service handling login and token refresh calls.
  */
+import { useCookie, useRuntimeConfig } from '#app'
 import { jwtDecode } from 'jwt-decode'
 import { useAuthStore } from '~/stores/useAuthStore'
 
@@ -77,11 +78,6 @@ export class AuthService {
   }
 
   async logout() {
-    await $fetch('/auth/logout', {
-      method: 'POST',
-      credentials: 'include',
-    })
-
     const authStore = useAuthStore()
     authStore.$reset()
 


### PR DESCRIPTION
## Summary
- remove the logout fetch call and reset the auth store and cookies locally
- explicitly import the Nuxt composables so the logout test can stub them
- update the logout unit test to assert the fetch call is skipped and cookies are cleared

## Testing
- pnpm --offline test

------
https://chatgpt.com/codex/tasks/task_e_68d2e10ebbd08333bf5aeeb69d9d498e