### PR TITLE
fix: render footer from default layout

### DIFF
--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -16,6 +16,12 @@
     <v-main>
       <slot />
     </v-main>
+
+    <TheMainFooter>
+      <template #footer>
+        <TheMainFooterContent />
+      </template>
+    </TheMainFooter>
   </v-app>
 </template>
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -14,11 +14,6 @@ const toggleDrawer = () => {
 
     <Bloc3Hz />
 
-    <TheMainFooter>
-      <template #footer>
-        <the-main-footer-content />
-      </template>
-    </TheMainFooter>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- render `TheMainFooter` from the default layout so Vuetify registers it as an SSR layout item
- remove the redundant footer usage from the home page to prevent duplicate rendering

## Testing
- pnpm --offline lint
- pnpm --offline test --run
- pnpm --offline generate
- pnpm --offline build

---
PR generated by AI agent. Estimated manual effort: 1.5h.

------
https://chatgpt.com/codex/tasks/task_e_68d2f0cbd4f0833383f31784230fd7d3