### PR TITLE
fix: keep main footer full width

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooter.vue
+++ b/frontend/app/components/shared/footers/TheMainFooter.vue
@@ -7,6 +7,12 @@
 </template>
 
 <style scoped>
+.main-footer {
+  width: 100%;
+  --v-layout-left: 0px;
+  --v-layout-right: 0px;
+}
+
 .main-footer :deep(a) {
   color: inherit;
 }


### PR DESCRIPTION
## Summary
- reset Vuetify layout offset CSS variables on the main footer so it renders full width immediately

## Testing
- pnpm --offline lint
- pnpm --offline test
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d2f75bc0508333963933665e46b95a