### PR TITLE
fix(frontend): avoid server build useCookie errors

### DIFF
--- a/frontend/app/plugins/auth-init.server.ts
+++ b/frontend/app/plugins/auth-init.server.ts
@@ -4,5 +4,8 @@ import { authService } from '~~/shared/api-client/services/auth.services'
  * Hydrates the authentication store on app startup using the token cookie.
  */
 export default defineNuxtPlugin(() => {
-  authService.syncAuthState()
+  const config = useRuntimeConfig()
+  const token = useCookie<string | null>(config.tokenCookieName)
+
+  authService.syncAuthState(token.value)
 })

--- a/frontend/app/stores/useAuthStore.spec.ts
+++ b/frontend/app/stores/useAuthStore.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 
 const logoutMock = vi.fn()
+const tokenCookie = { value: 'token' }
+const refreshCookie = { value: 'refresh' }
 
 vi.mock('~~/shared/api-client/services/auth.services', () => ({
   authService: {
@@ -9,13 +11,20 @@ vi.mock('~~/shared/api-client/services/auth.services', () => ({
   },
 }))
 
+vi.mock('~/utils/authCookies', () => ({
+  useAuthCookies: () => ({ tokenCookie, refreshCookie }),
+}))
+
 describe('useAuthStore', () => {
   beforeEach(() => {
+    vi.resetModules()
     setActivePinia(createPinia())
     logoutMock.mockReset()
+    tokenCookie.value = 'token'
+    refreshCookie.value = 'refresh'
   })
 
-  it('delegates logout handling to the auth service', async () => {
+  it('delegates logout handling to the auth service and clears cookies', async () => {
     logoutMock.mockResolvedValue(undefined)
     const { useAuthStore } = await import('./useAuthStore')
     const store = useAuthStore()
@@ -23,5 +32,7 @@ describe('useAuthStore', () => {
     await store.logout()
 
     expect(logoutMock).toHaveBeenCalledTimes(1)
+    expect(tokenCookie.value).toBeNull()
+    expect(refreshCookie.value).toBeNull()
   })
 })

--- a/frontend/app/stores/useAuthStore.ts
+++ b/frontend/app/stores/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { useAuthCookies } from '~/utils/authCookies'
 
 interface AuthState {
   roles: string[]
@@ -17,8 +18,11 @@ export const useAuthStore = defineStore('auth', {
   },
   actions: {
     async logout() {
+      const { tokenCookie, refreshCookie } = useAuthCookies()
       const { authService } = await import('~~/shared/api-client/services/auth.services')
       await authService.logout()
+      tokenCookie.value = null
+      refreshCookie.value = null
     },
   },
 })

--- a/frontend/app/utils/authCookies.ts
+++ b/frontend/app/utils/authCookies.ts
@@ -1,0 +1,7 @@
+export const useAuthCookies = () => {
+  const config = useRuntimeConfig()
+  const tokenCookie = useCookie<string | null>(config.tokenCookieName)
+  const refreshCookie = useCookie<string | null>(config.refreshCookieName)
+
+  return { tokenCookie, refreshCookie }
+}

--- a/frontend/shared/api-client/services/auth.services.spec.ts
+++ b/frontend/shared/api-client/services/auth.services.spec.ts
@@ -7,14 +7,18 @@ const runtimeConfig = {
   refreshCookieName: 'refresh_token',
 }
 
-const mockComposables = {
+vi.mock('#app', () => ({
   useRuntimeConfig: () => runtimeConfig,
   useCookie: () => ({ value: null }),
-}
-
-vi.mock('#app', () => mockComposables)
-vi.mock('#imports', () => mockComposables)
-vi.mock('nuxt/app', () => mockComposables)
+}))
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+  useCookie: () => ({ value: null }),
+}))
+vi.mock('nuxt/app', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+  useCookie: () => ({ value: null }),
+}))
 
 const fetchMock = vi.fn()
 vi.stubGlobal('$fetch', fetchMock)

--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -14,18 +14,16 @@ export class AuthService {
   /**
    * Hydrates the auth store from the access token cookie.
    */
-  syncAuthState() {
+  syncAuthState(tokenValue: string | null) {
     if (import.meta.client) {
       // The httpOnly cookie is not exposed to the browser, therefore we keep the state provided by SSR.
       return
     }
-    const config = useRuntimeConfig()
-    const token = useCookie<string | null>(config.tokenCookieName)
     const authStore = useAuthStore()
 
-    if (token.value) {
+    if (tokenValue) {
       try {
-        const decoded = jwtDecode<JwtPayload>(token.value)
+        const decoded = jwtDecode<JwtPayload>(tokenValue)
         authStore.$patch({
           roles: decoded.roles ?? [],
           isLoggedIn: true,
@@ -84,12 +82,6 @@ export class AuthService {
 
     const authStore = useAuthStore()
     authStore.$reset()
-
-    const config = useRuntimeConfig()
-    const tokenCookie = useCookie<string | null>(config.tokenCookieName)
-    const refreshCookie = useCookie<string | null>(config.refreshCookieName)
-    tokenCookie.value = null
-    refreshCookie.value = null
   }
 }
 


### PR DESCRIPTION
## Summary
- guard the authentication service from directly using Nuxt runtime composables so SSR builds do not crash
- hydrate the auth store by reading the token cookie in the server plugin and expose a helper to clear auth cookies on logout
- update associated unit tests and mocks to cover the new helper and injected dependencies

## Testing
- pnpm --offline lint
- pnpm --offline test run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d38f902b94833385009837804adcda