### PR TITLE
Ensure categories map exists before update

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/TaxonomyRealTimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/TaxonomyRealTimeAggregationService.java
@@ -39,11 +39,14 @@ public class TaxonomyRealTimeAggregationService extends AbstractAggregationServi
 
 		
 		String category = input.getCategory();
-		if (!StringUtils.isEmpty(category)) {
-			
-			// TODO : If return null
-			output.getCategoriesByDatasources().put(input.getDatasourceConfigName(), category);
-		}
+                if (!StringUtils.isEmpty(category)) {
+                        Map<String, String> categoriesByDatasources = output.getCategoriesByDatasources();
+                        if (categoriesByDatasources == null) {
+                                categoriesByDatasources = new HashMap<>();
+                                output.setCategoriesByDatasources(categoriesByDatasources);
+                        }
+                        categoriesByDatasources.put(input.getDatasourceConfigName(), category);
+                }
 		
 		onProduct(output, vConf);
 		


### PR DESCRIPTION
## Summary
- guard access to the categories-by-datasource map in `TaxonomyRealTimeAggregationService`
- create the map if it is absent before adding a new entry, removing the lingering TODO

## Testing
- mvn --offline -pl api -am test

------
https://chatgpt.com/codex/tasks/task_e_68d3d6ebe72883339cbd0d46545c0435