### PR TITLE
feat: add semantic header and footer structure

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,18 +1,27 @@
 <script lang="ts" setup>
+const emit = defineEmits<{
+  (event: 'toggle-drawer'): void
+}>()
 
 </script>
 
 <template>
-    <v-container fluid class="main-menu-container position-fixed">
-      <v-row>
-        <v-col cols="3">
-          <the-main-logo />
-        </v-col>
-        <v-col cols="9">
-          <the-hero-menu @toggle-drawer="$emit('toggle-drawer')" />
-        </v-col>
-      </v-row>
-    </v-container>
+    <v-sheet
+      tag="header"
+      elevation="0"
+      class="main-menu-container position-fixed"
+    >
+      <v-container fluid class="main-menu-content">
+        <v-row>
+          <v-col cols="3">
+            <the-main-logo />
+          </v-col>
+          <v-col cols="9">
+            <the-hero-menu @toggle-drawer="emit('toggle-drawer')" />
+          </v-col>
+        </v-row>
+      </v-container>
+    </v-sheet>
 </template>
 
 <style lang="sass" scoped>
@@ -20,5 +29,9 @@
   top: 0
   left: 0
   z-index: 100
+  width: 100%
   background-color: white
+
+.main-menu-content
+  max-width: 100%
 </style>

--- a/frontend/app/components/shared/footers/TheMainFooter.vue
+++ b/frontend/app/components/shared/footers/TheMainFooter.vue
@@ -1,7 +1,13 @@
 <script lang="ts" setup></script>
 
 <template>
-  <v-footer height="auto" color="secondary" class="main-footer text-white pa-0">
+  <v-footer
+    app
+    height="auto"
+    color="secondary"
+    class="main-footer text-white pa-0"
+    tag="footer"
+  >
     <slot name="footer" />
   </v-footer>
 </template>
@@ -9,6 +15,7 @@
 <style scoped>
 .main-footer {
   width: 100%;
+  display: block;
   --v-layout-left: 0px;
   --v-layout-right: 0px;
 }

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -13,7 +13,7 @@
       <the-mobile-menu @close="drawer = false" />
     </v-navigation-drawer>
 
-    <v-main>
+    <v-main tag="main">
       <slot />
     </v-main>
 


### PR DESCRIPTION
## Summary
- wrap the main menu in a Vuetify sheet rendered as a semantic header and declare its emitted event
- mark the primary content area as `<main>` to improve accessibility semantics
- update the footer component to render as `<footer>` while keeping layout intact

## Testing
- pnpm --offline lint
- pnpm --offline test
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d3db21ae2083339c5a5f79395e6481