### PR TITLE
fix: prevent header overlapping page content

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,9 +1,11 @@
 <script lang="ts" setup>
-
+defineEmits<{
+  'toggle-drawer': []
+}>()
 </script>
 
 <template>
-    <v-container fluid class="main-menu-container position-fixed">
+    <v-container fluid class="main-menu-container position-sticky">
       <v-row>
         <v-col cols="3">
           <the-main-logo />
@@ -18,7 +20,6 @@
 <style lang="sass" scoped>
 .main-menu-container
   top: 0
-  left: 0
   z-index: 100
   background-color: white
 </style>

--- a/frontend/app/pages/auth/login.vue
+++ b/frontend/app/pages/auth/login.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container style="max-width:400px" class="mt-10 py-10">
+  <v-container style="max-width:400px" >
     <v-form v-model="valid" @submit.prevent="onSubmit">
       <v-text-field
         v-model="username"


### PR DESCRIPTION
## Summary
- switch the home menu container to use sticky positioning so the layout reserves vertical space for it
- declare the toggle-drawer event that the menu container relays

## Testing
- pnpm --offline lint

------
https://chatgpt.com/codex/tasks/task_e_68d3da2c71588333baf4982b64a10729