### PR TITLE
feat: wrap main menu in header element

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -5,6 +5,7 @@ defineEmits<{
 </script>
 
 <template>
+  <header class="main-menu-header">
     <v-container fluid class="main-menu-container position-sticky">
       <v-row>
         <v-col cols="3">
@@ -15,9 +16,13 @@ defineEmits<{
         </v-col>
       </v-row>
     </v-container>
+  </header>
 </template>
 
 <style lang="sass" scoped>
+.main-menu-header
+  width: 100%
+
 .main-menu-container
   top: 0
   z-index: 100


### PR DESCRIPTION
## Summary
- wrap the main menu container with a semantic header tag to expose a <header> element in SSR
- keep existing layout logic intact by nesting the Vuetify container inside the new header wrapper
- add a simple style hook to ensure the header spans the full width

## Testing
- pnpm --offline lint
- pnpm --offline vitest run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d3f862f4d48333a6ad1d658204263b