### PR TITLE
feat: localize route slugs by domain

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
 import { useBlog } from '~/composables/blog/useBlog'
 const { articles, loading, error, fetchArticles } = useBlog()
 
@@ -9,6 +13,18 @@ const formatDate = (timestamp: number) => {
 
 // Debug mode - use environment variable or default to false
 const debugMode = ref(false)
+const { locale } = useI18n()
+const currentLocale = computed(() => normalizeLocale(locale.value))
+
+const navigateToArticle = (slug: string | null | undefined) => {
+  if (!slug) {
+    return
+  }
+
+  const path = resolveLocalizedRoutePath('blog-slug', currentLocale.value, { slug })
+
+  navigateTo(path)
+}
 
 // Fetch articles on component mount
 onMounted(() => {
@@ -115,7 +131,7 @@ onMounted(() => {
                 variant="outlined"
                 size="small"
                 color="primary"
-                @click="() => navigateTo(`/blog/${article.url}`)"
+                @click="() => navigateToArticle(article.url)"
               >
                 Lire plus
               </v-btn>

--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
 type FooterLink = {
   label: string
   href: string
@@ -8,14 +10,16 @@ type FooterLink = {
   rel?: string
 }
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const currentLocale = computed(() => normalizeLocale(locale.value))
+const blogPath = computed(() => resolveLocalizedRoutePath('blog', currentLocale.value))
 
 const currentYear = computed(() => new Date().getFullYear())
 
 const highlightLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.highlightLinks.ecoscore'),
-    href: '/ecoscore',
+    href: resolveLocalizedRoutePath('ecoscore', currentLocale.value),
   }
 ])
 
@@ -41,7 +45,7 @@ const comparatorLinks = computed<FooterLink[]>(() => [
 const communityLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.community.links.team'),
-    href: '/equipe',
+    href: resolveLocalizedRoutePath('team', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.community.links.partners'),
@@ -60,7 +64,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
   },
   {
     label: t('siteIdentity.footer.feedback.links.contact'),
-    href: '/contact',
+    href: resolveLocalizedRoutePath('contact', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.feedback.links.linkedin'),
@@ -85,7 +89,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         </p>
 
         <v-btn
-          :href="'/blog'"
+          :href="blogPath"
           variant="text"
           append-icon="mdi-arrow-right"
           class="footer-link-btn text-white px-0"

--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -36,49 +36,72 @@
 </template>
 
 <script setup lang="ts">
-const route = useRoute();
-const router = useRouter();
-const { isLoggedIn, logout } = useAuth();
+import { useI18n } from 'vue-i18n'
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+const route = useRoute()
+const router = useRouter()
+const { isLoggedIn, logout } = useAuth()
+const { t, locale } = useI18n()
+const currentLocale = computed(() => normalizeLocale(locale.value))
 
 const handleLogout = async () => {
   if (!isLoggedIn.value) {
-    return;
+    return
   }
 
   try {
-    await logout();
-    await router.push('/');
+    await logout()
+    await router.push('/')
   } catch (error) {
-    console.error('Logout failed', error);
+    console.error('Logout failed', error)
   }
-};
-
-defineEmits<{
-  "toggle-drawer": [];
-}>();
-
-interface MenuItem {
-  label: string;
-  path: string;
 }
 
-const menuItems: MenuItem[] = [
-  { label: 'Impact-score', path: '/impact-score' },
-  { label: 'Les produits', path: '/produits' },
-  { label: 'Blog', path: '/blog' },
-  { label: 'Contact', path: '/contact' }
-];
+defineEmits<{
+  'toggle-drawer': []
+}>()
+
+interface MenuItemDefinition {
+  labelKey: string
+  routeName: string
+}
+
+interface MenuItem extends MenuItemDefinition {
+  label: string
+  path: string
+}
+
+const baseMenuItems: MenuItemDefinition[] = [
+  { labelKey: 'siteIdentity.menu.items.impactScore', routeName: 'impact-score' },
+  { labelKey: 'siteIdentity.menu.items.products', routeName: 'produits' },
+  { labelKey: 'siteIdentity.menu.items.blog', routeName: 'blog' },
+  { labelKey: 'siteIdentity.menu.items.contact', routeName: 'contact' },
+]
+
+const menuItems = computed<MenuItem[]>(() =>
+  baseMenuItems.map((item) => ({
+    ...item,
+    label: t(item.labelKey),
+    path: resolveLocalizedRoutePath(item.routeName, currentLocale.value),
+  })),
+)
 
 const isActiveRoute = (path: string): boolean => {
-  if (path === '/') {
-    return route.path === '/';
+  if (!path) {
+    return false
   }
-  return route.path.startsWith(path);
-};
+
+  if (path === '/') {
+    return route.path === path
+  }
+
+  return route.path.startsWith(path)
+}
 
 const navigateToPage = (path: string): void => {
-  router.push(path);
-};
+  router.push(path)
+}
 </script>
 
 <style scoped lang="sass">

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -55,13 +55,10 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
-interface MenuItem {
-  title: string
-  to: string
-  icon: string
-}
+const { t, locale } = useI18n()
+const currentLocale = computed(() => normalizeLocale(locale.value))
 
 const emit = defineEmits<{
   close: []
@@ -69,6 +66,17 @@ const emit = defineEmits<{
 
 const { isLoggedIn, logout } = useAuth()
 const router = useRouter()
+
+interface MenuItemDefinition {
+  titleKey: string
+  routeName: string
+  icon: string
+}
+
+interface MenuItem extends MenuItemDefinition {
+  title: string
+  to: string
+}
 
 const handleLogout = async () => {
   if (!isLoggedIn.value) {
@@ -85,28 +93,36 @@ const handleLogout = async () => {
   }
 }
 
-const menuItems: MenuItem[] = [
+const baseMenuItems: MenuItemDefinition[] = [
   {
-    title: t('siteIdentity.menu.items.impactScore'),
-    to: '/impact-score',
-    icon: 'mdi-chart-line'
+    titleKey: 'siteIdentity.menu.items.impactScore',
+    routeName: 'impact-score',
+    icon: 'mdi-chart-line',
   },
   {
-    title: t('siteIdentity.menu.items.products'),
-    to: '/produits',
-    icon: 'mdi-package-variant'
+    titleKey: 'siteIdentity.menu.items.products',
+    routeName: 'produits',
+    icon: 'mdi-package-variant',
   },
   {
-    title: t('siteIdentity.menu.items.blog'),
-    to: '/blog',
-    icon: 'mdi-post'
+    titleKey: 'siteIdentity.menu.items.blog',
+    routeName: 'blog',
+    icon: 'mdi-post',
   },
   {
-    title: t('siteIdentity.menu.items.contact'),
-    to: '/contact',
-    icon: 'mdi-email'
-  }
+    titleKey: 'siteIdentity.menu.items.contact',
+    routeName: 'contact',
+    icon: 'mdi-email',
+  },
 ]
+
+const menuItems = computed<MenuItem[]>(() =>
+  baseMenuItems.map((item) => ({
+    ...item,
+    title: t(item.titleKey),
+    to: resolveLocalizedRoutePath(item.routeName, currentLocale.value),
+  })),
+)
 </script>
 
 <style scoped lang="sass">

--- a/frontend/app/pages/index-v1.vue
+++ b/frontend/app/pages/index-v1.vue
@@ -11,7 +11,7 @@
         Roles: {{ roles.join(', ') }}
       </p>
       <div class="d-flex ga-4">
-        <router-link to="/blog">
+        <router-link :to="blogPath">
           <v-btn color="primary" size="large" rounded="pill" class="elevation-2">
             <v-icon start icon="mdi-book-open" />
             Read our blog
@@ -96,8 +96,11 @@
 </template>
 
 <script setup lang="ts">
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
 const { hasRole, isLoggedIn, username, roles, logout } = useAuth()
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const blogPath = computed(() => resolveLocalizedRoutePath('blog', normalizeLocale(locale.value)))
 
 const router = useRouter()
 

--- a/frontend/docs/internationalisation.md
+++ b/frontend/docs/internationalisation.md
@@ -10,6 +10,16 @@ The helper is consumed by:
 
 The i18n module keeps the `no_prefix` routing strategy. Hostnames remain the single source of truth: users navigate unprefixed paths (for example `/produits`) and the helper ensures that the locale matches the expected language for the current domain on every request.
 
+## Localised route slugs
+
+Top-level routes now expose translated slugs per locale through [`shared/utils/localized-routes.ts`](../shared/utils/localized-routes.ts). The helper centralises the mapping between route names and locale-specific paths so that:
+
+- Navigation components (`The-hero-menu.vue`, `The-mobile-menu.vue`, etc.) can render the correct links for the active host.
+- Programmatic navigations (for instance, blog article cards) reuse the same mapping to avoid hard-coded `/blog/...` URLs.
+- `nuxt.config.ts` derives the `@nuxtjs/i18n` `pages` configuration from the shared table, ensuring that `/notre-blog` resolves to the blog index on the French hostname while `/our-blog` serves the English version.
+
+When adding a new page that requires translated slugs, declare its route name inside `LOCALIZED_ROUTE_PATHS` and rely on `resolveLocalizedRoutePath()` to compute URLs instead of concatenating strings.
+
 ## Current hostname mapping
 | Hostname        | Domain language | Nuxt locale | Notes                                     |
 |-----------------|-----------------|-------------|-------------------------------------------|

--- a/frontend/docs/internationalisation.md
+++ b/frontend/docs/internationalisation.md
@@ -1,7 +1,7 @@
 # Frontend internationalisation
 
 ## Overview
-The Nuxt 3 frontend determines the active language on every request by inspecting the incoming hostname. This logic is centralised in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) so that both client and server share the same mapping between hostnames, domain language codes (`'en' | 'fr'`), and Nuxt locales (`'en-US' | 'fr-FR'`).
+The Nuxt 3 frontend determines the active language on every request by inspecting the incoming hostname. This logic is centralised in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) so that both client and server share the same mapping between hostnames, domain language codes (`'en' | 'fr'`), and Nuxt locales (`'en-US' | 'fr-FR'`). The helper now also exposes `buildI18nLocaleDomains()`, allowing [`nuxt.config.ts`](../nuxt.config.ts) to hydrate each locale definition with its canonical domain plus any alternates (e.g. `localhost`) without duplicating configuration. With `differentDomains: true` enabled, the i18n module can reuse the same mapping for host-based locale detection while our plugin keeps SSR and CSR aligned.
 
 The helper is consumed by:
 
@@ -16,7 +16,7 @@ Top-level routes now expose translated slugs per locale through [`shared/utils/l
 
 - Navigation components (`The-hero-menu.vue`, `The-mobile-menu.vue`, etc.) can render the correct links for the active host.
 - Programmatic navigations (for instance, blog article cards) reuse the same mapping to avoid hard-coded `/blog/...` URLs.
-- `nuxt.config.ts` derives the `@nuxtjs/i18n` `pages` configuration from the shared table, ensuring that `/notre-blog` resolves to the blog index on the French hostname while `/our-blog` serves the English version.
+- `nuxt.config.ts` derives the `@nuxtjs/i18n` `pages` configuration from the shared table, ensuring that `/notre-blog` resolves to the blog index on the French hostname while `/our-blog` serves the English version. Because the module runs with `customRoutes: 'config'`, those slugs are now registered as real route aliases so visiting the translated path no longer results in a 404.
 
 When adding a new page that requires translated slugs, declare its route name inside `LOCALIZED_ROUTE_PATHS` and rely on `resolveLocalizedRoutePath()` to compute URLs instead of concatenating strings.
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,6 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
 import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
+import { buildI18nPagesConfig } from './shared/utils/localized-routes'
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
@@ -73,6 +74,7 @@ export default defineNuxtConfig({
     ],
     strategy: 'no_prefix',
     detectBrowserLanguage: false,
+    pages: buildI18nPagesConfig(),
   },
   css: [
     '~/assets/sass/main.sass', // Keep only the main SASS file

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,7 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
 import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
+import { buildI18nLocaleDomains } from './shared/utils/domain-language'
 import { buildI18nPagesConfig } from './shared/utils/localized-routes'
+
+const localeDomains = buildI18nLocaleDomains()
 
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
@@ -69,11 +72,13 @@ export default defineNuxtConfig({
     defaultLocale: 'en-US',
     langDir: '../i18n/locales',
     locales: [
-      { code: 'fr-FR', name: 'Français', file: 'fr-FR.json' },
-      { code: 'en-US', name: 'English', file: 'en-US.json' },
+      { code: 'fr-FR', name: 'Français', file: 'fr-FR.json', ...(localeDomains['fr-FR'] ?? {}) },
+      { code: 'en-US', name: 'English', file: 'en-US.json', ...(localeDomains['en-US'] ?? {}) },
     ],
     strategy: 'no_prefix',
     detectBrowserLanguage: false,
+    customRoutes: 'config',
+    differentDomains: true,
     pages: buildI18nPagesConfig(),
   },
   css: [

--- a/frontend/shared/utils/domain-language.spec.ts
+++ b/frontend/shared/utils/domain-language.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  HOST_DOMAIN_LANGUAGE_MAP,
+  buildI18nLocaleDomains,
+  getDomainLanguageFromHostname,
+  getNuxtLocaleForDomainLanguage,
+} from './domain-language'
+
+describe('domain-language helpers', () => {
+  it('builds locale domain mapping for Nuxt i18n configuration', () => {
+    const domainsConfig = buildI18nLocaleDomains()
+
+    const expectedConfig = Object.entries(HOST_DOMAIN_LANGUAGE_MAP).reduce(
+      (acc, [domain, domainLanguage]) => {
+        const locale = getNuxtLocaleForDomainLanguage(domainLanguage)
+        const current = acc[locale]
+
+        if (!current) {
+          acc[locale] = { domain, domains: [] }
+          return acc
+        }
+
+        current.domains.push(domain)
+        return acc
+      },
+      {} as Partial<Record<ReturnType<typeof getNuxtLocaleForDomainLanguage>, { domain: string; domains: string[] }>>,
+    )
+
+    Object.entries(expectedConfig).forEach(([locale, value]) => {
+      const config = domainsConfig[locale as keyof typeof domainsConfig]
+
+      expect(config.domain).toBe(value.domain)
+      expect(config.domains ?? []).toEqual(value.domains)
+    })
+  })
+
+  it('falls back to default mapping when hostname is missing', () => {
+    const resolution = getDomainLanguageFromHostname(null)
+
+    expect(resolution.domainLanguage).toBe('en')
+    expect(resolution.locale).toBe('en-US')
+    expect(resolution.matched).toBe(false)
+  })
+})

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -1,10 +1,10 @@
 export type DomainLanguage = 'en' | 'fr'
 export type NuxtLocale = 'en-US' | 'fr-FR'
 
-const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'en'
-const DEFAULT_NUXT_LOCALE: NuxtLocale = 'en-US'
+export const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'en'
+export const DEFAULT_NUXT_LOCALE: NuxtLocale = 'en-US'
 
-const HOST_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
+export const HOST_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
   'nudger.com': 'en',
   'nudger.fr': 'fr',
   localhost: 'fr',

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -11,6 +11,11 @@ export const HOST_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
   '127.0.0.1': 'en',
 }
 
+export interface NuxtI18nLocaleDomains {
+  domain: string
+  domains?: string[]
+}
+
 const DOMAIN_LANGUAGE_TO_LOCALE_MAP: Record<DomainLanguage, NuxtLocale> = {
   en: 'en-US',
   fr: 'fr-FR',
@@ -103,6 +108,36 @@ export const resolveDomainLanguage = (
 export const getNuxtLocaleForDomainLanguage = (
   domainLanguage: DomainLanguage
 ): NuxtLocale => DOMAIN_LANGUAGE_TO_LOCALE_MAP[domainLanguage]
+
+export const buildI18nLocaleDomains = (): Record<NuxtLocale, NuxtI18nLocaleDomains> => {
+  const localeHostMap = new Map<NuxtLocale, string[]>()
+
+  Object.entries(HOST_DOMAIN_LANGUAGE_MAP).forEach(([hostname, domainLanguage]) => {
+    const locale = getNuxtLocaleForDomainLanguage(domainLanguage)
+    const hostsForLocale = localeHostMap.get(locale)
+
+    if (hostsForLocale) {
+      hostsForLocale.push(hostname)
+      return
+    }
+
+    localeHostMap.set(locale, [hostname])
+  })
+
+  return Object.fromEntries(
+    Array.from(localeHostMap.entries()).map(([locale, hostnames]) => {
+      const [primaryDomain, ...alternateDomains] = hostnames
+
+      return [
+        locale,
+        {
+          domain: primaryDomain ?? '',
+          ...(alternateDomains.length > 0 ? { domains: alternateDomains } : {}),
+        } satisfies NuxtI18nLocaleDomains,
+      ]
+    }),
+  ) as Record<NuxtLocale, NuxtI18nLocaleDomains>
+}
 
 export const getDomainLanguageFromHostname = (
   hostname: string | null

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  LOCALIZED_ROUTE_PATHS,
+  buildI18nPagesConfig,
+  normalizeLocale,
+  resolveLocalizedRoutePath,
+} from './localized-routes'
+
+describe('localized-routes utilities', () => {
+  it('normalizes supported locales', () => {
+    expect(normalizeLocale('fr-FR')).toBe('fr-FR')
+    expect(normalizeLocale('en-US')).toBe('en-US')
+    expect(normalizeLocale('es-ES')).toBe('en-US')
+    expect(normalizeLocale(undefined)).toBe('en-US')
+  })
+
+  it('resolves localized static paths', () => {
+    expect(resolveLocalizedRoutePath('blog', 'fr-FR')).toBe('/notre-blog')
+    expect(resolveLocalizedRoutePath('blog', 'en-US')).toBe('/our-blog')
+  })
+
+  it('resolves localized dynamic paths', () => {
+    expect(resolveLocalizedRoutePath('blog-slug', 'fr-FR', { slug: 'article-test' })).toBe(
+      '/notre-blog/article-test',
+    )
+    expect(resolveLocalizedRoutePath('blog-slug', 'en-US', { slug: 'article-test' })).toBe(
+      '/our-blog/article-test',
+    )
+  })
+
+  it('falls back to default paths when no mapping exists', () => {
+    expect(resolveLocalizedRoutePath('impact-score', 'fr-FR')).toBe('/impact-score')
+    expect(resolveLocalizedRoutePath('contact', 'en-US')).toBe('/contact')
+  })
+
+  it('throws when required params are missing', () => {
+    expect(() => resolveLocalizedRoutePath('blog-slug', 'fr-FR')).toThrowError(
+      'Missing parameter "slug"',
+    )
+  })
+
+  it('builds a compatible i18n pages configuration', () => {
+    const config = buildI18nPagesConfig()
+
+    Object.entries(LOCALIZED_ROUTE_PATHS).forEach(([routeName, locales]) => {
+      expect(config[routeName]).toEqual(locales)
+    })
+  })
+})

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -18,6 +18,9 @@ describe('localized-routes utilities', () => {
   it('resolves localized static paths', () => {
     expect(resolveLocalizedRoutePath('blog', 'fr-FR')).toBe('/notre-blog')
     expect(resolveLocalizedRoutePath('blog', 'en-US')).toBe('/our-blog')
+    expect(resolveLocalizedRoutePath('contact', 'fr-FR')).toBe('/contact')
+    expect(resolveLocalizedRoutePath('impact-score', 'en-US')).toBe('/impact-score')
+    expect(resolveLocalizedRoutePath('ecoscore', 'fr-FR')).toBe('/ecoscore')
   })
 
   it('resolves localized dynamic paths', () => {
@@ -30,8 +33,8 @@ describe('localized-routes utilities', () => {
   })
 
   it('falls back to default paths when no mapping exists', () => {
-    expect(resolveLocalizedRoutePath('impact-score', 'fr-FR')).toBe('/impact-score')
-    expect(resolveLocalizedRoutePath('contact', 'en-US')).toBe('/contact')
+    expect(resolveLocalizedRoutePath('privacy', 'fr-FR')).toBe('/privacy')
+    expect(resolveLocalizedRoutePath('account', 'en-US')).toBe('/account')
   })
 
   it('throws when required params are missing', () => {

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -2,42 +2,13 @@ import type { NuxtLocale } from './domain-language'
 import { DEFAULT_NUXT_LOCALE } from './domain-language'
 
 export type LocalizedRouteName =
-  | 'blog'
-  | 'blog-slug'
-  | 'contact'
-  | 'ecoscore'
-  | 'impact-score'
-  | 'produits'
   | 'team'
 
 export type LocalizedRoutePath = `/${string}`
 export type LocalizedRoutePaths = Record<LocalizedRouteName, Record<NuxtLocale, LocalizedRoutePath>>
 
 export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
-  blog: {
-    'fr-FR': '/notre-blog',
-    'en-US': '/our-blog',
-  },
-  'blog-slug': {
-    'fr-FR': '/notre-blog/[slug]',
-    'en-US': '/our-blog/[slug]',
-  },
-  contact: {
-    'fr-FR': '/contact',
-    'en-US': '/contact',
-  },
-  ecoscore: {
-    'fr-FR': '/ecoscore',
-    'en-US': '/ecoscore',
-  },
-  'impact-score': {
-    'fr-FR': '/impact-score',
-    'en-US': '/impact-score',
-  },
-  produits: {
-    'fr-FR': '/produits',
-    'en-US': '/products',
-  },
+
   team: {
     'fr-FR': '/equipe',
     'en-US': '/team',

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -4,6 +4,9 @@ import { DEFAULT_NUXT_LOCALE } from './domain-language'
 export type LocalizedRouteName =
   | 'blog'
   | 'blog-slug'
+  | 'contact'
+  | 'ecoscore'
+  | 'impact-score'
   | 'produits'
   | 'team'
 
@@ -18,6 +21,18 @@ export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
   'blog-slug': {
     'fr-FR': '/notre-blog/[slug]',
     'en-US': '/our-blog/[slug]',
+  },
+  contact: {
+    'fr-FR': '/contact',
+    'en-US': '/contact',
+  },
+  ecoscore: {
+    'fr-FR': '/ecoscore',
+    'en-US': '/ecoscore',
+  },
+  'impact-score': {
+    'fr-FR': '/impact-score',
+    'en-US': '/impact-score',
   },
   produits: {
     'fr-FR': '/produits',

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -1,0 +1,83 @@
+import type { NuxtLocale } from './domain-language'
+import { DEFAULT_NUXT_LOCALE } from './domain-language'
+
+export type LocalizedRouteName =
+  | 'blog'
+  | 'blog-slug'
+  | 'produits'
+  | 'team'
+
+export type LocalizedRoutePath = `/${string}`
+export type LocalizedRoutePaths = Record<LocalizedRouteName, Record<NuxtLocale, LocalizedRoutePath>>
+
+export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
+  blog: {
+    'fr-FR': '/notre-blog',
+    'en-US': '/our-blog',
+  },
+  'blog-slug': {
+    'fr-FR': '/notre-blog/[slug]',
+    'en-US': '/our-blog/[slug]',
+  },
+  produits: {
+    'fr-FR': '/produits',
+    'en-US': '/products',
+  },
+  team: {
+    'fr-FR': '/equipe',
+    'en-US': '/team',
+  },
+} satisfies LocalizedRoutePaths
+
+const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
+
+type RouteParams = Record<string, string | number | undefined>
+
+const ROUTE_PARAM_PATTERN = /\[([^\]/]+)\]/g
+
+const injectParamsIntoPath = (
+  template: string,
+  params: RouteParams,
+): string =>
+  template.replace(ROUTE_PARAM_PATTERN, (segment, paramName) => {
+    const value = params[paramName]
+
+    if (value === undefined || value === null) {
+      throw new Error(`Missing parameter "${paramName}" for route template "${template}"`)
+    }
+
+    return encodeURIComponent(String(value))
+  })
+
+const normalizeRouteNameToPath = (routeName: string): LocalizedRoutePath => {
+  if (!routeName || routeName === 'index') {
+    return '/'
+  }
+
+  return (routeName.startsWith('/') ? routeName : `/${routeName}`) as LocalizedRoutePath
+}
+
+export const isSupportedLocale = (locale: string): locale is NuxtLocale =>
+  (SUPPORTED_LOCALES as readonly string[]).includes(locale)
+
+export const normalizeLocale = (locale: string | undefined | null): NuxtLocale =>
+  (locale && isSupportedLocale(locale) ? locale : DEFAULT_NUXT_LOCALE)
+
+export const resolveLocalizedRoutePath = (
+  routeName: string,
+  locale: string | undefined | null,
+  params: RouteParams = {},
+): string => {
+  const normalizedLocale = normalizeLocale(locale)
+  const localePaths = LOCALIZED_ROUTE_PATHS[routeName as LocalizedRouteName]
+  const template = (localePaths?.[normalizedLocale] ?? normalizeRouteNameToPath(routeName)) as string
+
+  return injectParamsIntoPath(template, params)
+}
+
+export const buildI18nPagesConfig = (): Record<string, Partial<Record<NuxtLocale, LocalizedRoutePath>>> =>
+  Object.fromEntries(
+    (Object.entries(LOCALIZED_ROUTE_PATHS) as [LocalizedRouteName, Record<NuxtLocale, LocalizedRoutePath>][]).map(
+      ([routeName, locales]) => [routeName, locales],
+    ),
+  )


### PR DESCRIPTION
## Summary
- add a shared localized route mapping and hook it into the Nuxt i18n page configuration
- update navigation components, blog cards, and the landing page to resolve links through the localized routes helper
- document the helper and cover it with dedicated unit tests

## Testing
- pnpm --offline lint
- pnpm --offline vitest run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d3f8c90f048333acb95d8f0fdba852