### PR TITLE
docs: document localized route handling

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -173,6 +173,34 @@ project/
 - `api-specs/openapitools.json` – OpenAPI generator CLI configuration
 - `.husky/` – Git hooks executed on commit
 
+## Route internationalisation
+
+The application keeps translated slugs in a single place so every layer can share
+them consistently. `shared/utils/localized-routes.ts` exposes:
+
+- `LOCALIZED_ROUTE_PATHS` – a record that maps each named route to the slug that
+  should be served per Nuxt locale.
+- `resolveLocalizedRoutePath(routeName, locale, params?)` – returns the
+  translated path for navigation components and programmatic redirects. Provide
+  any dynamic parameters (e.g. `{ slug: article.slug }`) and the helper injects
+  them into the template.
+- `buildI18nPagesConfig()` – used by `nuxt.config.ts` to generate the
+  `@nuxtjs/i18n` `pages` configuration so visiting translated slugs never yields
+  a 404.
+
+When you add a page that needs a translated slug:
+
+1. Register the page with a stable route name (for example `team`).
+2. Extend `LOCALIZED_ROUTE_PATHS` with the locale-to-path mapping, using Nuxt
+   locales such as `fr-FR` and `en-US`.
+3. Replace hard-coded strings in menus or components with
+   `resolveLocalizedRoutePath('team', locale)` so SSR and CSR generate the same
+   URL.
+
+Call `normalizeLocale(locale)` if you receive user input that may not already be
+a supported Nuxt locale. The helper falls back to the default locale to avoid
+runtime errors.
+
 ## Vue 3 & Nuxt 3 Conventions
 - Use `<script setup lang="ts">` in all components
 - Write components in TypeScript

--- a/frontend/docs/internationalisation.md
+++ b/frontend/docs/internationalisation.md
@@ -18,7 +18,16 @@ Top-level routes now expose translated slugs per locale through [`shared/utils/l
 - Programmatic navigations (for instance, blog article cards) reuse the same mapping to avoid hard-coded `/blog/...` URLs.
 - `nuxt.config.ts` derives the `@nuxtjs/i18n` `pages` configuration from the shared table, ensuring that `/notre-blog` resolves to the blog index on the French hostname while `/our-blog` serves the English version. Because the module runs with `customRoutes: 'config'`, those slugs are now registered as real route aliases so visiting the translated path no longer results in a 404.
 
-When adding a new page that requires translated slugs, declare its route name inside `LOCALIZED_ROUTE_PATHS` and rely on `resolveLocalizedRoutePath()` to compute URLs instead of concatenating strings.
+### Defining new localized routes
+
+1. Pick a stable route name for the page (e.g. the `team` page). Nuxt will use the file-based name (`pages/team.vue` → `team`).
+2. Update `LOCALIZED_ROUTE_PATHS` so each locale maps to the desired slug. Slugs must start with `/` and may include dynamic parameters using the Nuxt syntax (`/blog/[slug]`).
+3. Consume `resolveLocalizedRoutePath(routeName, locale, params?)` wherever a link is generated. The helper accepts optional params for dynamic segments—`resolveLocalizedRoutePath('blog-slug', 'fr-FR', { slug })` renders `/blog/${slug}` with URL encoding applied automatically.
+4. Import `normalizeLocale(locale)` when dealing with untrusted input. It coerces unknown locales back to the default (`DEFAULT_NUXT_LOCALE`) so navigation never breaks.
+
+### Sharing the configuration with Nuxt i18n
+
+`buildI18nPagesConfig()` exports the same mapping as a structure that Nuxt i18n understands. `nuxt.config.ts` feeds this output to the `pages` option, ensuring the module registers translated aliases and generates `<link rel="alternate">` tags for SEO. Keeping the data in one place guarantees SSR, CSR, and server routes all agree on which slug belongs to which locale.
 
 ## Current hostname mapping
 | Hostname        | Domain language | Nuxt locale | Notes                                     |


### PR DESCRIPTION
## Summary
- expand the frontend README with guidance on the shared localized route helper and how to add new slugs
- enhance the internationalisation guide with step-by-step instructions for defining routes and reusing the mapping inside Nuxt i18n

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d42ff529a0833390d0d2636ae2fc70