### PR TITLE
fix: stabilise hero menu header rendering

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -6,7 +6,7 @@ defineEmits<{
 
 <template>
   <header class="main-menu-header">
-    <v-container fluid class="main-menu-container position-sticky">
+    <v-container fluid class="main-menu-container">
       <v-row>
         <v-col cols="3">
           <the-main-logo />
@@ -21,10 +21,12 @@ defineEmits<{
 
 <style lang="sass" scoped>
 .main-menu-header
-  width: 100%
-
-.main-menu-container
+  position: sticky
   top: 0
   z-index: 100
+  width: 100%
+  background-color: white
+
+.main-menu-container
   background-color: white
 </style>


### PR DESCRIPTION
## Summary
- move the sticky positioning to the semantic header wrapper so the hero menu renders with the expected layout immediately
- keep the menu container styling intact without relying on the removed utility class

## Testing
- pnpm --offline lint *(fails: existing `vue/no-v-html` warning in app/components/domains/content/TextContent.vue)*
- pnpm --offline test *(fails: existing localized-routes.spec.ts expectations)*
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d4302503f4833380e6ef6528616a14