### PR TITLE
fix: load footer logo asset via useAsset

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -15,6 +15,7 @@ const currentLocale = computed(() => normalizeLocale(locale.value))
 const blogPath = computed(() => resolveLocalizedRoutePath('blog', currentLocale.value))
 
 const currentYear = computed(() => new Date().getFullYear())
+const nudgerLogo = useAsset('~/assets/images/nudger-logo-orange.svg')
 
 const highlightLinks = computed<FooterLink[]>(() => [
   {
@@ -174,7 +175,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
       <v-col cols="12" class="d-flex flex-column align-center ga-4">
         <NuxtLink to="/" class="footer-logo-link d-inline-flex">
           <v-img
-            src="@/assets/images/nudger-logo-orange.svg"
+            :src="nudgerLogo"
             :alt="t('siteIdentity.footer.logoAlt')"
             height="40"
             class="footer-logo"


### PR DESCRIPTION
## Summary
- load the Nudger footer logo through Nuxt's useAsset helper so the svg resolves at runtime

## Testing
- pnpm --offline lint *(fails: missing @nuxt/eslint-config dependency because node_modules are not installed in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d432c5184083339a672b64988fdead