### PR TITLE
fix: include vue compiler for tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^11.0.5",
     "@semantic-release/npm": "^12.0.2",
+    "@vue/compiler-dom": "3.5.21",
     "@typescript-eslint/parser": "^8.43.0",
     "@vite-pwa/nuxt": "^1.0.4",
     "@vue/test-utils": "^2.4.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@vite-pwa/nuxt':
         specifier: ^1.0.4
         version: 1.0.4(magicast@0.3.5)(vite@7.1.5(@types/node@24.3.1)(jiti@2.5.1)(sass@1.92.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
+      '@vue/compiler-dom':
+        specifier: 3.5.21
+        version: 3.5.21
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6


### PR DESCRIPTION
## Summary
- add the missing `@vue/compiler-dom` dev dependency so Vitest can compile Vue components during unit tests
- refresh the pnpm lockfile to capture the new dependency resolution

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d43abf115883338ec101ccd1d9ba5b