### PR TITLE
fix: avoid dynamic delete in blog articles spec

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/app/components/domains/blog/TheArticles.spec.ts
@@ -9,7 +9,17 @@ import TheArticles from './TheArticles.vue'
 const resolveLocalizedRoutePathSpy = vi.spyOn(localizedRoutes, 'resolveLocalizedRoutePath')
 
 // Mock the useBlog composable
-const mockArticles = [
+type MockArticle = {
+  id: string
+  title: string
+  summary: string
+  author: string
+  createdMs: number
+  image: string | null
+  url: string
+}
+
+const mockArticles: MockArticle[] = [
   {
     id: '1',
     title: 'Test Article 1',
@@ -29,6 +39,11 @@ const mockArticles = [
     url: 'test-article-2',
   },
 ]
+
+const cloneArticleWithoutImage = (article: MockArticle): MockArticle => ({
+  ...article,
+  image: null,
+})
 
 const articlesRef = ref(mockArticles)
 const paginatedArticlesRef = ref(mockArticles)
@@ -140,10 +155,13 @@ describe('TheArticles Component', () => {
   test('should handle articles without images', async () => {
     loadingRef.value = false
     errorRef.value = null
-    const imagelessArticle = mockArticles.find((article) => !article.image)
-    if (!imagelessArticle) {
-      throw new Error('Expected at least one article without an image')
+    const [firstArticle] = mockArticles
+    if (!firstArticle) {
+      throw new Error('Expected at least one article to clone')
     }
+
+    const imagelessArticle = cloneArticleWithoutImage(firstArticle)
+
     articlesRef.value = [imagelessArticle]
     paginatedArticlesRef.value = [imagelessArticle]
 


### PR DESCRIPTION
## Summary
- define a `MockArticle` test type and helper to clone articles without an image instead of mutating them
- update the "imageless article" scenario in `TheArticles.spec.ts` to rely on the helper, avoiding dynamic property deletes

## Testing
- pnpm lint
- pnpm test -- --run

---
_PR generated by AI agent in ~45 minutes_

------
https://chatgpt.com/codex/tasks/task_e_68d4ef16803483339f98f8db1a463c66