### PR TITLE
fix: localize blog pagination strings

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -21,7 +21,7 @@ const formatDate = (timestamp: number) => {
 
 // Debug mode - use environment variable or default to false
 const debugMode = ref(false)
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
 const route = useRoute()
 const router = useRouter()
@@ -46,6 +46,16 @@ const totalPages = computed(() => pagination.value.totalPages || 0)
 const totalElements = computed(() => pagination.value.totalElements || 0)
 const displayedArticlesCount = computed(() => paginatedArticles.value.length)
 const shouldDisplayPagination = computed(() => totalPages.value > 1)
+const paginationInfoMessage = computed(() =>
+  t('blog.pagination.info', {
+    current: currentPage.value,
+    total: totalPages.value,
+    count: totalElements.value,
+  }),
+)
+const paginationAriaLabel = computed(() => t('blog.pagination.ariaLabel'))
+const pageLinkLabel = (pageNumber: number) =>
+  t('blog.pagination.pageLink', { page: pageNumber })
 
 const navigateToArticle = (slug: string | null | undefined) => {
   if (!slug) {
@@ -223,15 +233,14 @@ const seoPageLinks = computed(() => {
         />
 
         <p class="pagination-info">
-          Showing page {{ currentPage }} of {{ totalPages }} ({{ totalElements }}
-          articles)
+          {{ paginationInfoMessage }}
         </p>
 
-        <nav class="visually-hidden" aria-label="Blog pagination links">
+        <nav class="visually-hidden" :aria-label="paginationAriaLabel">
           <ul>
             <li v-for="pageNumber in seoPageLinks" :key="pageNumber">
               <NuxtLink :to="{ query: buildPageQuery(pageNumber) }">
-                Blog page {{ pageNumber }}
+                {{ pageLinkLabel(pageNumber) }}
               </NuxtLink>
             </li>
           </ul>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -60,5 +60,12 @@
       "defaultCtaText": "Call to Action"
     },
     "siteName": "Nudger"
+  },
+  "blog": {
+    "pagination": {
+      "info": "Showing page {current} of {total} ({count} articles)",
+      "ariaLabel": "Blog pagination links",
+      "pageLink": "Blog page {page}"
+    }
   }
 }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -59,5 +59,12 @@
       "defaultCtaText": "Appel à l'action"
     },
     "siteName": "Nudger"
+  },
+  "blog": {
+    "pagination": {
+      "info": "Page {current} sur {total} ({count} articles)",
+      "ariaLabel": "Liens de pagination du blog",
+      "pageLink": "Page {page} du blog"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- internationalize the pagination info, aria label, and link labels in TheArticles component using vue-i18n
- add matching English and French locale messages for the blog pagination strings

## Testing
- pnpm --offline lint *(fails: existing @typescript-eslint/no-dynamic-delete violations in TheArticles.spec.ts)*
- pnpm --offline test
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d4f209aa3c83338f4b4c8b41895007