### PR TITLE
fix: add offline fallback for nuxt eslint config

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,11 +1,14 @@
-import { createConfigForNuxt } from '@nuxt/eslint-config'
+/**
+ * We use the Nuxt provided ESLint preset when it is available. When linting is
+ * executed in an offline environment without the package cache, resolving
+ * `@nuxt/eslint-config` fails. In that case we fall back to a minimal flat
+ * configuration that keeps linting functional instead of throwing an error.
+ */
 
-export default createConfigForNuxt({
-  features: {
-    typescript: true,
-  },
-})
-  .append({
+const nuxtConfigModule = await import('@nuxt/eslint-config').catch(() => null)
+
+const sharedOverrides = [
+  {
     rules: {
       'vue/multi-word-component-names': 'off',
       // Disable ESLint rules that could conflict with Prettier formatting
@@ -20,7 +23,128 @@ export default createConfigForNuxt({
       quotes: 'off',
       semi: 'off',
     },
-  })
-  .append({
+  },
+  {
     ignores: ['shared/api-client/**', 'src/api/**'],
-  })
+  },
+]
+
+let config
+
+if (nuxtConfigModule?.createConfigForNuxt) {
+  config = nuxtConfigModule
+    .createConfigForNuxt({
+      features: {
+        typescript: true,
+      },
+    })
+    .append(...sharedOverrides)
+} else {
+  console.warn(
+    'Using local fallback ESLint configuration because @nuxt/eslint-config could not be resolved.'
+  )
+  const fallback = await createFallbackConfig()
+  const overrides = fallback.hasVuePlugin
+    ? sharedOverrides
+    : sharedOverrides.map((entry) =>
+        entry.rules
+          ? {
+              ...entry,
+              rules: Object.fromEntries(
+                Object.entries(entry.rules).filter(([ruleName]) => !ruleName.startsWith('vue/'))
+              ),
+            }
+          : entry
+      )
+
+  config = [...fallback.configs, ...overrides]
+}
+
+export default config
+
+async function createFallbackConfig() {
+  const [jsModule, globalsModule, vueModule, tsParserModule] = await Promise.all([
+    import('@eslint/js').catch(() => null),
+    import('globals').catch(() => null),
+    import('eslint-plugin-vue').catch(() => null),
+    import('@typescript-eslint/parser').catch(() => null),
+  ])
+
+  const globals = globalsModule?.default || globalsModule || {}
+  const resolvedGlobals = {
+    browser: globals.browser || {},
+    es2021: globals.es2021 || {},
+    node: globals.node || {},
+  }
+  const recommendedJsConfig = jsModule?.configs?.recommended || {}
+  const vuePlugin = vueModule?.default || vueModule || null
+  const tsParser = tsParserModule?.default || tsParserModule || null
+
+  const baseConfig = {
+    name: 'nudger/fallback/javascript',
+    ...recommendedJsConfig,
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        ...resolvedGlobals.browser,
+        ...resolvedGlobals.es2021,
+        ...resolvedGlobals.node,
+      },
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+    },
+  }
+
+  if (!recommendedJsConfig.rules) {
+    baseConfig.rules = {}
+  }
+
+  const configs = [baseConfig]
+
+  if (tsParser) {
+    configs.push({
+      name: 'nudger/fallback/typescript',
+      files: ['**/*.{ts,tsx,vue}'],
+      languageOptions: {
+        parser: tsParser,
+        parserOptions: {
+          extraFileExtensions: ['.vue'],
+          project: false,
+          sourceType: 'module',
+        },
+      },
+    })
+  }
+
+  if (vuePlugin) {
+    const vueFlatConfig =
+      vuePlugin.configs?.['flat/vue3-recommended'] || vuePlugin.configs?.['flat/recommended']
+
+    if (vueFlatConfig) {
+      const normalized = Array.isArray(vueFlatConfig) ? vueFlatConfig : [vueFlatConfig]
+      normalized.forEach((entry, index) => {
+        configs.push({
+          name: entry.name || `nudger/fallback/vue-${index}`,
+          ...entry,
+        })
+      })
+    } else {
+      configs.push({
+        name: 'nudger/fallback/vue-basic',
+        files: ['**/*.vue'],
+        plugins: {
+          vue: vuePlugin,
+        },
+        rules: {},
+      })
+    }
+  }
+
+  return {
+    configs,
+    hasVuePlugin: Boolean(vuePlugin),
+  }
+}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -29,17 +29,21 @@ const sharedOverrides = [
   },
 ]
 
-let config
+const config = await resolveConfig()
 
-if (nuxtConfigModule?.createConfigForNuxt) {
-  config = nuxtConfigModule
-    .createConfigForNuxt({
-      features: {
-        typescript: true,
-      },
-    })
-    .append(...sharedOverrides)
-} else {
+export default config
+
+async function resolveConfig() {
+  if (nuxtConfigModule?.createConfigForNuxt) {
+    return nuxtConfigModule
+      .createConfigForNuxt({
+        features: {
+          typescript: true,
+        },
+      })
+      .append(...sharedOverrides)
+  }
+
   console.warn(
     'Using local fallback ESLint configuration because @nuxt/eslint-config could not be resolved.'
   )
@@ -57,10 +61,8 @@ if (nuxtConfigModule?.createConfigForNuxt) {
           : entry
       )
 
-  config = [...fallback.configs, ...overrides]
+  return [...fallback.configs, ...overrides]
 }
-
-export default config
 
 async function createFallbackConfig() {
   const [jsModule, globalsModule, vueModule, tsParserModule] = await Promise.all([


### PR DESCRIPTION
## Summary
- add a top-level fallback in `eslint.config.mjs` when `@nuxt/eslint-config` cannot be resolved
- create a minimal flat ESLint preset using available dependencies so linting still runs offline
- keep existing rule overrides and ignore patterns while avoiding vue-specific rules when the plugin is missing

## Testing
- pnpm --offline lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f73ba26083338ab9a673619cc27e