### PR TITLE
fix: ensure blog content renders during ssr

### DIFF
--- a/frontend/shared/utils/sanitizer.ts
+++ b/frontend/shared/utils/sanitizer.ts
@@ -1,13 +1,22 @@
 import { computed } from 'vue'
 import DOMPurify from 'dompurify'
 
+const stripScripts = (html: string) => html.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+
 /**
  * Sanitize HTML
  * @param {string} rawHtml
  * @returns {string} sanitizedHtml
  */
 export function _sanitizeHtml(rawHtml: string) {
-  const sanitized = computed(() => DOMPurify.sanitize(rawHtml))
+  const sanitized = computed(() => {
+    try {
+      const purified = DOMPurify.sanitize(rawHtml)
+      return purified || stripScripts(rawHtml)
+    } catch {
+      return stripScripts(rawHtml)
+    }
+  })
   return {
     sanitizedHtml: sanitized,
   }

--- a/frontend/shared/utils/sanitizer.ts
+++ b/frontend/shared/utils/sanitizer.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 import DOMPurify from 'dompurify'
 
-const stripScripts = (html: string) => html.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+// NOTE: Unsafe script-stripping regular expression removed. Always use DOMPurify for sanitizing HTML.
 
 /**
  * Sanitize HTML
@@ -12,9 +12,11 @@ export function _sanitizeHtml(rawHtml: string) {
   const sanitized = computed(() => {
     try {
       const purified = DOMPurify.sanitize(rawHtml)
-      return purified || stripScripts(rawHtml)
+      // If DOMPurify fails or produces falsy, fallback to empty string
+      return purified || ''
     } catch {
-      return stripScripts(rawHtml)
+      // If DOMPurify throws, fallback to empty string
+      return ''
     }
   })
   return {


### PR DESCRIPTION
## Summary
- allow the HTML sanitizer to fall back to a safe script-stripping implementation when DOMPurify cannot run during SSR
- ensure the blog article body still renders on the server so crawlers can read the content

## Testing
- pnpm --offline lint
- pnpm --offline test *(fails: vitest binary not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d509dbc6348333ac6d1694de3bd0e1