### PR TITLE
fix: address lint warnings in content and hero menu

### DIFF
--- a/frontend/app/components/domains/content/TextContent.vue
+++ b/frontend/app/components/domains/content/TextContent.vue
@@ -4,6 +4,7 @@ import { useContentBloc } from '~/composables/content/useContentBloc'
 import { useAuth } from '~/composables/useAuth'
 import { useRuntimeConfig } from '#app'
 import { DEFAULT_LOREM_LENGTH, _generateLoremIpsum } from '~/utils/content/_loremIpsum'
+import { _sanitizeHtml } from '~/shared/utils/sanitizer'
 import '~/assets/css/text-content.css'
 
 // Props
@@ -39,6 +40,8 @@ const displayHtml = computed(() => {
   return _generateLoremIpsum(fallbackLoremLength.value)
 })
 
+const { sanitizedHtml } = _sanitizeHtml(displayHtml)
+
 // Watcher / mount
 onMounted(() => {
   fetchBloc(props.blocId)
@@ -58,7 +61,8 @@ watch(
     <v-alert v-else-if="error" type="error" variant="tonal">{{ error }}</v-alert>
 
     <!-- Encapsulated XWiki content -->
-    <div v-else class="xwiki-sandbox" v-html="displayHtml" />
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div v-else class="xwiki-sandbox" v-html="sanitizedHtml" />
 
     <!-- Edit link -->
     <a

--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,18 +1,20 @@
 <script lang="ts" setup>
-
+const emit = defineEmits<{
+  (event: 'toggle-drawer'): void
+}>()
 </script>
 
 <template>
-    <v-container fluid class="main-menu-container position-fixed">
-      <v-row>
-        <v-col cols="3">
-          <the-main-logo />
-        </v-col>
-        <v-col cols="9">
-          <the-hero-menu @toggle-drawer="$emit('toggle-drawer')" />
-        </v-col>
-      </v-row>
-    </v-container>
+  <v-container fluid class="main-menu-container position-fixed">
+    <v-row>
+      <v-col cols="3">
+        <the-main-logo />
+      </v-col>
+      <v-col cols="9">
+        <the-hero-menu @toggle-drawer="emit('toggle-drawer')" />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <style lang="sass" scoped>

--- a/frontend/shared/utils/sanitizer.ts
+++ b/frontend/shared/utils/sanitizer.ts
@@ -1,4 +1,4 @@
-import { computed } from 'vue'
+import { computed, unref, type MaybeRefOrGetter } from 'vue'
 import DOMPurify from 'dompurify'
 
 // NOTE: Unsafe script-stripping regular expression removed. Always use DOMPurify for sanitizing HTML.
@@ -8,10 +8,11 @@ import DOMPurify from 'dompurify'
  * @param {string} rawHtml
  * @returns {string} sanitizedHtml
  */
-export function _sanitizeHtml(rawHtml: string) {
+export function _sanitizeHtml(rawHtml: MaybeRefOrGetter<string | null | undefined>) {
   const sanitized = computed(() => {
     try {
-      const purified = DOMPurify.sanitize(rawHtml)
+      const input = unref(rawHtml) ?? ''
+      const purified = DOMPurify.sanitize(input)
       // If DOMPurify fails or produces falsy, fallback to empty string
       return purified || ''
     } catch {


### PR DESCRIPTION
## Summary
- sanitize CMS-provided bloc content via the shared DOMPurify helper before rendering
- declare the toggle-drawer emit contract in the main menu container and use the typed emit helper
- generalize the shared `_sanitizeHtml` utility to work with reactive inputs from components

## Testing
- pnpm --offline lint

------
https://chatgpt.com/codex/tasks/task_e_68d50dd5e3048333865c8de55cbd50c4