### PR TITLE
fix: stop calling logout endpoint in auth service

### DIFF
--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -75,13 +75,14 @@ export class AuthService {
   }
 
   async logout() {
-    await $fetch('/auth/logout', {
-      method: 'POST',
-      credentials: 'include',
-    })
-
     const authStore = useAuthStore()
     authStore.$reset()
+
+    const config = useRuntimeConfig()
+    const tokenCookie = useCookie<string | null>(config.tokenCookieName)
+    const refreshCookie = useCookie<string | null>(config.refreshCookieName)
+    tokenCookie.value = null
+    refreshCookie.value = null
   }
 }
 


### PR DESCRIPTION
## Summary
- stop invoking the /auth/logout endpoint from the shared auth service
- clear authentication cookies directly in the auth service when logging out
- update the logout unit test to assert cookies are cleared and the fetch call is skipped

## Testing
- `pnpm --offline test --filter auth.services.spec.ts` *(fails: vitest binary is missing because node_modules are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50ffd8b6883339bb00f7cde17c725