### PR TITLE
fix: fetch blog article during ssr

### DIFF
--- a/frontend/app/pages/blog/[slug].vue
+++ b/frontend/app/pages/blog/[slug].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import { onMounted, computed } from 'vue'
+import { computed } from 'vue'
+import { useAsyncData } from '#imports'
 import { useBlog } from '~/composables/blog/useBlog'
 import type { BlogPostDto } from '~~/shared/api-client'
 
@@ -12,14 +13,21 @@ const route = useRoute()
 const router = useRouter()
 const { currentArticle, loading, error, fetchArticle } = useBlog()
 
+const slug = computed(() => route.params.slug as string)
+
+await useAsyncData(
+  () => `blog-article-${slug.value}`,
+  () => fetchArticle(slug.value),
+  {
+    server: true,
+    immediate: true,
+    watch: [slug],
+  },
+)
+
 const article = computed(
   () => currentArticle.value as BlogArticle | null
 )
-
-// Fetch the article when the page loads
-onMounted(() => {
-  fetchArticle(route.params.slug as string)
-})
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- fetch blog articles during SSR using useAsyncData so the rendered HTML contains the article content
- remove the client-only onMounted fetch and rely on the server result for hydration

## Testing
- pnpm --offline lint
- pnpm --offline test run *(fails: vitest binary missing in environment)*
- pnpm --offline generate *(fails: nuxt binary missing in environment)*
- pnpm --offline build *(fails: postcss package missing in environment)*

---
PR generated by AI agent. Estimated effort for a human developer: 0.5h.


------
https://chatgpt.com/codex/tasks/task_e_68d50eb7bb988333a047ecc71e8cf9ba