### PR TITLE
fix(frontend): ensure client logout clears auth cookies

### DIFF
--- a/frontend/shared/api-client/services/auth.services.spec.ts
+++ b/frontend/shared/api-client/services/auth.services.spec.ts
@@ -2,11 +2,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '~/stores/useAuthStore'
 
-const runtimeConfig = {
-  tokenCookieName: 'access_token',
-  refreshCookieName: 'refresh_token',
-}
-
 interface MockCookie {
   value: string | null
 }
@@ -14,28 +9,8 @@ interface MockCookie {
 let tokenCookie: MockCookie = { value: null }
 let refreshCookie: MockCookie = { value: null }
 
-const useCookieMock = (name: string): MockCookie => {
-  if (name === runtimeConfig.tokenCookieName) {
-    return tokenCookie
-  }
-  if (name === runtimeConfig.refreshCookieName) {
-    return refreshCookie
-  }
-
-  throw new Error(`Unexpected cookie requested: ${name}`)
-}
-
-vi.mock('#app', () => ({
-  useRuntimeConfig: () => runtimeConfig,
-  useCookie: useCookieMock,
-}))
-vi.mock('#imports', () => ({
-  useRuntimeConfig: () => runtimeConfig,
-  useCookie: useCookieMock,
-}))
-vi.mock('nuxt/app', () => ({
-  useRuntimeConfig: () => runtimeConfig,
-  useCookie: useCookieMock,
+vi.mock('~/utils/authCookies', () => ({
+  useAuthCookies: () => ({ tokenCookie, refreshCookie }),
 }))
 
 const fetchMock = vi.fn()

--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -3,6 +3,7 @@
  */
 import { jwtDecode } from 'jwt-decode'
 import { useAuthStore } from '~/stores/useAuthStore'
+import { useAuthCookies } from '~/utils/authCookies'
 
 interface JwtPayload {
   roles?: string[]
@@ -78,9 +79,7 @@ export class AuthService {
     const authStore = useAuthStore()
     authStore.$reset()
 
-    const config = useRuntimeConfig()
-    const tokenCookie = useCookie<string | null>(config.tokenCookieName)
-    const refreshCookie = useCookie<string | null>(config.refreshCookieName)
+    const { tokenCookie, refreshCookie } = useAuthCookies()
     tokenCookie.value = null
     refreshCookie.value = null
   }


### PR DESCRIPTION
## Summary
- reuse the shared `useAuthCookies` helper inside `AuthService.logout` so the same cookie refs are reset when logging out
- update the auth service unit test to stub `useAuthCookies`, keeping cookie assertions aligned with the new logout flow

## Testing
- pnpm --offline lint
- pnpm --offline test --run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d51cd096748333be9cc644b54db28a