### PR TITLE
fix: implement authenticated logout flow

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/auth/AuthController.java
@@ -1,9 +1,13 @@
 package org.open4goods.nudgerfrontapi.controller.auth;
 
+import java.time.Duration;
+
 import org.open4goods.nudgerfrontapi.dto.auth.AuthTokensDto;
 import org.open4goods.nudgerfrontapi.dto.auth.LoginRequest;
-import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.dto.auth.LogoutResponse;
 import org.open4goods.nudgerfrontapi.service.auth.JwtService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,7 +17,6 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -98,5 +101,31 @@ public class AuthController {
         } catch (Exception ex) {
             return ResponseEntity.status(401).build();
         }
+    }
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "Logout user",
+            description = "Expire the access and refresh token cookies so the session becomes invalid.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Logout successful",
+                            content = @Content(schema = @Schema(implementation = LogoutResponse.class)))
+            }
+    )
+    public ResponseEntity<LogoutResponse> logout() {
+        ResponseCookie clearAccessToken = ResponseCookie.from("access-token", "")
+                .httpOnly(true)
+                .maxAge(Duration.ZERO)
+                .path("/")
+                .build();
+        ResponseCookie clearRefreshToken = ResponseCookie.from("refresh-token", "")
+                .httpOnly(true)
+                .maxAge(Duration.ZERO)
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, clearAccessToken.toString(), clearRefreshToken.toString())
+                .body(new LogoutResponse(true));
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/LogoutResponse.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/auth/LogoutResponse.java
@@ -1,0 +1,12 @@
+package org.open4goods.nudgerfrontapi.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response returned after a successful logout request.
+ */
+public record LogoutResponse(
+        @Schema(description = "Indicates whether the logout request succeeded.")
+        boolean success
+) {
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/AuthControllerIT.java
@@ -63,4 +63,17 @@ class AuthControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists("access-token"));
     }
+
+    @Test
+    void logoutClearsAuthCookies() throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .cookie(new jakarta.servlet.http.Cookie("access-token", "access"),
+                                new jakarta.servlet.http.Cookie("refresh-token", "refresh"))
+                        .param("domainLanguage", "FR"))
+                .andExpect(status().isOk())
+                .andExpect(cookie().value("access-token", ""))
+                .andExpect(cookie().maxAge("access-token", 0))
+                .andExpect(cookie().value("refresh-token", ""))
+                .andExpect(cookie().maxAge("refresh-token", 0));
+    }
 }

--- a/frontend/app/stores/useAuthStore.spec.ts
+++ b/frontend/app/stores/useAuthStore.spec.ts
@@ -2,17 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 
 const logoutMock = vi.fn()
-const tokenCookie = { value: 'token' }
-const refreshCookie = { value: 'refresh' }
-
 vi.mock('~~/shared/api-client/services/auth.services', () => ({
   authService: {
     logout: logoutMock,
   },
-}))
-
-vi.mock('~/utils/authCookies', () => ({
-  useAuthCookies: () => ({ tokenCookie, refreshCookie }),
 }))
 
 describe('useAuthStore', () => {
@@ -20,11 +13,9 @@ describe('useAuthStore', () => {
     vi.resetModules()
     setActivePinia(createPinia())
     logoutMock.mockReset()
-    tokenCookie.value = 'token'
-    refreshCookie.value = 'refresh'
   })
 
-  it('delegates logout handling to the auth service and clears cookies', async () => {
+  it('delegates logout handling to the auth service', async () => {
     logoutMock.mockResolvedValue(undefined)
     const { useAuthStore } = await import('./useAuthStore')
     const store = useAuthStore()
@@ -32,7 +23,5 @@ describe('useAuthStore', () => {
     await store.logout()
 
     expect(logoutMock).toHaveBeenCalledTimes(1)
-    expect(tokenCookie.value).toBeNull()
-    expect(refreshCookie.value).toBeNull()
   })
 })

--- a/frontend/app/stores/useAuthStore.ts
+++ b/frontend/app/stores/useAuthStore.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia'
-import { useAuthCookies } from '~/utils/authCookies'
 
 interface AuthState {
   roles: string[]
@@ -18,11 +17,8 @@ export const useAuthStore = defineStore('auth', {
   },
   actions: {
     async logout() {
-      const { tokenCookie, refreshCookie } = useAuthCookies()
       const { authService } = await import('~~/shared/api-client/services/auth.services')
       await authService.logout()
-      tokenCookie.value = null
-      refreshCookie.value = null
     },
   },
 })

--- a/frontend/shared/api-client/services/auth.services.spec.ts
+++ b/frontend/shared/api-client/services/auth.services.spec.ts
@@ -39,7 +39,8 @@ describe('AuthService.logout', () => {
 
     await authService.logout()
 
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/auth/logout', { method: 'POST' })
     expect(authStore.isLoggedIn).toBe(false)
     expect(authStore.roles).toEqual([])
     expect(authStore.username).toBeNull()

--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -77,11 +77,17 @@ export class AuthService {
 
   async logout() {
     const authStore = useAuthStore()
-    authStore.$reset()
-
     const { tokenCookie, refreshCookie } = useAuthCookies()
-    tokenCookie.value = null
-    refreshCookie.value = null
+
+    try {
+      await $fetch('/auth/logout', {
+        method: 'POST',
+      })
+    } finally {
+      authStore.$reset()
+      tokenCookie.value = null
+      refreshCookie.value = null
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a front-api /auth/logout endpoint that expires auth cookies and documents the response
- return a structured logout payload and extend controller IT coverage for cookie clearing
- route the frontend logout flow through the Nuxt server endpoint so cookies and store state are reset reliably

## Testing
- pnpm --offline lint
- pnpm --offline test
- pnpm --offline generate
- pnpm --offline build
- mvn --offline -pl front-api -am clean install

------
https://chatgpt.com/codex/tasks/task_e_68d5219748d48333bc6c8938b092ddcb