### PR TITLE
fix: persist blog article state across ssr

### DIFF
--- a/frontend/app/composables/blog/useBlog.ts
+++ b/frontend/app/composables/blog/useBlog.ts
@@ -7,18 +7,39 @@ const DEFAULT_PAGE_SIZE = 12
 
 export const useBlog = () => {
   // Reactive state
-  const articles = ref<BlogPostDto[]>([])
-  const currentArticle = ref<BlogPostDto | null>(null)
-  const tags = ref<BlogTagDto[]>([])
-  const selectedTag = ref<string | null>(null)
-  const loading = ref(false)
-  const error = ref<string | null>(null)
-  const pagination = ref({
-    page: 1,
-    size: DEFAULT_PAGE_SIZE,
-    totalElements: 0,
-    totalPages: 0,
-  })
+  const articles = useState<BlogPostDto[]>(
+    'blog-articles',
+    () => [],
+  )
+  const currentArticle = useState<BlogPostDto | null>(
+    'blog-current-article',
+    () => null,
+  )
+  const tags = useState<BlogTagDto[]>(
+    'blog-tags',
+    () => [],
+  )
+  const selectedTag = useState<string | null>(
+    'blog-selected-tag',
+    () => null,
+  )
+  const loading = useState(
+    'blog-loading',
+    () => false,
+  )
+  const error = useState<string | null>(
+    'blog-error',
+    () => null,
+  )
+  const pagination = useState(
+    'blog-pagination',
+    () => ({
+      page: 1,
+      size: DEFAULT_PAGE_SIZE,
+      totalElements: 0,
+      totalPages: 0,
+    }),
+  )
 
   /**
    * Fetch blog articles for a specific page from the backend proxy


### PR DESCRIPTION
## Summary
- persist blog composable state with Nuxt `useState` so article data survives SSR hydration
- ensure loading, pagination, and tag metadata reuse the same hydrated state across page transitions

## Testing
- pnpm --offline lint

---
AI-generated PR. Estimated 0.7h of manual work.

------
https://chatgpt.com/codex/tasks/task_e_68d527215af88333a73b7666cf755f8e