### PR TITLE
fix: guard blog article fetch when slug missing

### DIFF
--- a/frontend/app/pages/blog/[slug].vue
+++ b/frontend/app/pages/blog/[slug].vue
@@ -13,11 +13,25 @@ const route = useRoute()
 const router = useRouter()
 const { currentArticle, loading, error, fetchArticle } = useBlog()
 
-const slug = computed(() => route.params.slug as string)
+const slug = computed(() => {
+  const rawSlug = route.params.slug
+
+  if (Array.isArray(rawSlug)) {
+    return rawSlug.find((value) => typeof value === 'string' && value.trim().length > 0) ?? null
+  }
+
+  if (typeof rawSlug !== 'string') {
+    return null
+  }
+
+  const trimmed = rawSlug.trim()
+
+  return trimmed.length > 0 ? trimmed : null
+})
 
 await useAsyncData(
-  () => `blog-article-${slug.value}`,
-  () => fetchArticle(slug.value),
+  () => (slug.value ? `blog-article-${slug.value}` : 'blog-article'),
+  () => (slug.value ? fetchArticle(slug.value) : Promise.resolve(null)),
   {
     server: true,
     immediate: true,


### PR DESCRIPTION
## Summary
- sanitize the blog article slug route parameter before fetching article data
- avoid triggering the article fetch when no valid slug is present to prevent 404 proxy calls

## Testing
- pnpm --offline lint
- pnpm --offline test *(fails: vitest not found in environment)*
- pnpm --offline generate *(fails: nuxt binary not available in environment)*
- pnpm --offline build *(fails: missing postcss dependency in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68d52d3236e083338b5af6e04fdeb619