### PR TITLE
fix(frontend): preserve route after auth actions

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -52,7 +52,7 @@ const handleLogout = async () => {
 
   try {
     await logout()
-    await router.push('/')
+    await router.replace(route.fullPath || '/')
   } catch (error) {
     console.error('Logout failed', error)
   }

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -66,6 +66,7 @@ const emit = defineEmits<{
 
 const { isLoggedIn, logout } = useAuth()
 const router = useRouter()
+const route = useRoute()
 
 interface MenuItemDefinition {
   titleKey: string
@@ -85,7 +86,7 @@ const handleLogout = async () => {
 
   try {
     await logout()
-    await router.push('/')
+    await router.replace(route.fullPath || '/')
   } catch (error) {
     console.error('Logout failed', error)
   } finally {

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -6,10 +6,12 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 const isLoggedIn = ref(false)
 const logoutMock = vi.fn()
 const routerPush = vi.fn()
+const routerReplace = vi.fn()
 const routerInstance = {
   push: routerPush,
+  replace: routerReplace,
 }
-const currentRoute = reactive({ path: '/' })
+const currentRoute = reactive({ path: '/', fullPath: '/' })
 
 function useRouteMock() {
   return currentRoute
@@ -72,6 +74,7 @@ describe('Shared menu authentication controls', () => {
     isLoggedIn.value = false
     logoutMock.mockReset()
     routerPush.mockReset()
+    routerReplace.mockReset()
     logoutMock.mockResolvedValue(undefined)
   })
 

--- a/frontend/app/pages/index-v1.vue
+++ b/frontend/app/pages/index-v1.vue
@@ -18,7 +18,10 @@
           </v-btn>
         </router-link>
         <!-- Display login button only when the user is not authenticated -->
-        <router-link v-if="!isLoggedIn" to="/auth/login">
+        <router-link
+          v-if="!isLoggedIn"
+          :to="{ path: '/auth/login', query: { redirect: currentRoute.fullPath } }"
+        >
           <v-btn color="secondary" size="large" rounded="pill" class="elevation-2">
             <v-icon start icon="mdi-login" />
             Login
@@ -103,11 +106,12 @@ const { t, locale } = useI18n()
 const blogPath = computed(() => resolveLocalizedRoutePath('blog', normalizeLocale(locale.value)))
 
 const router = useRouter()
+const currentRoute = useRoute()
 
 const handleLogout = async () => {
   try {
     await logout()
-    await router.push('/')
+    await router.replace(currentRoute.fullPath || '/')
   } catch (error) {
     console.error('Logout failed', error)
   }


### PR DESCRIPTION
## Summary
- redirect authenticated users back to the page that initiated login by passing a redirect query and resolving it safely during login
- keep logout flows on the originating page by reusing the current route instead of forcing a homepage redirect, including the home hero and mobile menus
- update the shared menu tests to mock router state compatible with the new navigation behaviour

## Testing
- pnpm --offline lint
- pnpm --offline test run
- pnpm --offline generate
- pnpm --offline build

------
https://chatgpt.com/codex/tasks/task_e_68d52c34674483339f998d91ac4dc803