### PR TITLE
feat(frontend): add SEO metadata to blog listing page

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -62,6 +62,13 @@
     "siteName": "Nudger"
   },
   "blog": {
+    "seo": {
+      "baseTitle": "Nudger Blog – Impact Score insights",
+      "tagTitle": "{tag} articles – Nudger Blog",
+      "pageTitle": "{title} – Page {page}",
+      "description": "Explore the latest guides on sustainable appliances and energy-efficient choices from Nudger.",
+      "tagDescription": "Browse {tag} articles on Nudger's blog for sustainable, energy-efficient advice."
+    },
     "pagination": {
       "info": "Showing page {current} of {total} ({count} articles)",
       "ariaLabel": "Blog pagination links",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -61,6 +61,13 @@
     "siteName": "Nudger"
   },
   "blog": {
+    "seo": {
+      "baseTitle": "Blog Nudger – Analyses Impact Score",
+      "tagTitle": "Articles {tag} – Blog Nudger",
+      "pageTitle": "{title} – Page {page}",
+      "description": "Découvrez les guides et actualités de Nudger sur les appareils durables et les choix économes en énergie.",
+      "tagDescription": "Parcourez les articles {tag} du blog Nudger pour trouver des conseils durables et économes en énergie."
+    },
     "pagination": {
       "info": "Page {current} sur {total} ({count} articles)",
       "ariaLabel": "Liens de pagination du blog",


### PR DESCRIPTION
## Summary
- compute canonical URLs, social cards, and JSON-LD metadata for the blog listing
- expose the SEO computeds for testing and localize the dynamic strings
- expand the unit test suite to validate SEO output while stubbing head/meta calls

## Testing
- pnpm --offline test --run components/domains/blog/TheArticles.spec.ts

---
PR generated by AI agent – estimated 2h developer effort.

------
https://chatgpt.com/codex/tasks/task_e_68d68f1c65f0833388b06a330865bd6e