### PR TITLE
fix: tighten blog article spec typing

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -222,6 +222,7 @@ TypeScript Usage
 - Use TypeScript throughoutpreferinterfaces over types fobetterextendability and merging.
 - Avoid enums, opting for mapforimproved type safety and flexibility.
 - Use functional componentwithTypeScript interfaces.
+- Never use the `any` type; prefer `unknown` with dedicated type guards when you need a fallback.
 UI and Styling
 - Use Vuetify UI forcomponents and styling.
 - Implement responsive Vuetify approach and mobile-firstapproach.


### PR DESCRIPTION
## Summary
- replace loose `any` assertions in the blog article spec with typed helpers and guards
- add dedicated structured data interfaces to validate SEO metadata in tests
- update the frontend agents guide to forbid using the `any` type

## Testing
- pnpm --offline lint *(fails: vue/no-expose-after-await reported for existing component code)*

------
https://chatgpt.com/codex/tasks/task_e_68d69a9815e48333a3b2560bc0aa9a42