### PR TITLE
test: guard blog structured data assertion

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/app/components/domains/blog/TheArticles.spec.ts
@@ -492,7 +492,12 @@ describe('TheArticles Component', () => {
     expect(structured.url).toMatch(/^https?:\/\/[^/]+\/blog\?page=2&tag=Energy$/)
     const hasPart = Array.isArray(structured.hasPart) ? structured.hasPart : []
     expect(hasPart.length).toBeGreaterThan(0)
-    expect(hasPart[0]['@type']).toBe('BlogPosting')
+    const firstHasPart = hasPart[0]
+    if (!firstHasPart) {
+      throw new Error('Expected the structured data to contain at least one blog posting entry')
+    }
+
+    expect(firstHasPart['@type']).toBe('BlogPosting')
   })
 
   test('loads tags from the API when none are cached', async () => {


### PR DESCRIPTION
## Summary
- guard the structured data expectation in the blog articles spec so TypeScript knows the value is defined before asserting

## Testing
- pnpm --offline vitest run app/components/domains/blog/TheArticles.spec.ts *(fails: existing assertion for pageSeoTitle remains red)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a08983c48333bbc3af435e5b9452