### PR TITLE
feat: manage robots directives per environment

### DIFF
--- a/frontend/app/plugins/robots.client.ts
+++ b/frontend/app/plugins/robots.client.ts
@@ -1,0 +1,11 @@
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+
+  if (config.public.appEnv !== 'production') {
+    useHead({
+      meta: [
+        { name: 'robots', content: 'noindex, nofollow, noarchive' },
+      ],
+    })
+  }
+})

--- a/frontend/app/public/robots.txt
+++ b/frontend/app/public/robots.txt
@@ -1,2 +1,0 @@
-User-Agent: *
-Disallow:

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -4,6 +4,9 @@ import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer
 import { buildI18nLocaleDomains } from './shared/utils/domain-language'
 import { buildI18nPagesConfig } from './shared/utils/localized-routes'
 
+const appEnv = process.env.NUXT_PUBLIC_APP_ENV || 'development'
+const shouldBlockIndexing = appEnv !== 'production'
+
 const localeDomains = buildI18nLocaleDomains()
 
 export default defineNuxtConfig({
@@ -35,6 +38,15 @@ export default defineNuxtConfig({
     //'/articles/**': { static: true },
     // Admin area rendered on the client side
     '/admin/**': { ssr: false },
+    ...(shouldBlockIndexing
+      ? {
+          '/**': {
+            headers: {
+              'X-Robots-Tag': 'noindex, nofollow, noarchive',
+            },
+          },
+        }
+      : {}),
   },
   modules: [
     "vuetify-nuxt-module",
@@ -143,6 +155,8 @@ export default defineNuxtConfig({
       // Base URL of the backend API
       // Roles allowed to edit content blocks (defaults to backend role names)
       editRoles: (process.env.EDITOR_ROLES || 'ROLE_SITEEDITOR,XWIKIADMINGROUP').split(','),
-    }
+      appEnv,
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'http://localhost:3000',
+    },
   },
 })

--- a/frontend/server/routes/robots.txt.get.ts
+++ b/frontend/server/routes/robots.txt.get.ts
@@ -1,0 +1,18 @@
+export default defineEventHandler((event) => {
+  const config = useRuntimeConfig(event)
+  const isProduction = config.public.appEnv === 'production'
+
+  setHeader(event, 'Content-Type', 'text/plain; charset=utf-8')
+
+  if (!isProduction) {
+    return ['User-agent: *', 'Disallow: /'].join('\n')
+  }
+
+  const normalizedSiteUrl = (config.public.siteUrl || '').replace(/\/$/, '')
+
+  return [
+    'User-agent: *',
+    'Allow: /',
+    `Sitemap: ${normalizedSiteUrl}/sitemap.xml`,
+  ].join('\n')
+})


### PR DESCRIPTION
## Summary
- expose `appEnv` and `siteUrl` in the public runtime config and add conditional `X-Robots-Tag` headers so non-production builds stay private by default
- serve an environment-aware `robots.txt` via Nitro and inject a client-side meta fallback to enforce noindex outside production
- remove the legacy static `robots.txt` asset that conflicted with the dynamic handler

## Testing
- pnpm --offline lint *(fails: existing vue/no-expose-after-await issue in app/components/domains/blog/TheArticles.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68d69cc5bb008333b3d64dc177d31d4a