### PR TITLE
fix: ensure blog articles component exposes data before async load

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -138,8 +138,6 @@ const ensureTagsLoaded = async () => {
   }
 }
 
-await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
-
 watch(
   () => [route.query.page, route.query.tag],
   async (_, __, onCleanup) => {
@@ -439,6 +437,8 @@ defineExpose({
   primaryArticleImage,
   structuredData,
 })
+
+await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- move the blog articles component's initial async load to after `defineExpose` so the SEO helpers are exposed synchronously

## Testing
- pnpm --offline lint

------
https://chatgpt.com/codex/tasks/task_e_68d6ac1ef924833392d8f1c265454fa6