### PR TITLE
fix: reuse blog pagination aria label key

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -79,7 +79,8 @@ const paginationInfoMessage = computed(() =>
     count: totalElements.value,
   }),
 )
-const paginationAriaLabel = computed(() => t('blog.pagination.ariaLabel'))
+const paginationAriaLabelKey = 'blog.pagination.ariaLabel'
+const paginationAriaLabel = computed(() => t(paginationAriaLabelKey))
 const pageLinkLabel = (pageNumber: number) =>
   t('blog.pagination.pageLink', { page: pageNumber })
 const buildArticleTitleId = (index: number) => `blog-article-card-title-${index}`
@@ -739,7 +740,7 @@ await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
             :length="totalPages"
             :model-value="currentPage"
             :total-visible="5"
-            :aria-label="paginationAriaLabel"
+            :aria-label="paginationAriaLabelKey"
             :aria-controls="articleListId"
             @update:model-value="handlePageChange"
           />


### PR DESCRIPTION
## Summary
- define a reusable constant for the blog pagination aria-label translation key
- update the pagination component to use the key while nav containers keep the resolved label

## Testing
- pnpm --offline lint
- pnpm --offline test

------
https://chatgpt.com/codex/tasks/task_e_68d6b7fe34ec8333bb57dc8039988fcd