### PR TITLE
feat: add localized impact score route and update footer navigation

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -3,12 +3,25 @@ import { useI18n } from 'vue-i18n'
 
 import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
-type FooterLink = {
+type InternalFooterLink = {
+  label: string
+  to: string
+}
+
+type ExternalFooterLink = {
   label: string
   href: string
   target?: string
   rel?: string
 }
+
+type FooterLink = InternalFooterLink | ExternalFooterLink
+
+const isInternalLink = (link: FooterLink): link is InternalFooterLink => 'to' in link
+
+const getNavigationProps = (link: FooterLink) => (isInternalLink(link) ? { to: link.to } : { href: link.href })
+
+const getFooterLinkKey = (link: FooterLink) => (isInternalLink(link) ? link.to : link.href)
 
 const { t, locale } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
@@ -19,52 +32,52 @@ const currentYear = computed(() => new Date().getFullYear())
 const highlightLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.highlightLinks.ecoscore'),
-    href: resolveLocalizedRoutePath('ecoscore', currentLocale.value),
-  }
+    to: resolveLocalizedRoutePath('impact-score', currentLocale.value),
+  },
 ])
 
 const comparatorLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.comparator.links.openData'),
-    href: '/opendata',
+    to: '/opendata',
   },
   {
     label: t('siteIdentity.footer.comparator.links.openSource'),
-    href: '/opensource',
+    to: '/opensource',
   },
   {
     label: t('siteIdentity.footer.comparator.links.privacy'),
-    href: '/politique-confidentialite',
+    to: '/politique-confidentialite',
   },
   {
     label: t('siteIdentity.footer.comparator.links.legal'),
-    href: '/mentions-legales',
+    to: '/mentions-legales',
   },
 ])
 
 const communityLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.community.links.team'),
-    href: resolveLocalizedRoutePath('team', currentLocale.value),
+    to: resolveLocalizedRoutePath('team', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.community.links.partners'),
-    href: '/partenaires',
+    to: '/partenaires',
   },
 ])
 
 const feedbackLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.feedback.links.idea'),
-    href: '/feedback/idea',
+    to: '/feedback/idea',
   },
   {
     label: t('siteIdentity.footer.feedback.links.issue'),
-    href: '/feedback/issue',
+    to: '/feedback/issue',
   },
   {
     label: t('siteIdentity.footer.feedback.links.contact'),
-    href: resolveLocalizedRoutePath('contact', currentLocale.value),
+    to: resolveLocalizedRoutePath('contact', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.feedback.links.linkedin'),
@@ -89,7 +102,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         </p>
 
         <v-btn
-          :href="blogPath"
+          :to="blogPath"
           variant="text"
           append-icon="mdi-arrow-right"
           class="footer-link-btn text-white px-0"
@@ -102,11 +115,13 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         <div class="d-flex flex-column ga-2">
           <v-btn
             v-for="link in highlightLinks"
-            :key="link.href"
-            :href="link.href"
+            :key="getFooterLinkKey(link)"
+            v-bind="getNavigationProps(link)"
             variant="text"
             append-icon="mdi-arrow-right"
             class="footer-link-btn text-white px-0"
+            :target="link.target"
+            :rel="link.rel"
           >
             {{ link.label }}
           </v-btn>
@@ -118,9 +133,11 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
           <v-list-item
             v-for="link in comparatorLinks"
-            :key="link.href"
-            :href="link.href"
+            :key="getFooterLinkKey(link)"
+            v-bind="getNavigationProps(link)"
             class="footer-list-item px-0"
+            :target="link.target"
+            :rel="link.rel"
           >
             <template #title>
               <span class="text-body-2">{{ link.label }}</span>
@@ -137,9 +154,11 @@ const feedbackLinks = computed<FooterLink[]>(() => [
           <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
             <v-list-item
               v-for="link in communityLinks"
-              :key="link.href"
-              :href="link.href"
+              :key="getFooterLinkKey(link)"
+              v-bind="getNavigationProps(link)"
               class="footer-list-item px-0"
+              :target="link.target"
+              :rel="link.rel"
             >
               <template #title>
                 <span class="text-body-2">{{ link.label }}</span>
@@ -154,8 +173,8 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
           <v-list-item
             v-for="link in feedbackLinks"
-            :key="link.href"
-            :href="link.href"
+            :key="getFooterLinkKey(link)"
+            v-bind="getNavigationProps(link)"
             class="footer-list-item px-0"
             :target="link.target"
             :rel="link.rel"

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -18,6 +18,8 @@ describe('localized-routes utilities', () => {
   it('resolves localized static paths', () => {
     expect(resolveLocalizedRoutePath('team', 'fr-FR')).toBe('/equipe')
     expect(resolveLocalizedRoutePath('team', 'en-US')).toBe('/team')
+    expect(resolveLocalizedRoutePath('impact-score', 'fr-FR')).toBe('/ecoscore')
+    expect(resolveLocalizedRoutePath('impact-score', 'en-US')).toBe('/impact-score')
   })
 
 

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -2,12 +2,18 @@ import type { NuxtLocale } from './domain-language'
 import { DEFAULT_NUXT_LOCALE } from './domain-language'
 
 export type LocalizedRouteName =
+  | 'impact-score'
   | 'team'
 
 export type LocalizedRoutePath = `/${string}`
 export type LocalizedRoutePaths = Record<LocalizedRouteName, Record<NuxtLocale, LocalizedRoutePath>>
 
 export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
+
+  'impact-score': {
+    'fr-FR': '/ecoscore',
+    'en-US': '/impact-score',
+  },
 
   team: {
     'fr-FR': '/equipe',


### PR DESCRIPTION
## Summary
- add an `impact-score` localized route mapping to `/impact-score` and `/ecoscore`
- expand footer link metadata to differentiate internal Nuxt links from external URLs
- render footer links with `:to` for Nuxt navigation so the highlight button targets the Impact Score page

## Testing
- pnpm --offline vitest run shared/utils/localized-routes.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6ba27eed48333986081274ba7dda1