### PR TITLE
feat(frontend): implement localized team page

### DIFF
--- a/frontend/app/components/domains/team/TeamCallouts.vue
+++ b/frontend/app/components/domains/team/TeamCallouts.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface Props {
+  partnersBlocId: string
+  partnersTitle: string
+  partnersCta: string
+  partnersLink: string
+  contactTitle: string
+  contactDescription: string
+  contactCta: string
+  contactLink: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <section class="team-callouts" role="region" aria-labelledby="team-callouts-title">
+    <v-container class="py-12">
+      <v-row class="g-6" align="stretch">
+        <v-col cols="12" lg="8">
+          <v-card class="team-callouts__card" elevation="6" rounded="xl">
+            <v-card-item>
+              <h3 id="team-callouts-title" class="team-callouts__title">
+                {{ props.partnersTitle }}
+              </h3>
+            </v-card-item>
+            <v-card-text class="team-callouts__text">
+              <TextContent :bloc-id="props.partnersBlocId" :ipsum-length="120" />
+            </v-card-text>
+            <v-card-actions>
+              <v-btn
+                :href="props.partnersLink"
+                color="primary"
+                variant="elevated"
+                size="large"
+              >
+                {{ props.partnersCta }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+
+        <v-col cols="12" lg="4">
+          <v-card class="team-callouts__card team-callouts__card--accent" elevation="4" rounded="xl">
+            <v-card-item>
+              <h3 class="team-callouts__title team-callouts__title--accent">
+                {{ props.contactTitle }}
+              </h3>
+            </v-card-item>
+            <v-card-text class="team-callouts__description">
+              {{ props.contactDescription }}
+            </v-card-text>
+            <v-card-actions>
+              <v-btn
+                :href="props.contactLink"
+                color="secondary"
+                variant="tonal"
+                size="large"
+              >
+                {{ props.contactCta }}
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.team-callouts
+  background: linear-gradient(135deg, rgba(236, 248, 239, 0.7), rgba(227, 242, 253, 0.75))
+  padding-inline: clamp(1rem, 4vw, 4rem)
+
+  &__card
+    height: 100%
+    display: flex
+    flex-direction: column
+    justify-content: space-between
+    padding: clamp(1.5rem, 3vw, 2.5rem)
+    gap: 1.5rem
+
+  &__card--accent
+    background: linear-gradient(135deg, rgba(25, 118, 210, 0.1), rgba(25, 118, 210, 0.2))
+    color: rgb(21, 46, 73)
+
+  &__title
+    font-size: clamp(1.6rem, 2.3vw, 2rem)
+    font-weight: 700
+    margin: 0
+
+  &__title--accent
+    color: inherit
+
+  &__text :deep(.text-content)
+    padding: 0
+
+  &__text :deep(.xwiki-sandbox)
+    font-size: 1.05rem
+    line-height: 1.7
+
+  &__description
+    font-size: 1.05rem
+    line-height: 1.7
+</style>

--- a/frontend/app/components/domains/team/TeamHero.vue
+++ b/frontend/app/components/domains/team/TeamHero.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { useId } from 'vue'
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface Props {
+  title: string
+  subtitle: string
+  descriptionBlocId: string
+  eyebrow?: string
+}
+
+const props = defineProps<Props>()
+
+const headingId = useId()
+</script>
+
+<template>
+  <v-sheet
+    class="team-hero"
+    color="primary"
+    data-test="team-hero"
+    role="region"
+    :aria-labelledby="headingId"
+  >
+    <v-container class="py-12 text-center">
+      <div class="team-hero__wrapper">
+        <v-chip
+          v-if="props.eyebrow"
+          color="white"
+          variant="tonal"
+          size="small"
+          class="team-hero__eyebrow"
+          label
+        >
+          {{ props.eyebrow }}
+        </v-chip>
+
+        <h1 :id="headingId" class="team-hero__title text-white">{{ props.title }}</h1>
+        <p class="team-hero__subtitle text-white">{{ props.subtitle }}</p>
+
+        <div class="team-hero__content text-white text-body-1">
+          <TextContent :bloc-id="props.descriptionBlocId" :ipsum-length="180" />
+        </div>
+      </div>
+    </v-container>
+  </v-sheet>
+</template>
+
+<style scoped lang="sass">
+.team-hero
+  position: relative
+  overflow: hidden
+  background: linear-gradient(135deg, rgba(25, 118, 210, 0.95), rgba(67, 160, 71, 0.9))
+  color: white
+
+  &__wrapper
+    max-width: 720px
+    margin: 0 auto
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__eyebrow
+    align-self: center
+    font-weight: 600
+    letter-spacing: 0.08em
+    text-transform: uppercase
+
+  &__title
+    font-size: clamp(2.1rem, 5vw, 3rem)
+    font-weight: 700
+    margin: 0
+
+  &__subtitle
+    font-size: clamp(1.2rem, 2.5vw, 1.5rem)
+    margin: 0
+    opacity: 0.85
+
+  &__content :deep(.text-content)
+    padding: 0
+
+  &__content :deep(.xwiki-sandbox)
+    font-size: clamp(1rem, 1.6vw, 1.15rem)
+    line-height: 1.6
+</style>

--- a/frontend/app/components/domains/team/TeamMemberCard.vue
+++ b/frontend/app/components/domains/team/TeamMemberCard.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+import TextContent from '~/components/domains/content/TextContent.vue'
+import type { Member } from '~~/shared/api-client'
+
+interface Props {
+  member: Member
+  variant?: 'core' | 'contributor'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  variant: 'core',
+})
+
+const { t } = useI18n()
+
+const titleId = useId()
+const descriptionId = useId()
+
+const displayName = computed(() => props.member.name?.trim() || t('team.cards.unknownName'))
+
+const baseBlocId = computed(() => {
+  const rawName = props.member.name?.trim() ?? ''
+  const path = `pages/team/${rawName}`
+  return path.replaceAll('/', ':')
+})
+
+const titleBlocId = computed(() => `${baseBlocId.value}-title`)
+
+const portraitAlt = computed(() => t('team.cards.portraitAlt', { name: displayName.value }))
+
+const linkedInLabel = computed(() => t('team.cards.linkedIn', { name: displayName.value }))
+
+const hasLinkedIn = computed(() => Boolean(props.member.linkedInUrl))
+</script>
+
+<template>
+  <v-card
+    class="team-member-card"
+    elevation="4"
+    rounded="xl"
+    role="article"
+    :aria-labelledby="titleId"
+    :aria-describedby="descriptionId"
+  >
+    <div class="team-member-card__avatar" aria-hidden="true">
+      <NuxtImg
+        :src="props.member.imageUrl || '/nudger-icon-512x512.png'"
+        :alt="portraitAlt"
+        width="128"
+        height="128"
+        class="team-member-card__image"
+        loading="lazy"
+      />
+    </div>
+
+    <v-card-item>
+      <v-card-title :id="titleId" class="team-member-card__name">
+        {{ displayName }}
+      </v-card-title>
+      <v-card-subtitle class="team-member-card__title">
+        <TextContent :bloc-id="titleBlocId" :ipsum-length="8" />
+      </v-card-subtitle>
+    </v-card-item>
+
+    <v-card-text :id="descriptionId" class="team-member-card__bio">
+      <TextContent :bloc-id="baseBlocId" :ipsum-length="60" />
+    </v-card-text>
+
+    <v-card-actions class="team-member-card__actions">
+      <v-btn
+        v-if="hasLinkedIn"
+        :href="props.member.linkedInUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        color="primary"
+        variant="tonal"
+        prepend-icon="mdi-linkedin"
+        :aria-label="linkedInLabel"
+      >
+        {{ t('team.cards.connect') }}
+      </v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<style scoped lang="sass">
+.team-member-card
+  display: flex
+  flex-direction: column
+  align-items: center
+  text-align: center
+  padding-top: 2.5rem
+  background: white
+  height: 100%
+  position: relative
+  overflow: hidden
+
+  &__avatar
+    position: absolute
+    top: -3.5rem
+    left: 50%
+    transform: translateX(-50%)
+    width: 112px
+    height: 112px
+    border-radius: 50%
+    border: 6px solid white
+    box-shadow: 0 12px 28px rgba(33, 150, 243, 0.25)
+    background: linear-gradient(135deg, rgba(33, 150, 243, 0.15), rgba(76, 175, 80, 0.15))
+    display: flex
+    align-items: center
+    justify-content: center
+
+  &__image
+    border-radius: 50%
+    width: 100%
+    height: 100%
+    object-fit: cover
+
+  &__name
+    margin-top: 3.75rem
+    font-weight: 700
+    font-size: 1.25rem
+
+  &__title :deep(.text-content)
+    padding: 0
+    margin-top: 0.25rem
+    color: rgba(0, 0, 0, 0.6)
+
+  &__title :deep(.xwiki-sandbox)
+    font-size: 0.95rem
+
+  &__bio
+    margin-top: 0.75rem
+
+  &__bio :deep(.text-content)
+    padding: 0
+
+  &__bio :deep(.xwiki-sandbox)
+    font-size: 0.95rem
+    line-height: 1.6
+
+  &__actions
+    justify-content: center
+    padding-bottom: 1.5rem
+</style>

--- a/frontend/app/components/domains/team/TeamMembersSection.vue
+++ b/frontend/app/components/domains/team/TeamMembersSection.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { computed, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+import TextContent from '~/components/domains/content/TextContent.vue'
+import TeamMemberCard from './TeamMemberCard.vue'
+import type { Member } from '~~/shared/api-client'
+
+interface Props {
+  title: string
+  members?: Member[]
+  descriptionBlocId?: string
+  variant?: 'light' | 'muted'
+  id?: string
+  eyebrow?: string
+  memberVariant?: 'core' | 'contributor'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  members: () => [],
+  variant: 'light',
+  id: undefined,
+  descriptionBlocId: undefined,
+  eyebrow: undefined,
+  memberVariant: 'core',
+})
+
+const generatedId = useId()
+const headingId = computed(() => props.id ?? generatedId)
+const regionLabelledBy = computed(() => headingId.value)
+
+const hasMembers = computed(() => props.members.length > 0)
+const { t } = useI18n()
+</script>
+
+<template>
+  <section
+    :id="props.id"
+    class="team-members-section"
+    :class="[`team-members-section--${props.variant}`]"
+    role="region"
+    :aria-labelledby="regionLabelledBy"
+  >
+    <v-container class="py-12">
+      <div class="team-members-section__header">
+        <v-chip
+          v-if="props.eyebrow"
+          class="team-members-section__eyebrow"
+          color="primary"
+          size="small"
+          label
+          variant="tonal"
+        >
+          {{ props.eyebrow }}
+        </v-chip>
+
+        <h2 :id="headingId" class="team-members-section__title">
+          {{ props.title }}
+        </h2>
+
+        <div v-if="props.descriptionBlocId" class="team-members-section__intro">
+          <TextContent :bloc-id="props.descriptionBlocId" :ipsum-length="100" />
+        </div>
+      </div>
+
+      <v-row v-if="hasMembers" class="team-members-section__grid" align="stretch" justify="center">
+        <v-col
+          v-for="member in props.members"
+          :key="member.name"
+          cols="12"
+          sm="6"
+          lg="4"
+          xl="3"
+          class="d-flex"
+        >
+          <TeamMemberCard :member="member" :variant="props.memberVariant" class="flex-grow-1" />
+        </v-col>
+      </v-row>
+
+      <v-alert
+        v-else
+        type="info"
+        variant="tonal"
+        border="start"
+        class="mt-6"
+      >
+        {{ t('team.sections.empty') }}
+      </v-alert>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.team-members-section
+  position: relative
+  padding-inline: clamp(1rem, 4vw, 4rem)
+
+  &--light
+    background: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(245, 250, 255, 0.8) 100%)
+
+  &--muted
+    background: linear-gradient(180deg, rgba(248, 250, 252, 0.95) 0%, rgba(238, 244, 250, 0.95) 100%)
+
+  &__header
+    text-align: center
+    max-width: 720px
+    margin: 0 auto 3rem
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__eyebrow
+    align-self: center
+    letter-spacing: 0.08em
+    text-transform: uppercase
+
+  &__title
+    font-size: clamp(1.8rem, 3vw, 2.5rem)
+    font-weight: 700
+    margin: 0
+
+  &__intro :deep(.text-content)
+    padding: 0
+
+  &__intro :deep(.xwiki-sandbox)
+    font-size: 1.05rem
+    line-height: 1.7
+
+  &__grid
+    gap: 2.5rem 1.5rem
+</style>

--- a/frontend/app/pages/team/index.vue
+++ b/frontend/app/pages/team/index.vue
@@ -1,5 +1,138 @@
 <template>
-  <div>
-    ...team
+  <div class="team-page">
+    <TeamHero
+      :title="t('team.hero.title')"
+      :subtitle="t('team.hero.subtitle')"
+      :eyebrow="t('team.hero.eyebrow')"
+      :description-bloc-id="HERO_CORE_BLOC_ID"
+    />
+
+    <v-progress-linear
+      v-if="pending"
+      indeterminate
+      color="primary"
+      class="team-page__loader"
+      :aria-label="t('team.loading')"
+      role="progressbar"
+    />
+
+    <v-container v-if="error" class="py-6">
+      <v-alert
+        type="error"
+        variant="tonal"
+        border="start"
+        prominent
+        class="mb-4"
+        role="alert"
+      >
+        {{ t('team.errors.loadFailed') }}
+      </v-alert>
+      <v-btn color="primary" variant="tonal" @click="refresh">
+        {{ t('common.actions.retry') }}
+      </v-btn>
+    </v-container>
+
+    <TeamMembersSection
+      id="core-team"
+      :title="t('team.sections.core.title')"
+      :eyebrow="t('team.sections.core.eyebrow')"
+      :description-bloc-id="HERO_CORE_BLOC_ID"
+      :members="coreMembers"
+      member-variant="core"
+      variant="light"
+    />
+
+    <TeamMembersSection
+      id="contributors"
+      :title="t('team.sections.contributors.title')"
+      :eyebrow="t('team.sections.contributors.eyebrow')"
+      :description-bloc-id="CONTRIBUTORS_HERO_BLOC_ID"
+      :members="contributors"
+      member-variant="contributor"
+      variant="muted"
+    />
+
+    <TeamCallouts
+      :partners-title="t('team.callouts.partners.title')"
+      :partners-cta="t('team.callouts.partners.cta')"
+      :partners-link="partnersLink"
+      :partners-bloc-id="PARTNERS_BLOC_ID"
+      :contact-title="t('team.callouts.contact.title')"
+      :contact-description="t('team.callouts.contact.description')"
+      :contact-cta="t('team.callouts.contact.cta')"
+      :contact-link="contactLink"
+    />
   </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { TeamProperties } from '~~/shared/api-client'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+const HERO_CORE_BLOC_ID = 'pages:team:hero-core-team:'
+const CONTRIBUTORS_HERO_BLOC_ID = 'pages:team:hero-contributors-team:'
+const PARTNERS_BLOC_ID = 'pages:team:partenaires:'
+
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+const requestURL = useRequestURL()
+
+const { data, pending, error, refresh } = await useAsyncData<TeamProperties>('team-roster', () =>
+  $fetch<TeamProperties>('/api/team')
+)
+
+const coreMembers = computed(() => data.value?.cores ?? [])
+const contributors = computed(() => data.value?.contributors ?? [])
+
+const partnersLink = computed(() => {
+  const link = String(t('team.callouts.partners.link'))
+  if (link.startsWith('http')) {
+    return link
+  }
+
+  if (link.startsWith('/')) {
+    return link
+  }
+
+  return localePath(link)
+})
+
+const contactLink = computed(() => localePath('contact'))
+
+const canonicalUrl = computed(
+  () => new URL(resolveLocalizedRoutePath('team', locale.value), requestURL.origin).toString()
+)
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+
+useSeoMeta({
+  title: () => String(t('team.seo.title')),
+  description: () => String(t('team.seo.description')),
+  ogTitle: () => String(t('team.seo.title')),
+  ogDescription: () => String(t('team.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+  twitterCard: () => 'summary_large_image',
+  twitterTitle: () => String(t('team.seo.title')),
+  twitterDescription: () => String(t('team.seo.description')),
+  twitterImage: () => ogImageUrl.value,
+})
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+  ],
+}))
+</script>
+
+<style scoped lang="sass">
+.team-page
+  display: flex
+  flex-direction: column
+  gap: 0
+
+  &__loader
+    margin: 0
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -95,5 +95,49 @@
     "actions": {
       "retry": "Retry"
     }
+  },
+  "team": {
+    "seo": {
+      "title": "Meet the Nudger team",
+      "description": "Discover the collective of entrepreneurs, engineers and volunteers building the sustainable shopping assistant Nudger."
+    },
+    "hero": {
+      "eyebrow": "Our collective",
+      "title": "The people behind Nudger",
+      "subtitle": "A passionate crew blending tech, sustainability and social impact."
+    },
+    "loading": "Loading team members…",
+    "errors": {
+      "loadFailed": "We could not load the team roster. Please try again."
+    },
+    "sections": {
+      "empty": "The team roster will be published soon.",
+      "core": {
+        "title": "Core team",
+        "eyebrow": "Leadership"
+      },
+      "contributors": {
+        "title": "Contributors",
+        "eyebrow": "Community"
+      }
+    },
+    "cards": {
+      "portraitAlt": "Portrait of {name}",
+      "linkedIn": "Open {name}'s LinkedIn profile",
+      "connect": "Connect on LinkedIn",
+      "unknownName": "a team member"
+    },
+    "callouts": {
+      "partners": {
+        "title": "Our partners",
+        "cta": "Discover our partners",
+        "link": "/partners"
+      },
+      "contact": {
+        "title": "Curious to chat?",
+        "description": "Want to co-create the future of responsible shopping or ask us something specific? We would love to talk.",
+        "cta": "Contact us"
+      }
+    }
   }
 }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -94,5 +94,49 @@
     "actions": {
       "retry": "Réessayer"
     }
+  },
+  "team": {
+    "seo": {
+      "title": "Découvrez l'équipe Nudger",
+      "description": "Rencontrez les entrepreneuses, ingénieurs et bénévoles qui construisent l'assistant d'achat responsable Nudger."
+    },
+    "hero": {
+      "eyebrow": "Notre collectif",
+      "title": "Les femmes et les hommes derrière Nudger",
+      "subtitle": "Une équipe engagée qui mêle tech, environnement et impact social."
+    },
+    "loading": "Chargement des membres…",
+    "errors": {
+      "loadFailed": "Impossible de charger la liste de l'équipe. Merci de réessayer."
+    },
+    "sections": {
+      "empty": "Les profils seront bientôt disponibles.",
+      "core": {
+        "title": "La core-team",
+        "eyebrow": "Pilotage"
+      },
+      "contributors": {
+        "title": "Les contributeurs",
+        "eyebrow": "Communauté"
+      }
+    },
+    "cards": {
+      "portraitAlt": "Portrait de {name}",
+      "linkedIn": "Ouvrir le profil LinkedIn de {name}",
+      "connect": "Voir sur LinkedIn",
+      "unknownName": "un membre de l'équipe"
+    },
+    "callouts": {
+      "partners": {
+        "title": "Nos partenaires",
+        "cta": "Découvrir les partenaires",
+        "link": "/partenaires"
+      },
+      "contact": {
+        "title": "Envie d'échanger ?",
+        "description": "Vous souhaitez en savoir plus sur le projet ou rejoindre l'aventure ? Parlons-en.",
+        "cta": "Nous contacter"
+      }
+    }
   }
 }

--- a/frontend/server/api/team.ts
+++ b/frontend/server/api/team.ts
@@ -1,0 +1,28 @@
+import { useTeamService } from '~~/shared/api-client/services/team.services'
+import type { TeamProperties } from '~~/shared/api-client'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../utils/log-backend-error'
+
+export default defineEventHandler(async (event): Promise<TeamProperties> => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=1800, s-maxage=1800')
+
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const teamService = useTeamService(domainLanguage)
+
+  try {
+    return await teamService.fetchTeam()
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error fetching team roster', backendError.logMessage, backendError)
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/shared/api-client/services/index.ts
+++ b/frontend/shared/api-client/services/index.ts
@@ -2,3 +2,4 @@
 export { useBlogService } from './blog.services'
 export { useContentService } from './content.services'
 export { authService } from './auth.services'
+export { useTeamService } from './team.services'

--- a/frontend/shared/api-client/services/team.services.ts
+++ b/frontend/shared/api-client/services/team.services.ts
@@ -1,0 +1,28 @@
+import { TeamApi, Configuration, TeamDomainLanguageEnum } from '..'
+import type { TeamProperties } from '..'
+import type { DomainLanguage } from '../../utils/domain-language'
+
+/**
+ * Team service responsible for fetching team roster data from the backend API.
+ */
+export const useTeamService = (domainLanguage: DomainLanguage) => {
+  const config = useRuntimeConfig()
+  const apiConfig = new Configuration({ basePath: config.apiUrl })
+  const api = new TeamApi(apiConfig)
+
+  const fetchTeam = async (): Promise<TeamProperties> => {
+    const language =
+      domainLanguage === 'fr'
+        ? TeamDomainLanguageEnum.Fr
+        : TeamDomainLanguageEnum.En
+
+    try {
+      return await api.team({ domainLanguage: language })
+    } catch (error) {
+      console.error('Error fetching team roster:', error)
+      throw error
+    }
+  }
+
+  return { fetchTeam }
+}


### PR DESCRIPTION
## Summary
- create dedicated Vuetify components to render the team hero, member grid, and partner/contact callouts
- expose a Nuxt server endpoint backed by a typed Team service to load roster data without client-side API calls
- localize SEO copy and UI strings for the /team and /equipe routes while wiring TextContent blocs for CMS content

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b0a34be083338841bc16aa13fd9a