### PR TITLE
docs(frontend): add front-api auth checklist

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -70,6 +70,14 @@ Document any intentionally skipped check in your summary/PR.
 - Update or extend README, AGENTS.md, architectural notes, and comments when behaviour changes.
 - Keep comments in English; translate legacy ones as you touch the file.
 
+## Front API authentication checklist
+- All Nuxt server routes must call `front-api` through the shared configuration helper in `~/app/plugins/api-token.server.ts`. Use the generated OpenAPI services or `$fetch` so that helper can always inject the `X-Shared-Token` header.
+- Keep the `MACHINE_TOKEN` runtime value synchronised with the backend's `front.security.shared-token` property; drift breaks machine-to-machine authentication.
+- Before modifying authentication-sensitive code:
+  1. Confirm the shared helper still wraps every outbound call to `config.apiUrl`.
+  2. Re-validate the `MACHINE_TOKEN`/`front.security.shared-token` pairing in local and deployment secrets.
+  3. Exercise the affected flows (login, refresh, logout, and generated client calls) to prove headers and cookies remain intact.
+
 ## MCP & Developer Tooling
 - Ensure the Nuxt MCP server is running on port 3000 when working with Claude Code / Vuetify MCP features (`nuxt dev` already exposes it).
 - Claude-specific shortcuts (e.g., `/css-class-validator`) remain available; keep instructions compatible with Claude’s CLAUDE.md expectations.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -71,7 +71,7 @@ Document any intentionally skipped check in your summary/PR.
 - Keep comments in English; translate legacy ones as you touch the file.
 
 ## Front API authentication checklist
-- All Nuxt server routes must call `front-api` through the shared configuration helper in `~/app/plugins/api-token.server.ts`. Use the generated OpenAPI services or `$fetch` so that helper can always inject the `X-Shared-Token` header.
+- All Nuxt server routes must call `front-api` through the shared configuration helper in `~/app/plugins/api-token.server.ts`. Always use the generated OpenAPI services so that helper can always inject the `X-Shared-Token` header.
 - Keep the `MACHINE_TOKEN` runtime value synchronised with the backend's `front.security.shared-token` property; drift breaks machine-to-machine authentication.
 - Before modifying authentication-sensitive code:
   1. Confirm the shared helper still wraps every outbound call to `config.apiUrl`.


### PR DESCRIPTION
## Summary
- note that Nuxt server routes must use the shared front-api configuration helper so X-Shared-Token is always attached
- document keeping MACHINE_TOKEN aligned with front.security.shared-token and add a checklist for auth-sensitive changes

## Testing
- not run (not needed for docs changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7c7e259008333ac3422817ba4c525