### PR TITLE
feat(frontend): centralize backend api config for nuxt services

### DIFF
--- a/frontend/server/api/team.spec.ts
+++ b/frontend/server/api/team.spec.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type TeamRouteHandler = typeof import('./team')['default']
+
+const runtimeConfig = vi.hoisted(() => ({
+  apiUrl: '',
+  machineToken: '',
+}))
+
+const setResponseHeaderMock = vi.hoisted(() => vi.fn())
+
+vi.mock('#imports', () => ({
+  defineEventHandler: (fn: TeamRouteHandler) => fn,
+  setResponseHeader: setResponseHeaderMock,
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+vi.mock('nuxt/app', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => runtimeConfig,
+}))
+
+describe('GET /api/team Nitro endpoint', () => {
+  const fetchMock = vi.fn<Parameters<typeof fetch>, Promise<Response>>()
+  let handler: TeamRouteHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          cores: [],
+          contributors: [],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    )
+
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal('defineEventHandler', (fn: TeamRouteHandler) => fn)
+
+    runtimeConfig.apiUrl = 'https://backend.example.test'
+    runtimeConfig.machineToken = 'test-token-123'
+    setResponseHeaderMock.mockReset()
+    vi.stubGlobal('setResponseHeader', setResponseHeaderMock)
+    process.env.API_URL = 'https://backend.example.test'
+    process.env.MACHINE_TOKEN = 'test-token-123'
+
+    handler = (await import('./team')).default
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('forwards the shared token header to the backend request', async () => {
+    const event = {
+      node: {
+        req: {
+          headers: {
+            host: 'nudger.com',
+          },
+        },
+        res: {},
+      },
+    } as unknown as Parameters<typeof handler>[0]
+
+    await handler(event)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, init] = fetchMock.mock.calls[0]
+    const headers = (init?.headers ?? {}) as Record<string, string>
+
+    expect(headers['X-Shared-Token']).toBe('test-token-123')
+  })
+})

--- a/frontend/shared/api-client/services/content.services.ts
+++ b/frontend/shared/api-client/services/content.services.ts
@@ -1,21 +1,34 @@
-import { ContentApi, Configuration } from '..'
+import { ContentApi } from '..'
 import type { XwikiContentBlocDto } from '..'
 import type { DomainLanguage } from '../../utils/domain-language'
+import { createBackendApiConfig } from './createBackendApiConfig'
 
 /**
  * Content service for fetching HTML blocs from the backend
  */
 export const useContentService = (domainLanguage: DomainLanguage) => {
-  const config = useRuntimeConfig()
-  const apiConfig = new Configuration({ basePath: config.apiUrl })
-  const api = new ContentApi(apiConfig)
+  const isVitest = typeof process !== 'undefined' && process.env?.VITEST === 'true'
+  const isServerRuntime = import.meta.server || isVitest
+  let api: ContentApi | undefined
+
+  const resolveApi = () => {
+    if (!isServerRuntime) {
+      throw new Error('useContentService() is only available on the server runtime.')
+    }
+
+    if (!api) {
+      api = new ContentApi(createBackendApiConfig())
+    }
+
+    return api
+  }
 
   /**
    * Retrieve a content bloc by its identifier
    * @param blocId - XWiki bloc identifier
    */
   const getBloc = async (blocId: string): Promise<XwikiContentBlocDto> => {
-    return await api.contentBloc({ blocId, domainLanguage })
+    return await resolveApi().contentBloc({ blocId, domainLanguage })
   }
 
   return { getBloc }

--- a/frontend/shared/api-client/services/createBackendApiConfig.ts
+++ b/frontend/shared/api-client/services/createBackendApiConfig.ts
@@ -1,0 +1,29 @@
+import { Configuration } from '..'
+
+/**
+ * Factory that builds a backend API configuration seeded with the runtime configuration.
+ *
+ * Ensures the shared machine token is injected on every request so downstream
+ * services can authenticate the proxy calls.
+ */
+export const createBackendApiConfig = (): Configuration => {
+  const isVitest = typeof process !== 'undefined' && process.env?.VITEST === 'true'
+  const isServerRuntime = import.meta.server || isVitest
+
+  if (!isServerRuntime) {
+    throw new Error('createBackendApiConfig() can only be used on the server runtime.')
+  }
+
+  const { apiUrl, machineToken } = useRuntimeConfig()
+
+  if (!machineToken) {
+    throw new Error('Missing runtime configuration value "machineToken"; backend calls cannot be authenticated.')
+  }
+
+  return new Configuration({
+    basePath: apiUrl,
+    headers: {
+      'X-Shared-Token': machineToken,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add a shared helper that builds authenticated backend API configurations from the Nuxt runtime settings
- refactor team, blog, and content services to reuse the helper only during SSR execution
- add a Nitro route unit test that asserts the X-Shared-Token header is forwarded when calling /api/team

## Testing
- `pnpm vitest run server/api/team.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d7c7cc16c8833398dd8633fefc3a54