### PR TITLE
Fix team member bloc IDs for CMS content

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/TeamProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/TeamProperties.java
@@ -56,12 +56,24 @@ public class TeamProperties {
                 example = "/assets/img/team/Goulven.jpeg")
         private String imageUrl;
 
+        @Schema(description = "XWiki bloc identifier providing the member biography.",
+                example = "pages:team:goulven-furet:")
+        private String blocId;
+
         public String getName() {
             return name;
         }
 
         public void setName(String name) {
             this.name = name;
+        }
+
+        public String getBlocId() {
+            return blocId;
+        }
+
+        public void setBlocId(String blocId) {
+            this.blocId = blocId;
         }
 
         public String getLinkedInUrl() {

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -44,50 +44,62 @@ management:
 team-config:
   cores:
     - name: Goulven Furet
+      blocId: 'pages:team:goulven-furet:'
       linkedInUrl: https://www.linkedin.com/in/goulven-furet-b448b582/
       imageUrl: /images/team/Goulven.jpeg
 
     - name: Bérangère Leven
+      blocId: 'pages:team:berangere-leven:'
       linkedInUrl: https://www.linkedin.com/in/b%C3%A9rang%C3%A8re-leven/
       imageUrl: /images/team/Berangere.jpeg
 
     - name: Thomas Vandewalle
+      blocId: 'pages:team:thomas-vandewalle:'
       linkedInUrl: https://www.linkedin.com/in/thomas-vandewalle-fr001/
       imageUrl: /images/team/Thomas.jpeg
 
     - name: Candide Chérel
+      blocId: 'pages:team:candide-cherel:'
       linkedInUrl: https://www.linkedin.com/in/candide-cherel/?originalSubdomain=fr
       imageUrl: /images/team/Candide.jpeg
 
     - name: Yann Mingant
+      blocId: 'pages:team:yann-mingant:'
       linkedInUrl: https://www.linkedin.com/in/yann-mingant-5118b7177/
       imageUrl: /images/team/Yann.jpeg
 
     - name: Louis-Marie Toudoire
+      blocId: 'pages:team:louis-marie-toudoire:'
       linkedInUrl: https://www.linkedin.com/in/scezen/?originalSubdomain=fr
       imageUrl: /images/team/Louis-Marie.jpeg
 
     - name: Laurent Blondel
+      blocId: 'pages:team:laurent-blondel:'
       linkedInUrl: https://www.linkedin.com/in/laurent-blondel-33543532/
       imageUrl: /images/team/Laurent.jpeg
 
     - name: Max Ziliani
+      blocId: 'pages:team:max-ziliani:'
       linkedInUrl: https://www.linkedin.com/in/maxziliani/
       imageUrl: /images/team/Max.jpeg
 
   contributors:
     - name: Loïc Gourmelon
+      blocId: 'pages:team:loic-gourmelon:'
       linkedInUrl: https://www.linkedin.com/in/gourmelonloic/
       imageUrl: /images/team/Loic.jpeg
 
     - name: Thierry Ledan
+      blocId: 'pages:team:thierry-ledan:'
       linkedInUrl: https://www.linkedin.com/in/thierry-ledan-43650a183/
       imageUrl: /images/team/Thierry.jpeg
 
     - name: Nicolas Bonamy
+      blocId: 'pages:team:nicolas-bonamy:'
       linkedInUrl: https://www.linkedin.com/in/nicolas-bonamy-827b63a3/
       imageUrl: /images/team/Nicolas.jpeg
 
     - name: Stephane Castrec
+      blocId: 'pages:team:stephane-castrec:'
       linkedInUrl: https://www.linkedin.com/in/scastrec/
       imageUrl: /images/team/Stephane.jpeg

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/TeamControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/TeamControllerTest.java
@@ -26,11 +26,13 @@ class TeamControllerTest {
 
         TeamProperties.Member core = new TeamProperties.Member();
         core.setName("Jane Doe");
+        core.setBlocId("pages:team:jane-doe:");
         core.setLinkedInUrl("https://www.linkedin.com/in/janedoe/");
         core.setImageUrl("/img/jane.jpeg");
 
         TeamProperties.Member contributor = new TeamProperties.Member();
         contributor.setName("John Roe");
+        contributor.setBlocId("pages:team:john-roe:");
         contributor.setLinkedInUrl("https://www.linkedin.com/in/johnroe/");
         contributor.setImageUrl("/img/john.jpeg");
 
@@ -47,6 +49,7 @@ class TeamControllerTest {
         mockMvc.perform(get("/team").param("domainLanguage", "fr"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.cores[0].name").value("Jane Doe"))
+                .andExpect(jsonPath("$.cores[0].blocId").value("pages:team:jane-doe:"))
                 .andExpect(jsonPath("$.contributors[0].imageUrl").value("/img/john.jpeg"));
     }
 }

--- a/frontend/app/components/domains/team/TeamMemberCard.vue
+++ b/frontend/app/components/domains/team/TeamMemberCard.vue
@@ -110,7 +110,7 @@ const hasLinkedIn = computed(() => Boolean(props.member.linkedInUrl))
   background: white
   height: 100%
   position: relative
-  overflow: hidden
+  overflow: visible
 
   &__avatar
     position: absolute

--- a/frontend/app/components/domains/team/TeamMemberCard.vue
+++ b/frontend/app/components/domains/team/TeamMemberCard.vue
@@ -2,6 +2,7 @@
 import { computed, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Member } from '~~/shared/api-client'
+import { _slugify } from '~~/shared/utils/_slugify'
 
 interface Props {
   member: Member
@@ -20,12 +21,27 @@ const descriptionId = useId()
 const displayName = computed(() => props.member.name?.trim() || t('team.cards.unknownName'))
 
 const baseBlocId = computed(() => {
-  const rawName = props.member.name?.trim() ?? ''
-  const path = `pages:team:${rawName}`
-  return path
+  const explicit = props.member.blocId?.trim()
+  if (explicit) {
+    return explicit
+  }
+
+  const slug = _slugify(props.member.name ?? '')
+  if (!slug) {
+    return ''
+  }
+
+  return `pages:team:${slug}:`
 })
 
-const titleBlocId = computed(() => `${baseBlocId.value}-title`)
+const titleBlocId = computed(() => {
+  const base = baseBlocId.value
+  if (!base) {
+    return ''
+  }
+
+  return base.endsWith(':') ? `${base.slice(0, -1)}-title:` : `${base}-title`
+})
 
 const portraitAlt = computed(() => t('team.cards.portraitAlt', { name: displayName.value }))
 

--- a/frontend/shared/api-client/models/Member.ts
+++ b/frontend/shared/api-client/models/Member.ts
@@ -26,6 +26,12 @@ export interface Member {
      */
     name?: string;
     /**
+     * XWiki bloc identifier containing the member biography.
+     * @type {string}
+     * @memberof Member
+     */
+    blocId?: string;
+    /**
      * LinkedIn profile URL of the member.
      * @type {string}
      * @memberof Member
@@ -55,8 +61,9 @@ export function MemberFromJSONTyped(json: any, ignoreDiscriminator: boolean): Me
         return json;
     }
     return {
-        
+
         'name': json['name'] == null ? undefined : json['name'],
+        'blocId': json['blocId'] == null ? undefined : json['blocId'],
         'linkedInUrl': json['linkedInUrl'] == null ? undefined : json['linkedInUrl'],
         'imageUrl': json['imageUrl'] == null ? undefined : json['imageUrl'],
     };
@@ -72,8 +79,9 @@ export function MemberToJSONTyped(value?: Member | null, ignoreDiscriminator: bo
     }
 
     return {
-        
+
         'name': value['name'],
+        'blocId': value['blocId'],
         'linkedInUrl': value['linkedInUrl'],
         'imageUrl': value['imageUrl'],
     };

--- a/frontend/shared/utils/_slugify.spec.ts
+++ b/frontend/shared/utils/_slugify.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { _slugify } from './_slugify'
+
+describe('_slugify', () => {
+  it('normalizes accents and punctuation', () => {
+    expect(_slugify('Bérangère Leven')).toBe('berangere-leven')
+  })
+
+  it('collapses whitespace and symbols into single hyphen', () => {
+    expect(_slugify('  Candide   Chérel!! ')).toBe('candide-cherel')
+  })
+
+  it('uses fallback when input yields empty slug', () => {
+    expect(_slugify('!!!', { fallback: 'member' })).toBe('member')
+  })
+})

--- a/frontend/shared/utils/_slugify.ts
+++ b/frontend/shared/utils/_slugify.ts
@@ -1,0 +1,29 @@
+export interface SlugifyOptions {
+  fallback?: string
+}
+
+/**
+ * Convert a human readable string into a URL/XWiki friendly slug.
+ * Accents are stripped and non-alphanumeric characters collapse into hyphens.
+ */
+export const _slugify = (input: string, options: SlugifyOptions = {}): string => {
+  if (!input) {
+    return options.fallback ?? ''
+  }
+
+  const normalized = input
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/['’]/g, '')
+
+  const slug = normalized
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+
+  if (!slug) {
+    return options.fallback ?? ''
+  }
+
+  return slug
+}


### PR DESCRIPTION
## Summary
- add an explicit `blocId` property to team members in the front-api config and expose it through the DTO
- update the Nuxt TeamMemberCard to rely on the configured bloc id (with slugified fallback) instead of interpolating raw names
- introduce a shared `_slugify` helper and tests so bloc identifiers are generated consistently on the frontend

## Testing
- mvn -pl front-api test
- pnpm vitest run shared/utils/_slugify.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7d56435408333b4553b9f58891560