### PR TITLE
Enforce domain-localized route slugs

### DIFF
--- a/frontend/app/middleware/enforce-locale-path.global.ts
+++ b/frontend/app/middleware/enforce-locale-path.global.ts
@@ -1,0 +1,23 @@
+import { createError } from 'h3'
+import { useNuxtApp } from '#imports'
+import { matchLocalizedRouteByPath, normalizeLocale } from '~~/shared/utils/localized-routes'
+
+export default defineNuxtRouteMiddleware((to) => {
+  const nuxtApp = useNuxtApp()
+  const i18n = nuxtApp.$i18n as { locale?: { value?: string | null } } | undefined
+  const activeLocale = normalizeLocale(i18n?.locale?.value ?? undefined)
+  const matchedRoute = matchLocalizedRouteByPath(to.path)
+
+  if (!matchedRoute) {
+    return
+  }
+
+  if (matchedRoute.locale !== activeLocale) {
+    return abortNavigation(
+      createError({
+        statusCode: 404,
+        statusMessage: 'Not Found',
+      }),
+    )
+  }
+})

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   LOCALIZED_ROUTE_PATHS,
   buildI18nPagesConfig,
+  matchLocalizedRouteByPath,
   normalizeLocale,
   resolveLocalizedRoutePath,
 } from './localized-routes'
@@ -20,14 +21,17 @@ describe('localized-routes utilities', () => {
     expect(resolveLocalizedRoutePath('team', 'en-US')).toBe('/team')
   })
 
+  it('matches paths back to their localized routes', () => {
+    expect(matchLocalizedRouteByPath('/equipe')).toEqual({ routeName: 'team', locale: 'fr-FR' })
+    expect(matchLocalizedRouteByPath('/team')).toEqual({ routeName: 'team', locale: 'en-US' })
+    expect(matchLocalizedRouteByPath('/unknown')).toBeNull()
+  })
+
 
   it('falls back to default paths when no mapping exists', () => {
     expect(resolveLocalizedRoutePath('privacy', 'fr-FR')).toBe('/privacy')
     expect(resolveLocalizedRoutePath('account', 'en-US')).toBe('/account')
   })
-
-
-
   it('builds a compatible i18n pages configuration', () => {
     const config = buildI18nPagesConfig()
 


### PR DESCRIPTION
## Summary
- add a global middleware that rejects localized pages when the slug does not match the active domain locale
- extend the localized route utilities with helpers to match slugs back to their locale-aware configuration
- cover the new matching helper with unit tests to keep the mapping logic verifiable

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68d816958afc833389e7771c423bbbb5