### PR TITLE
Fix Nuxt image module public directory

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -109,6 +109,7 @@ export default defineNuxtConfig({
     }
   },
   image: {
+    dir: 'public',
     // The screen sizes predefined by `@nuxt/image`:
     screens: {
       'xs': 320,


### PR DESCRIPTION
## Summary
- point the `@nuxt/image` module at the actual `public` directory so team portraits resolve without an extra `app/` prefix

## Testing
- pnpm dev
- curl -sS http://localhost:3000/_ipx/_/images/team/Goulven.jpeg -o /tmp/test.jpg -D -

------
https://chatgpt.com/codex/tasks/task_e_68d8f6cc37cc8333a5b5c37dbfbf72ea