### PR TITLE
fix: use absolute nuxt image dir

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -1,5 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
+import { fileURLToPath } from 'node:url'
+
 import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
 import { buildI18nLocaleDomains } from './shared/utils/domain-language'
 import { buildI18nPagesConfig } from './shared/utils/localized-routes'
@@ -109,7 +111,7 @@ export default defineNuxtConfig({
     }
   },
   image: {
-    dir: 'public',
+    dir: fileURLToPath(new URL('./app/public', import.meta.url)),
     // The screen sizes predefined by `@nuxt/image`:
     screens: {
       'xs': 320,


### PR DESCRIPTION
## Summary
- import `fileURLToPath` in `nuxt.config.ts`
- point the Nuxt image directory to the absolute `app/public` path so @nuxt/image stops prefixing `app/`

## Testing
- pnpm dev
- curl http://localhost:3000/_ipx/_/images/team/Goulven.jpeg

------
https://chatgpt.com/codex/tasks/task_e_68d900c2fe28833393e828e29ecd7318