### PR TITLE
Align blog and team pages with shared Vuetify width

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -440,7 +440,7 @@ await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
 </script>
 
 <template>
-  <v-container class="py-6 px-4 mx-auto" max-width="1200">
+  <v-container class="py-6 px-4 mx-auto" max-width="xl">
     <v-sheet
       v-if="availableTags.length || activeTag"
       class="mb-6 d-flex flex-column gap-3 pa-4"

--- a/frontend/app/components/domains/team/TeamCallouts.vue
+++ b/frontend/app/components/domains/team/TeamCallouts.vue
@@ -17,7 +17,7 @@ const props = defineProps<Props>()
 
 <template>
   <section class="team-callouts" role="region" aria-labelledby="team-callouts-title">
-    <v-container class="py-12">
+    <v-container class="py-12 px-4 mx-auto" max-width="xl">
       <v-row class="g-6" align="stretch">
         <v-col cols="12" lg="8">
           <v-card class="team-callouts__card" elevation="6" rounded="xl">
@@ -72,7 +72,6 @@ const props = defineProps<Props>()
 <style scoped lang="sass">
 .team-callouts
   background: linear-gradient(135deg, rgba(236, 248, 239, 0.7), rgba(227, 242, 253, 0.75))
-  padding-inline: clamp(1rem, 4vw, 4rem)
 
   &__card
     height: 100%

--- a/frontend/app/components/domains/team/TeamHero.vue
+++ b/frontend/app/components/domains/team/TeamHero.vue
@@ -21,7 +21,7 @@ const headingId = useId()
     role="region"
     :aria-labelledby="headingId"
   >
-    <v-container class="py-12 text-center">
+    <v-container class="py-12 px-4 text-center mx-auto" max-width="xl">
       <div class="team-hero__wrapper">
 
         <h1 :id="headingId" class="team-hero__title text-white">{{ props.title }}</h1>
@@ -43,7 +43,6 @@ const headingId = useId()
   color: white
 
   &__wrapper
-    max-width: 720px
     margin: 0 auto
     display: flex
     flex-direction: column

--- a/frontend/app/components/domains/team/TeamMembersSection.vue
+++ b/frontend/app/components/domains/team/TeamMembersSection.vue
@@ -38,7 +38,7 @@ const { t } = useI18n()
     role="region"
     :aria-labelledby="regionLabelledBy"
   >
-    <v-container class="py-12">
+    <v-container class="py-12 px-4 mx-auto" max-width="xl">
       <div class="team-members-section__header">
 
         <h2 :id="headingId" class="team-members-section__title">
@@ -80,7 +80,6 @@ const { t } = useI18n()
 <style scoped lang="sass">
 .team-members-section
   position: relative
-  padding-inline: clamp(1rem, 4vw, 4rem)
 
   &--light
     background: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(245, 250, 255, 0.8) 100%)
@@ -90,7 +89,6 @@ const { t } = useI18n()
 
   &__header
     text-align: center
-    max-width: 720px
     margin: 0 auto 3rem
     display: flex
     flex-direction: column

--- a/frontend/app/pages/blog/[slug].vue
+++ b/frontend/app/pages/blog/[slug].vue
@@ -45,9 +45,9 @@ const article = computed(
 </script>
 
 <template>
-  <v-container class="py-10">
-    <v-row justify="center">
-      <v-col cols="12" md="10" lg="8">
+  <v-container class="py-10 px-4 mx-auto" max-width="xl">
+    <v-row>
+      <v-col cols="12">
         <v-btn variant="text" prepend-icon="mdi-arrow-left" @click="router.back()">
           Retour
         </v-btn>

--- a/frontend/app/pages/team/index.vue
+++ b/frontend/app/pages/team/index.vue
@@ -15,7 +15,7 @@
       role="progressbar"
     />
 
-    <v-container v-if="error" class="py-6">
+    <v-container v-if="error" class="py-6 px-4 mx-auto" max-width="xl">
       <v-alert
         type="error"
         variant="tonal"


### PR DESCRIPTION
## Summary
- switch blog listing, blog detail, and team page containers to the shared Vuetify `xl` max-width and responsive padding
- remove bespoke 720px caps and inline padding so team hero, member list, and callouts expand with the container

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d90070882883338278688bde9f8176