### PR TITLE
Fix team member image URL resolution for dev server

### DIFF
--- a/frontend/server/api/team.spec.ts
+++ b/frontend/server/api/team.spec.ts
@@ -80,4 +80,45 @@ describe('GET /api/team Nitro endpoint', () => {
 
     expect(headers['X-Shared-Token']).toBe('test-token-123')
   })
+
+  it('normalizes relative member image URLs against the backend base URL', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          cores: [
+            {
+              name: 'Relative Image',
+              imageUrl: '/images/team/relative.jpeg',
+            },
+          ],
+          contributors: [
+            {
+              name: 'Absolute Image',
+              imageUrl: 'https://cdn.example.test/avatar.png',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      )
+    )
+
+    const event = {
+      node: {
+        req: {
+          headers: {
+            host: 'nudger.fr',
+          },
+        },
+        res: {},
+      },
+    } as unknown as Parameters<typeof handler>[0]
+
+    const result = await handler(event)
+
+    expect(result.cores[0]?.imageUrl).toBe('https://backend.example.test/images/team/relative.jpeg')
+    expect(result.contributors[0]?.imageUrl).toBe('https://cdn.example.test/avatar.png')
+  })
 })

--- a/frontend/server/api/team.ts
+++ b/frontend/server/api/team.ts
@@ -1,8 +1,35 @@
+import { useRuntimeConfig } from '#imports'
 import { useTeamService } from '~~/shared/api-client/services/team.services'
-import type { TeamProperties } from '~~/shared/api-client'
+import type { Member, TeamProperties } from '~~/shared/api-client'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../utils/log-backend-error'
+
+const resolveImageUrl = (imageUrl: string | undefined, baseUrl: string | undefined): string | undefined => {
+  if (!imageUrl) {
+    return imageUrl
+  }
+
+  if (/^https?:\/\//i.test(imageUrl) || imageUrl.startsWith('//')) {
+    return imageUrl
+  }
+
+  if (!baseUrl) {
+    return imageUrl
+  }
+
+  try {
+    return new URL(imageUrl, baseUrl).toString()
+  } catch {
+    return imageUrl
+  }
+}
+
+const normalizeMemberImageUrls = (members: Member[], baseUrl: string | undefined): Member[] =>
+  members.map((member) => ({
+    ...member,
+    imageUrl: resolveImageUrl(member.imageUrl, baseUrl),
+  }))
 
 export default defineEventHandler(async (event): Promise<TeamProperties> => {
   setResponseHeader(event, 'Cache-Control', 'public, max-age=1800, s-maxage=1800')
@@ -10,11 +37,19 @@ export default defineEventHandler(async (event): Promise<TeamProperties> => {
   const rawHost =
     event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
   const { domainLanguage } = resolveDomainLanguage(rawHost)
+  const runtimeConfig = useRuntimeConfig(event)
 
   const teamService = useTeamService(domainLanguage)
 
   try {
-    return await teamService.fetchTeam()
+    const roster = await teamService.fetchTeam()
+    const baseUrl = runtimeConfig?.apiUrl
+
+    return {
+      ...roster,
+      cores: normalizeMemberImageUrls(roster.cores, baseUrl),
+      contributors: normalizeMemberImageUrls(roster.contributors, baseUrl),
+    }
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
     console.error('Error fetching team roster', backendError.logMessage, backendError)


### PR DESCRIPTION
## Summary
- normalize the /api/team response so member image URLs are resolved against the backend base URL
- add a Nitro endpoint test covering relative and absolute image URLs

## Testing
- pnpm test --run server/api/team.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d924312394833380e8136e7f220c8a