### PR TITLE
Fix blog tag filter header styling

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -452,9 +452,9 @@ await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
       :aria-busy="tagsLoading"
       :aria-controls="articleListId"
     >
-      <div class="d-flex align-center gap-2 text-primary font-weight-medium">
+      <div class="d-flex align-center gap-2 font-weight-medium">
         <v-icon icon="mdi-tag-multiple" size="small" color="primary" aria-hidden="true" />
-        <span class="text-subtitle-1">{{ t('blog.list.tagsTitle') }}</span>
+        <span class="text-subtitle-1 text-high-emphasis">{{ t('blog.list.tagsTitle') }}</span>
       </div>
 
       <v-chip-group


### PR DESCRIPTION
## Summary
- remove the primary text color from the blog tag filter header to avoid link-like styling
- keep the icon highlighted while ensuring the label text uses the standard high-emphasis color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d94bfd1d50833384260b6428194691