### PR TITLE
Fix blog articles computed type

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -240,7 +240,7 @@ const seoPageLinks = computed(() => {
   return Array.from({ length: pages }, (_, index) => index + 1)
 })
 
-const visibleArticles = computed<BlogPostDto[]>(() => paginatedArticles.value ?? [])
+const visibleArticles = paginatedArticles
 const sanitizedTag = computed(() => {
   const tag = activeTag.value
 


### PR DESCRIPTION
## Summary
- reference the existing paginated articles ref instead of wrapping it in a mutable computed to satisfy readonly typing

## Testing
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68da276e7134833396325fb4ba3952ac