### PR TITLE
Add captcha-protected contact endpoint to front API

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -87,6 +87,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -11,9 +11,13 @@ import org.open4goods.verticals.GoogleTaxonomyService;
 import org.open4goods.verticals.VerticalsConfigService;
 import org.open4goods.xwiki.services.XwikiFacadeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 @Configuration
 /**
@@ -31,6 +35,29 @@ public class AppConfig {
     @Bean
     ProductRepository productRepository() {
         return new ProductRepository();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JavaMailSender.class)
+    JavaMailSender javaMailSender(
+            @Value("${spring.mail.host:localhost}") String host,
+            @Value("${spring.mail.port:25}") int port,
+            @Value("${spring.mail.username:}") String username,
+            @Value("${spring.mail.password:}") String password,
+            @Value("${spring.mail.protocol:}") String protocol) {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setPort(port);
+        if (!username.isBlank()) {
+            sender.setUsername(username);
+        }
+        if (!password.isBlank()) {
+            sender.setPassword(password);
+        }
+        if (!protocol.isBlank()) {
+            sender.setProtocol(protocol);
+        }
+        return sender;
     }
 
     @Bean

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/ContactProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/ContactProperties.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Configuration properties backing the public contact form.
+ */
+@Component
+@ConfigurationProperties(prefix = "front.contact")
+public class ContactProperties {
+
+    /** Email address receiving contact form submissions. */
+    @Schema(description = "Recipient email address for contact form submissions.", example = "contact@nudger.fr")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
@@ -1,17 +1,18 @@
 package org.open4goods.nudgerfrontapi.controller.api;
 
 import org.open4goods.model.RolesConstants;
-import org.open4goods.nudgerfrontapi.dto.contact.ContactPageDto;
 import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
 import org.open4goods.nudgerfrontapi.dto.contact.ContactResponseDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.nudgerfrontapi.service.ContactService;
+import org.open4goods.nudgerfrontapi.utils.IpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,37 +39,12 @@ import jakarta.validation.Valid;
 @Tag(name = "Contact", description = "Public contact form")
 public class ContactController {
 
-    private static final String SUCCESS_MESSAGE = "Votre message a bien été envoyé !";
+	private static final Logger LOGGER = LoggerFactory.getLogger(ContactController.class);
 
     private final ContactService contactService;
 
     public ContactController(ContactService contactService) {
         this.contactService = contactService;
-    }
-
-    @GetMapping
-    @Operation(
-            summary = "Get contact page metadata",
-            description = "Return the static metadata required to render the contact page.",
-            parameters = {
-                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
-                            description = "Language driving localisation of textual fields (future use).",
-                            schema = @Schema(implementation = DomainLanguage.class))
-            },
-            responses = {
-                    @ApiResponse(responseCode = "200", description = "Metadata returned",
-                            headers = @Header(name = "X-Locale",
-                                    description = "Resolved locale for textual payloads.",
-                                    schema = @Schema(type = "string", example = "fr-FR")),
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ContactPageDto.class)))
-            }
-    )
-    public ResponseEntity<ContactPageDto> metadata(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
-        return ResponseEntity.ok()
-                .cacheControl(CacheControl.noCache())
-                .header("X-Locale", domainLanguage.languageTag())
-                .body(new ContactPageDto("nous contacter"));
     }
 
     @PostMapping
@@ -87,9 +62,6 @@ public class ContactController {
                             schema = @Schema(implementation = ContactRequestDto.class))),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Message forwarded",
-                            headers = @Header(name = "X-Locale",
-                                    description = "Resolved locale for textual payloads.",
-                                    schema = @Schema(type = "string", example = "fr-FR")),
                             content = @Content(mediaType = "application/json",
                                     schema = @Schema(implementation = ContactResponseDto.class))),
                     @ApiResponse(responseCode = "400", description = "Captcha verification failed",
@@ -104,36 +76,23 @@ public class ContactController {
                                                      @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
                                                      HttpServletRequest httpRequest) {
         try {
-            contactService.submit(request, resolveClientIp(httpRequest));
+            contactService.submit(request, IpUtils.getIp(httpRequest));
             return ResponseEntity.ok()
                     .cacheControl(CacheControl.noCache())
                     .header("X-Locale", domainLanguage.languageTag())
-                    .body(new ContactResponseDto(true, SUCCESS_MESSAGE));
+                    .body(new ContactResponseDto(true));
         } catch (SecurityException e) {
+        	LOGGER.warn("Security exception while sending email",e);
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .cacheControl(CacheControl.noCache())
                     .header("X-Locale", domainLanguage.languageTag())
-                    .body(new ContactResponseDto(false, errorMessage(e.getMessage())));
+                    .body(new ContactResponseDto(false));
         } catch (Exception e) {
+        	LOGGER.warn("Exception while sending email",e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .cacheControl(CacheControl.noCache())
                     .header("X-Locale", domainLanguage.languageTag())
-                    .body(new ContactResponseDto(false, errorMessage(e.getMessage())));
+                    .body(new ContactResponseDto(false));
         }
-    }
-
-    private String errorMessage(String detail) {
-        return "Le mail n'a pas pu être envoyé : " + detail;
-    }
-
-    private String resolveClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Real-Ip");
-        if (ip == null || ip.isBlank()) {
-            ip = request.getHeader("X-Forwarded-For");
-        }
-        if (ip == null || ip.isBlank()) {
-            ip = request.getRemoteAddr();
-        }
-        return ip;
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
@@ -1,0 +1,139 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.contact.ContactPageDto;
+import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
+import org.open4goods.nudgerfrontapi.dto.contact.ContactResponseDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.ContactService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+
+/**
+ * REST controller exposing the public contact form used by the Nudger frontend.
+ */
+@RestController
+@RequestMapping("/contact")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Contact", description = "Public contact form")
+public class ContactController {
+
+    private static final String SUCCESS_MESSAGE = "Votre message a bien été envoyé !";
+
+    private final ContactService contactService;
+
+    public ContactController(ContactService contactService) {
+        this.contactService = contactService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get contact page metadata",
+            description = "Return the static metadata required to render the contact page.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Metadata returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ContactPageDto.class)))
+            }
+    )
+    public ResponseEntity<ContactPageDto> metadata(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(new ContactPageDto("nous contacter"));
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Submit a contact message",
+            description = "Verify captcha token and forward the message to the support mailbox.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true,
+                    description = "Contact message payload.",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ContactRequestDto.class))),
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Message forwarded",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ContactResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Captcha verification failed",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ContactResponseDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Mail dispatch failed",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ContactResponseDto.class)))
+            }
+    )
+    public ResponseEntity<ContactResponseDto> submit(@Valid @RequestBody ContactRequestDto request,
+                                                     @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+                                                     HttpServletRequest httpRequest) {
+        try {
+            contactService.submit(request, resolveClientIp(httpRequest));
+            return ResponseEntity.ok()
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new ContactResponseDto(true, SUCCESS_MESSAGE));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new ContactResponseDto(false, errorMessage(e.getMessage())));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new ContactResponseDto(false, errorMessage(e.getMessage())));
+        }
+    }
+
+    private String errorMessage(String detail) {
+        return "Le mail n'a pas pu être envoyé : " + detail;
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Real-Ip");
+        if (ip == null || ip.isBlank()) {
+            ip = request.getHeader("X-Forwarded-For");
+        }
+        if (ip == null || ip.isBlank()) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactPageDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactPageDto.java
@@ -1,0 +1,11 @@
+package org.open4goods.nudgerfrontapi.dto.contact;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Static metadata returned for the contact page.
+ */
+public record ContactPageDto(
+        @Schema(description = "Identifier of the contact page used by the legacy UI.", example = "nous contacter")
+        String page) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactRequestDto.java
@@ -1,0 +1,34 @@
+package org.open4goods.nudgerfrontapi.dto.contact;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request payload submitted by the contact form.
+ */
+public record ContactRequestDto(
+        @NotBlank
+        @Size(max = 255)
+        @Schema(description = "Full name of the person submitting the form.", example = "Jean Dupont")
+        String name,
+
+        @NotBlank
+        @Email
+        @Schema(description = "Email address of the sender.", example = "jean.dupont@example.com", format = "email")
+        String email,
+
+        @NotBlank
+        @Size(max = 5_000)
+        @Schema(description = "Message written by the sender.", example = "Bonjour, j'aimerais en savoir plus sur vos actions.")
+        String message,
+
+        @NotBlank
+        @JsonProperty("h-captcha-response")
+        @Schema(name = "h-captcha-response", description = "Token returned by the hCaptcha widget.",
+                example = "10000000-aaaa-bbbb-cccc-000000000001")
+        String captchaResponse) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactResponseDto.java
@@ -7,9 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 public record ContactResponseDto(
         @Schema(description = "Indicates whether the submission has been processed successfully.", example = "true")
-        boolean success,
-
-        @Schema(description = "Informational message returned to the caller.",
-                example = "Votre message a bien été envoyé !")
-        String message) {
+        boolean success
+      ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactResponseDto.java
@@ -1,0 +1,15 @@
+package org.open4goods.nudgerfrontapi.dto.contact;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response returned after a contact form submission.
+ */
+public record ContactResponseDto(
+        @Schema(description = "Indicates whether the submission has been processed successfully.", example = "true")
+        boolean success,
+
+        @Schema(description = "Informational message returned to the caller.",
+                example = "Votre message a bien été envoyé !")
+        String message) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactMailService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactMailService.java
@@ -1,0 +1,45 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import jakarta.mail.internet.MimeMessage;
+
+/**
+ * Thin wrapper around {@link JavaMailSender} dedicated to contact form emails.
+ */
+@Service
+public class ContactMailService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContactMailService.class);
+
+    private final JavaMailSender mailSender;
+
+    public ContactMailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    /**
+     * Send a plain text email using the configured mail sender.
+     *
+     * @param to recipient email address
+     * @param body message body
+     * @param subject email subject line
+     * @param from sender email address used for reply-to
+     * @throws Exception when the underlying mail sender cannot dispatch the message
+     */
+    public void send(String to, String body, String subject, String from) throws Exception {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message);
+        helper.setTo(to);
+        helper.setText(body);
+        helper.setSubject(subject);
+        helper.setFrom(from);
+        helper.setReplyTo(from);
+        mailSender.send(message);
+        LOGGER.debug("Contact email sent to {} with subject {}", to, subject);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
@@ -1,0 +1,39 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.config.ContactProperties;
+import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
+import org.open4goods.services.captcha.service.HcaptchaService;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service orchestrating contact form submissions: captcha verification and email dispatching.
+ */
+@Service
+public class ContactService {
+
+    private static final String SUBJECT_PREFIX = "nudger.fr > Message de ";
+
+    private final ContactMailService contactMailService;
+    private final ContactProperties contactProperties;
+    private final HcaptchaService hcaptchaService;
+
+    public ContactService(ContactMailService contactMailService, ContactProperties contactProperties,
+            HcaptchaService hcaptchaService) {
+        this.contactMailService = contactMailService;
+        this.contactProperties = contactProperties;
+        this.hcaptchaService = hcaptchaService;
+    }
+
+    /**
+     * Verify captcha and forward the contact message by email.
+     *
+     * @param request contact request payload
+     * @param clientIp IP address reported by the caller
+     * @throws Exception when captcha verification or email dispatch fails
+     */
+    public void submit(ContactRequestDto request, String clientIp) throws Exception {
+        hcaptchaService.verifyRecaptcha(clientIp, request.captchaResponse());
+        contactMailService.send(contactProperties.getEmail(), request.message(), SUBJECT_PREFIX + request.name(),
+                request.email());
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/utils/IpUtils.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/utils/IpUtils.java
@@ -1,0 +1,28 @@
+package org.open4goods.nudgerfrontapi.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
+/**
+ * Helper to retrieve IP from an HttpServletRequest, giving preference to the standard proxy IP forward headers
+ * NOTE and tip for the hacker : When used in IP banning, can be easily compromised with randomizing proxy forward headers 
+ */
+public class IpUtils {
+
+	public static String getIp(final HttpServletRequest request) {
+
+		String ip = request.getHeader("X-Real-Ip");
+
+		if (StringUtils.isEmpty(ip)) {
+			ip = request.getHeader("X-Forwarded-For");
+		}
+
+		if (StringUtils.isEmpty(ip)) {
+			ip = request.getRemoteAddr();
+		}
+
+		return ip;
+
+	}
+
+}

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -2,6 +2,9 @@ server:
   port: 8082
   forward-headers-strategy: framework
 spring:
+  mail:
+    host: ${SPRING_MAIL_HOST:localhost}
+    port: ${SPRING_MAIL_PORT:25}
   security:
     oauth2:
       resourceserver:
@@ -19,6 +22,8 @@ front:
   resourceProviderRootPath: "https://nudger.fr"
   cache:
     path: ./cache
+  contact:
+    email: ${FRONT_CONTACT_EMAIL:contact@nudger.fr}
   security:
     enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -5,11 +5,6 @@ spring:
   mail:
     host: ${SPRING_MAIL_HOST:localhost}
     port: ${SPRING_MAIL_PORT:25}
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          secret-key: ${front.security.jwt-secret}
 
 springdoc:
   api-docs:
@@ -23,7 +18,7 @@ front:
   cache:
     path: ./cache
   contact:
-    email: ${FRONT_CONTACT_EMAIL:contact@nudger.fr}
+    email: ${FRONT_CONTACT_EMAIL}
   security:
     enabled: true
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
@@ -34,10 +29,7 @@ front:
     anonymous: 100
     authenticated: 1000
     
-xwiki:
-    username: nudger
-    password: nudger
-    baseUrl: https://wiki.nudger.fr
+
 
 
 management:

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ContactServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ContactServiceTest.java
@@ -1,0 +1,53 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.config.ContactProperties;
+import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
+import org.open4goods.services.captcha.service.HcaptchaService;
+
+/**
+ * Unit tests for {@link ContactService}.
+ */
+class ContactServiceTest {
+
+    private ContactMailService contactMailService;
+    private ContactProperties contactProperties;
+    private HcaptchaService hcaptchaService;
+    private ContactService contactService;
+
+    @BeforeEach
+    void setUp() {
+        contactMailService = mock(ContactMailService.class);
+        contactProperties = new ContactProperties();
+        contactProperties.setEmail("contact@nudger.fr");
+        hcaptchaService = mock(HcaptchaService.class);
+        contactService = new ContactService(contactMailService, contactProperties, hcaptchaService);
+    }
+
+    @Test
+    void submitShouldVerifyCaptchaAndSendEmail() throws Exception {
+        ContactRequestDto request = new ContactRequestDto("Jean", "jean@example.com", "Bonjour", "token");
+
+        contactService.submit(request, "127.0.0.1");
+
+        verify(hcaptchaService).verifyRecaptcha("127.0.0.1", "token");
+        verify(contactMailService).send("contact@nudger.fr", "Bonjour", "nudger.fr > Message de Jean",
+                "jean@example.com");
+    }
+
+    @Test
+    void submitShouldPropagateExceptions() throws Exception {
+        ContactRequestDto request = new ContactRequestDto("Jane", "jane@example.com", "Salut", "token");
+        doThrow(new Exception("smtp error")).when(contactMailService)
+                .send("contact@nudger.fr", "Salut", "nudger.fr > Message de Jane", "jane@example.com");
+
+        assertThrows(Exception.class, () -> contactService.submit(request, "192.168.0.1"));
+        verify(hcaptchaService).verifyRecaptcha("192.168.0.1", "token");
+    }
+}


### PR DESCRIPTION
## Summary
- add a `/contact` controller mirroring the legacy form with full Swagger metadata and domain language handling
- introduce DTOs, properties, and a dedicated mail service to send captcha-verified contact messages
- enable JavaMail support and cover the submission flow with a unit test

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68da25736098833399a819597de3f1d7