### PR TITLE
Fix contact page i18n placeholders and LinkedIn link

### DIFF
--- a/frontend/app/components/domains/contact/ContactDetailsSection.vue
+++ b/frontend/app/components/domains/contact/ContactDetailsSection.vue
@@ -45,11 +45,12 @@
                   :href="link.href"
                   :title="link.label"
                   :aria-label="link.ariaLabel || link.label"
-                  target="_blank"
-                  rel="noopener"
                   variant="tonal"
                   color="primary"
                   prepend-icon="mdi-open-in-new"
+                  :target="isExternalLink(link.href) ? '_blank' : undefined"
+                  :rel="isExternalLink(link.href) ? 'noopener' : undefined"
+                  @click="handleLinkClick(link, $event)"
                 >
                   {{ link.label }}
                 </v-btn>
@@ -87,6 +88,28 @@ withDefaults(
     eyebrow: undefined,
   },
 )
+
+const isExternalLink = (href: string) => /^(?:https?:)?\/\//.test(href) || href.startsWith('mailto:') || href.startsWith('tel:')
+
+const handleLinkClick = (link: ContactDetailLink, event: MouseEvent) => {
+  if (!link.href) {
+    event.preventDefault()
+    return
+  }
+
+  if (link.href.startsWith('#')) {
+    event.preventDefault()
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const targetId = link.href.slice(1)
+    const element = document.getElementById(targetId)
+
+    element?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}
 </script>
 
 <style scoped lang="sass">

--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -15,6 +15,7 @@ const currentLocale = computed(() => normalizeLocale(locale.value))
 const blogPath = computed(() => resolveLocalizedRoutePath('blog', currentLocale.value))
 
 const currentYear = computed(() => new Date().getFullYear())
+const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
 
 const highlightLinks = computed<FooterLink[]>(() => [
   {
@@ -68,7 +69,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
   },
   {
     label: t('siteIdentity.footer.feedback.links.linkedin'),
-    href: 'https://www.linkedin.com/company/comparateur-nudger/',
+    href: linkedinUrl.value,
     target: '_blank',
     rel: 'nofollow noopener',
   },

--- a/frontend/app/pages/contact/index.vue
+++ b/frontend/app/pages/contact/index.vue
@@ -52,6 +52,8 @@ const submitting = ref(false)
 const success = ref(false)
 const formError = ref<string | null>(null)
 
+const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
+
 const heroHighlights = computed<HeroHighlight[]>(() => [
   { icon: 'mdi-account-heart-outline', text: String(t('contact.hero.highlights.commitment')) },
   { icon: 'mdi-lightbulb-on-outline', text: String(t('contact.hero.highlights.expertise')) },
@@ -108,7 +110,7 @@ const contactDetailItems = computed<ContactDetailItem[]>(() => [
     links: [
       {
         label: String(t('contact.details.cards.community.cta')),
-        href: 'https://www.linkedin.com/company/nudger/',
+        href: linkedinUrl.value,
         ariaLabel: String(t('contact.details.cards.community.ctaAria')),
       },
     ],

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -15,6 +15,9 @@
         "contact": "Contact"
       }
     },
+    "links": {
+      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
+    },
     "footer": {
       "rightsReserved": "All Rights Reserved",
       "accessibleTitle": "Footer information",
@@ -206,7 +209,7 @@
         },
         "email": {
           "label": "Email address",
-          "placeholder": "you@example.org"
+          "placeholder": "you@@example.org"
         },
         "message": {
           "label": "Message",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -15,6 +15,9 @@
         "contact": "Contact"
       }
     },
+    "links": {
+      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
+    },
     "footer": {
       "rightsReserved": "Tous droits réservés",
       "accessibleTitle": "Informations du pied de page",
@@ -207,7 +210,7 @@
         },
         "email": {
           "label": "Votre e-mail",
-          "placeholder": "vous@exemple.org"
+          "placeholder": "vous@@exemple.org"
         },
         "message": {
           "label": "Votre message",


### PR DESCRIPTION
## Summary
- escape the contact form email placeholders to avoid vue-i18n linked-key parsing errors
- centralize the LinkedIn URL in i18n bundles and reuse it in the footer and contact page
- add smooth scrolling for internal contact-detail links while keeping external link behaviour

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da66aa98f08333a8b69f824de13bda