### PR TITLE
feat(frontend): add theme toggle to hero and mobile menus

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -20,5 +20,6 @@
   top: 0
   left: 0
   z-index: 100
-  background-color: white
+  background-color: rgb(var(--v-theme-surface-default))
+  color: rgb(var(--v-theme-text-neutral-strong))
 </style>

--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -13,6 +13,7 @@
           <v-list-item-title>{{ item.label }}</v-list-item-title>
         </v-list-item>
       </v-list>
+      <ThemeToggle test-id="hero-theme-toggle" />
       <v-btn
         v-if="isLoggedIn"
         color="secondary"
@@ -36,6 +37,7 @@
 </template>
 
 <script setup lang="ts">
+import ThemeToggle from './ThemeToggle.vue'
 import { useI18n } from 'vue-i18n'
 import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
@@ -106,14 +108,14 @@ const navigateToPage = (path: string): void => {
 
 <style scoped lang="sass">
 .main-menu-items
-  color: black
+  color: rgb(var(--v-theme-text-neutral-strong))
   font-size: 1rem
   cursor: pointer
   font-weight: bolder
   transition: color 0.3s ease
   &:hover
-    color: green
+    color: rgb(var(--v-theme-accent-supporting))
   &.active
-    color: green
+    color: rgb(var(--v-theme-accent-supporting))
     font-weight: 900
 </style>

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -35,6 +35,18 @@
         </v-list-item-title>
       </v-list-item>
 
+      <v-list-item class="px-6 py-4">
+        <template #prepend>
+          <v-icon icon="mdi-theme-light-dark" class="me-4" />
+        </template>
+        <v-list-item-title class="text-body-1">
+          {{ themeToggleLabel }}
+        </v-list-item-title>
+        <template #append>
+          <ThemeToggle test-id="mobile-theme-toggle" density="compact" />
+        </template>
+      </v-list-item>
+
       <v-list-item
         v-if="isLoggedIn"
         class="px-6 py-4"
@@ -53,12 +65,18 @@
 </template>
 
 <script setup lang="ts">
+import ThemeToggle from './ThemeToggle.vue'
 import { useI18n } from 'vue-i18n'
 
 import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
 const { t, locale } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
+
+const themeToggleLabel = computed(() => {
+  const translation = t('siteIdentity.menu.themeToggle')
+  return translation === 'siteIdentity.menu.themeToggle' ? 'Toggle theme' : translation
+})
 
 const emit = defineEmits<{
   close: []

--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -1,0 +1,110 @@
+<template>
+  <v-btn-toggle
+    v-model="selectedTheme"
+    class="theme-toggle"
+    :density="density"
+    color="accent"
+    mandatory
+    rounded="pill"
+    :data-testid="testId"
+  >
+    <v-tooltip :text="lightTooltip" location="bottom">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          :value="'light'"
+          :aria-label="lightAriaLabel"
+          :data-testid="`${testId}-light`"
+          :size="size"
+          icon
+          variant="plain"
+        >
+          <v-icon icon="mdi-white-balance-sunny" />
+        </v-btn>
+      </template>
+    </v-tooltip>
+
+    <v-tooltip :text="darkTooltip" location="bottom">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          :value="'dark'"
+          :aria-label="darkAriaLabel"
+          :data-testid="`${testId}-dark`"
+          :size="size"
+          icon
+          variant="plain"
+        >
+          <v-icon icon="mdi-weather-night" />
+        </v-btn>
+      </template>
+    </v-tooltip>
+  </v-btn-toggle>
+</template>
+
+<script setup lang="ts">
+import { usePreferredDark, useStorage } from '@vueuse/core'
+import { computed, toRef, watch } from 'vue'
+import { useTheme } from 'vuetify'
+
+type ThemeName = 'light' | 'dark'
+
+const props = withDefaults(
+  defineProps<{
+    density?: 'default' | 'comfortable' | 'compact'
+    size?: 'x-small' | 'small' | 'default'
+    testId?: string
+  }>(),
+  {
+    density: 'comfortable',
+    size: 'small',
+    testId: 'theme-toggle',
+  },
+)
+
+const theme = useTheme()
+const preferredDark = usePreferredDark()
+const storedPreference = useStorage<ThemeName>('open4goods-preferred-theme', preferredDark.value ? 'dark' : 'light')
+
+const applyTheme = (value: ThemeName) => {
+  if (theme.global.name.value !== value) {
+    theme.global.name.value = value
+  }
+
+  if (storedPreference.value !== value) {
+    storedPreference.value = value
+  }
+}
+
+watch(
+  [storedPreference, preferredDark],
+  ([stored, prefersDark]) => {
+    const nextTheme = stored ?? (prefersDark ? 'dark' : 'light')
+    applyTheme(nextTheme)
+  },
+  { immediate: true },
+)
+
+const selectedTheme = computed<ThemeName>({
+  get: () => (theme.global.name.value === 'dark' ? 'dark' : 'light'),
+  set: (value) => applyTheme(value),
+})
+
+const lightTooltip = computed(() => 'Switch to light theme')
+const darkTooltip = computed(() => 'Switch to dark theme')
+const lightAriaLabel = computed(() => 'Activate light theme')
+const darkAriaLabel = computed(() => 'Activate dark theme')
+
+const density = toRef(props, 'density')
+const size = toRef(props, 'size')
+const testId = toRef(props, 'testId')
+</script>
+
+<style scoped lang="sass">
+.theme-toggle
+  background-color: rgba(var(--v-theme-surface-muted), 0.6)
+  :deep(.v-btn)
+    color: rgb(var(--v-theme-text-neutral-strong))
+  :deep(.v-btn.v-btn--active)
+    color: rgb(var(--v-theme-accent-supporting))
+</style>

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -1,5 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
+import type { Ref } from 'vue'
 import { reactive, ref } from 'vue'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -12,6 +13,20 @@ const routerInstance = {
   replace: routerReplace,
 }
 const currentRoute = reactive({ path: '/', fullPath: '/' })
+
+type ThemeName = 'light' | 'dark'
+
+const themeName = ref<ThemeName>('light')
+const storedThemePreference = ref<ThemeName | undefined>()
+const preferredDarkMock = ref(false)
+
+const useStorageMock = vi.fn((_: string, defaultValue: ThemeName) => {
+  if (!storedThemePreference.value) {
+    storedThemePreference.value = defaultValue
+  }
+
+  return storedThemePreference as Ref<ThemeName>
+})
 
 function useRouteMock() {
   return currentRoute
@@ -32,6 +47,19 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
   }),
+}))
+
+vi.mock('vuetify', () => ({
+  useTheme: () => ({
+    global: {
+      name: themeName,
+    },
+  }),
+}))
+
+vi.mock('@vueuse/core', () => ({
+  usePreferredDark: () => preferredDarkMock,
+  useStorage: useStorageMock,
 }))
 
 type NuxtImports = typeof import('#imports')
@@ -76,6 +104,10 @@ describe('Shared menu authentication controls', () => {
     routerPush.mockReset()
     routerReplace.mockReset()
     logoutMock.mockResolvedValue(undefined)
+    themeName.value = 'light'
+    storedThemePreference.value = undefined
+    preferredDarkMock.value = false
+    useStorageMock.mockClear()
   })
 
   it('does not render logout controls when logged out', async () => {
@@ -109,5 +141,31 @@ describe('Shared menu authentication controls', () => {
 
     expect(logoutMock).toHaveBeenCalledTimes(1)
     expect(wrapper.emitted('close')).toBeTruthy()
+  })
+
+  it('renders theme toggles and synchronises the stored preference', async () => {
+    const heroWrapper = await mountSuspended(TheHeroMenu)
+
+    expect(heroWrapper.find('[data-testid="hero-theme-toggle"]').exists()).toBe(true)
+
+    const darkToggle = heroWrapper.get('[data-testid="hero-theme-toggle-dark"]')
+
+    await darkToggle.trigger('click')
+    await flushPromises()
+
+    expect(themeName.value).toBe('dark')
+    expect(storedThemePreference.value).toBe('dark')
+
+    const mobileWrapper = await mountSuspended(TheMobileMenu)
+
+    expect(mobileWrapper.find('[data-testid="mobile-theme-toggle"]').exists()).toBe(true)
+
+    const lightToggle = mobileWrapper.get('[data-testid="mobile-theme-toggle-light"]')
+
+    await lightToggle.trigger('click')
+    await flushPromises()
+
+    expect(themeName.value).toBe('light')
+    expect(storedThemePreference.value).toBe('light')
   })
 })


### PR DESCRIPTION
## Summary
- add a reusable ThemeToggle segmented control that syncs Vuetify theme choice with stored preferences
- surface the toggle in hero and mobile menus and switch menu styling to theme-aware tokens
- extend the shared menu spec to cover the new toggle interactions

## Testing
- pnpm vitest run menus-auth

------
https://chatgpt.com/codex/tasks/task_e_68da8ab382608333a5c16dc9ef6ad6fc