### PR TITLE
Localize theme toggle text

### DIFF
--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -45,6 +45,7 @@
 <script setup lang="ts">
 import { usePreferredDark, useStorage } from '@vueuse/core'
 import { computed, toRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useTheme } from 'vuetify'
 
 type ThemeName = 'light' | 'dark'
@@ -62,6 +63,7 @@ const props = withDefaults(
   },
 )
 
+const { t } = useI18n()
 const theme = useTheme()
 const preferredDark = usePreferredDark()
 const storedPreference = useStorage<ThemeName>('open4goods-preferred-theme', preferredDark.value ? 'dark' : 'light')
@@ -90,10 +92,10 @@ const selectedTheme = computed<ThemeName>({
   set: (value) => applyTheme(value),
 })
 
-const lightTooltip = computed(() => 'Switch to light theme')
-const darkTooltip = computed(() => 'Switch to dark theme')
-const lightAriaLabel = computed(() => 'Activate light theme')
-const darkAriaLabel = computed(() => 'Activate dark theme')
+const lightTooltip = computed(() => t('siteIdentity.menu.theme.lightTooltip'))
+const darkTooltip = computed(() => t('siteIdentity.menu.theme.darkTooltip'))
+const lightAriaLabel = computed(() => t('siteIdentity.menu.theme.lightAriaLabel'))
+const darkAriaLabel = computed(() => t('siteIdentity.menu.theme.darkAriaLabel'))
 
 const density = toRef(props, 'density')
 const size = toRef(props, 'size')

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -8,6 +8,13 @@
     "menu": {
       "title": "Menu",
       "closeLabel": "Close menu",
+      "themeToggle": "Toggle theme",
+      "theme": {
+        "lightTooltip": "Switch to light theme",
+        "darkTooltip": "Switch to dark theme",
+        "lightAriaLabel": "Activate light theme",
+        "darkAriaLabel": "Activate dark theme"
+      },
       "items": {
         "impactScore": "Impact Score",
         "products": "Products",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -8,6 +8,13 @@
     "menu": {
       "title": "Menu",
       "closeLabel": "Fermer le menu",
+      "themeToggle": "Changer de thème",
+      "theme": {
+        "lightTooltip": "Passer au thème clair",
+        "darkTooltip": "Passer au thème sombre",
+        "lightAriaLabel": "Activer le thème clair",
+        "darkAriaLabel": "Activer le thème sombre"
+      },
       "items": {
         "impactScore": "Impact-score",
         "products": "Les produits",


### PR DESCRIPTION
## Summary
- localize the shared theme toggle component tooltips and aria labels via vue-i18n
- add English and French translations for the theme toggle label and helper text

## Testing
- pnpm test --run

------
https://chatgpt.com/codex/tasks/task_e_68da937508148333b922cb3433e8f669