### PR TITLE
Improve contact page SEO metadata and accessibility

### DIFF
--- a/frontend/app/components/domains/contact/ContactHero.vue
+++ b/frontend/app/components/domains/contact/ContactHero.vue
@@ -45,7 +45,7 @@
             color="primary"
             theme="dark"
             aria-labelledby="contact-hero-card-heading"
-            role="presentation"
+            role="region"
           >
             <div class="contact-hero__card-overlay" aria-hidden="true" />
             <div class="contact-hero__card-inner">

--- a/frontend/app/pages/contact/index.vue
+++ b/frontend/app/pages/contact/index.vue
@@ -42,7 +42,11 @@ import type {
 } from '~/components/domains/contact/ContactHero.vue'
 import type { ContactDetailItem } from '~/components/domains/contact/ContactDetailsSection.vue'
 
-const { t, locale } = useI18n()
+definePageMeta({
+  ssr: true,
+})
+
+const { t, locale, availableLocales } = useI18n()
 const runtimeConfig = useRuntimeConfig()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
@@ -121,7 +125,20 @@ const canonicalUrl = computed(() =>
   new URL(resolveLocalizedRoutePath('contact', locale.value), requestURL.origin).toString(),
 )
 
+const siteName = computed(() => String(t('siteIdentity.siteName')))
+const ogLocale = computed(() => locale.value.replace('-', '_'))
 const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+const ogImageAlt = computed(() => String(t('contact.seo.imageAlt')))
+const twitterSite = computed(() => String(t('contact.seo.twitterSite')))
+const twitterImageAlt = computed(() => String(t('contact.seo.twitterImageAlt')))
+
+const alternateLinks = computed(() =>
+  availableLocales.map((availableLocale) => ({
+    rel: 'alternate' as const,
+    hreflang: availableLocale,
+    href: new URL(resolveLocalizedRoutePath('contact', availableLocale), requestURL.origin).toString(),
+  })),
+)
 
 const fallbackErrorMessage = computed(() => String(t('contact.form.feedback.genericError')))
 
@@ -192,15 +209,21 @@ useSeoMeta({
   ogUrl: () => canonicalUrl.value,
   ogType: () => 'website',
   ogImage: () => ogImageUrl.value,
+  ogSiteName: () => siteName.value,
+  ogLocale: () => ogLocale.value,
+  ogImageAlt: () => ogImageAlt.value,
   twitterCard: () => 'summary_large_image',
   twitterTitle: () => String(t('contact.seo.title')),
   twitterDescription: () => String(t('contact.seo.description')),
   twitterImage: () => ogImageUrl.value,
+  twitterSite: () => twitterSite.value,
+  twitterImageAlt: () => twitterImageAlt.value,
 })
 
 useHead(() => ({
   link: [
     { rel: 'canonical', href: canonicalUrl.value },
+    ...alternateLinks.value,
   ],
 }))
 </script>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -144,7 +144,10 @@
   "contact": {
     "seo": {
       "title": "Contact Nudger",
-      "description": "Get in touch with the Nudger collective for partnerships, product questions or impact insights."
+      "description": "Get in touch with the Nudger collective for partnerships, product questions or impact insights.",
+      "imageAlt": "Nudger logomark used for the contact page preview",
+      "twitterImageAlt": "Nudger logomark used for the contact page preview",
+      "twitterSite": "@nudger_app"
     },
     "hero": {
       "eyebrow": "Let's talk",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -145,7 +145,10 @@
   "contact": {
     "seo": {
       "title": "Nous contacter | Nudger",
-      "description": "Prenez contact avec l'équipe Nudger pour un partenariat, une question produit ou un échange sur l'impact."
+      "description": "Prenez contact avec l'équipe Nudger pour un partenariat, une question produit ou un échange sur l'impact.",
+      "imageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact",
+      "twitterImageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact",
+      "twitterSite": "@nudger_app"
     },
     "hero": {
       "eyebrow": "Entrons en contact",


### PR DESCRIPTION
## Summary
- ensure the contact hero channel card exposes a semantic region so aria-labelledby is honored by assistive tech
- enable SSR rendering and emit localized SEO metadata, including OG/Twitter fields and hreflang alternates, on the contact page
- add the required translation strings for the new metadata fields in both English and French locales

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da95c1f7bc83339b9a8ce06ef0f14a