### PR TITLE
Remove Twitter SEO metadata and update guidelines

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -106,6 +106,10 @@ Document any intentionally skipped check in your summary/PR.
 - Update or extend README, AGENTS.md, architectural notes, and comments when behaviour changes.
 - Keep comments in English; translate legacy ones as you touch the file.
 
+## SEO metadata policy
+- Only include Open Graph meta tags when defining SEO metadata. Twitter-specific tags are not allowed.
+- Every page must declare SEO metadata (title, description, Open Graph fields) and those strings have to be internationalised through the i18n resources.
+
 ## Backend API authentication guidelines
 - Instantiate backend OpenAPI clients through `createBackendApiConfig()` from the shared API client utilities. The helper injects the `X-Shared-Token` header and fails fast when `MACHINE_TOKEN` is absent—never call `new Configuration()` directly.
 - Only create backend API instances during SSR/Vitest execution (e.g. inside Nuxt event handlers). Services such as `useBlogService`, `useContentService`, and `useTeamService` must lazily obtain their API via the helper to keep the shared token out of browser bundles.

--- a/frontend/app/components/domains/blog/TheArticle.vue
+++ b/frontend/app/components/domains/blog/TheArticle.vue
@@ -151,7 +151,6 @@ useSeoMeta({
   ogDescription: computed(() => metaDescription.value || undefined),
   ogType: 'article',
   ogImage: computed(() => article.value.image || undefined),
-  twitterCard: computed(() => (article.value.image ? 'summary_large_image' : 'summary')),
   articlePublishedTime: computed(() => publishedDate.value?.iso),
   articleModifiedTime: computed(() => updatedDate.value?.iso ?? publishedDate.value?.iso),
   ogUrl: canonicalUrl,

--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -419,8 +419,6 @@ useSeoMeta({
   ogType: 'website',
   ogUrl: canonicalUrl,
   ogImage: computed(() => primaryArticleImage.value || undefined),
-  twitterCard: computed(() => (primaryArticleImage.value ? 'summary_large_image' : 'summary')),
-  twitterImage: computed(() => primaryArticleImage.value || undefined),
 })
 
 useHead(() => ({

--- a/frontend/app/pages/contact/index.vue
+++ b/frontend/app/pages/contact/index.vue
@@ -129,9 +129,6 @@ const siteName = computed(() => String(t('siteIdentity.siteName')))
 const ogLocale = computed(() => locale.value.replace('-', '_'))
 const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
 const ogImageAlt = computed(() => String(t('contact.seo.imageAlt')))
-const twitterSite = computed(() => String(t('contact.seo.twitterSite')))
-const twitterImageAlt = computed(() => String(t('contact.seo.twitterImageAlt')))
-
 const alternateLinks = computed(() =>
   availableLocales.map((availableLocale) => ({
     rel: 'alternate' as const,
@@ -212,12 +209,6 @@ useSeoMeta({
   ogSiteName: () => siteName.value,
   ogLocale: () => ogLocale.value,
   ogImageAlt: () => ogImageAlt.value,
-  twitterCard: () => 'summary_large_image',
-  twitterTitle: () => String(t('contact.seo.title')),
-  twitterDescription: () => String(t('contact.seo.description')),
-  twitterImage: () => ogImageUrl.value,
-  twitterSite: () => twitterSite.value,
-  twitterImageAlt: () => twitterImageAlt.value,
 })
 
 useHead(() => ({

--- a/frontend/app/pages/team/index.vue
+++ b/frontend/app/pages/team/index.vue
@@ -111,10 +111,6 @@ useSeoMeta({
   ogUrl: () => canonicalUrl.value,
   ogType: () => 'website',
   ogImage: () => ogImageUrl.value,
-  twitterCard: () => 'summary_large_image',
-  twitterTitle: () => String(t('team.seo.title')),
-  twitterDescription: () => String(t('team.seo.description')),
-  twitterImage: () => ogImageUrl.value,
 })
 
 useHead(() => ({

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -152,9 +152,7 @@
     "seo": {
       "title": "Contact Nudger",
       "description": "Get in touch with the Nudger collective for partnerships, product questions or impact insights.",
-      "imageAlt": "Nudger logomark used for the contact page preview",
-      "twitterImageAlt": "Nudger logomark used for the contact page preview",
-      "twitterSite": "@nudger_app"
+      "imageAlt": "Nudger logomark used for the contact page preview"
     },
     "hero": {
       "eyebrow": "Let's talk",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -153,9 +153,7 @@
     "seo": {
       "title": "Nous contacter | Nudger",
       "description": "Prenez contact avec l'équipe Nudger pour un partenariat, une question produit ou un échange sur l'impact.",
-      "imageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact",
-      "twitterImageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact",
-      "twitterSite": "@nudger_app"
+      "imageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact"
     },
     "hero": {
       "eyebrow": "Entrons en contact",


### PR DESCRIPTION
## Summary
- remove Twitter-specific SEO metadata from the contact, team and blog pages/components
- delete the unused Twitter metadata translation keys
- document the Open Graph only SEO policy in the frontend agent guide

## Testing
- pnpm lint *(fails: existing lint warnings about v-html usage and undeclared event)*

------
https://chatgpt.com/codex/tasks/task_e_68da9e493e4c83339e10326618975db7