### PR TITLE
feat(frontend): add i18n in-context edit workflow

### DIFF
--- a/frontend/app/lib/i18n-inctx/editor.ts
+++ b/frontend/app/lib/i18n-inctx/editor.ts
@@ -1,0 +1,56 @@
+import type { EditorCleanup, InContextEditDetail } from './types'
+
+type EditorModule = typeof import('./github-editor')
+
+let editorModulePromise: Promise<EditorModule> | undefined
+let activeCleanup: EditorCleanup
+
+async function loadModule(): Promise<EditorModule> {
+  editorModulePromise ??= import('./github-editor')
+  return editorModulePromise
+}
+
+export async function openEditor(detail: InContextEditDetail): Promise<EditorCleanup> {
+  const module = await loadModule()
+
+  if (activeCleanup) {
+    await Promise.resolve(activeCleanup())
+    activeCleanup = undefined
+  }
+
+  if (typeof module.openEditor !== 'function') {
+    return undefined
+  }
+
+  const session = await module.openEditor(detail)
+  const cleanup: EditorCleanup = typeof session === 'function'
+    ? session
+    : session && typeof session === 'object' && 'close' in session && typeof session.close === 'function'
+      ? () => session.close()
+      : undefined
+
+  if (cleanup) {
+    activeCleanup = cleanup
+  }
+
+  return cleanup
+}
+
+export async function shutdownEditor(): Promise<void> {
+  if (activeCleanup) {
+    const cleanup = activeCleanup
+    activeCleanup = undefined
+    await Promise.resolve(cleanup())
+  }
+
+  if (!editorModulePromise) {
+    return
+  }
+
+  const module = await editorModulePromise
+  editorModulePromise = undefined
+
+  if (typeof module.shutdownEditor === 'function') {
+    await module.shutdownEditor()
+  }
+}

--- a/frontend/app/lib/i18n-inctx/github-editor.ts
+++ b/frontend/app/lib/i18n-inctx/github-editor.ts
@@ -1,0 +1,88 @@
+import type { InContextEditDetail } from './types'
+
+const REPO_OWNER = 'open4good'
+const REPO_NAME = 'open4goods'
+const DEFAULT_BRANCH = 'main'
+const LOCALES_DIRECTORY = 'frontend/i18n/locales'
+
+let activeEditorWindow: Window | null = null
+
+function resolveLocale(detail: InContextEditDetail): string {
+  if (detail.locale) {
+    return detail.locale
+  }
+
+  if (typeof document !== 'undefined') {
+    const lang = document.documentElement?.getAttribute('lang')
+    if (lang) {
+      return lang
+    }
+  }
+
+  return 'en-US'
+}
+
+function buildEditUrl(locale: string, key: string): string {
+  const normalizedLocale = locale.trim().replace(/\s+/g, '')
+  const fileName = normalizedLocale.endsWith('.json') ? normalizedLocale : `${normalizedLocale}.json`
+  const encodedFile = encodeURIComponent(fileName)
+  const base = `https://github.com/${REPO_OWNER}/${REPO_NAME}/edit/${DEFAULT_BRANCH}/${LOCALES_DIRECTORY}/${encodedFile}`
+  const anchor = `i18n-key=${encodeURIComponent(key)}`
+  return `${base}#${anchor}`
+}
+
+async function focusEditorWindow(url: string) {
+  if (!activeEditorWindow || activeEditorWindow.closed) {
+    activeEditorWindow = window.open(url, '_blank', 'noopener')
+    return
+  }
+
+  try {
+    activeEditorWindow.focus()
+    activeEditorWindow.location.href = url
+  } catch (error) {
+    console.warn('[i18n-inctx]', 'Unable to reuse existing editor window', error)
+    activeEditorWindow = window.open(url, '_blank', 'noopener')
+  }
+}
+
+async function copyKeyToClipboard(key: string) {
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    return
+  }
+
+  try {
+    await navigator.clipboard.writeText(key)
+  } catch (error) {
+    console.warn('[i18n-inctx]', 'Failed to copy translation key to clipboard', error)
+  }
+}
+
+export async function openEditor(detail: InContextEditDetail) {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+
+  const locale = resolveLocale(detail)
+  const url = buildEditUrl(locale, detail.key)
+
+  await Promise.allSettled([copyKeyToClipboard(detail.key), focusEditorWindow(url)])
+
+  return {
+    close() {
+      if (activeEditorWindow && !activeEditorWindow.closed) {
+        activeEditorWindow.close()
+      }
+
+      activeEditorWindow = null
+    },
+  }
+}
+
+export async function shutdownEditor() {
+  if (activeEditorWindow && !activeEditorWindow.closed) {
+    activeEditorWindow.close()
+  }
+
+  activeEditorWindow = null
+}

--- a/frontend/app/lib/i18n-inctx/overlay.ts
+++ b/frontend/app/lib/i18n-inctx/overlay.ts
@@ -26,7 +26,7 @@ let highlightStyleElement: HTMLStyleElement | null = null
 let editListener: ((event: CustomEvent<InContextEditDetail>) => void) | null = null
 let editorCleanup: EditorCleanup
 let editorModuleLoaded = false
-const attachedElements = new WeakSet<HTMLElement>()
+let attachedElements: WeakSet<HTMLElement> = new WeakSet()
 
 const isClient = typeof window !== 'undefined' && typeof document !== 'undefined'
 
@@ -241,7 +241,7 @@ export function teardown() {
   cleanupHighlights()
   cleanupEditListener()
   cleanupStyle()
-  attachedElements.clear()
+  attachedElements = new WeakSet()
 
   if (editorCleanup) {
     const cleanup = editorCleanup

--- a/frontend/app/lib/i18n-inctx/overlay.ts
+++ b/frontend/app/lib/i18n-inctx/overlay.ts
@@ -1,0 +1,260 @@
+import type { EditorCleanup, InContextEditDetail } from './types'
+
+export const EDIT_EVENT_NAME = 'i18n-inctx:edit'
+
+const DATA_KEY_ATTRIBUTE = 'data-i18n-key'
+const DATA_LOCALE_ATTRIBUTE = 'data-i18n-locale'
+const DEFAULT_HIGHLIGHT_CLASS = 'i18n-inctx__highlight'
+const HIGHLIGHT_STYLE_ID = 'i18n-inctx-style'
+
+interface CreateEventHandlersOptions {
+  key: string
+  element: HTMLElement
+  locale?: string
+  highlightClass: string
+}
+
+interface EventHandlers {
+  pointerenter: (event: PointerEvent) => void
+  pointerleave: (event: PointerEvent) => void
+  click: (event: MouseEvent) => void
+  cleanup: () => void
+}
+
+const highlightDisposers: Array<() => void> = []
+let highlightStyleElement: HTMLStyleElement | null = null
+let editListener: ((event: CustomEvent<InContextEditDetail>) => void) | null = null
+let editorCleanup: EditorCleanup
+let editorModuleLoaded = false
+const attachedElements = new WeakSet<HTMLElement>()
+
+const isClient = typeof window !== 'undefined' && typeof document !== 'undefined'
+
+function ensureHighlightStyle(className: string) {
+  if (!isClient) {
+    return
+  }
+
+  const styleId = `${HIGHLIGHT_STYLE_ID}-${className}`
+  const existing = document.getElementById(styleId) as HTMLStyleElement | null
+
+  if (existing) {
+    highlightStyleElement = existing
+    return
+  }
+
+  if (highlightStyleElement) {
+    highlightStyleElement.remove()
+    highlightStyleElement = null
+  }
+
+  const style = document.createElement('style')
+  style.id = styleId
+  style.textContent = `.${className} { outline: 2px dashed rgba(59, 130, 246, 0.85); outline-offset: 2px; cursor: pointer; }`
+  document.head.appendChild(style)
+  highlightStyleElement = style
+}
+
+function defaultResolveLocale(element: HTMLElement): string | undefined {
+  const explicitLocale = element.getAttribute(DATA_LOCALE_ATTRIBUTE) ?? element.dataset.i18nLocale
+  if (explicitLocale) {
+    return explicitLocale
+  }
+
+  if (isClient) {
+    const lang = document.documentElement?.getAttribute('lang')
+    if (lang) {
+      return lang
+    }
+  }
+
+  return undefined
+}
+
+function dispatchEditEvent(detail: InContextEditDetail) {
+  const { element } = detail
+  const editEvent = new CustomEvent<InContextEditDetail>(EDIT_EVENT_NAME, {
+    bubbles: true,
+    composed: true,
+    detail,
+  })
+
+  element.dispatchEvent(editEvent)
+}
+
+export function createEventHandlers({ key, element, locale, highlightClass }: CreateEventHandlersOptions): EventHandlers {
+  const applyHighlight = () => element.classList.add(highlightClass)
+  const clearHighlight = () => element.classList.remove(highlightClass)
+
+  const pointerenter = () => {
+    applyHighlight()
+  }
+
+  const pointerleave = () => {
+    clearHighlight()
+  }
+
+  const click = (event: MouseEvent) => {
+    if (!event.altKey) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    dispatchEditEvent({
+      key,
+      element,
+      locale,
+    })
+  }
+
+  const cleanup = () => {
+    clearHighlight()
+  }
+
+  return { pointerenter, pointerleave, click, cleanup }
+}
+
+interface InstallOptions {
+  root?: ParentNode
+  highlightClass?: string
+  filter?: (element: HTMLElement, key: string) => boolean
+  resolveLocale?: (element: HTMLElement) => string | undefined
+}
+
+function ensureEditListener() {
+  if (!isClient || editListener) {
+    return
+  }
+
+  editListener = async (rawEvent: CustomEvent<InContextEditDetail>) => {
+    const { detail } = rawEvent
+    if (!detail) {
+      return
+    }
+
+    try {
+      const editor = await import('./editor')
+      editorModuleLoaded = true
+
+      if (editorCleanup) {
+        await Promise.resolve(editorCleanup())
+        editorCleanup = undefined
+      }
+
+      editorCleanup = await editor.openEditor(detail)
+    } catch (error) {
+      console.error('[i18n-inctx]', 'Unable to launch translation editor', error)
+    }
+  }
+
+  document.addEventListener(EDIT_EVENT_NAME, editListener as EventListener)
+}
+
+function cleanupEditListener() {
+  if (!isClient || !editListener) {
+    return
+  }
+
+  document.removeEventListener(EDIT_EVENT_NAME, editListener as EventListener)
+  editListener = null
+}
+
+function cleanupHighlights() {
+  while (highlightDisposers.length > 0) {
+    const dispose = highlightDisposers.pop()
+    try {
+      dispose?.()
+    } catch (error) {
+      console.error('[i18n-inctx]', 'Failed to dispose highlight listener', error)
+    }
+  }
+}
+
+function cleanupStyle() {
+  if (!isClient || !highlightStyleElement) {
+    return
+  }
+
+  highlightStyleElement.remove()
+  highlightStyleElement = null
+}
+
+export function install({
+  root = isClient ? document : undefined,
+  highlightClass = DEFAULT_HIGHLIGHT_CLASS,
+  filter,
+  resolveLocale = defaultResolveLocale,
+}: InstallOptions = {}) {
+  if (!isClient || !root) {
+    return
+  }
+
+  ensureHighlightStyle(highlightClass)
+  ensureEditListener()
+
+  const scope = root instanceof Document ? root.body ?? document.body : root
+  if (!scope) {
+    return
+  }
+
+  const nodes = scope.querySelectorAll<HTMLElement>(`[${DATA_KEY_ATTRIBUTE}]`)
+  nodes.forEach((element) => {
+    if (attachedElements.has(element)) {
+      return
+    }
+
+    const key = element.getAttribute(DATA_KEY_ATTRIBUTE) ?? element.dataset.i18nKey
+    if (!key) {
+      return
+    }
+
+    if (filter && !filter(element, key)) {
+      return
+    }
+
+    const locale = resolveLocale(element)
+    const handlers = createEventHandlers({ key, element, locale, highlightClass })
+
+    element.addEventListener('pointerenter', handlers.pointerenter)
+    element.addEventListener('pointerleave', handlers.pointerleave)
+    element.addEventListener('click', handlers.click)
+
+    highlightDisposers.push(() => {
+      element.removeEventListener('pointerenter', handlers.pointerenter)
+      element.removeEventListener('pointerleave', handlers.pointerleave)
+      element.removeEventListener('click', handlers.click)
+      handlers.cleanup()
+      attachedElements.delete(element)
+    })
+
+    attachedElements.add(element)
+  })
+}
+
+export function teardown() {
+  if (!isClient) {
+    return
+  }
+
+  cleanupHighlights()
+  cleanupEditListener()
+  cleanupStyle()
+  attachedElements.clear()
+
+  if (editorCleanup) {
+    const cleanup = editorCleanup
+    editorCleanup = undefined
+    void Promise.resolve(cleanup())
+  }
+
+  if (editorModuleLoaded) {
+    editorModuleLoaded = false
+    void import('./editor')
+      .then((module) => module.shutdownEditor())
+      .catch((error) => {
+        console.error('[i18n-inctx]', 'Failed to shutdown editor', error)
+      })
+  }
+}

--- a/frontend/app/lib/i18n-inctx/types.ts
+++ b/frontend/app/lib/i18n-inctx/types.ts
@@ -1,0 +1,13 @@
+export interface InContextEditDetail {
+  /** Translation key selected for contextual editing. */
+  key: string
+  /**
+   * Element that triggered the edit request. Consumers may use it to provide
+   * additional UX feedback (focus, scroll into view, etc.).
+   */
+  element: HTMLElement
+  /** Active locale associated with the key. */
+  locale?: string
+}
+
+export type EditorCleanup = (() => void | Promise<void>) | undefined


### PR DESCRIPTION
## Summary
- add an overlay controller that raises an `i18n-inctx:edit` event on Alt+Click and cleans up highlight listeners on teardown
- register an edit dispatcher that lazy-loads the GitHub editor helper and tears it down with the overlay
- implement the GitHub editor bridge and shared types used to describe in-context edit requests

## Testing
- pnpm lint *(emits existing warnings about v-html usage and undeclared emits)*

------
https://chatgpt.com/codex/tasks/task_e_68daa31e006c833390bd3ef88d0b4fa4