### PR TITLE
feat(frontend): support layout-aware XWiki pages

### DIFF
--- a/frontend/app/composables/cms/useFullPage.spec.ts
+++ b/frontend/app/composables/cms/useFullPage.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeLayout } from '~/composables/cms/useFullPage'
+
+describe('useFullPage layout normalization', () => {
+  it('keeps supported layout values', () => {
+    expect(normalizeLayout('layout3')).toBe('layout3')
+  })
+
+  it('falls back to the default layout for unsupported values', () => {
+    expect(normalizeLayout('unsupported')).toBe('layout1')
+    expect(normalizeLayout(undefined)).toBe('layout1')
+  })
+})

--- a/frontend/app/composables/cms/useFullPage.ts
+++ b/frontend/app/composables/cms/useFullPage.ts
@@ -1,11 +1,46 @@
 import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import type { CmsFullPage } from '~~/shared/api-client/services/pages.services'
 
-const SUPPORTED_LAYOUTS = new Set(['layout1'])
-const SUPPORTED_WIDTHS = new Set(['container', 'container-fluid', 'container-semi-fluid'])
+const DEFAULT_LAYOUT = 'layout1'
 
-type SupportedLayout = 'layout1'
-type SupportedWidth = 'container' | 'container-fluid' | 'container-semi-fluid'
+const SUPPORTED_LAYOUT_VALUES = [
+  'layout1',
+  'layout2',
+  'layout3',
+  'layout4',
+  'layout5',
+  'layout6',
+  'layout7',
+  'layout8',
+  'layout9',
+  'layout10',
+  'layout11',
+  'layout12',
+] as const
+
+const SUPPORTED_WIDTH_VALUES = ['container', 'container-fluid', 'container-semi-fluid'] as const
+
+export type SupportedLayout = (typeof SUPPORTED_LAYOUT_VALUES)[number]
+type SupportedWidth = (typeof SUPPORTED_WIDTH_VALUES)[number]
+
+export const SUPPORTED_LAYOUTS = new Set<SupportedLayout>(SUPPORTED_LAYOUT_VALUES)
+const SUPPORTED_WIDTHS = new Set<SupportedWidth>(SUPPORTED_WIDTH_VALUES)
+
+const isSupportedLayout = (layout: string): layout is SupportedLayout =>
+  SUPPORTED_LAYOUTS.has(layout as SupportedLayout)
+
+const isSupportedWidth = (width: string): width is SupportedWidth =>
+  SUPPORTED_WIDTHS.has(width as SupportedWidth)
+
+export const normalizeLayout = (layout: string | null | undefined): SupportedLayout => {
+  const normalized = (layout ?? DEFAULT_LAYOUT).toLowerCase()
+  return isSupportedLayout(normalized) ? normalized : DEFAULT_LAYOUT
+}
+
+const normalizeWidth = (width: string | null | undefined): SupportedWidth => {
+  const normalized = (width ?? 'container').toLowerCase()
+  return isSupportedWidth(normalized) ? normalized : 'container'
+}
 
 interface PageProperties {
   layout?: string
@@ -43,16 +78,10 @@ export const useFullPage = async (
   const page = computed(() => asyncState.data.value)
   const properties = computed<PageProperties>(() => ({ ...(page.value?.properties ?? {}) }))
 
-  const requestedLayout = computed(() => (properties.value.layout ?? 'layout1').toLowerCase())
-  const layout = computed<SupportedLayout>(() => {
-    const normalized = requestedLayout.value
-    return (SUPPORTED_LAYOUTS.has(normalized) ? normalized : 'layout1') as SupportedLayout
-  })
+  const requestedLayout = computed(() => (properties.value.layout ?? DEFAULT_LAYOUT).toLowerCase())
+  const layout = computed<SupportedLayout>(() => normalizeLayout(requestedLayout.value))
 
-  const width = computed<SupportedWidth>(() => {
-    const rawWidth = properties.value.width ?? 'container'
-    return (SUPPORTED_WIDTHS.has(rawWidth) ? rawWidth : 'container') as SupportedWidth
-  })
+  const width = computed<SupportedWidth>(() => normalizeWidth(properties.value.width))
 
   const pageTitle = computed(() => properties.value.pageTitle ?? page.value?.wikiPage?.title ?? '')
   const metaTitle = computed(() => properties.value.metaTitle ?? pageTitle.value)

--- a/frontend/app/pages/xwiki-fullpage.vue
+++ b/frontend/app/pages/xwiki-fullpage.vue
@@ -41,9 +41,14 @@ const canEdit = computed(() => {
 const containerClass = computed(() => [
   'cms-page__container',
   `cms-page__container--${width.value}`,
+  `cms-page__container--${layout.value}`,
 ])
 
 const containerMaxWidth = computed(() => {
+  if (layout.value === 'layout3') {
+    return undefined
+  }
+
   switch (width.value) {
     case 'container':
       return 'lg'
@@ -54,7 +59,35 @@ const containerMaxWidth = computed(() => {
   }
 })
 
-const isFluidContainer = computed(() => width.value === 'container-fluid')
+const isFluidContainer = computed(() => layout.value === 'layout3' || width.value === 'container-fluid')
+
+const showHero = computed(() => layout.value === 'layout1')
+const usesCardContent = computed(() => layout.value === 'layout1')
+
+const rootClasses = computed(() => [
+  'cms-page',
+  `cms-page--${layout.value}`,
+])
+
+const contentWrapper = computed(() => {
+  if (usesCardContent.value) {
+    return {
+      component: 'v-sheet',
+      props: {
+        class: ['cms-page__content', 'cms-page__content--card'],
+        elevation: 0,
+        rounded: 'xl',
+      } as const,
+    }
+  }
+
+  return {
+    component: 'div',
+    props: {
+      class: ['cms-page__content', 'cms-page__content--flat'],
+    } as const,
+  }
+})
 
 useSeoMeta({
   title: () => metaTitle.value || pageTitle.value,
@@ -65,8 +98,8 @@ useSeoMeta({
 </script>
 
 <template>
-  <div class="cms-page" :data-layout="layout" :data-requested-layout="requestedLayout">
-    <section class="cms-page__hero" role="banner">
+  <div :class="rootClasses" :data-layout="layout" :data-requested-layout="requestedLayout">
+    <section v-if="showHero" class="cms-page__hero" role="banner">
       <v-container class="cms-page__hero-container" fluid>
         <div class="cms-page__hero-content">
           <p class="cms-page__hero-eyebrow">
@@ -109,7 +142,7 @@ useSeoMeta({
       :max-width="containerMaxWidth"
       :fluid="isFluidContainer"
     >
-      <v-sheet class="cms-page__content" elevation="0" rounded="xl">
+      <component :is="contentWrapper.component" v-bind="contentWrapper.props">
         <div v-if="error" class="cms-page__error" role="alert">
           <v-alert type="error" variant="tonal" border="start" prominent>
             {{ t('cms.page.error') }}
@@ -123,7 +156,7 @@ useSeoMeta({
           <!-- eslint-disable-next-line vue/no-v-html -->
           <div class="xwiki-sandbox" v-html="htmlContent" />
         </div>
-      </v-sheet>
+      </component>
     </v-container>
   </div>
 </template>
@@ -209,12 +242,32 @@ useSeoMeta({
 .cms-page__container--container-semi-fluid
   max-width: min(1100px, 92vw) !important
 
+.cms-page__container--layout3
+  padding-block: clamp(1.5rem, 3vw, 3rem)
+
+.cms-page--layout3
+  gap: clamp(1.5rem, 3vw, 3rem)
+
+.cms-page--layout3 .cms-page__html
+  font-size: 1rem
+
 .cms-page__content
+  display: flex
+  flex-direction: column
+  gap: clamp(1.25rem, 2.5vw, 2rem)
+
+.cms-page__content--card
   padding: clamp(1.75rem, 3vw, 3rem)
   border-radius: 24px
   background: rgb(var(--v-theme-surface-default))
   box-shadow: 0 24px 48px rgba(var(--v-theme-shadow-primary-600), 0.12)
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+
+.cms-page__content--flat
+  padding: 0
+  background: transparent
+  box-shadow: none
+  border: none
 
 .cms-page__error
   display: flex
@@ -254,6 +307,9 @@ useSeoMeta({
     padding-block: 2.5rem
 
   .cms-page__content
+    gap: clamp(1rem, 3vw, 1.5rem)
+
+  .cms-page__content--card
     padding: clamp(1.5rem, 4vw, 2rem)
 
   .cms-page__html


### PR DESCRIPTION
## Summary
- expand the CMS full page composable to recognise the full catalogue of XWiki layouts while keeping the raw layout string available
- update the XWiki fullpage route to vary its hero and content wrappers based on the resolved layout so SSR and hydration stay in sync
- add a regression test that guarantees layout3 stays treated as a first-class option

## Testing
- pnpm test -- --filter useFullPage

------
https://chatgpt.com/codex/tasks/task_e_68dbaa2982ec8333a0de8a3991004ad4