### PR TITLE
refactor: drop unused full page layout handling

### DIFF
--- a/frontend/app/composables/cms/useFullPage.ts
+++ b/frontend/app/composables/cms/useFullPage.ts
@@ -1,14 +1,11 @@
 import { computed, toValue, type MaybeRefOrGetter } from 'vue'
 import type { CmsFullPage } from '~~/shared/api-client/services/pages.services'
 
-const SUPPORTED_LAYOUTS = new Set(['layout1'])
 const SUPPORTED_WIDTHS = new Set(['container', 'container-fluid', 'container-semi-fluid'])
 
-type SupportedLayout = 'layout1'
 type SupportedWidth = 'container' | 'container-fluid' | 'container-semi-fluid'
 
 interface PageProperties {
-  layout?: string
   width?: string
   pageTitle?: string
   metaTitle?: string
@@ -43,12 +40,6 @@ export const useFullPage = async (
   const page = computed(() => asyncState.data.value)
   const properties = computed<PageProperties>(() => ({ ...(page.value?.properties ?? {}) }))
 
-  const requestedLayout = computed(() => (properties.value.layout ?? 'layout1').toLowerCase())
-  const layout = computed<SupportedLayout>(() => {
-    const normalized = requestedLayout.value
-    return (SUPPORTED_LAYOUTS.has(normalized) ? normalized : 'layout1') as SupportedLayout
-  })
-
   const width = computed<SupportedWidth>(() => {
     const rawWidth = properties.value.width ?? 'container'
     return (SUPPORTED_WIDTHS.has(rawWidth) ? rawWidth : 'container') as SupportedWidth
@@ -63,8 +54,6 @@ export const useFullPage = async (
   return {
     page,
     properties,
-    layout,
-    requestedLayout,
     width,
     pageTitle,
     metaTitle,

--- a/frontend/app/pages/xwiki-fullpage.vue
+++ b/frontend/app/pages/xwiki-fullpage.vue
@@ -18,8 +18,6 @@ if (!matchedRoute.value) {
 const pageId = computed(() => matchedRoute.value?.pageId ?? null)
 
 const {
-  layout,
-  requestedLayout,
   width,
   pageTitle,
   metaTitle,
@@ -65,7 +63,7 @@ useSeoMeta({
 </script>
 
 <template>
-  <div class="cms-page" :data-layout="layout" :data-requested-layout="requestedLayout">
+  <div class="cms-page">
     <section class="cms-page__hero" role="banner">
       <v-container class="cms-page__hero-container" fluid>
         <div class="cms-page__hero-content">


### PR DESCRIPTION
## Summary
- simplify `useFullPage` by removing unused layout handling so it only exposes width/title/content metadata
- update the XWiki full page to stop binding layout-related data attributes
- clean up references to the removed composable fields across the frontend

## Testing
- pnpm lint
- CI=1 pnpm vitest run
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbc37ebd6883338e86611dcc96b839