### PR TITLE
Expose auth cookie names in runtime config

### DIFF
--- a/frontend/app/composables/auth/useUserRoles.ts
+++ b/frontend/app/composables/auth/useUserRoles.ts
@@ -4,7 +4,8 @@ interface JwtPayload { roles?: string[] }
 
 export const useUserRoles = () => {
   const config = useRuntimeConfig()
-  const token = useCookie<string | null>(config.tokenCookieName)
+  const tokenCookieName = config.public.tokenCookieName ?? config.tokenCookieName
+  const token = useCookie<string | null>(tokenCookieName)
 
   const roles = computed<string[]>(() => {
     if (!token.value) return []

--- a/frontend/app/plugins/auth-refresh.client.ts
+++ b/frontend/app/plugins/auth-refresh.client.ts
@@ -6,7 +6,8 @@ import { authService } from '~~/shared/api-client/services/auth.services'
  */
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig()
-  const token = useCookie<string | null>(config.tokenCookieName)
+  const tokenCookieName = config.public.tokenCookieName ?? config.tokenCookieName
+  const token = useCookie<string | null>(tokenCookieName)
 
   const checkExpiration = async () => {
     if (!token.value) return

--- a/frontend/app/utils/authCookies.ts
+++ b/frontend/app/utils/authCookies.ts
@@ -1,7 +1,10 @@
 export const useAuthCookies = () => {
   const config = useRuntimeConfig()
-  const tokenCookie = useCookie<string | null>(config.tokenCookieName)
-  const refreshCookie = useCookie<string | null>(config.refreshCookieName)
+  const tokenCookieName = config.public.tokenCookieName ?? config.tokenCookieName
+  const refreshCookieName = config.public.refreshCookieName ?? config.refreshCookieName
+
+  const tokenCookie = useCookie<string | null>(tokenCookieName)
+  const refreshCookie = useCookie<string | null>(refreshCookieName)
 
   return { tokenCookie, refreshCookie }
 }

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -8,6 +8,12 @@ import { buildI18nPagesConfig } from './shared/utils/localized-routes'
 
 const localeDomains = buildI18nLocaleDomains()
 
+const DEFAULT_TOKEN_COOKIE_NAME = 'access_token'
+const DEFAULT_REFRESH_COOKIE_NAME = 'refresh_token'
+
+const TOKEN_COOKIE_NAME = process.env.TOKEN_COOKIE_NAME || DEFAULT_TOKEN_COOKIE_NAME
+const REFRESH_COOKIE_NAME = process.env.REFRESH_COOKIE_NAME || DEFAULT_REFRESH_COOKIE_NAME
+
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   srcDir: 'app',
@@ -223,9 +229,9 @@ export default defineNuxtConfig({
   // These can be overridden via a .env file
   runtimeConfig: {
     // Name of the cookie storing the JWT
-    tokenCookieName: process.env.TOKEN_COOKIE_NAME || 'access_token',
+    tokenCookieName: TOKEN_COOKIE_NAME,
     // Name of the cookie storing the refresh token
-    refreshCookieName: process.env.REFRESH_COOKIE_NAME || 'refresh_token',
+    refreshCookieName: REFRESH_COOKIE_NAME,
     // Shared token for server-to-server authentication (server-only)
     machineToken: process.env.MACHINE_TOKEN || '',
     apiUrl: process.env.API_URL || 'http://localhost:8082',
@@ -236,6 +242,9 @@ export default defineNuxtConfig({
       // Roles allowed to edit content blocks (defaults to backend role names)
       editRoles: (process.env.EDITOR_ROLES || 'ROLE_SITEEDITOR,XWIKIADMINGROUP').split(','),
       hcaptchaSiteKey: process.env.HCAPTCHA_SITE_KEY || '',
+      tokenCookieName: TOKEN_COOKIE_NAME,
+      refreshCookieName: REFRESH_COOKIE_NAME,
     }
   },
 })
+


### PR DESCRIPTION
## Summary
- define shared constants for the auth token and refresh cookie names and expose them through the public runtime config
- update auth helpers and plugins to consume the public cookie names with SSR-safe fallbacks

## Testing
- pnpm dev


------
https://chatgpt.com/codex/tasks/task_e_68dbc829862c83338b36d58aaf7ccd06