### PR TITLE
feat: expose flattened XWiki page DTO to frontend

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -1,16 +1,14 @@
 package org.open4goods.nudgerfrontapi.controller.api;
 
-import java.time.Duration;
 import java.util.Locale;
 
 import org.open4goods.model.RolesConstants;
 import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.xwiki.FullPageDto;
 import org.open4goods.nudgerfrontapi.dto.xwiki.XwikiContentBlocDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
-import org.open4goods.xwiki.model.FullPage;
 import org.open4goods.xwiki.services.XWikiHtmlService;
-import org.open4goods.xwiki.services.XwikiFacadeService;
-import org.springframework.http.CacheControl;
+import org.open4goods.nudgerfrontapi.service.XwikiFullPageService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -43,12 +41,12 @@ public class ContentsController {
 
 
     private final XWikiHtmlService xwikiHtmlService;
-    private final XwikiFacadeService xwikiFacadeService;
+    private final XwikiFullPageService xwikiFullPageService;
 
     public ContentsController(XWikiHtmlService xwikiHtmlService,
-                              XwikiFacadeService xwikiFacadeService) {
+                              XwikiFullPageService xwikiFullPageService) {
         this.xwikiHtmlService = xwikiHtmlService;
-        this.xwikiFacadeService = xwikiFacadeService;
+        this.xwikiFullPageService = xwikiFullPageService;
     }
 
 
@@ -127,17 +125,17 @@ public class ContentsController {
                             headers = @io.swagger.v3.oas.annotations.headers.Header(name = "X-Locale",
                                     description = "Resolved locale for textual payloads.",
                                     schema = @Schema(type = "string", example = "fr-FR")),
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = FullPage.class))),
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = FullPageDto.class))),
                     @ApiResponse(responseCode = "404", description = "Page not found"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
-    public ResponseEntity<FullPage> page(@PathVariable String xwikiPageId,
-                                         @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
-                                         Locale locale) {
+    public ResponseEntity<FullPageDto> page(@PathVariable String xwikiPageId,
+                                            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+                                            Locale locale) {
 
         String normalized = translatePageId(xwikiPageId.replace(":", "/"));
-        FullPage page = xwikiFacadeService.getFullPage(normalized, domainLanguage.languageTag());
+        FullPageDto page = xwikiFullPageService.getFullPage(normalized, domainLanguage.languageTag());
         return ResponseEntity.ok()
                 .cacheControl(CacheControlConstants.ONE_HOUR_PUBLIC_CACHE)
                 .body(page);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -86,30 +86,6 @@ public class ContentsController {
                 .cacheControl(CacheControlConstants.ONE_HOUR_PUBLIC_CACHE)
                 .body(body);
     }
-
-    @GetMapping("/pages")
-    @Operation(
-            summary = "List XWiki pages",
-            description = "List of pages available for rendering",
-            parameters = {
-                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
-                            description = "Language driving localisation of textual fields (future use).",
-                            schema = @Schema(implementation = DomainLanguage.class))
-            },
-            responses = {
-                    @ApiResponse(responseCode = "501", description = "Not implemented",
-                            headers = @io.swagger.v3.oas.annotations.headers.Header(name = "X-Locale",
-                                    description = "Resolved locale for textual payloads.",
-                                    schema = @Schema(type = "string", example = "fr-FR")))
-            }
-    )
-    public ResponseEntity<Void> pages(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
-        // TODO: implement listing of pages
-
-
-        return ResponseEntity.status(501).build();
-    }
-
     @GetMapping("/pages/{xwikiPageId}")
     @Operation(
             summary = "Get XWiki page",
@@ -134,7 +110,7 @@ public class ContentsController {
                                             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
                                             Locale locale) {
 
-        String normalized = translatePageId(xwikiPageId.replace(":", "/"));
+        String normalized = translatePageId(xwikiPageId);
         FullPageDto page = xwikiFullPageService.getFullPage(normalized, domainLanguage.languageTag());
         return ResponseEntity.ok()
                 .cacheControl(CacheControlConstants.ONE_HOUR_PUBLIC_CACHE)

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/FullPageDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/xwiki/FullPageDto.java
@@ -1,0 +1,145 @@
+package org.open4goods.nudgerfrontapi.dto.xwiki;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO representing a flattened view of an XWiki {@code FullPage}.
+ *
+ * @param htmlContent                rendered HTML content of the page
+ * @param id                         technical identifier of the XWiki document
+ * @param fullName                   fully qualified document name
+ * @param wiki                       wiki identifier hosting the page
+ * @param space                      hierarchical space containing the document
+ * @param name                       document local name
+ * @param title                      current display title of the page
+ * @param rawTitle                   raw title before localisation or processing
+ * @param parent                     identifier of the parent document
+ * @param parentId                   identifier of the parent document without wiki prefix
+ * @param version                    human readable version string
+ * @param author                     technical author reference
+ * @param authorName                 display name of the author
+ * @param xwikiRelativeUrl           relative URL to the page rendered by XWiki
+ * @param xwikiAbsoluteUrl           absolute URL to the page rendered by XWiki
+ * @param syntax                     syntax used to author the page content
+ * @param language                   current language of the document
+ * @param majorVersion               major version number
+ * @param minorVersion               minor version number
+ * @param hidden                     whether the page is hidden from listings
+ * @param created                    ISO timestamp representing document creation date
+ * @param creator                    technical reference of the page creator
+ * @param creatorName                display name of the page creator
+ * @param modified                   ISO timestamp representing the last modification date
+ * @param modifier                   technical reference of the last modifier
+ * @param modifierName               display name of the last modifier
+ * @param originalMetadataAuthor     technical reference that provided the original metadata
+ * @param originalMetadataAuthorName display name for the original metadata author
+ * @param layout                     CMS specific layout identifier
+ * @param pageTitle                  preferred title to display on the frontend
+ * @param metaTitle                  SEO meta title
+ * @param width                      layout width directive
+ * @param metaDescription            SEO meta description
+ * @param editLink                   direct edit link for the page in XWiki
+ */
+public record FullPageDto(
+        @Schema(description = "Rendered HTML content of the page.")
+        String htmlContent,
+
+        @Schema(description = "Technical identifier of the XWiki document.", example = "xwiki:webpages.default.legal-notice.WebHome")
+        String id,
+
+        @Schema(description = "Fully qualified document name.", example = "webpages.default.legal-notice.WebHome")
+        String fullName,
+
+        @Schema(description = "Wiki identifier hosting the page.", example = "xwiki")
+        String wiki,
+
+        @Schema(description = "Hierarchical space containing the document.", example = "webpages.default.legal-notice")
+        String space,
+
+        @Schema(description = "Document local name.", example = "WebHome")
+        String name,
+
+        @Schema(description = "Current display title of the page.", example = "legal-notice")
+        String title,
+
+        @Schema(description = "Raw title before localisation or processing.", example = "legal-notice")
+        String rawTitle,
+
+        @Schema(description = "Identifier of the parent document.", example = "xwiki:webpages.default.legal-notice.WebHome")
+        String parent,
+
+        @Schema(description = "Identifier of the parent document without wiki prefix.", example = "xwiki:webpages.default.legal-notice.WebHome")
+        String parentId,
+
+        @Schema(description = "Human readable version string.", example = "2.1")
+        String version,
+
+        @Schema(description = "Technical author reference.", example = "XWiki.Goulven", nullable = true)
+        String author,
+
+        @Schema(description = "Display name of the author.", nullable = true)
+        String authorName,
+
+        @Schema(description = "Relative URL to the page rendered by XWiki.", format = "uri", example = "https://wiki.nudger.fr/bin/view/webpages/default/legal-notice/")
+        String xwikiRelativeUrl,
+
+        @Schema(description = "Absolute URL to the page rendered by XWiki.", format = "uri", example = "https://wiki.nudger.fr/bin/view/webpages/default/legal-notice/")
+        String xwikiAbsoluteUrl,
+
+        @Schema(description = "Syntax used to author the page content.", example = "xwiki/2.1")
+        String syntax,
+
+        @Schema(description = "Current language of the document.", example = "fr")
+        String language,
+
+        @Schema(description = "Major version number.", example = "2")
+        Integer majorVersion,
+
+        @Schema(description = "Minor version number.", example = "1")
+        Integer minorVersion,
+
+        @Schema(description = "Whether the page is hidden from listings.", example = "false")
+        boolean hidden,
+
+        @Schema(description = "ISO timestamp representing document creation date.", format = "date-time", example = "2024-08-08T13:13:55.000+00:00")
+        String created,
+
+        @Schema(description = "Technical reference of the page creator.", example = "XWiki.o4g", nullable = true)
+        String creator,
+
+        @Schema(description = "Display name of the page creator.", nullable = true)
+        String creatorName,
+
+        @Schema(description = "ISO timestamp representing the last modification date.", format = "date-time", example = "2024-08-08T13:13:55.000+00:00")
+        String modified,
+
+        @Schema(description = "Technical reference of the last modifier.", example = "XWiki.o4g", nullable = true)
+        String modifier,
+
+        @Schema(description = "Display name of the last modifier.", nullable = true)
+        String modifierName,
+
+        @Schema(description = "Technical reference that provided the original metadata.", example = "xwiki:XWiki.Goulven", nullable = true)
+        String originalMetadataAuthor,
+
+        @Schema(description = "Display name for the original metadata author.", nullable = true)
+        String originalMetadataAuthorName,
+
+        @Schema(description = "CMS specific layout identifier.", example = "layout3", nullable = true)
+        String layout,
+
+        @Schema(description = "Preferred title to display on the frontend.", example = "Les mentions légales et les CGU de Nudger", nullable = true)
+        String pageTitle,
+
+        @Schema(description = "SEO meta title.", example = "Mentions légales | Nudger", nullable = true)
+        String metaTitle,
+
+        @Schema(description = "Layout width directive.", allowableValues = {"container", "container-fluid", "container-semi-fluid"}, example = "container-semi-fluid", nullable = true)
+        String width,
+
+        @Schema(description = "SEO meta description.", example = "Les mentions légales de Nudger", nullable = true)
+        String metaDescription,
+
+        @Schema(description = "Direct edit link for the page in XWiki.", format = "uri", example = "https://wiki.nudger.fr/bin/edit/webpages/default/legal-notice/WebHome", nullable = true)
+        String editLink) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
@@ -1,0 +1,105 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.Map;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.open4goods.nudgerfrontapi.dto.xwiki.FullPageDto;
+import org.open4goods.xwiki.model.FullPage;
+import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.springframework.stereotype.Service;
+import org.xwiki.rest.model.jaxb.Page;
+
+/**
+ * Service responsible for retrieving XWiki {@link FullPage} instances and mapping them to {@link FullPageDto}.
+ */
+@Service
+public class XwikiFullPageService {
+
+    private final XwikiFacadeService xwikiFacadeService;
+
+    public XwikiFullPageService(XwikiFacadeService xwikiFacadeService) {
+        this.xwikiFacadeService = xwikiFacadeService;
+    }
+
+    /**
+     * Fetches a {@link FullPage} from XWiki and converts it into a {@link FullPageDto} representation.
+     *
+     * @param pageId      identifier of the page to fetch
+     * @param languageTag language tag used to retrieve the localised page
+     * @return flattened DTO representation of the XWiki page
+     */
+    public FullPageDto getFullPage(String pageId, String languageTag) {
+        FullPage fullPage = xwikiFacadeService.getFullPage(pageId, languageTag);
+        return mapToDto(fullPage);
+    }
+
+    private FullPageDto mapToDto(FullPage fullPage) {
+        Page wikiPage = fullPage.getWikiPage();
+        Map<String, String> properties = fullPage.getProperties();
+        if (properties == null) {
+            properties = Collections.emptyMap();
+        }
+
+        return new FullPageDto(
+                fullPage.getHtmlContent(),
+                wikiPage != null ? wikiPage.getId() : null,
+                wikiPage != null ? wikiPage.getFullName() : null,
+                wikiPage != null ? wikiPage.getWiki() : null,
+                wikiPage != null ? wikiPage.getSpace() : null,
+                wikiPage != null ? wikiPage.getName() : null,
+                wikiPage != null ? wikiPage.getTitle() : null,
+                wikiPage != null ? wikiPage.getRawTitle() : null,
+                wikiPage != null ? wikiPage.getParent() : null,
+                wikiPage != null ? wikiPage.getParentId() : null,
+                wikiPage != null ? wikiPage.getVersion() : null,
+                wikiPage != null ? wikiPage.getAuthor() : null,
+                wikiPage != null ? wikiPage.getAuthorName() : null,
+                wikiPage != null ? wikiPage.getXwikiRelativeUrl() : null,
+                wikiPage != null ? wikiPage.getXwikiAbsoluteUrl() : null,
+                wikiPage != null ? wikiPage.getSyntax() : null,
+                wikiPage != null ? wikiPage.getLanguage() : null,
+                wikiPage != null ? wikiPage.getMajorVersion() : null,
+                wikiPage != null ? wikiPage.getMinorVersion() : null,
+                wikiPage != null && Boolean.TRUE.equals(wikiPage.isHidden()),
+                toIsoString(wikiPage != null ? wikiPage.getCreated() : null),
+                wikiPage != null ? wikiPage.getCreator() : null,
+                wikiPage != null ? wikiPage.getCreatorName() : null,
+                toIsoString(wikiPage != null ? wikiPage.getModified() : null),
+                wikiPage != null ? wikiPage.getModifier() : null,
+                wikiPage != null ? wikiPage.getModifierName() : null,
+                wikiPage != null ? wikiPage.getOriginalMetadataAuthor() : null,
+                wikiPage != null ? wikiPage.getOriginalMetadataAuthorName() : null,
+                properties.get("layout"),
+                properties.get("pageTitle"),
+                properties.get("metaTitle"),
+                properties.get("width"),
+                properties.get("metaDescription"),
+                fullPage.getEditLink()
+        );
+    }
+
+    private String toIsoString(Calendar calendar) {
+        if (calendar == null) {
+            return null;
+        }
+        GregorianCalendar gregorianCalendar;
+        if (calendar instanceof GregorianCalendar existing) {
+            gregorianCalendar = existing;
+        } else {
+            gregorianCalendar = new GregorianCalendar(calendar.getTimeZone());
+            gregorianCalendar.setTimeInMillis(calendar.getTimeInMillis());
+        }
+        try {
+            XMLGregorianCalendar xmlCalendar = DatatypeFactory.newInstance().newXMLGregorianCalendar(gregorianCalendar);
+            return xmlCalendar.toXMLFormat();
+        } catch (DatatypeConfigurationException e) {
+            return gregorianCalendar.toInstant().toString();
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
@@ -46,8 +46,9 @@ public class XwikiFullPageService {
             properties = Collections.emptyMap();
         }
 
+        String htmlContent = xwikiFacadeService.getxWikiHtmlService().getHtmlClassWebPage(fullPage.getWikiPage().getId());
         return new FullPageDto(
-                fullPage.getHtmlContent(),
+        		htmlContent,
                 wikiPage != null ? wikiPage.getId() : null,
                 wikiPage != null ? wikiPage.getFullName() : null,
                 wikiPage != null ? wikiPage.getWiki() : null,

--- a/frontend/app/composables/cms/useFullPage.ts
+++ b/frontend/app/composables/cms/useFullPage.ts
@@ -5,13 +5,6 @@ const SUPPORTED_WIDTHS = new Set(['container', 'container-fluid', 'container-sem
 
 type SupportedWidth = 'container' | 'container-fluid' | 'container-semi-fluid'
 
-interface PageProperties {
-  width?: string
-  pageTitle?: string
-  metaTitle?: string
-  metaDescription?: string
-}
-
 export const useFullPage = async (
   pageId: MaybeRefOrGetter<string | null | undefined>,
 ) => {
@@ -38,22 +31,20 @@ export const useFullPage = async (
   )
 
   const page = computed(() => asyncState.data.value)
-  const properties = computed<PageProperties>(() => ({ ...(page.value?.properties ?? {}) }))
 
   const width = computed<SupportedWidth>(() => {
-    const rawWidth = properties.value.width ?? 'container'
+    const rawWidth = page.value?.width ?? 'container'
     return (SUPPORTED_WIDTHS.has(rawWidth) ? rawWidth : 'container') as SupportedWidth
   })
 
-  const pageTitle = computed(() => properties.value.pageTitle ?? page.value?.wikiPage?.title ?? '')
-  const metaTitle = computed(() => properties.value.metaTitle ?? pageTitle.value)
-  const metaDescription = computed(() => properties.value.metaDescription ?? '')
+  const pageTitle = computed(() => page.value?.pageTitle ?? page.value?.title ?? '')
+  const metaTitle = computed(() => page.value?.metaTitle ?? pageTitle.value)
+  const metaDescription = computed(() => page.value?.metaDescription ?? '')
   const htmlContent = computed(() => page.value?.htmlContent ?? '')
   const editLink = computed(() => page.value?.editLink ?? null)
 
   return {
     page,
-    properties,
     width,
     pageTitle,
     metaTitle,

--- a/frontend/shared/api-client/services/pages.services.ts
+++ b/frontend/shared/api-client/services/pages.services.ts
@@ -1,9 +1,44 @@
 import { ContentApi } from '..'
-import type { FullPage } from '..'
 import type { DomainLanguage } from '../../utils/domain-language'
 import { createBackendApiConfig } from './createBackendApiConfig'
 
-export type CmsFullPage = FullPage & { editLink?: string | null }
+export interface CmsFullPage {
+  htmlContent: string
+  id?: string | null
+  fullName?: string | null
+  wiki?: string | null
+  space?: string | null
+  name?: string | null
+  title?: string | null
+  rawTitle?: string | null
+  parent?: string | null
+  parentId?: string | null
+  version?: string | null
+  author?: string | null
+  authorName?: string | null
+  xwikiRelativeUrl?: string | null
+  xwikiAbsoluteUrl?: string | null
+  syntax?: string | null
+  language?: string | null
+  majorVersion?: number | null
+  minorVersion?: number | null
+  hidden?: boolean
+  created?: string | null
+  creator?: string | null
+  creatorName?: string | null
+  modified?: string | null
+  modifier?: string | null
+  modifierName?: string | null
+  originalMetadataAuthor?: string | null
+  originalMetadataAuthorName?: string | null
+  layout?: string | null
+  pageTitle?: string | null
+  metaTitle?: string | null
+  width?: string | null
+  metaDescription?: string | null
+  editLink?: string | null
+  [key: string]: unknown
+}
 
 export const usePagesService = (domainLanguage: DomainLanguage) => {
   const isVitest = typeof process !== 'undefined' && process.env?.VITEST === 'true'


### PR DESCRIPTION
## Summary
- add a FullPageDto and dedicated service so the contents endpoint returns a flattened XWiki page payload with full Swagger annotations
- switch the CMS composable and pages service to consume the flattened fields instead of nested wikiPage/properties data

## Testing
- mvn --offline -pl front-api -am test
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dcd0b7007083338d374ac1ea59c7ee