### PR TITLE
feat: allow multiple localized wiki pages

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
 import { buildI18nLocaleDomains } from './shared/utils/domain-language'
-import { buildI18nPagesConfig } from './shared/utils/localized-routes'
+import { LOCALIZED_WIKI_PATHS, buildI18nPagesConfig } from './shared/utils/localized-routes'
 
 const localeDomains = buildI18nLocaleDomains()
 
@@ -219,5 +219,31 @@ export default defineNuxtConfig({
       editRoles: (process.env.EDITOR_ROLES || 'ROLE_SITEEDITOR,XWIKIADMINGROUP').split(','),
       hcaptchaSiteKey: process.env.HCAPTCHA_SITE_KEY || '',
     }
+  },
+  hooks: {
+    'pages:extend'(pages) {
+      const wikiSourcePage = pages.find(page => page.file?.includes('/app/pages/xwiki-fullpage.vue'))
+
+      if (!wikiSourcePage) {
+        return
+      }
+
+      Object.keys(LOCALIZED_WIKI_PATHS).forEach(routeName => {
+        if (routeName === wikiSourcePage.name) {
+          return
+        }
+
+        if (pages.some(page => page.name === routeName)) {
+          return
+        }
+
+        const clonedPage = structuredClone(wikiSourcePage)
+
+        clonedPage.name = routeName
+        clonedPage.path = `/${routeName}`
+
+        pages.push(clonedPage)
+      })
+    },
   },
 })

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -21,19 +21,29 @@ describe('localized-routes utilities', () => {
   it('resolves localized static paths', () => {
     expect(resolveLocalizedRoutePath('team', 'fr-FR')).toBe('/equipe')
     expect(resolveLocalizedRoutePath('team', 'en-US')).toBe('/team')
-    expect(resolveLocalizedRoutePath('xwiki-fullpage', 'fr-FR')).toBe('/mentions-legales')
-    expect(resolveLocalizedRoutePath('xwiki-fullpage', 'en-US')).toBe('/legal-notice')
+    expect(resolveLocalizedRoutePath('legal-notice', 'fr-FR')).toBe('/mentions-legales')
+    expect(resolveLocalizedRoutePath('legal-notice', 'en-US')).toBe('/legal-notice')
+    expect(resolveLocalizedRoutePath('data-privacy', 'fr-FR')).toBe('/politique-confidentialite')
+    expect(resolveLocalizedRoutePath('data-privacy', 'en-US')).toBe('/data-privacy')
   })
 
   it('matches paths back to their localized routes', () => {
     expect(matchLocalizedRouteByPath('/equipe')).toEqual({ routeName: 'team', locale: 'fr-FR' })
     expect(matchLocalizedRouteByPath('/team')).toEqual({ routeName: 'team', locale: 'en-US' })
     expect(matchLocalizedRouteByPath('/mentions-legales')).toEqual({
-      routeName: 'xwiki-fullpage',
+      routeName: 'legal-notice',
       locale: 'fr-FR',
     })
     expect(matchLocalizedRouteByPath('/legal-notice')).toEqual({
-      routeName: 'xwiki-fullpage',
+      routeName: 'legal-notice',
+      locale: 'en-US',
+    })
+    expect(matchLocalizedRouteByPath('/politique-confidentialite')).toEqual({
+      routeName: 'data-privacy',
+      locale: 'fr-FR',
+    })
+    expect(matchLocalizedRouteByPath('/data-privacy')).toEqual({
+      routeName: 'data-privacy',
       locale: 'en-US',
     })
     expect(matchLocalizedRouteByPath('/unknown')).toBeNull()
@@ -41,14 +51,24 @@ describe('localized-routes utilities', () => {
 
   it('exposes wiki page identifiers for localized CMS routes', () => {
     expect(matchLocalizedWikiRouteByPath('/mentions-legales')).toEqual({
-      routeName: 'xwiki-fullpage',
+      routeName: 'legal-notice',
       locale: 'fr-FR',
-      pageId: LOCALIZED_WIKI_PATHS['xwiki-fullpage']['fr-FR'].pageId,
+      pageId: LOCALIZED_WIKI_PATHS['legal-notice']['fr-FR'].pageId,
     })
     expect(matchLocalizedWikiRouteByPath('/legal-notice')).toEqual({
-      routeName: 'xwiki-fullpage',
+      routeName: 'legal-notice',
       locale: 'en-US',
-      pageId: LOCALIZED_WIKI_PATHS['xwiki-fullpage']['en-US'].pageId,
+      pageId: LOCALIZED_WIKI_PATHS['legal-notice']['en-US'].pageId,
+    })
+    expect(matchLocalizedWikiRouteByPath('/politique-confidentialite')).toEqual({
+      routeName: 'data-privacy',
+      locale: 'fr-FR',
+      pageId: LOCALIZED_WIKI_PATHS['data-privacy']['fr-FR'].pageId,
+    })
+    expect(matchLocalizedWikiRouteByPath('/data-privacy')).toEqual({
+      routeName: 'data-privacy',
+      locale: 'en-US',
+      pageId: LOCALIZED_WIKI_PATHS['data-privacy']['en-US'].pageId,
     })
     expect(matchLocalizedWikiRouteByPath('/team')).toBeNull()
   })

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -18,7 +18,7 @@ export interface LocalizedWikiRouteConfig {
 export type LocalizedWikiPaths = Record<string, Record<NuxtLocale, LocalizedWikiRouteConfig>>
 
 export const LOCALIZED_WIKI_PATHS = {
-  'xwiki-fullpage': {
+  'legal-notice': {
     'fr-FR': {
       path: '/mentions-legales',
       pageId: 'webpages:default:legal-notice:WebHome',
@@ -26,6 +26,16 @@ export const LOCALIZED_WIKI_PATHS = {
     'en-US': {
       path: '/legal-notice',
       pageId: 'webpages:default:legal-notice:en',
+    },
+  },
+  'data-privacy': {
+    'fr-FR': {
+      path: '/politique-confidentialite',
+      pageId: 'webpages:default:data-privacy:WebHome',
+    },
+    'en-US': {
+      path: '/data-privacy',
+      pageId: 'webpages:default:data-privacy:WebHome',
     },
   },
 } satisfies LocalizedWikiPaths


### PR DESCRIPTION
## Summary
- allow individual CMS pages to register localized wiki routes for the shared xwiki renderer
- add the legal notice and data privacy pages with locale specific paths and page ids
- expand localized route tests to cover the new wiki entries and ensure lookups return the correct route names

## Testing
- CI=1 pnpm test -- --run
- pnpm build
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68de1ceaa24c83339385f3eeb10759d0