### PR TITLE
Fix layout offset for main navigation

### DIFF
--- a/frontend/app/components/domains/home/hero/HeroSection.vue
+++ b/frontend/app/components/domains/home/hero/HeroSection.vue
@@ -40,5 +40,5 @@ defineEmits<{
 
 <style scoped lang="sass">
 .container-video
-  margin-top: 14vh
+  margin-top: 0
 </style>

--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,25 +1,35 @@
 <script lang="ts" setup>
+const emit = defineEmits<{
+  (event: 'toggle-drawer'): void
+}>()
 
+const handleToggleDrawer = () => emit('toggle-drawer')
 </script>
 
 <template>
-    <v-container fluid class="main-menu-container position-fixed">
-      <v-row>
-        <v-col cols="3">
+  <v-app-bar
+    app
+    flat
+    color="surface-default"
+    class="main-menu-app-bar"
+  >
+    <v-container fluid class="py-0">
+      <div class="d-flex align-center w-100">
+        <v-app-bar-title class="d-flex align-center">
           <the-main-logo />
-        </v-col>
-        <v-col cols="9">
-          <the-hero-menu @toggle-drawer="$emit('toggle-drawer')" />
-        </v-col>
-      </v-row>
+        </v-app-bar-title>
+        <v-spacer />
+        <the-hero-menu @toggle-drawer="handleToggleDrawer" />
+      </div>
     </v-container>
+  </v-app-bar>
 </template>
 
 <style lang="sass" scoped>
-.main-menu-container
-  top: 0
-  left: 0
-  z-index: 100
-  background-color: rgb(var(--v-theme-surface-default))
+.main-menu-app-bar
   color: rgb(var(--v-theme-text-neutral-strong))
+
+@media (max-width: 959px)
+  .main-menu-app-bar
+    padding-inline: 8px
 </style>


### PR DESCRIPTION
## Summary
- replace the fixed header wrapper with a Vuetify `v-app-bar` so page content is offset automatically
- remove the manual hero margin now that the app bar handles spacing

## Testing
- pnpm install
- pnpm dev --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68de1e577b688333b257563f8210a72c