### PR TITLE
Fix blog pagination hydration mismatch

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/app/components/domains/blog/TheArticles.spec.ts
@@ -400,6 +400,13 @@ const VImgStub = defineComponent({
   },
 })
 
+const ClientOnlyStub = defineComponent({
+  name: 'ClientOnlyStub',
+  setup(_, { slots }) {
+    return () => slots.default?.()
+  },
+})
+
 const NuxtLinkStub = defineComponent({
   name: 'NuxtLinkStub',
   props: {
@@ -442,6 +449,7 @@ const globalStubs = {
   VImg: VImgStub,
   VSpacer: VSpacerStub,
   VPagination: VPaginationStub,
+  ClientOnly: ClientOnlyStub,
   NuxtLink: NuxtLinkStub,
 }
 

--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -655,16 +655,18 @@ await Promise.all([ensureTagsLoaded(), loadArticlesFromRoute()])
         color="transparent"
         elevation="0"
       >
-        <nav :aria-label="paginationAriaLabel">
-          <v-pagination
-            :length="totalPages"
-            :model-value="currentPage"
-            :total-visible="5"
-            :aria-label="paginationAriaLabelKey"
-            :aria-controls="articleListId"
-            @update:model-value="handlePageChange"
-          />
-        </nav>
+        <ClientOnly>
+          <nav :aria-label="paginationAriaLabel">
+            <v-pagination
+              :length="totalPages"
+              :model-value="currentPage"
+              :total-visible="5"
+              :aria-label="paginationAriaLabelKey"
+              :aria-controls="articleListId"
+              @update:model-value="handlePageChange"
+            />
+          </nav>
+        </ClientOnly>
 
         <p class="text-body-2 text-medium-emphasis text-center" aria-live="polite">
           {{ paginationInfoMessage }}


### PR DESCRIPTION
## Summary
- wrap the blog paginator in `<ClientOnly>` to prevent Vuetify hydration warnings while keeping the SSR fallback navigation intact
- stub Nuxt's `ClientOnly` component in the TheArticles unit tests so pagination markup still renders during Vitest runs

## Testing
- pnpm lint
- pnpm vitest run TheArticles

------
https://chatgpt.com/codex/tasks/task_e_68de1d6bc9088333a431582b1b44c164