### PR TITLE
feat(frontend): add open source landing page

### DIFF
--- a/frontend/app/components/domains/opensource/OpensourceContributionSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourceContributionSection.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface ContributionStep {
+  title: string
+  descriptionBlocId: string
+  icon: string
+}
+
+defineProps<{
+  eyebrow: string
+  title: string
+  descriptionBlocId: string
+  steps: ContributionStep[]
+}>()
+</script>
+
+<template>
+  <section class="opensource-contribution" aria-labelledby="opensource-contribution-title">
+    <v-container class="py-14">
+      <div class="section-header">
+        <v-chip
+          v-if="eyebrow"
+          label
+          size="small"
+          color="accent-supporting"
+          class="section-chip"
+        >
+          {{ eyebrow }}
+        </v-chip>
+        <h2 id="opensource-contribution-title" class="section-title">{{ title }}</h2>
+        <TextContent :bloc-id="descriptionBlocId" :ipsum-length="200" />
+      </div>
+
+      <div class="steps-grid" role="list">
+        <article v-for="(step, index) in steps" :key="step.title" class="step-card" role="listitem">
+          <header class="step-header">
+            <div class="step-index" aria-hidden="true">{{ index + 1 }}</div>
+            <div class="step-icon">
+              <v-icon :icon="step.icon" size="28" aria-hidden="true" />
+            </div>
+          </header>
+          <h3 class="step-title">{{ step.title }}</h3>
+          <TextContent :bloc-id="step.descriptionBlocId" :ipsum-length="150" />
+        </article>
+      </div>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.opensource-contribution
+  background: rgba(var(--v-theme-surface-alt), 1)
+
+.section-header
+  max-width: 720px
+  margin: 0 auto 3rem
+  text-align: center
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.section-chip
+  align-self: center
+  font-weight: 600
+  letter-spacing: 0.08em
+
+.section-title
+  font-size: clamp(2rem, 3.5vw, 2.75rem)
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.steps-grid
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))
+  gap: 1.5rem
+
+.step-card
+  background: rgba(var(--v-theme-surface-default), 1)
+  border-radius: 24px
+  padding: clamp(1.75rem, 3vw, 2.25rem)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+  box-shadow: 0 18px 36px rgba(var(--v-theme-shadow-primary-600), 0.08)
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.step-header
+  display: flex
+  align-items: center
+  gap: 1rem
+
+.step-index
+  width: 44px
+  height: 44px
+  border-radius: 12px
+  background: rgba(var(--v-theme-surface-primary-100), 1)
+  display: grid
+  place-items: center
+  font-weight: 700
+  font-size: 1.1rem
+  color: rgba(var(--v-theme-text-on-accent), 0.9)
+
+.step-icon
+  width: 44px
+  height: 44px
+  border-radius: 12px
+  background: rgba(var(--v-theme-surface-primary-080), 0.9)
+  display: grid
+  place-items: center
+  color: rgba(var(--v-theme-accent-primary-highlight), 1)
+
+.step-title
+  font-size: 1.25rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+</style>

--- a/frontend/app/components/domains/opensource/OpensourceHero.vue
+++ b/frontend/app/components/domains/opensource/OpensourceHero.vue
@@ -19,7 +19,6 @@ interface HeroCta {
 
 withDefaults(
   defineProps<{
-    eyebrow: string
     title: string
     subtitle: string
     descriptionBlocId: string
@@ -39,16 +38,6 @@ withDefaults(
       <v-container class="py-16 position-relative">
         <v-row class="align-center" :no-gutters="false" justify="space-between">
           <v-col cols="12" md="7" class="d-flex flex-column gap-4">
-            <v-chip
-              v-if="eyebrow"
-              label
-              color="accent-supporting"
-              class="hero-chip"
-              variant="flat"
-              size="small"
-            >
-              {{ eyebrow }}
-            </v-chip>
 
             <div class="hero-headline">
               <h1 id="opensource-hero-title" class="hero-title">

--- a/frontend/app/components/domains/opensource/OpensourceHero.vue
+++ b/frontend/app/components/domains/opensource/OpensourceHero.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface HeroStat {
+  value: string
+  label: string
+}
+
+interface HeroCta {
+  label: string
+  href: string
+  ariaLabel: string
+  icon?: string
+  color?: string
+  variant?: 'flat' | 'outlined' | 'tonal' | 'text' | 'plain'
+  target?: string
+  rel?: string
+}
+
+withDefaults(
+  defineProps<{
+    eyebrow: string
+    title: string
+    subtitle: string
+    descriptionBlocId: string
+    stats?: HeroStat[]
+    ctas?: HeroCta[]
+  }>(),
+  {
+    stats: () => [],
+    ctas: () => [],
+  },
+)
+</script>
+
+<template>
+  <section class="opensource-hero" aria-labelledby="opensource-hero-title">
+    <div class="hero-surface">
+      <v-container class="py-16 position-relative">
+        <v-row class="align-center" :no-gutters="false" justify="space-between">
+          <v-col cols="12" md="7" class="d-flex flex-column gap-4">
+            <v-chip
+              v-if="eyebrow"
+              label
+              color="accent-supporting"
+              class="hero-chip"
+              variant="flat"
+              size="small"
+            >
+              {{ eyebrow }}
+            </v-chip>
+
+            <div class="hero-headline">
+              <h1 id="opensource-hero-title" class="hero-title">
+                <span class="fw-light">{{ title }}</span>
+              </h1>
+              <p class="hero-subtitle">{{ subtitle }}</p>
+            </div>
+
+            <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
+
+            <div class="hero-ctas" role="group" aria-label="Hero call to actions">
+              <v-btn
+                v-for="cta in ctas"
+                :key="cta.href"
+                :href="cta.href"
+                :aria-label="cta.ariaLabel"
+                :color="cta.color ?? 'primary'"
+                :variant="cta.variant ?? 'flat'"
+                :target="cta.target"
+                :rel="cta.rel"
+                size="large"
+                class="me-3 mb-3"
+                append-icon="mdi-arrow-top-right"
+              >
+                <template v-if="cta.icon" #prepend>
+                  <v-icon :icon="cta.icon" aria-hidden="true" />
+                </template>
+                {{ cta.label }}
+              </v-btn>
+            </div>
+
+            <v-divider v-if="stats.length" class="my-4" color="accent-supporting" />
+
+            <div v-if="stats.length" class="hero-stats" role="list">
+              <div v-for="stat in stats" :key="stat.label" class="hero-stat" role="listitem">
+                <span class="hero-stat-value">{{ stat.value }}</span>
+                <span class="hero-stat-label">{{ stat.label }}</span>
+              </div>
+            </div>
+          </v-col>
+
+          <v-col cols="12" md="5" class="mt-10 mt-md-0">
+            <v-card class="hero-card" elevation="12" rounded="xl" aria-hidden="true">
+              <div class="hero-card-content">
+                <v-icon icon="mdi-source-branch" class="hero-card-icon" size="64" />
+                <p class="hero-card-text">
+                  <span class="fw-medium">Open4goods</span> est construit en commun. Chaque pull request, issue ou retour
+                  utilisateur façonne une plateforme plus transparente.
+                </p>
+                <v-divider class="my-4" />
+                <ul class="hero-card-list">
+                  <li>
+                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
+                    <span>Code et données publiés sous licences ouvertes</span>
+                  </li>
+                  <li>
+                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
+                    <span>Revue collaborative des contributions</span>
+                  </li>
+                  <li>
+                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
+                    <span>Gouvernance partagée et documentation vivante</span>
+                  </li>
+                </ul>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.opensource-hero
+  position: relative
+  background: radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-start), 0.65), rgba(var(--v-theme-hero-gradient-end), 0.85))
+  color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
+  overflow: hidden
+
+.hero-surface
+  position: relative
+  isolation: isolate
+
+.hero-surface::after
+  content: ''
+  position: absolute
+  inset: 0
+  background: linear-gradient(135deg, rgba(var(--v-theme-hero-overlay-soft), 0.08) 0%, rgba(var(--v-theme-hero-overlay-soft), 0.2) 50%, rgba(var(--v-theme-hero-overlay-soft), 0.1) 100%)
+  z-index: 0
+
+.hero-surface > .v-container
+  position: relative
+  z-index: 1
+
+.hero-chip
+  align-self: flex-start
+  font-weight: 600
+  letter-spacing: 0.08em
+  text-transform: uppercase
+
+.hero-headline
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+
+.hero-title
+  font-size: clamp(2.5rem, 5vw, 3.75rem)
+  margin: 0
+  line-height: 1.1
+
+.hero-subtitle
+  font-size: 1.2rem
+  opacity: 0.9
+  margin: 0
+
+.hero-ctas
+  display: flex
+  flex-wrap: wrap
+  gap: 0.75rem
+
+.hero-stats
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr))
+  gap: 1.5rem
+
+.hero-stat
+  display: flex
+  flex-direction: column
+  gap: 0.25rem
+
+.hero-stat-value
+  font-size: 1.75rem
+  font-weight: 700
+
+.hero-stat-label
+  font-size: 0.95rem
+  opacity: 0.85
+
+.hero-card
+  background: rgba(var(--v-theme-surface-glass), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+  backdrop-filter: blur(18px)
+
+.hero-card-content
+  padding: clamp(1.5rem, 3vw, 2.5rem)
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+  color: rgba(var(--v-theme-text-neutral-strong), 0.95)
+
+.hero-card-icon
+  align-self: flex-start
+  color: rgba(var(--v-theme-accent-primary-highlight), 0.85)
+
+.hero-card-text
+  font-size: 1rem
+  margin: 0
+
+.hero-card-list
+  list-style: none
+  padding: 0
+  margin: 0
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.hero-card-list li
+  display: flex
+  align-items: center
+  gap: 0.75rem
+  font-size: 0.95rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.hero-card-list li .v-icon
+  color: rgba(var(--v-theme-accent-supporting), 0.9)
+</style>

--- a/frontend/app/components/domains/opensource/OpensourcePillarsSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourcePillarsSection.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface PillarCardAction {
+  label: string
+  href: string
+  ariaLabel: string
+  target?: string
+  rel?: string
+}
+
+interface PillarCard {
+  icon: string
+  title: string
+  descriptionBlocId: string
+  action?: PillarCardAction
+}
+
+defineProps<{
+  eyebrow: string
+  title: string
+  descriptionBlocId: string
+  cards: PillarCard[]
+}>()
+</script>
+
+<template>
+  <section class="opensource-pillars" aria-labelledby="opensource-pillars-title">
+    <v-container class="py-14">
+      <div class="section-header">
+        <v-chip
+          v-if="eyebrow"
+          label
+          size="small"
+          color="accent-supporting"
+          class="section-chip"
+        >
+          {{ eyebrow }}
+        </v-chip>
+
+        <h2 id="opensource-pillars-title" class="section-title">{{ title }}</h2>
+        <TextContent :bloc-id="descriptionBlocId" :ipsum-length="200" />
+      </div>
+
+      <v-row class="mt-6" align="stretch" dense>
+        <v-col v-for="card in cards" :key="card.title" cols="12" md="4" class="d-flex">
+          <v-card class="pillar-card" rounded="xl" elevation="6">
+            <div class="pillar-icon">
+              <v-icon :icon="card.icon" size="40" aria-hidden="true" />
+            </div>
+            <div class="pillar-content">
+              <h3 class="pillar-title">{{ card.title }}</h3>
+              <TextContent :bloc-id="card.descriptionBlocId" :ipsum-length="160" />
+            </div>
+            <div v-if="card.action" class="pillar-action">
+              <v-btn
+                :href="card.action.href"
+                variant="text"
+                color="primary"
+                :aria-label="card.action.ariaLabel"
+                :target="card.action.target"
+                :rel="card.action.rel"
+                append-icon="mdi-arrow-top-right"
+              >
+                {{ card.action.label }}
+              </v-btn>
+            </div>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.opensource-pillars
+  background: rgba(var(--v-theme-surface-muted), 1)
+
+.section-header
+  max-width: 760px
+  margin: 0 auto
+  text-align: center
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.section-chip
+  align-self: center
+  font-weight: 600
+  letter-spacing: 0.08em
+
+.section-title
+  font-size: clamp(2rem, 3.5vw, 2.75rem)
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.pillar-card
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  padding: clamp(1.5rem, 3vw, 2rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.95)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+  box-shadow: 0 24px 48px rgba(var(--v-theme-shadow-primary-600), 0.1)
+
+.pillar-icon
+  width: 56px
+  height: 56px
+  border-radius: 16px
+  background: rgba(var(--v-theme-surface-primary-080), 0.9)
+  display: grid
+  place-items: center
+  color: rgba(var(--v-theme-accent-primary-highlight), 1)
+
+.pillar-content
+  flex: 1
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.pillar-title
+  font-size: 1.3rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.pillar-action
+  margin-top: auto
+</style>

--- a/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+interface ResourceLink {
+  icon: string
+  title: string
+  descriptionBlocId: string
+  href: string
+  ariaLabel: string
+  target?: string
+  rel?: string
+}
+
+interface ContactCta {
+  title: string
+  descriptionBlocId: string
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
+defineProps<{
+  eyebrow: string
+  title: string
+  descriptionBlocId: string
+  resources: ResourceLink[]
+  contact: ContactCta
+}>()
+</script>
+
+<template>
+  <section class="opensource-resources" aria-labelledby="opensource-resources-title">
+    <v-container class="py-14">
+      <div class="section-header">
+        <v-chip
+          v-if="eyebrow"
+          label
+          size="small"
+          color="accent-supporting"
+          class="section-chip"
+        >
+          {{ eyebrow }}
+        </v-chip>
+        <h2 id="opensource-resources-title" class="section-title">{{ title }}</h2>
+        <TextContent :bloc-id="descriptionBlocId" :ipsum-length="200" />
+      </div>
+
+      <v-row class="mt-8" align="stretch" dense>
+        <v-col v-for="resource in resources" :key="resource.href" cols="12" md="4" class="d-flex">
+          <v-card class="resource-card" rounded="xl" elevation="4">
+            <div class="resource-icon" aria-hidden="true">
+              <v-icon :icon="resource.icon" size="36" />
+            </div>
+            <div class="resource-body">
+              <h3 class="resource-title">{{ resource.title }}</h3>
+              <TextContent :bloc-id="resource.descriptionBlocId" :ipsum-length="140" />
+            </div>
+            <v-btn
+              :href="resource.href"
+              :aria-label="resource.ariaLabel"
+              :target="resource.target"
+              :rel="resource.rel"
+              variant="text"
+              color="primary"
+              append-icon="mdi-arrow-top-right"
+              class="mt-auto align-self-start"
+            >
+              {{ resource.title }}
+            </v-btn>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-card class="contact-card" rounded="xl" elevation="8">
+        <div class="contact-content">
+          <div class="contact-text">
+            <h3 class="contact-title">{{ contact.title }}</h3>
+            <TextContent :bloc-id="contact.descriptionBlocId" :ipsum-length="180" />
+          </div>
+          <v-btn
+            :href="contact.ctaHref"
+            color="accent-supporting"
+            variant="flat"
+            size="large"
+            :aria-label="contact.ctaAriaLabel"
+            append-icon="mdi-arrow-right"
+          >
+            {{ contact.ctaLabel }}
+          </v-btn>
+        </div>
+      </v-card>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+.opensource-resources
+  background: rgba(var(--v-theme-surface-default), 1)
+
+.section-header
+  max-width: 760px
+  margin: 0 auto
+  text-align: center
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.section-chip
+  align-self: center
+  font-weight: 600
+  letter-spacing: 0.08em
+
+.section-title
+  font-size: clamp(2rem, 3.5vw, 2.75rem)
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.resource-card
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  padding: clamp(1.5rem, 3vw, 2rem)
+  background: rgba(var(--v-theme-surface-glass), 0.95)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
+
+.resource-icon
+  width: 54px
+  height: 54px
+  border-radius: 16px
+  background: rgba(var(--v-theme-surface-primary-080), 0.95)
+  display: grid
+  place-items: center
+  color: rgba(var(--v-theme-accent-primary-highlight), 1)
+
+.resource-body
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.resource-title
+  font-size: 1.25rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.contact-card
+  margin-top: 4rem
+  padding: clamp(2rem, 4vw, 3rem)
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-callout-start), 0.95), rgba(var(--v-theme-surface-callout-end), 0.95))
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3)
+
+.contact-content
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+@media (min-width: 960px)
+  .contact-content
+    flex-direction: row
+    align-items: center
+    justify-content: space-between
+
+.contact-title
+  font-size: 1.8rem
+  margin: 0 0 0.5rem 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+</style>

--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -128,17 +128,7 @@ const heroCtas = computed<HeroCtaDisplay[]>(() => [
     variant: 'flat',
     target: '_blank',
     rel: 'noopener',
-  },
-  {
-    label: String(t('opensource.hero.secondaryCta.label')),
-    ariaLabel: String(t('opensource.hero.secondaryCta.ariaLabel')),
-    href: 'https://github.com/open4good/open4goods#readme',
-    icon: 'mdi-file-document-outline',
-    variant: 'outlined',
-    color: 'accent-supporting',
-    target: '_blank',
-    rel: 'noopener',
-  },
+  }
 ])
 
 const pillarCards = computed<PillarCardDisplay[]>(() => [

--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -1,0 +1,275 @@
+<template>
+  <div class="opensource-page">
+    <OpensourceHero
+      :eyebrow="t('opensource.hero.eyebrow')"
+      :title="t('opensource.hero.title')"
+      :subtitle="t('opensource.hero.subtitle')"
+      description-bloc-id="webpages:opensource:hero-description"
+      :stats="heroStats"
+      :ctas="heroCtas"
+    />
+
+    <OpensourcePillarsSection
+      :eyebrow="t('opensource.pillars.eyebrow')"
+      :title="t('opensource.pillars.title')"
+      description-bloc-id="webpages:opensource:pillars-intro"
+      :cards="pillarCards"
+    />
+
+    <OpensourceContributionSection
+      :eyebrow="t('opensource.contribution.eyebrow')"
+      :title="t('opensource.contribution.title')"
+      description-bloc-id="webpages:opensource:contribute-intro"
+      :steps="contributionSteps"
+    />
+
+    <OpensourceResourcesSection
+      :eyebrow="t('opensource.resources.eyebrow')"
+      :title="t('opensource.resources.title')"
+      description-bloc-id="webpages:opensource:resources-intro"
+      :resources="resourceLinks"
+      :contact="contactCta"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import OpensourceHero from '~/components/domains/opensource/OpensourceHero.vue'
+import OpensourcePillarsSection from '~/components/domains/opensource/OpensourcePillarsSection.vue'
+import OpensourceContributionSection from '~/components/domains/opensource/OpensourceContributionSection.vue'
+import OpensourceResourcesSection from '~/components/domains/opensource/OpensourceResourcesSection.vue'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+interface HeroStatDisplay {
+  value: string
+  label: string
+}
+
+interface HeroCtaDisplay {
+  label: string
+  href: string
+  ariaLabel: string
+  icon?: string
+  color?: string
+  variant?: 'flat' | 'outlined' | 'tonal' | 'text' | 'plain'
+  target?: string
+  rel?: string
+}
+
+interface PillarCardDisplay {
+  icon: string
+  title: string
+  descriptionBlocId: string
+  action?: {
+    label: string
+    href: string
+    ariaLabel: string
+    target?: string
+    rel?: string
+  }
+}
+
+interface ContributionStepDisplay {
+  title: string
+  descriptionBlocId: string
+  icon: string
+}
+
+interface ResourceLinkDisplay {
+  icon: string
+  title: string
+  descriptionBlocId: string
+  href: string
+  ariaLabel: string
+  target?: string
+  rel?: string
+}
+
+interface ContactCtaDisplay {
+  title: string
+  descriptionBlocId: string
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
+definePageMeta({
+  ssr: true,
+})
+
+const { t, locale, availableLocales } = useI18n()
+const requestURL = useRequestURL()
+const localePath = useLocalePath()
+
+const heroStats = computed<HeroStatDisplay[]>(() => [
+  {
+    value: String(t('opensource.hero.stats.open.value')),
+    label: String(t('opensource.hero.stats.open.label')),
+  },
+  {
+    value: String(t('opensource.hero.stats.ssr.value')),
+    label: String(t('opensource.hero.stats.ssr.label')),
+  },
+  {
+    value: String(t('opensource.hero.stats.community.value')),
+    label: String(t('opensource.hero.stats.community.label')),
+  },
+])
+
+const heroCtas = computed<HeroCtaDisplay[]>(() => [
+  {
+    label: String(t('opensource.hero.primaryCta.label')),
+    ariaLabel: String(t('opensource.hero.primaryCta.ariaLabel')),
+    href: 'https://github.com/open4good/open4goods',
+    icon: 'mdi-github',
+    color: 'primary',
+    variant: 'flat',
+    target: '_blank',
+    rel: 'noopener',
+  },
+  {
+    label: String(t('opensource.hero.secondaryCta.label')),
+    ariaLabel: String(t('opensource.hero.secondaryCta.ariaLabel')),
+    href: 'https://github.com/open4good/open4goods#readme',
+    icon: 'mdi-file-document-outline',
+    variant: 'outlined',
+    color: 'accent-supporting',
+    target: '_blank',
+    rel: 'noopener',
+  },
+])
+
+const pillarCards = computed<PillarCardDisplay[]>(() => [
+  {
+    icon: 'mdi-source-branch-sync',
+    title: String(t('opensource.pillars.cards.transparency.title')),
+    descriptionBlocId: 'webpages:opensource:pillars-transparency',
+    action: {
+      label: String(t('opensource.pillars.cards.transparency.cta')),
+      ariaLabel: String(t('opensource.pillars.cards.transparency.ariaLabel')),
+      href: 'https://github.com/open4good/open4goods',
+      target: '_blank',
+      rel: 'noopener',
+    },
+  },
+  {
+    icon: 'mdi-earth-check',
+    title: String(t('opensource.pillars.cards.methodology.title')),
+    descriptionBlocId: 'webpages:opensource:pillars-methodology',
+    action: {
+      label: String(t('opensource.pillars.cards.methodology.cta')),
+      ariaLabel: String(t('opensource.pillars.cards.methodology.ariaLabel')),
+      href: localePath('impact-score'),
+    },
+  },
+  {
+    icon: 'mdi-account-group-outline',
+    title: String(t('opensource.pillars.cards.community.title')),
+    descriptionBlocId: 'webpages:opensource:pillars-community',
+    action: {
+      label: String(t('opensource.pillars.cards.community.cta')),
+      ariaLabel: String(t('opensource.pillars.cards.community.ariaLabel')),
+      href: localePath('team'),
+    },
+  },
+])
+
+const contributionSteps = computed<ContributionStepDisplay[]>(() => [
+  {
+    title: String(t('opensource.contribution.steps.setup.title')),
+    descriptionBlocId: 'webpages:opensource:contribute-setup',
+    icon: 'mdi-console',
+  },
+  {
+    title: String(t('opensource.contribution.steps.issues.title')),
+    descriptionBlocId: 'webpages:opensource:contribute-issues',
+    icon: 'mdi-lightbulb-on-outline',
+  },
+  {
+    title: String(t('opensource.contribution.steps.share.title')),
+    descriptionBlocId: 'webpages:opensource:contribute-share',
+    icon: 'mdi-heart-outline',
+  },
+])
+
+const resourceLinks = computed<ResourceLinkDisplay[]>(() => [
+  {
+    icon: 'mdi-book-open-page-variant',
+    title: String(t('opensource.resources.links.guide.title')),
+    descriptionBlocId: 'webpages:opensource:resources-guide',
+    href: 'https://github.com/open4good/open4goods#readme',
+    ariaLabel: String(t('opensource.resources.links.guide.ariaLabel')),
+    target: '_blank',
+    rel: 'noopener',
+  },
+  {
+    icon: 'mdi-view-kanban',
+    title: String(t('opensource.resources.links.issues.title')),
+    descriptionBlocId: 'webpages:opensource:resources-issues',
+    href: 'https://github.com/open4good/open4goods/issues',
+    ariaLabel: String(t('opensource.resources.links.issues.ariaLabel')),
+    target: '_blank',
+    rel: 'noopener',
+  },
+  {
+    icon: 'mdi-newspaper-variant-outline',
+    title: String(t('opensource.resources.links.updates.title')),
+    descriptionBlocId: 'webpages:opensource:resources-updates',
+    href: localePath('blog'),
+    ariaLabel: String(t('opensource.resources.links.updates.ariaLabel')),
+  },
+])
+
+const contactCta = computed<ContactCtaDisplay>(() => ({
+  title: String(t('opensource.resources.contact.title')),
+  descriptionBlocId: 'webpages:opensource:community-callout',
+  ctaLabel: String(t('opensource.resources.contact.cta.label')),
+  ctaHref: localePath('contact'),
+  ctaAriaLabel: String(t('opensource.resources.contact.cta.ariaLabel')),
+}))
+
+const canonicalUrl = computed(() =>
+  new URL(resolveLocalizedRoutePath('opensource', locale.value), requestURL.origin).toString(),
+)
+
+const siteName = computed(() => String(t('siteIdentity.siteName')))
+const ogLocale = computed(() => locale.value.replace('-', '_'))
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+const ogImageAlt = computed(() => String(t('opensource.seo.imageAlt')))
+
+const alternateLinks = computed(() =>
+  availableLocales.map((availableLocale) => ({
+    rel: 'alternate' as const,
+    hreflang: availableLocale,
+    href: new URL(resolveLocalizedRoutePath('opensource', availableLocale), requestURL.origin).toString(),
+  })),
+)
+
+useSeoMeta({
+  title: () => String(t('opensource.seo.title')),
+  description: () => String(t('opensource.seo.description')),
+  ogTitle: () => String(t('opensource.seo.title')),
+  ogDescription: () => String(t('opensource.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+  ogSiteName: () => siteName.value,
+  ogLocale: () => ogLocale.value,
+  ogImageAlt: () => ogImageAlt.value,
+})
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+    ...alternateLinks.value,
+  ],
+}))
+</script>
+
+<style scoped lang="sass">
+.opensource-page
+  display: flex
+  flex-direction: column
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -148,6 +148,101 @@
       }
     }
   },
+  "opensource": {
+    "seo": {
+      "title": "Open source at Nudger",
+      "description": "Discover how Nudger shares its code, data and governance to build a responsible shopping commons together.",
+      "imageAlt": "Nudger logomark representing the open source programme"
+    },
+    "hero": {
+      "eyebrow": "Open source by design",
+      "title": "We build a commons for responsible shopping",
+      "subtitle": "Code, data and governance are transparent so anyone can audit and improve Nudger.",
+      "primaryCta": {
+        "label": "Explore the repositories",
+        "ariaLabel": "Open the Nudger GitHub organization in a new tab"
+      },
+      "secondaryCta": {
+        "label": "Read the contribution guide",
+        "ariaLabel": "Open the Nudger contribution guide on GitHub in a new tab"
+      },
+      "stats": {
+        "open": {
+          "value": "100%",
+          "label": "of our code is published under open licences"
+        },
+        "ssr": {
+          "value": "SSR",
+          "label": "Universal rendering ensures performance and accessibility"
+        },
+        "community": {
+          "value": "Community",
+          "label": "Collective roadmap shaped with contributors and partners"
+        }
+      }
+    },
+    "pillars": {
+      "eyebrow": "Our commitments",
+      "title": "An open ecosystem you can trust",
+      "cards": {
+        "transparency": {
+          "title": "Transparent architecture",
+          "cta": "Browse the source code",
+          "ariaLabel": "Open the Nudger GitHub repository in a new tab"
+        },
+        "methodology": {
+          "title": "Documented methodology",
+          "cta": "Understand the Impact Score",
+          "ariaLabel": "Navigate to the Impact Score page"
+        },
+        "community": {
+          "title": "Inclusive community",
+          "cta": "Meet the team",
+          "ariaLabel": "Navigate to the Nudger team page"
+        }
+      }
+    },
+    "contribution": {
+      "eyebrow": "Contribute",
+      "title": "Join the collective in a few steps",
+      "steps": {
+        "setup": {
+          "title": "Set up the project locally"
+        },
+        "issues": {
+          "title": "Pick an issue that inspires you"
+        },
+        "share": {
+          "title": "Share, review and celebrate"
+        }
+      }
+    },
+    "resources": {
+      "eyebrow": "Resources",
+      "title": "Everything you need to get started",
+      "links": {
+        "guide": {
+          "title": "Contribution guide",
+          "ariaLabel": "Open the Nudger contribution guide on GitHub in a new tab"
+        },
+        "issues": {
+          "title": "Issue tracker",
+          "ariaLabel": "Open the Nudger GitHub issues board in a new tab"
+        },
+        "updates": {
+          "title": "Community updates",
+          "ariaLabel": "Open the Nudger blog"
+        }
+      },
+      "contact": {
+        "title": "Need a human sparring partner?",
+        "cta": {
+          "label": "Contact the team",
+          "ariaLabel": "Navigate to the contact page"
+        }
+      }
+    }
+  },
   "contact": {
     "seo": {
       "title": "Contact Nudger",

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -155,16 +155,11 @@
       "imageAlt": "Nudger logomark representing the open source programme"
     },
     "hero": {
-      "eyebrow": "Open source by design",
       "title": "We build a commons for responsible shopping",
       "subtitle": "Code, data and governance are transparent so anyone can audit and improve Nudger.",
       "primaryCta": {
         "label": "Explore the repositories",
         "ariaLabel": "Open the Nudger GitHub organization in a new tab"
-      },
-      "secondaryCta": {
-        "label": "Read the contribution guide",
-        "ariaLabel": "Open the Nudger contribution guide on GitHub in a new tab"
       },
       "stats": {
         "open": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -156,16 +156,11 @@
       "imageAlt": "Logotype Nudger représentant le programme open source"
     },
     "hero": {
-      "eyebrow": "Ouvert par nature",
       "title": "Construire ensemble un bien commun numérique",
       "subtitle": "Code, données et gouvernance sont transparents pour que chacun·e puisse auditer et améliorer Nudger.",
       "primaryCta": {
         "label": "Explorer les dépôts",
         "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet"
-      },
-      "secondaryCta": {
-        "label": "Lire le guide de contribution",
-        "ariaLabel": "Ouvrir le guide de contribution Nudger sur GitHub dans un nouvel onglet"
       },
       "stats": {
         "open": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -149,6 +149,101 @@
       }
     }
   },
+  "opensource": {
+    "seo": {
+      "title": "Open source chez Nudger",
+      "description": "Découvrez comment Nudger partage son code, ses données et sa gouvernance pour construire ensemble un bien commun de l'achat responsable.",
+      "imageAlt": "Logotype Nudger représentant le programme open source"
+    },
+    "hero": {
+      "eyebrow": "Ouvert par nature",
+      "title": "Construire ensemble un bien commun numérique",
+      "subtitle": "Code, données et gouvernance sont transparents pour que chacun·e puisse auditer et améliorer Nudger.",
+      "primaryCta": {
+        "label": "Explorer les dépôts",
+        "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet"
+      },
+      "secondaryCta": {
+        "label": "Lire le guide de contribution",
+        "ariaLabel": "Ouvrir le guide de contribution Nudger sur GitHub dans un nouvel onglet"
+      },
+      "stats": {
+        "open": {
+          "value": "100%",
+          "label": "du code publié sous licences libres"
+        },
+        "ssr": {
+          "value": "SSR",
+          "label": "Rendu universel pour des performances accessibles"
+        },
+        "community": {
+          "value": "Collectif",
+          "label": "Feuille de route co-construite avec les contributrices et contributeurs"
+        }
+      }
+    },
+    "pillars": {
+      "eyebrow": "Nos engagements",
+      "title": "Un écosystème ouvert et fiable",
+      "cards": {
+        "transparency": {
+          "title": "Architecture transparente",
+          "cta": "Voir le code source",
+          "ariaLabel": "Ouvrir le dépôt GitHub de Nudger dans un nouvel onglet"
+        },
+        "methodology": {
+          "title": "Méthodologie documentée",
+          "cta": "Comprendre l'Impact-score",
+          "ariaLabel": "Aller vers la page Impact-score"
+        },
+        "community": {
+          "title": "Communauté inclusive",
+          "cta": "Rencontrer l'équipe",
+          "ariaLabel": "Aller vers la page équipe Nudger"
+        }
+      }
+    },
+    "contribution": {
+      "eyebrow": "Contribuer",
+      "title": "Rejoignez le collectif en quelques étapes",
+      "steps": {
+        "setup": {
+          "title": "Installer le projet en local"
+        },
+        "issues": {
+          "title": "Choisir une issue qui vous inspire"
+        },
+        "share": {
+          "title": "Partager, relire et célébrer"
+        }
+      }
+    },
+    "resources": {
+      "eyebrow": "Ressources",
+      "title": "Tout pour bien démarrer",
+      "links": {
+        "guide": {
+          "title": "Guide de contribution",
+          "ariaLabel": "Ouvrir le guide de contribution Nudger sur GitHub dans un nouvel onglet"
+        },
+        "issues": {
+          "title": "Tableau des issues",
+          "ariaLabel": "Ouvrir le tableau des issues GitHub de Nudger dans un nouvel onglet"
+        },
+        "updates": {
+          "title": "Actualités de la communauté",
+          "ariaLabel": "Ouvrir le blog Nudger"
+        }
+      },
+      "contact": {
+        "title": "Envie d'un échange humain ?",
+        "cta": {
+          "label": "Contacter l'équipe",
+          "ariaLabel": "Aller vers la page contact"
+        }
+      }
+    }
+  },
   "contact": {
     "seo": {
       "title": "Nous contacter | Nudger",

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -5,6 +5,7 @@ const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
 
 export type LocalizedRouteName =
    'team'
+   | 'opensource'
    | LocalizedWikiRouteName
 
 export type LocalizedRoutePath = `/${string}`
@@ -57,6 +58,10 @@ const mapWikiRoutesToLocalizedPaths = <T extends Record<string, Record<NuxtLocal
 const LOCALIZED_WIKI_ROUTE_PATHS = mapWikiRoutesToLocalizedPaths(LOCALIZED_WIKI_PATHS)
 
 export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
+  opensource: {
+    'fr-FR': '/opensource',
+    'en-US': '/opensource',
+  },
   team: {
     'fr-FR': '/equipe',
     'en-US': '/team',

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -5,7 +5,6 @@ const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
 
 export type LocalizedRouteName =
    'team'
-   | 'opensource'
    | LocalizedWikiRouteName
 
 export type LocalizedRoutePath = `/${string}`
@@ -58,10 +57,6 @@ const mapWikiRoutesToLocalizedPaths = <T extends Record<string, Record<NuxtLocal
 const LOCALIZED_WIKI_ROUTE_PATHS = mapWikiRoutesToLocalizedPaths(LOCALIZED_WIKI_PATHS)
 
 export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
-  opensource: {
-    'fr-FR': '/opensource',
-    'en-US': '/opensource',
-  },
   team: {
     'fr-FR': '/equipe',
     'en-US': '/team',


### PR DESCRIPTION
## Summary
- implement the SSR `/opensource` page with hero, pillars, contribution and resources sections plus SEO metadata
- add dedicated Vuetify components powered by `TextContent` blocs for open source storytelling
- extend localized routing and i18n strings for the new page in English and French

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de39c36f94833398f5c3f76be78463