### PR TITLE
feat(frontend): refresh opensource messaging and feedback

### DIFF
--- a/frontend/app/components/domains/opensource/OpensourceHero.vue
+++ b/frontend/app/components/domains/opensource/OpensourceHero.vue
@@ -3,7 +3,13 @@ import TextContent from '~/components/domains/content/TextContent.vue'
 
 interface HeroStat {
   value: string
-  label: string
+  label?: string
+  labelRich?: {
+    before?: string
+    linkText: string
+    href: string
+    after?: string
+  }
 }
 
 interface HeroCta {
@@ -17,6 +23,18 @@ interface HeroCta {
   rel?: string
 }
 
+interface HeroInfoCardItem {
+  icon?: string
+  text: string
+}
+
+interface HeroInfoCard {
+  icon: string
+  highlight?: string
+  description?: string
+  items: HeroInfoCardItem[]
+}
+
 withDefaults(
   defineProps<{
     title: string
@@ -24,10 +42,14 @@ withDefaults(
     descriptionBlocId: string
     stats?: HeroStat[]
     ctas?: HeroCta[]
+    ctaGroupLabel?: string
+    infoCard?: HeroInfoCard
   }>(),
   {
     stats: () => [],
     ctas: () => [],
+    ctaGroupLabel: undefined,
+    infoCard: undefined,
   },
 )
 </script>
@@ -48,7 +70,7 @@ withDefaults(
 
             <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
 
-            <div class="hero-ctas" role="group" aria-label="Hero call to actions">
+            <div class="hero-ctas" role="group" :aria-label="ctaGroupLabel">
               <v-btn
                 v-for="cta in ctas"
                 :key="cta.href"
@@ -72,34 +94,40 @@ withDefaults(
             <v-divider v-if="stats.length" class="my-4" color="accent-supporting" />
 
             <div v-if="stats.length" class="hero-stats" role="list">
-              <div v-for="stat in stats" :key="stat.label" class="hero-stat" role="listitem">
+              <div
+                v-for="stat in stats"
+                :key="stat.label ?? stat.labelRich?.linkText ?? stat.value"
+                class="hero-stat"
+                role="listitem"
+              >
                 <span class="hero-stat-value">{{ stat.value }}</span>
-                <span class="hero-stat-label">{{ stat.label }}</span>
+                <span class="hero-stat-label">
+                  <template v-if="stat.labelRich">
+                    <span v-if="stat.labelRich.before">{{ stat.labelRich.before }} </span>
+                    <NuxtLink :to="stat.labelRich.href" class="hero-stat-link">
+                      {{ stat.labelRich.linkText }}
+                    </NuxtLink>
+                    <span v-if="stat.labelRich.after"> {{ stat.labelRich.after }}</span>
+                  </template>
+                  <template v-else>{{ stat.label }}</template>
+                </span>
               </div>
             </div>
           </v-col>
 
           <v-col cols="12" md="5" class="mt-10 mt-md-0">
-            <v-card class="hero-card" elevation="12" rounded="xl" aria-hidden="true">
+            <v-card v-if="infoCard" class="hero-card" elevation="12" rounded="xl" aria-hidden="true">
               <div class="hero-card-content">
-                <v-icon icon="mdi-source-branch" class="hero-card-icon" size="64" />
+                <v-icon :icon="infoCard.icon" class="hero-card-icon" size="64" />
                 <p class="hero-card-text">
-                  <span class="fw-medium">Open4goods</span> est construit en commun. Chaque pull request, issue ou retour
-                  utilisateur façonne une plateforme plus transparente.
+                  <span v-if="infoCard.highlight" class="fw-medium">{{ infoCard.highlight }}</span>
+                  <span v-if="infoCard.description">{{ infoCard.description }}</span>
                 </p>
                 <v-divider class="my-4" />
                 <ul class="hero-card-list">
-                  <li>
-                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
-                    <span>Code et données publiés sous licences ouvertes</span>
-                  </li>
-                  <li>
-                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
-                    <span>Revue collaborative des contributions</span>
-                  </li>
-                  <li>
-                    <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
-                    <span>Gouvernance partagée et documentation vivante</span>
+                  <li v-for="(item, index) in infoCard.items" :key="index">
+                    <v-icon v-if="item.icon" :icon="item.icon" size="small" />
+                    <span>{{ item.text }}</span>
                   </li>
                 </ul>
               </div>
@@ -177,6 +205,12 @@ withDefaults(
   font-size: 0.95rem
   opacity: 0.85
 
+.hero-stat-link
+  color: inherit
+  text-decoration: underline
+  text-decoration-thickness: 2px
+  text-underline-offset: 4px
+
 .hero-card
   background: rgba(var(--v-theme-surface-glass), 0.9)
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
@@ -197,6 +231,9 @@ withDefaults(
   font-size: 1rem
   margin: 0
 
+.hero-card-text .fw-medium
+  margin-right: 0.25rem
+  
 .hero-card-list
   list-style: none
   padding: 0

--- a/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
@@ -19,13 +19,28 @@ interface ContactCta {
   ctaAriaLabel: string
 }
 
-defineProps<{
-  eyebrow: string
+interface FeedbackCallout {
   title: string
-  descriptionBlocId: string
-  resources: ResourceLink[]
-  contact: ContactCta
-}>()
+  description: string
+  points: string[]
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
+withDefaults(
+  defineProps<{
+    eyebrow: string
+    title: string
+    descriptionBlocId: string
+    resources: ResourceLink[]
+    contact: ContactCta
+    feedbackCallout?: FeedbackCallout
+  }>(),
+  {
+    feedbackCallout: undefined,
+  },
+)
 </script>
 
 <template>
@@ -86,6 +101,38 @@ defineProps<{
             append-icon="mdi-arrow-right"
           >
             {{ contact.ctaLabel }}
+          </v-btn>
+        </div>
+      </v-card>
+
+      <v-card
+        v-if="feedbackCallout"
+        class="feedback-card"
+        rounded="xl"
+        elevation="6"
+        role="region"
+        :aria-label="feedbackCallout.title"
+      >
+        <div class="feedback-content">
+          <div class="feedback-text">
+            <h3 class="feedback-title">{{ feedbackCallout.title }}</h3>
+            <p class="feedback-description">{{ feedbackCallout.description }}</p>
+            <ul class="feedback-points">
+              <li v-for="(point, index) in feedbackCallout.points" :key="index">
+                <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
+                <span>{{ point }}</span>
+              </li>
+            </ul>
+          </div>
+          <v-btn
+            :href="feedbackCallout.ctaHref"
+            color="primary"
+            variant="flat"
+            size="large"
+            :aria-label="feedbackCallout.ctaAriaLabel"
+            append-icon="mdi-arrow-right"
+          >
+            {{ feedbackCallout.ctaLabel }}
           </v-btn>
         </div>
       </v-card>
@@ -163,4 +210,49 @@ defineProps<{
   font-size: 1.8rem
   margin: 0 0 0.5rem 0
   color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.feedback-card
+  margin-top: 2rem
+  padding: clamp(1.75rem, 3.5vw, 2.5rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.95)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+
+.feedback-content
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+@media (min-width: 960px)
+  .feedback-content
+    flex-direction: row
+    align-items: center
+    justify-content: space-between
+
+.feedback-text
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.feedback-title
+  font-size: 1.6rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.feedback-description
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 1)
+
+.feedback-points
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+  padding: 0
+  margin: 0
+  list-style: none
+
+.feedback-points li
+  display: flex
+  align-items: center
+  gap: 0.5rem
+  color: rgba(var(--v-theme-text-neutral-strong), 0.9)
 </style>

--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -7,6 +7,8 @@
       description-bloc-id="webpages:opensource:hero-description"
       :stats="heroStats"
       :ctas="heroCtas"
+      :cta-group-label="heroCtaGroupLabel"
+      :info-card="heroInfoCard"
     />
 
     <OpensourcePillarsSection
@@ -29,6 +31,7 @@
       description-bloc-id="webpages:opensource:resources-intro"
       :resources="resourceLinks"
       :contact="contactCta"
+      :feedback-callout="feedbackCallout"
     />
   </div>
 </template>
@@ -44,7 +47,13 @@ import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
 interface HeroStatDisplay {
   value: string
-  label: string
+  label?: string
+  labelRich?: {
+    before?: string
+    linkText: string
+    href: string
+    after?: string
+  }
 }
 
 interface HeroCtaDisplay {
@@ -95,6 +104,22 @@ interface ContactCtaDisplay {
   ctaAriaLabel: string
 }
 
+interface HeroInfoCardDisplay {
+  icon: string
+  highlight?: string
+  description?: string
+  items: { icon?: string; text: string }[]
+}
+
+interface FeedbackCalloutDisplay {
+  title: string
+  description: string
+  points: string[]
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
 definePageMeta({
   ssr: true,
 })
@@ -103,20 +128,29 @@ const { t, locale, availableLocales } = useI18n()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
 
-const heroStats = computed<HeroStatDisplay[]>(() => [
-  {
-    value: String(t('opensource.hero.stats.open.value')),
-    label: String(t('opensource.hero.stats.open.label')),
-  },
-  {
-    value: String(t('opensource.hero.stats.ssr.value')),
-    label: String(t('opensource.hero.stats.ssr.label')),
-  },
-  {
-    value: String(t('opensource.hero.stats.community.value')),
-    label: String(t('opensource.hero.stats.community.label')),
-  },
-])
+const heroStats = computed<HeroStatDisplay[]>(() => {
+  const openDataAfter = String(t('opensource.hero.stats.ssr.labelRich.after'))
+
+  return [
+    {
+      value: String(t('opensource.hero.stats.open.value')),
+      label: String(t('opensource.hero.stats.open.label')),
+    },
+    {
+      value: String(t('opensource.hero.stats.ssr.value')),
+      labelRich: {
+        before: String(t('opensource.hero.stats.ssr.labelRich.before')),
+        linkText: String(t('opensource.hero.stats.ssr.labelRich.linkText')),
+        href: localePath('opendata'),
+        after: openDataAfter.trim().length ? openDataAfter : undefined,
+      },
+    },
+    {
+      value: String(t('opensource.hero.stats.community.value')),
+      label: String(t('opensource.hero.stats.community.label')),
+    },
+  ]
+})
 
 const heroCtas = computed<HeroCtaDisplay[]>(() => [
   {
@@ -130,6 +164,28 @@ const heroCtas = computed<HeroCtaDisplay[]>(() => [
     rel: 'noopener',
   }
 ])
+
+const heroCtaGroupLabel = computed(() => String(t('opensource.hero.ctaGroupLabel')))
+
+const heroInfoCard = computed<HeroInfoCardDisplay>(() => ({
+  icon: 'mdi-source-branch',
+  highlight: String(t('opensource.hero.infoCard.highlight')),
+  description: String(t('opensource.hero.infoCard.description')),
+  items: [
+    {
+      icon: 'mdi-checkbox-marked-circle-outline',
+      text: String(t('opensource.hero.infoCard.items.openLicenses')),
+    },
+    {
+      icon: 'mdi-checkbox-marked-circle-outline',
+      text: String(t('opensource.hero.infoCard.items.collaborativeReviews')),
+    },
+    {
+      icon: 'mdi-checkbox-marked-circle-outline',
+      text: String(t('opensource.hero.infoCard.items.sharedGovernance')),
+    },
+  ],
+}))
 
 const pillarCards = computed<PillarCardDisplay[]>(() => [
   {
@@ -218,6 +274,19 @@ const contactCta = computed<ContactCtaDisplay>(() => ({
   ctaLabel: String(t('opensource.resources.contact.cta.label')),
   ctaHref: localePath('contact'),
   ctaAriaLabel: String(t('opensource.resources.contact.cta.ariaLabel')),
+}))
+
+const feedbackCallout = computed<FeedbackCalloutDisplay>(() => ({
+  title: String(t('opensource.resources.feedback.title')),
+  description: String(t('opensource.resources.feedback.description')),
+  points: [
+    String(t('opensource.resources.feedback.points.bugs')),
+    String(t('opensource.resources.feedback.points.features')),
+    String(t('opensource.resources.feedback.points.votes')),
+  ],
+  ctaLabel: String(t('opensource.resources.feedback.cta.label')),
+  ctaHref: localePath('feedback'),
+  ctaAriaLabel: String(t('opensource.resources.feedback.cta.ariaLabel')),
 }))
 
 const canonicalUrl = computed(() =>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -161,18 +161,32 @@
         "label": "Explore the repositories",
         "ariaLabel": "Open the Nudger GitHub organization in a new tab"
       },
+      "ctaGroupLabel": "Primary hero actions",
       "stats": {
         "open": {
-          "value": "100%",
-          "label": "of our code is published under open licences"
+          "value": "OpenSource",
+          "label": "Open code you can inspect"
         },
         "ssr": {
-          "value": "SSR",
-          "label": "Universal rendering ensures performance and accessibility"
+          "value": "OpenData",
+          "labelRich": {
+            "before": "Product insights",
+            "linkText": "available for free",
+            "after": ""
+          }
         },
         "community": {
           "value": "Community",
           "label": "Collective roadmap shaped with contributors and partners"
+        }
+      },
+      "infoCard": {
+        "highlight": "Open4goods",
+        "description": "grows with everyone. Every pull request, issue or piece of feedback makes the platform more transparent.",
+        "items": {
+          "openLicenses": "Code and data published under open licences",
+          "collaborativeReviews": "Collaborative reviews of contributions",
+          "sharedGovernance": "Shared governance and living documentation"
         }
       }
     },
@@ -234,6 +248,19 @@
         "cta": {
           "label": "Contact the team",
           "ariaLabel": "Navigate to the contact page"
+        }
+      },
+      "feedback": {
+        "title": "Share feedback and ideas",
+        "description": "Report bugs, submit feature ideas and help us prioritise what matters next.",
+        "points": {
+          "bugs": "Log a bug in just a few clicks",
+          "features": "Suggest new features and improvements",
+          "votes": "Vote on the topics that matter to you"
+        },
+        "cta": {
+          "label": "Open the feedback board",
+          "ariaLabel": "Navigate to the user feedback page"
         }
       }
     }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -162,18 +162,32 @@
         "label": "Explorer les dépôts",
         "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet"
       },
+      "ctaGroupLabel": "Appels à l'action principaux",
       "stats": {
         "open": {
-          "value": "100%",
-          "label": "du code publié sous licences libres"
+          "value": "OpenSource",
+          "label": "Code ouvert et disponible"
         },
         "ssr": {
-          "value": "SSR",
-          "label": "Rendu universel pour des performances accessibles"
+          "value": "OpenData",
+          "labelRich": {
+            "before": "Les informations produits",
+            "linkText": "disponibles gratuitement",
+            "after": ""
+          }
         },
         "community": {
           "value": "Collectif",
           "label": "Feuille de route co-construite avec les contributrices et contributeurs"
+        }
+      },
+      "infoCard": {
+        "highlight": "Open4goods",
+        "description": "est construit en commun. Chaque pull request, issue ou retour utilisateur façonne une plateforme plus transparente.",
+        "items": {
+          "openLicenses": "Code et données publiés sous licences ouvertes",
+          "collaborativeReviews": "Revue collaborative des contributions",
+          "sharedGovernance": "Gouvernance partagée et documentation vivante"
         }
       }
     },
@@ -235,6 +249,19 @@
         "cta": {
           "label": "Contacter l'équipe",
           "ariaLabel": "Aller vers la page contact"
+        }
+      },
+      "feedback": {
+        "title": "Partagez vos idées et retours",
+        "description": "Soumettez les bugs rencontrés, vos envies de fonctionnalités et aidez-nous à prioriser le produit.",
+        "points": {
+          "bugs": "Signalez un bug en quelques clics",
+          "features": "Proposez des idées de fonctionnalités",
+          "votes": "Votez pour les évolutions qui comptent pour vous"
+        },
+        "cta": {
+          "label": "Accéder au tableau de feedback",
+          "ariaLabel": "Aller vers la page des retours utilisateurs"
         }
       }
     }


### PR DESCRIPTION
## Summary
- update the open source hero statistics and supporting card copy using i18n strings
- add a localized feedback callout and opendata link to the open source resources section
- externalize new French and English translations for hero, resources, and feedback messaging

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68de7c192bec83338a475d6116ce0bc3