### PR TITLE
Ensure blog article dates format deterministically

### DIFF
--- a/frontend/app/components/domains/blog/TheArticle.vue
+++ b/frontend/app/components/domains/blog/TheArticle.vue
@@ -21,10 +21,12 @@ const article = computed(() => props.article)
 
 const articleTitle = computed(() => article.value.title?.trim() || 'Article')
 const articleSummary = computed(() => article.value.summary?.trim() ?? '')
-const { t, locale } = useI18n()
+const i18n = useI18n()
+const { t } = i18n
+const resolvedLocale = computed(() => i18n.locale?.value ?? 'en-US')
 const dateFormatter = computed(
   () =>
-    new Intl.DateTimeFormat(locale.value, {
+    new Intl.DateTimeFormat(resolvedLocale.value, {
       dateStyle: 'long',
       timeZone: 'UTC',
     }),

--- a/frontend/app/components/domains/blog/TheArticle.vue
+++ b/frontend/app/components/domains/blog/TheArticle.vue
@@ -21,7 +21,14 @@ const article = computed(() => props.article)
 
 const articleTitle = computed(() => article.value.title?.trim() || 'Article')
 const articleSummary = computed(() => article.value.summary?.trim() ?? '')
-const { t } = useI18n()
+const { t, locale } = useI18n()
+const dateFormatter = computed(
+  () =>
+    new Intl.DateTimeFormat(locale.value, {
+      dateStyle: 'long',
+      timeZone: 'UTC',
+    }),
+)
 const { isLoggedIn } = useAuth()
 
 const buildDateInfo = (timestamp?: number) => {
@@ -36,7 +43,7 @@ const buildDateInfo = (timestamp?: number) => {
 
   return {
     iso: date.toISOString(),
-    label: new Intl.DateTimeFormat(undefined, { dateStyle: 'long' }).format(date),
+    label: dateFormatter.value.format(date),
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse the active i18n locale when formatting blog article dates
- enforce a fixed UTC timezone so SSR and CSR produce matching date labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de88be41ac8333be89854f551ce8cf