### PR TITLE
refactor: delegate v-app shell to layouts

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -1,7 +1,5 @@
 <template>
   <NuxtLayout>
-    <v-app>
-      <NuxtPage />
-    </v-app>
+    <NuxtPage />
   </NuxtLayout>
 </template>


### PR DESCRIPTION
## Summary
- remove the redundant `v-app` wrapper from the Nuxt app entry so layouts own the Vuetify shell
- confirmed that the default layout already provides the single `v-app` instance expected per page

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68de8cff0b4883339bcc231cc490ba9a