### PR TITLE
Fix blog article date formatting for SSR parity

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.spec.ts
+++ b/frontend/app/components/domains/blog/TheArticles.spec.ts
@@ -569,6 +569,11 @@ describe('TheArticles.vue', () => {
     expect(timeElement.attributes('datetime')).toBe(
       new Date(firstArticle.createdMs ?? 0).toISOString(),
     )
+    expect(timeElement.text().trim()).toBe(
+      new Intl.DateTimeFormat(localeRef.value, { timeZone: 'UTC' }).format(
+        new Date(firstArticle.createdMs ?? 0),
+      ),
+    )
 
     const images = wrapper.findAll('[data-test="article-image"]')
     const [firstImage, secondImage] = images

--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -16,6 +16,12 @@ const {
   fetchTags,
 } = useBlog()
 
+const { t, locale } = useI18n()
+
+const dateFormatter = computed(
+  () => new Intl.DateTimeFormat(locale.value || undefined, { timeZone: 'UTC' }),
+)
+
 // Format date helper
 const formatDate = (timestamp: number) => {
   const date = new Date(timestamp)
@@ -24,7 +30,7 @@ const formatDate = (timestamp: number) => {
     return ''
   }
 
-  return date.toLocaleDateString()
+  return dateFormatter.value.format(date)
 }
 
 const buildDateIsoString = (timestamp: number) => {
@@ -32,8 +38,6 @@ const buildDateIsoString = (timestamp: number) => {
 
   return Number.isNaN(date.getTime()) ? '' : date.toISOString()
 }
-
-const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const currentPage = ref(1)


### PR DESCRIPTION
## Summary
- replace the blog article date formatter with an Intl.DateTimeFormat that reuses the active locale and a fixed UTC timezone so SSR/CSR output match
- update the TheArticles unit test to assert the rendered human-readable date string

## Testing
- pnpm vitest run app/components/domains/blog/TheArticles.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68deae531ebc833389c2ac0e5b29d044