### PR TITLE
Wrap mobile navigation drawer in ClientOnly

### DIFF
--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -3,15 +3,17 @@
     <The-main-menu-container @toggle-drawer="toggleDrawer" />
 
     <!-- Mobile menu -->
-    <v-navigation-drawer
-      v-model="drawer"
-      location="start"
-      temporary
-      width="300"
-      class="mobile-menu-drawer"
-    >
-      <the-mobile-menu @close="drawer = false" />
-    </v-navigation-drawer>
+    <ClientOnly>
+      <v-navigation-drawer
+        v-model="drawer"
+        location="start"
+        temporary
+        width="300"
+        class="mobile-menu-drawer"
+      >
+        <the-mobile-menu @close="drawer = false" />
+      </v-navigation-drawer>
+    </ClientOnly>
 
     <v-main>
       <slot />


### PR DESCRIPTION
## Summary
- wrap the default layout's mobile navigation drawer in Nuxt's ClientOnly component to restrict rendering to the browser

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfaca163fc83338e4081621268fc7d