### PR TITLE
Stabilize hero layout with server-computed app bar height

### DIFF
--- a/frontend/app/components/domains/home/hero/The-hero-video.vue
+++ b/frontend/app/components/domains/home/hero/The-hero-video.vue
@@ -193,8 +193,10 @@ $subtitle-max-width: 600px
 .hero-section
   position: relative
   width: 100%
-  height: 100vh
   min-height: $hero-min-height
+  min-height: clamp(#{$hero-min-height}, calc(100dvh - var(--app-bar-height, 64px)), 100dvh)
+  padding-top: var(--app-bar-height, 64px)
+  box-sizing: border-box
   overflow: hidden
   display: flex
   align-items: center
@@ -301,14 +303,9 @@ $subtitle-max-width: 600px
   animation: spin 1s linear infinite
 
 // RESPONSIVE DESIGN
-@media (max-width: 1024px)
-  .hero-section
-    height: 80vh
-
-@media (max-width: 768px)
-  .hero-section
-    height: 70vh
-    min-height: 500px
+  @media (max-width: 768px)
+    .hero-section
+      min-height: clamp(500px, calc(100dvh - var(--app-bar-height, 56px)), 100dvh)
 
   .hero-content
     padding: 0 1rem

--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,31 +1,54 @@
 <script lang="ts" setup>
+import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
+
+const props = withDefaults(defineProps<{
+  appBarHeight?: number
+}>(), {
+  appBarHeight: undefined,
+})
+
 const emit = defineEmits<{
   (event: 'toggle-drawer'): void
 }>()
+
+const { mdAndUp } = useDisplay()
+
+const fallbackHeight = computed(() => (mdAndUp.value ? 64 : 56))
+const resolvedAppBarHeight = computed(() => props.appBarHeight ?? fallbackHeight.value)
+const appBarCssVariables = computed(() => ({
+  '--app-bar-height': `${resolvedAppBarHeight.value}px`,
+}))
 
 const handleToggleDrawer = () => emit('toggle-drawer')
 </script>
 
 <template>
-  <v-app-bar
-    app
-    flat
-    color="surface-default"
-    class="main-menu-app-bar"
-  >
-    <v-container fluid class="py-0">
-      <div class="d-flex align-center w-100">
-        <v-app-bar-title class="d-flex align-center">
-          <the-main-logo />
-        </v-app-bar-title>
-        <v-spacer />
-        <the-hero-menu @toggle-drawer="handleToggleDrawer" />
-      </div>
-    </v-container>
-  </v-app-bar>
+  <div class="main-menu-wrapper" :style="appBarCssVariables">
+    <v-app-bar
+      app
+      flat
+      :height="resolvedAppBarHeight"
+      color="surface-default"
+      class="main-menu-app-bar"
+    >
+      <v-container fluid class="py-0">
+        <div class="d-flex align-center w-100">
+          <v-app-bar-title class="d-flex align-center">
+            <the-main-logo />
+          </v-app-bar-title>
+          <v-spacer />
+          <the-hero-menu @toggle-drawer="handleToggleDrawer" />
+        </div>
+      </v-container>
+    </v-app-bar>
+  </div>
 </template>
 
 <style lang="sass" scoped>
+.main-menu-wrapper
+  --app-bar-height: 64px
+
 .main-menu-app-bar
   color: rgb(var(--v-theme-text-neutral-strong))
 

--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -1,23 +1,18 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { useDisplay } from 'vuetify'
 
 const props = withDefaults(defineProps<{
   appBarHeight?: number
 }>(), {
-  appBarHeight: undefined,
+  appBarHeight: 64,
 })
 
 const emit = defineEmits<{
   (event: 'toggle-drawer'): void
 }>()
 
-const { mdAndUp } = useDisplay()
-
-const fallbackHeight = computed(() => (mdAndUp.value ? 64 : 56))
-const resolvedAppBarHeight = computed(() => props.appBarHeight ?? fallbackHeight.value)
 const appBarCssVariables = computed(() => ({
-  '--app-bar-height': `${resolvedAppBarHeight.value}px`,
+  '--app-bar-height': `${props.appBarHeight}px`,
 }))
 
 const handleToggleDrawer = () => emit('toggle-drawer')
@@ -28,7 +23,7 @@ const handleToggleDrawer = () => emit('toggle-drawer')
     <v-app-bar
       app
       flat
-      :height="resolvedAppBarHeight"
+      :height="props.appBarHeight"
       color="surface-default"
       class="main-menu-app-bar"
     >

--- a/frontend/app/composables/useAppBarHeight.ts
+++ b/frontend/app/composables/useAppBarHeight.ts
@@ -1,0 +1,38 @@
+import { computed, watchEffect } from 'vue'
+import { useRequestEvent, useState } from '#imports'
+import { useDisplay } from 'vuetify'
+
+const DESKTOP_APP_BAR_HEIGHT = 64
+const MOBILE_APP_BAR_HEIGHT = 56
+const MOBILE_UA_REGEX = /Mobile|Android|iP(ad|hone|od)|IEMobile|BlackBerry|Opera Mini/i
+
+export function useAppBarHeight() {
+  const requestEvent = useRequestEvent()
+  const userAgent = requestEvent?.node.req.headers['user-agent'] ?? ''
+  const initialHeight = MOBILE_UA_REGEX.test(userAgent)
+    ? MOBILE_APP_BAR_HEIGHT
+    : DESKTOP_APP_BAR_HEIGHT
+
+  const appBarHeight = useState('app-bar-height', () => initialHeight)
+
+  if (import.meta.client) {
+    const { mdAndUp } = useDisplay()
+
+    watchEffect(() => {
+      const targetHeight = mdAndUp.value ? DESKTOP_APP_BAR_HEIGHT : MOBILE_APP_BAR_HEIGHT
+
+      if (appBarHeight.value !== targetHeight) {
+        appBarHeight.value = targetHeight
+      }
+    })
+  }
+
+  const appBarCssVariables = computed(() => ({
+    '--app-bar-height': `${appBarHeight.value}px`,
+  }))
+
+  return {
+    appBarHeight,
+    appBarCssVariables,
+  }
+}

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -1,6 +1,9 @@
 <template>
   <v-app>
-    <The-main-menu-container @toggle-drawer="toggleDrawer" />
+    <The-main-menu-container
+      :app-bar-height="appBarHeight"
+      @toggle-drawer="toggleDrawer"
+    />
 
     <!-- Mobile menu -->
     <v-navigation-drawer
@@ -13,7 +16,7 @@
       <the-mobile-menu @close="drawer = false" />
     </v-navigation-drawer>
 
-    <v-main>
+    <v-main :style="appBarCssVariables">
       <slot />
     </v-main>
 
@@ -26,11 +29,21 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
+
 const drawer = useState('mobileDrawer', () => false)
-const drawerStore = useState("mobileDrawer", () => false);
+const drawerStore = useState('mobileDrawer', () => false)
+
+const { mdAndUp } = useDisplay()
+
+const appBarHeight = computed(() => (mdAndUp.value ? 64 : 56))
+const appBarCssVariables = computed(() => ({
+  '--app-bar-height': `${appBarHeight.value}px`,
+}))
 
 const toggleDrawer = () => {
-  drawerStore.value = !drawerStore.value;
-};
+  drawerStore.value = !drawerStore.value
+}
 </script>
 

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-app :style="appBarCssVariables">
     <The-main-menu-container
       :app-bar-height="appBarHeight"
       @toggle-drawer="toggleDrawer"
@@ -29,18 +29,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { useDisplay } from 'vuetify'
-
 const drawer = useState('mobileDrawer', () => false)
 const drawerStore = useState('mobileDrawer', () => false)
 
-const { mdAndUp } = useDisplay()
-
-const appBarHeight = computed(() => (mdAndUp.value ? 64 : 56))
-const appBarCssVariables = computed(() => ({
-  '--app-bar-height': `${appBarHeight.value}px`,
-}))
+const { appBarHeight, appBarCssVariables } = useAppBarHeight()
 
 const toggleDrawer = () => {
   drawerStore.value = !drawerStore.value


### PR DESCRIPTION
## Summary
- compute the app bar height on both the main menu and default layout using Vuetify breakpoints and expose it as a shared CSS custom property
- propagate the shared `--app-bar-height` variable to `<v-main>` so page content renders with a consistent offset during SSR and hydration
- update the hero video styling to rely on the shared app bar height, using dynamic `min-height` and top padding instead of hard-coded viewport heights

## Testing
- pnpm lint *(warns about legacy `vue/no-v-html` usage in TextContent.vue)*
- pnpm test -- --run The-hero-video.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfac8fb1c48333ae358360e039a0f5