### PR TITLE
Add hydration spacer before app content

### DIFF
--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -15,6 +15,12 @@
       </v-navigation-drawer>
     </ClientOnly>
 
+    <ClientOnly>
+      <template #fallback>
+        <div class="pre-hydration-app-bar-spacer" aria-hidden="true" />
+      </template>
+    </ClientOnly>
+
     <v-main>
       <slot />
     </v-main>
@@ -35,4 +41,12 @@ const toggleDrawer = () => {
   drawerStore.value = !drawerStore.value;
 };
 </script>
+
+<style scoped lang="sass">
+.pre-hydration-app-bar-spacer
+  height: 64px
+
+  @media (max-width: 959px)
+    height: 56px
+</style>
 


### PR DESCRIPTION
## Summary
- add a ClientOnly fallback spacer before the main content to preserve layout before hydration
- define scoped SASS styles so the spacer matches Vuetify app-bar heights on desktop and mobile

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfd72b128883339bb9244e4cfdfd11