### PR TITLE
Fix footer routing and hydrate Vuetify theme from SSR

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
+import type { RouteLocationRaw } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
 type FooterLink = {
   label: string
-  href: string
+  to?: RouteLocationRaw
+  href?: string
   target?: string
   rel?: string
 }
@@ -20,52 +22,52 @@ const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
 const highlightLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.highlightLinks.ecoscore'),
-    href: resolveLocalizedRoutePath('ecoscore', currentLocale.value),
+    to: resolveLocalizedRoutePath('ecoscore', currentLocale.value),
   }
 ])
 
 const comparatorLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.comparator.links.openData'),
-    href: '/opendata',
+    to: '/opendata',
   },
   {
     label: t('siteIdentity.footer.comparator.links.openSource'),
-    href: '/opensource',
+    to: '/opensource',
   },
   {
     label: t('siteIdentity.footer.comparator.links.privacy'),
-    href: resolveLocalizedRoutePath('data-privacy', currentLocale.value),
+    to: resolveLocalizedRoutePath('data-privacy', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.comparator.links.legal'),
-    href: resolveLocalizedRoutePath('legal-notice', currentLocale.value),
+    to: resolveLocalizedRoutePath('legal-notice', currentLocale.value),
   },
 ])
 
 const communityLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.community.links.team'),
-    href: resolveLocalizedRoutePath('team', currentLocale.value),
+    to: resolveLocalizedRoutePath('team', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.community.links.partners'),
-    href: '/partenaires',
+    to: '/partenaires',
   },
 ])
 
 const feedbackLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.feedback.links.idea'),
-    href: '/feedback/idea',
+    to: '/feedback/idea',
   },
   {
     label: t('siteIdentity.footer.feedback.links.issue'),
-    href: '/feedback/issue',
+    to: '/feedback/issue',
   },
   {
     label: t('siteIdentity.footer.feedback.links.contact'),
-    href: resolveLocalizedRoutePath('contact', currentLocale.value),
+    to: resolveLocalizedRoutePath('contact', currentLocale.value),
   },
   {
     label: t('siteIdentity.footer.feedback.links.linkedin'),
@@ -90,7 +92,7 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         </p>
 
         <v-btn
-          :href="blogPath"
+          :to="blogPath"
           variant="text"
           append-icon="mdi-arrow-right"
           class="footer-link-btn text-white px-0"
@@ -101,14 +103,15 @@ const feedbackLinks = computed<FooterLink[]>(() => [
 
       <v-col cols="12" md="4">
         <div class="d-flex flex-column ga-2">
-          <v-btn
-            v-for="link in highlightLinks"
-            :key="link.href"
-            :href="link.href"
-            variant="text"
-            append-icon="mdi-arrow-right"
-            class="footer-link-btn text-white px-0"
-          >
+        <v-btn
+          v-for="link in highlightLinks"
+          :key="String(link.to ?? link.href ?? link.label)"
+          :to="link.to"
+          :href="link.href"
+          variant="text"
+          append-icon="mdi-arrow-right"
+          class="footer-link-btn text-white px-0"
+        >
             {{ link.label }}
           </v-btn>
         </div>
@@ -119,7 +122,8 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
           <v-list-item
             v-for="link in comparatorLinks"
-            :key="link.href"
+            :key="String(link.to ?? link.href ?? link.label)"
+            :to="link.to"
             :href="link.href"
             class="footer-list-item px-0"
           >
@@ -136,15 +140,16 @@ const feedbackLinks = computed<FooterLink[]>(() => [
             {{ t('siteIdentity.footer.community.title') }}
           </div>
           <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
-            <v-list-item
-              v-for="link in communityLinks"
-              :key="link.href"
-              :href="link.href"
-              class="footer-list-item px-0"
-            >
-              <template #title>
-                <span class="text-body-2">{{ link.label }}</span>
-              </template>
+          <v-list-item
+            v-for="link in communityLinks"
+            :key="String(link.to ?? link.href ?? link.label)"
+            :to="link.to"
+            :href="link.href"
+            class="footer-list-item px-0"
+          >
+            <template #title>
+              <span class="text-body-2">{{ link.label }}</span>
+            </template>
             </v-list-item>
           </v-list>
         </div>
@@ -155,7 +160,8 @@ const feedbackLinks = computed<FooterLink[]>(() => [
         <v-list density="compact" bg-color="transparent" class="footer-list pa-0 mt-2">
           <v-list-item
             v-for="link in feedbackLinks"
-            :key="link.href"
+            :key="String(link.to ?? link.href ?? link.label)"
+            :to="link.to"
             :href="link.href"
             class="footer-list-item px-0"
             :target="link.target"

--- a/frontend/app/plugins/vuetify-theme.ts
+++ b/frontend/app/plugins/vuetify-theme.ts
@@ -1,0 +1,29 @@
+import { usePreferredDark } from '@vueuse/core'
+
+import { THEME_PREFERENCE_KEY, resolveThemeName, type ThemeName } from '~~/shared/constants/theme'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const storedPreference = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
+    sameSite: 'lax',
+    path: '/',
+    watch: false,
+  })
+
+  const isClient = typeof window !== 'undefined'
+  let themeName = resolveThemeName(storedPreference.value)
+
+  if (!storedPreference.value && isClient) {
+    const prefersDark = usePreferredDark()
+    themeName = prefersDark.value ? 'dark' : 'light'
+  }
+
+  if (nuxtApp.$vuetify?.theme?.global?.name) {
+    if (nuxtApp.$vuetify.theme.global.name.value !== themeName) {
+      nuxtApp.$vuetify.theme.global.name.value = themeName
+    }
+  }
+
+  if (!storedPreference.value && isClient) {
+    storedPreference.value = themeName
+  }
+})

--- a/frontend/app/plugins/vuetify-theme.ts
+++ b/frontend/app/plugins/vuetify-theme.ts
@@ -1,3 +1,5 @@
+import type { NuxtApp } from 'nuxt/app'
+
 import { usePreferredDark } from '@vueuse/core'
 
 import type { Ref } from 'vue'
@@ -12,29 +14,66 @@ type VuetifyThemeBridge = {
   }
 }
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const storedPreference = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
-    sameSite: 'lax',
-    path: '/',
-    watch: false,
-  })
+const resolveVuetifyInstance = (nuxtApp: NuxtApp): VuetifyThemeBridge | undefined => {
+  const direct = nuxtApp.$vuetify as unknown as VuetifyThemeBridge | undefined
 
-  const isClient = typeof window !== 'undefined'
-  let themeName = resolveThemeName(storedPreference.value)
-
-  if (!storedPreference.value && isClient) {
-    const prefersDark = usePreferredDark()
-    themeName = prefersDark.value ? 'dark' : 'light'
+  if (direct?.theme?.global?.name) {
+    return direct
   }
 
-  const vuetify = nuxtApp.$vuetify as VuetifyThemeBridge | undefined
+  const fromGlobals = nuxtApp.vueApp.config.globalProperties.$vuetify as unknown as VuetifyThemeBridge | undefined
+
+  if (fromGlobals?.theme?.global?.name) {
+    return fromGlobals
+  }
+
+  return undefined
+}
+
+const applyVuetifyTheme = (nuxtApp: NuxtApp, value: ThemeName) => {
+  const vuetify = resolveVuetifyInstance(nuxtApp)
   const globalThemeName = vuetify?.theme?.global?.name
 
-  if (globalThemeName && globalThemeName.value !== themeName) {
-    globalThemeName.value = themeName
+  if (globalThemeName && globalThemeName.value !== value) {
+    globalThemeName.value = value
   }
+}
 
-  if (!storedPreference.value && isClient) {
-    storedPreference.value = themeName
-  }
+const themePlugin = defineNuxtPlugin({
+  name: 'open4goods:vuetify-theme',
+  enforce: 'pre',
+  setup(nuxt) {
+    const nuxtApp = nuxt as NuxtApp
+    const storedPreference = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
+      sameSite: 'lax',
+      path: '/',
+      watch: false,
+    })
+
+    const isClient = typeof window !== 'undefined'
+    let themeName = resolveThemeName(storedPreference.value)
+
+    if (!storedPreference.value && isClient) {
+      const prefersDark = usePreferredDark()
+      themeName = prefersDark.value ? 'dark' : 'light'
+    }
+
+    const syncTheme = () => applyVuetifyTheme(nuxtApp, themeName)
+
+    // Ensure the preferred theme is already set before Vue renders on the server.
+    syncTheme()
+
+    nuxtApp.hooks.hook('app:created', syncTheme)
+    nuxtApp.hooks.hook('app:mounted', syncTheme)
+
+    if (!storedPreference.value && isClient) {
+      storedPreference.value = themeName
+    }
+
+    if (import.meta.server) {
+      nuxtApp.payload.state.preferredTheme = themeName
+    }
+  },
 })
+
+export default themePlugin

--- a/frontend/app/plugins/vuetify-theme.ts
+++ b/frontend/app/plugins/vuetify-theme.ts
@@ -1,6 +1,16 @@
 import { usePreferredDark } from '@vueuse/core'
 
+import type { Ref } from 'vue'
+
 import { THEME_PREFERENCE_KEY, resolveThemeName, type ThemeName } from '~~/shared/constants/theme'
+
+type VuetifyThemeBridge = {
+  theme?: {
+    global?: {
+      name?: Ref<ThemeName>
+    }
+  }
+}
 
 export default defineNuxtPlugin((nuxtApp) => {
   const storedPreference = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
@@ -17,10 +27,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     themeName = prefersDark.value ? 'dark' : 'light'
   }
 
-  if (nuxtApp.$vuetify?.theme?.global?.name) {
-    if (nuxtApp.$vuetify.theme.global.name.value !== themeName) {
-      nuxtApp.$vuetify.theme.global.name.value = themeName
-    }
+  const vuetify = nuxtApp.$vuetify as VuetifyThemeBridge | undefined
+  const globalThemeName = vuetify?.theme?.global?.name
+
+  if (globalThemeName && globalThemeName.value !== themeName) {
+    globalThemeName.value = themeName
   }
 
   if (!storedPreference.value && isClient) {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -48,6 +48,10 @@ export default defineNuxtConfig({
     'nuxt-mcp'
   ],
 
+  vueuse: {
+    ssrHandlers: true,
+  },
+
   vuetify: {
       vuetifyOptions: {
         theme: {

--- a/frontend/shared/constants/theme.ts
+++ b/frontend/shared/constants/theme.ts
@@ -1,0 +1,18 @@
+export type ThemeName = 'light' | 'dark'
+
+export const THEME_PREFERENCE_KEY = 'open4goods-preferred-theme'
+
+export const resolveThemeName = (
+  value: string | null | undefined,
+  fallback: ThemeName = 'light',
+): ThemeName => {
+  if (value === 'dark') {
+    return 'dark'
+  }
+
+  if (value === 'light') {
+    return 'light'
+  }
+
+  return fallback
+}


### PR DESCRIPTION
## Summary
- convert footer buttons and list items to use Nuxt router navigation for internal links to stop theme flashes on reload
- add a shared theme constant, SSR plugin, and updated ThemeToggle logic to read/write the preferred theme via cookie + storage
- adjust the ThemeToggle unit test to the new persistence behaviour and import paths

## Testing
- pnpm lint *(warns about existing v-html usage)*
- pnpm vitest run app/components/shared/menus/menus-auth.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfe0518c3c8333a1a366b68b33954c