### PR TITLE
Refine open source page layout

### DIFF
--- a/frontend/app/components/domains/opensource/OpensourceHero.vue
+++ b/frontend/app/components/domains/opensource/OpensourceHero.vue
@@ -1,17 +1,6 @@
 <script setup lang="ts">
 import TextContent from '~/components/domains/content/TextContent.vue'
 
-interface HeroStat {
-  value: string
-  label?: string
-  labelRich?: {
-    before?: string
-    linkText: string
-    href: string
-    after?: string
-  }
-}
-
 interface HeroCta {
   label: string
   href: string
@@ -40,13 +29,11 @@ withDefaults(
     title: string
     subtitle: string
     descriptionBlocId: string
-    stats?: HeroStat[]
     ctas?: HeroCta[]
     ctaGroupLabel?: string
     infoCard?: HeroInfoCard
   }>(),
   {
-    stats: () => [],
     ctas: () => [],
     ctaGroupLabel: undefined,
     infoCard: undefined,
@@ -89,29 +76,6 @@ withDefaults(
                 </template>
                 {{ cta.label }}
               </v-btn>
-            </div>
-
-            <v-divider v-if="stats.length" class="my-4" color="accent-supporting" />
-
-            <div v-if="stats.length" class="hero-stats" role="list">
-              <div
-                v-for="stat in stats"
-                :key="stat.label ?? stat.labelRich?.linkText ?? stat.value"
-                class="hero-stat"
-                role="listitem"
-              >
-                <span class="hero-stat-value">{{ stat.value }}</span>
-                <span class="hero-stat-label">
-                  <template v-if="stat.labelRich">
-                    <span v-if="stat.labelRich.before">{{ stat.labelRich.before }} </span>
-                    <NuxtLink :to="stat.labelRich.href" class="hero-stat-link">
-                      {{ stat.labelRich.linkText }}
-                    </NuxtLink>
-                    <span v-if="stat.labelRich.after"> {{ stat.labelRich.after }}</span>
-                  </template>
-                  <template v-else>{{ stat.label }}</template>
-                </span>
-              </div>
             </div>
           </v-col>
 
@@ -186,30 +150,6 @@ withDefaults(
   display: flex
   flex-wrap: wrap
   gap: 0.75rem
-
-.hero-stats
-  display: grid
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr))
-  gap: 1.5rem
-
-.hero-stat
-  display: flex
-  flex-direction: column
-  gap: 0.25rem
-
-.hero-stat-value
-  font-size: 1.75rem
-  font-weight: 700
-
-.hero-stat-label
-  font-size: 0.95rem
-  opacity: 0.85
-
-.hero-stat-link
-  color: inherit
-  text-decoration: underline
-  text-decoration-thickness: 2px
-  text-underline-offset: 4px
 
 .hero-card
   background: rgba(var(--v-theme-surface-glass), 0.9)

--- a/frontend/app/components/domains/opensource/OpensourcePillarsSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourcePillarsSection.vue
@@ -16,11 +16,21 @@ interface PillarCard {
   action?: PillarCardAction
 }
 
+interface FeedbackCallout {
+  title: string
+  description: string
+  points: string[]
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
 defineProps<{
   eyebrow: string
   title: string
   descriptionBlocId: string
   cards: PillarCard[]
+  feedbackCallout?: FeedbackCallout
 }>()
 </script>
 
@@ -68,6 +78,38 @@ defineProps<{
           </v-card>
         </v-col>
       </v-row>
+
+      <v-card
+        v-if="feedbackCallout"
+        class="feedback-card"
+        rounded="xl"
+        elevation="6"
+        role="region"
+        :aria-label="feedbackCallout.title"
+      >
+        <div class="feedback-content">
+          <div class="feedback-text">
+            <h3 class="feedback-title">{{ feedbackCallout.title }}</h3>
+            <p class="feedback-description">{{ feedbackCallout.description }}</p>
+            <ul class="feedback-points">
+              <li v-for="(point, index) in feedbackCallout.points" :key="index">
+                <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
+                <span>{{ point }}</span>
+              </li>
+            </ul>
+          </div>
+          <v-btn
+            :href="feedbackCallout.ctaHref"
+            color="primary"
+            variant="flat"
+            size="large"
+            :aria-label="feedbackCallout.ctaAriaLabel"
+            append-icon="mdi-arrow-right"
+          >
+            {{ feedbackCallout.ctaLabel }}
+          </v-btn>
+        </div>
+      </v-card>
     </v-container>
   </section>
 </template>
@@ -125,4 +167,53 @@ defineProps<{
 
 .pillar-action
   margin-top: auto
+
+.feedback-card
+  margin-top: 3rem
+  padding: clamp(1.75rem, 3.5vw, 2.5rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.95)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+
+.feedback-content
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+@media (min-width: 960px)
+  .feedback-content
+    flex-direction: row
+    align-items: center
+    justify-content: space-between
+
+.feedback-text
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.feedback-title
+  font-size: 1.6rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.feedback-description
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 1)
+
+.feedback-points
+  list-style: none
+  padding: 0
+  margin: 0
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.feedback-points li
+  display: flex
+  gap: 0.5rem
+  align-items: center
+  font-size: 0.95rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 1)
+
+.feedback-points .v-icon
+  color: rgba(var(--v-theme-accent-supporting), 1)
 </style>

--- a/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
+++ b/frontend/app/components/domains/opensource/OpensourceResourcesSection.vue
@@ -19,10 +19,9 @@ interface ContactCta {
   ctaAriaLabel: string
 }
 
-interface FeedbackCallout {
+interface OpendataCallout {
   title: string
   description: string
-  points: string[]
   ctaLabel: string
   ctaHref: string
   ctaAriaLabel: string
@@ -35,10 +34,10 @@ withDefaults(
     descriptionBlocId: string
     resources: ResourceLink[]
     contact: ContactCta
-    feedbackCallout?: FeedbackCallout
+    opendataCallout?: OpendataCallout
   }>(),
   {
-    feedbackCallout: undefined,
+    opendataCallout: undefined,
   },
 )
 </script>
@@ -86,6 +85,32 @@ withDefaults(
         </v-col>
       </v-row>
 
+      <v-card
+        v-if="opendataCallout"
+        class="opendata-card"
+        rounded="xl"
+        elevation="8"
+        role="region"
+        :aria-label="opendataCallout.title"
+      >
+        <div class="opendata-content">
+          <div class="opendata-text">
+            <h3 class="opendata-title">{{ opendataCallout.title }}</h3>
+            <p class="opendata-description">{{ opendataCallout.description }}</p>
+          </div>
+          <v-btn
+            :href="opendataCallout.ctaHref"
+            color="primary"
+            variant="flat"
+            size="large"
+            :aria-label="opendataCallout.ctaAriaLabel"
+            append-icon="mdi-arrow-right"
+          >
+            {{ opendataCallout.ctaLabel }}
+          </v-btn>
+        </div>
+      </v-card>
+
       <v-card class="contact-card" rounded="xl" elevation="8">
         <div class="contact-content">
           <div class="contact-text">
@@ -105,37 +130,6 @@ withDefaults(
         </div>
       </v-card>
 
-      <v-card
-        v-if="feedbackCallout"
-        class="feedback-card"
-        rounded="xl"
-        elevation="6"
-        role="region"
-        :aria-label="feedbackCallout.title"
-      >
-        <div class="feedback-content">
-          <div class="feedback-text">
-            <h3 class="feedback-title">{{ feedbackCallout.title }}</h3>
-            <p class="feedback-description">{{ feedbackCallout.description }}</p>
-            <ul class="feedback-points">
-              <li v-for="(point, index) in feedbackCallout.points" :key="index">
-                <v-icon icon="mdi-checkbox-marked-circle-outline" size="small" />
-                <span>{{ point }}</span>
-              </li>
-            </ul>
-          </div>
-          <v-btn
-            :href="feedbackCallout.ctaHref"
-            color="primary"
-            variant="flat"
-            size="large"
-            :aria-label="feedbackCallout.ctaAriaLabel"
-            append-icon="mdi-arrow-right"
-          >
-            {{ feedbackCallout.ctaLabel }}
-          </v-btn>
-        </div>
-      </v-card>
     </v-container>
   </section>
 </template>
@@ -189,6 +183,37 @@ withDefaults(
   margin: 0
   color: rgba(var(--v-theme-text-neutral-strong), 1)
 
+.opendata-card
+  margin-top: 3.5rem
+  padding: clamp(1.75rem, 3vw, 2.5rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.96)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+
+.opendata-content
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+@media (min-width: 960px)
+  .opendata-content
+    flex-direction: row
+    align-items: center
+    justify-content: space-between
+
+.opendata-text
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.opendata-title
+  font-size: 1.6rem
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
+
+.opendata-description
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 1)
+
 .contact-card
   margin-top: 4rem
   padding: clamp(2rem, 4vw, 3rem)
@@ -210,49 +235,4 @@ withDefaults(
   font-size: 1.8rem
   margin: 0 0 0.5rem 0
   color: rgba(var(--v-theme-text-neutral-strong), 1)
-
-.feedback-card
-  margin-top: 2rem
-  padding: clamp(1.75rem, 3.5vw, 2.5rem)
-  background: rgba(var(--v-theme-surface-glass-strong), 0.95)
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
-
-.feedback-content
-  display: flex
-  flex-direction: column
-  gap: 1.5rem
-
-@media (min-width: 960px)
-  .feedback-content
-    flex-direction: row
-    align-items: center
-    justify-content: space-between
-
-.feedback-text
-  display: flex
-  flex-direction: column
-  gap: 0.75rem
-
-.feedback-title
-  font-size: 1.6rem
-  margin: 0
-  color: rgba(var(--v-theme-text-neutral-strong), 1)
-
-.feedback-description
-  margin: 0
-  color: rgba(var(--v-theme-text-neutral-secondary), 1)
-
-.feedback-points
-  display: flex
-  flex-direction: column
-  gap: 0.5rem
-  padding: 0
-  margin: 0
-  list-style: none
-
-.feedback-points li
-  display: flex
-  align-items: center
-  gap: 0.5rem
-  color: rgba(var(--v-theme-text-neutral-strong), 0.9)
 </style>

--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -4,7 +4,6 @@
       :title="t('opensource.hero.title')"
       :subtitle="t('opensource.hero.subtitle')"
       description-bloc-id="webpages:opensource:hero-description"
-      :stats="heroStats"
       :ctas="heroCtas"
       :cta-group-label="heroCtaGroupLabel"
       :info-card="heroInfoCard"
@@ -15,6 +14,7 @@
       :title="t('opensource.pillars.title')"
       description-bloc-id="webpages:opensource:pillars-intro"
       :cards="pillarCards"
+      :feedback-callout="feedbackCallout"
     />
 
     <OpensourceContributionSection
@@ -30,7 +30,7 @@
       description-bloc-id="webpages:opensource:resources-intro"
       :resources="resourceLinks"
       :contact="contactCta"
-      :feedback-callout="feedbackCallout"
+      :opendata-callout="opendataCallout"
     />
   </div>
 </template>
@@ -43,17 +43,6 @@ import OpensourcePillarsSection from '~/components/domains/opensource/Opensource
 import OpensourceContributionSection from '~/components/domains/opensource/OpensourceContributionSection.vue'
 import OpensourceResourcesSection from '~/components/domains/opensource/OpensourceResourcesSection.vue'
 import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
-
-interface HeroStatDisplay {
-  value: string
-  label?: string
-  labelRich?: {
-    before?: string
-    linkText: string
-    href: string
-    after?: string
-  }
-}
 
 interface HeroCtaDisplay {
   label: string
@@ -119,6 +108,14 @@ interface FeedbackCalloutDisplay {
   ctaAriaLabel: string
 }
 
+interface OpendataCalloutDisplay {
+  title: string
+  description: string
+  ctaLabel: string
+  ctaHref: string
+  ctaAriaLabel: string
+}
+
 definePageMeta({
   ssr: true,
 })
@@ -126,30 +123,6 @@ definePageMeta({
 const { t, locale, availableLocales } = useI18n()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
-
-const heroStats = computed<HeroStatDisplay[]>(() => {
-  const openDataAfter = String(t('opensource.hero.stats.ssr.labelRich.after'))
-
-  return [
-    {
-      value: String(t('opensource.hero.stats.open.value')),
-      label: String(t('opensource.hero.stats.open.label')),
-    },
-    {
-      value: String(t('opensource.hero.stats.ssr.value')),
-      labelRich: {
-        before: String(t('opensource.hero.stats.ssr.labelRich.before')),
-        linkText: String(t('opensource.hero.stats.ssr.labelRich.linkText')),
-        href: localePath('opendata'),
-        after: openDataAfter.trim().length ? openDataAfter : undefined,
-      },
-    },
-    {
-      value: String(t('opensource.hero.stats.community.value')),
-      label: String(t('opensource.hero.stats.community.label')),
-    },
-  ]
-})
 
 const heroCtas = computed<HeroCtaDisplay[]>(() => [
   {
@@ -286,6 +259,14 @@ const feedbackCallout = computed<FeedbackCalloutDisplay>(() => ({
   ctaLabel: String(t('opensource.resources.feedback.cta.label')),
   ctaHref: localePath('feedback'),
   ctaAriaLabel: String(t('opensource.resources.feedback.cta.ariaLabel')),
+}))
+
+const opendataCallout = computed<OpendataCalloutDisplay>(() => ({
+  title: String(t('opensource.resources.opendata.title')),
+  description: String(t('opensource.resources.opendata.description')),
+  ctaLabel: String(t('opensource.resources.opendata.cta.label')),
+  ctaHref: localePath('opendata'),
+  ctaAriaLabel: String(t('opensource.resources.opendata.cta.ariaLabel')),
 }))
 
 const canonicalUrl = computed(() =>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -162,24 +162,6 @@
         "ariaLabel": "Open the Nudger GitHub organization in a new tab"
       },
       "ctaGroupLabel": "Primary hero actions",
-      "stats": {
-        "open": {
-          "value": "OpenSource",
-          "label": "Open code you can inspect"
-        },
-        "ssr": {
-          "value": "OpenData",
-          "labelRich": {
-            "before": "Product insights",
-            "linkText": "available for free",
-            "after": ""
-          }
-        },
-        "community": {
-          "value": "Community",
-          "label": "Collective roadmap shaped with contributors and partners"
-        }
-      },
       "infoCard": {
         "highlight": "Open4goods",
         "description": "grows with everyone. Every pull request, issue or piece of feedback makes the platform more transparent.",
@@ -241,6 +223,14 @@
         "updates": {
           "title": "Community updates",
           "ariaLabel": "Open the Nudger blog"
+        }
+      },
+      "opendata": {
+        "title": "Open data for transparent decisions",
+        "description": "Nudger datasets are published so you can analyse product footprints, cross-check our scoring and build your own projects.",
+        "cta": {
+          "label": "Browse the open data portal",
+          "ariaLabel": "Navigate to the open data page"
         }
       },
       "contact": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -163,24 +163,6 @@
         "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet"
       },
       "ctaGroupLabel": "Appels à action principaux",
-      "stats": {
-        "open": {
-          "value": "Open Source",
-          "label": "Code ouvert et disponible"
-        },
-        "ssr": {
-          "value": "Open Data",
-          "labelRich": {
-            "before": "Les informations produits",
-            "linkText": "disponibles gratuitement",
-            "after": ""
-          }
-        },
-        "community": {
-          "value": "Collectif",
-          "label": "Feuille de route co-construite avec les contributrices et contributeurs"
-        }
-      },
       "infoCard": {
         "highlight": "Open4goods",
         "description": "est construit en commun. Chaque pull request, issue ou retour utilisateur façonne une plateforme plus transparente.",
@@ -242,6 +224,14 @@
         "updates": {
           "title": "Actualités de la communauté",
           "ariaLabel": "Ouvrir le blog Nudger"
+        }
+      },
+      "opendata": {
+        "title": "Des données ouvertes pour vos analyses",
+        "description": "Les jeux de données Nudger sont publiés pour que vous puissiez auditer nos scores, explorer les empreintes produits et créer vos propres projets.",
+        "cta": {
+          "label": "Découvrir l'espace open data",
+          "ariaLabel": "Aller vers la page open data"
         }
       },
       "contact": {


### PR DESCRIPTION
## Summary
- remove the hero statistics block and adjust the open source hero component
- relocate the feedback callout into the pillars section and style it for that layout
- add an open data callout card in the resources section and update i18n strings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2878e8c648333aeebebacb657c653