### PR TITLE
Add feedback page and improve backend error handling

### DIFF
--- a/frontend/app/components/domains/feedback/FeedbackHero.vue
+++ b/frontend/app/components/domains/feedback/FeedbackHero.vue
@@ -1,0 +1,290 @@
+<template>
+  <section class="feedback-hero" aria-labelledby="feedback-hero-heading">
+    <div class="feedback-hero__background" aria-hidden="true" />
+
+    <v-container class="py-16">
+      <v-row class="align-center">
+        <v-col cols="12" md="7">
+          <div class="feedback-hero__content">
+            <p class="feedback-hero__eyebrow">{{ eyebrow }}</p>
+            <h1 id="feedback-hero-heading" class="feedback-hero__title">
+              {{ title }}
+            </h1>
+            <p class="feedback-hero__subtitle">
+              {{ subtitle }}
+            </p>
+            <TextContent
+              :bloc-id="descriptionBlocId"
+              :ipsum-length="220"
+              class="feedback-hero__description"
+            />
+
+            <div class="feedback-hero__actions" role="group" :aria-label="ctaGroupLabel">
+              <v-btn
+                v-if="primaryCta"
+                color="primary"
+                size="large"
+                class="feedback-hero__cta"
+                :href="primaryCta.href"
+                :to="primaryCta.to"
+                :aria-label="primaryCta.ariaLabel"
+                :target="primaryCta.target"
+                :rel="primaryCta.rel"
+                :append-icon="primaryCta.icon"
+              >
+                {{ primaryCta.label }}
+              </v-btn>
+
+              <v-btn
+                v-if="secondaryCta"
+                variant="outlined"
+                size="large"
+                class="feedback-hero__cta"
+                :href="secondaryCta.href"
+                :to="secondaryCta.to"
+                :aria-label="secondaryCta.ariaLabel"
+                :target="secondaryCta.target"
+                :rel="secondaryCta.rel"
+                :append-icon="secondaryCta.icon"
+              >
+                {{ secondaryCta.label }}
+              </v-btn>
+            </div>
+
+            <ul v-if="highlights.length > 0" class="feedback-hero__highlights" role="list">
+              <li v-for="highlight in highlights" :key="highlight.title" class="feedback-hero__highlight-item">
+                <v-avatar size="44" class="feedback-hero__highlight-icon" color="surface-primary-120">
+                  <v-icon :icon="highlight.icon" size="26" color="primary" />
+                </v-avatar>
+                <div class="feedback-hero__highlight-text">
+                  <p class="feedback-hero__highlight-title">{{ highlight.title }}</p>
+                  <p v-if="highlight.description" class="feedback-hero__highlight-description">
+                    {{ highlight.description }}
+                  </p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </v-col>
+
+        <v-col cols="12" md="5">
+          <v-card class="feedback-hero__card" elevation="8" rounded="xl" role="presentation">
+            <div class="feedback-hero__card-header">
+              <v-icon icon="mdi-vote" size="36" color="primary" />
+              <span class="feedback-hero__card-eyebrow">{{ stats.eyebrow }}</span>
+            </div>
+            <p class="feedback-hero__card-title">{{ stats.title }}</p>
+            <p class="feedback-hero__card-description">{{ stats.description }}</p>
+            <v-divider class="my-4" />
+            <ul class="feedback-hero__card-list" role="list">
+              <li v-for="item in stats.items" :key="item.label" class="feedback-hero__card-item">
+                <v-icon :icon="item.icon" size="22" color="primary" class="me-2" />
+                <span class="feedback-hero__card-item-label">{{ item.label }}</span>
+              </li>
+            </ul>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+type HeroLink = {
+  label: string
+  ariaLabel: string
+  href?: string
+  to?: string
+  target?: string
+  rel?: string
+  icon?: string
+}
+
+type HeroHighlight = {
+  icon: string
+  title: string
+  description?: string
+}
+
+type HeroStatItem = {
+  icon: string
+  label: string
+}
+
+type HeroStats = {
+  eyebrow: string
+  title: string
+  description: string
+  items: HeroStatItem[]
+}
+
+defineProps<{
+  eyebrow: string
+  title: string
+  subtitle: string
+  descriptionBlocId: string
+  primaryCta?: HeroLink
+  secondaryCta?: HeroLink
+  ctaGroupLabel: string
+  highlights: HeroHighlight[]
+  stats: HeroStats
+}>()
+</script>
+
+<style scoped lang="scss">
+.feedback-hero {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(
+      135deg,
+      rgba(var(--v-theme-hero-gradient-start), 0.88),
+      rgba(var(--v-theme-hero-gradient-mid), 0.82)
+    ),
+    radial-gradient(circle at top right, rgba(var(--v-theme-hero-gradient-end), 0.6), transparent 45%);
+  color: rgb(var(--v-theme-hero-pill-on-dark));
+
+  &__background {
+    position: absolute;
+    inset: 0;
+    opacity: 0.25;
+    background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400" fill="none"%3E%3Ccircle cx="200" cy="200" r="180" stroke="white" stroke-width="1" stroke-opacity="0.2"/%3E%3Ccircle cx="200" cy="200" r="140" stroke="white" stroke-width="1" stroke-opacity="0.12" stroke-dasharray="6 12"/%3E%3C/svg%3E');
+    background-size: cover;
+  }
+
+  &__content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-weight: 600;
+    color: rgba(var(--v-theme-hero-pill-on-dark), 0.76);
+    margin-bottom: 0.5rem;
+  }
+
+  &__title {
+    font-size: clamp(2.5rem, 4vw, 3.75rem);
+    font-weight: 700;
+    line-height: 1.1;
+    margin-bottom: 0.5rem;
+  }
+
+  &__subtitle {
+    font-size: clamp(1.2rem, 2vw, 1.5rem);
+    color: rgba(var(--v-theme-hero-pill-on-dark), 0.86);
+    margin-bottom: 0.75rem;
+  }
+
+  &__description {
+    max-width: 48rem;
+    color: rgba(var(--v-theme-hero-pill-on-dark), 0.82);
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+  }
+
+  &__cta {
+    font-weight: 600;
+  }
+
+  &__highlights {
+    list-style: none;
+    padding: 0;
+    margin: 2rem 0 0;
+    display: grid;
+    gap: 1rem;
+  }
+
+  &__highlight-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  &__highlight-icon {
+    backdrop-filter: blur(8px);
+    box-shadow: 0 10px 30px rgba(var(--v-theme-shadow-primary-600), 0.18);
+  }
+
+  &__highlight-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  &__highlight-description {
+    margin: 0;
+    color: rgba(var(--v-theme-hero-pill-on-dark), 0.72);
+  }
+
+  &__card {
+    position: relative;
+    z-index: 1;
+    padding: clamp(1.5rem, 3vw, 2.25rem);
+    background: rgba(var(--v-theme-surface-glass), 0.96);
+    backdrop-filter: blur(16px);
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35);
+    color: rgb(var(--v-theme-text-neutral-strong));
+    margin-top: clamp(1.5rem, 4vw, 0rem);
+  }
+
+  &__card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  &__card-eyebrow {
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: rgba(var(--v-theme-text-neutral-strong), 0.7);
+  }
+
+  &__card-title {
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin-bottom: 0.5rem;
+  }
+
+  &__card-description {
+    margin: 0;
+    color: rgba(var(--v-theme-text-neutral-strong), 0.75);
+  }
+
+  &__card-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  &__card-item {
+    display: flex;
+    align-items: center;
+  }
+
+  &__card-item-label {
+    font-weight: 500;
+  }
+}
+
+@media (max-width: 960px) {
+  .feedback-hero__card {
+    margin-top: 2rem;
+  }
+}
+</style>

--- a/frontend/app/components/domains/feedback/FeedbackIssueList.vue
+++ b/frontend/app/components/domains/feedback/FeedbackIssueList.vue
@@ -1,0 +1,280 @@
+<template>
+  <section :aria-labelledby="headingId" class="feedback-issue-list">
+    <header class="feedback-issue-list__header">
+      <h3 :id="headingId" class="feedback-issue-list__title">{{ title }}</h3>
+      <TextContent :bloc-id="descriptionBlocId" :ipsum-length="160" class="feedback-issue-list__description" />
+    </header>
+
+    <v-alert v-if="statusMessage" type="info" variant="tonal" border="start" class="mb-4" role="status">
+      {{ statusMessage }}
+    </v-alert>
+
+    <v-alert v-if="errorMessage" type="error" variant="tonal" border="start" class="mb-4" role="alert">
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-skeleton-loader
+      v-if="loading && !errorMessage"
+      type="list-item-three-line"
+      class="mb-4"
+      :elevation="2"
+    />
+
+    <div v-if="!loading && !errorMessage && issues.length === 0" class="feedback-issue-list__empty" role="status">
+      <v-icon icon="mdi-emoticon-thought" size="36" color="primary" class="mb-2" />
+      <p class="mb-0">{{ emptyStateLabel }}</p>
+    </div>
+
+    <v-list
+      v-else
+      class="feedback-issue-list__items"
+      bg-color="transparent"
+      role="list"
+      density="comfortable"
+    >
+      <v-list-item
+        v-for="issue in issues"
+        :key="issueKey(issue)"
+        class="feedback-issue-list__item"
+        :aria-label="issue.title"
+      >
+        <template #prepend>
+          <v-avatar size="40" class="feedback-issue-list__issue-avatar" color="surface-primary-120">
+            <v-icon :icon="issueIcon" size="24" color="primary" />
+          </v-avatar>
+        </template>
+
+        <template #title>
+          <div class="feedback-issue-list__issue-header">
+            <span class="feedback-issue-list__issue-number">#{{ issue.number ?? '—' }}</span>
+            <p class="feedback-issue-list__issue-title">{{ issue.title }}</p>
+          </div>
+        </template>
+
+        <template #subtitle>
+          <div class="feedback-issue-list__issue-meta">
+            <span class="feedback-issue-list__issue-votes">
+              <v-icon icon="mdi-thumb-up-outline" size="18" class="me-1" />
+              {{ issue.votes ?? 0 }}
+            </span>
+            <v-btn
+              v-if="issue.url"
+              :href="issue.url"
+              target="_blank"
+              rel="noopener"
+              variant="text"
+              size="small"
+              :aria-label="`${openIssueLabel} ${issue.number ?? ''}`"
+              append-icon="mdi-open-in-new"
+            >
+              {{ openIssueLabel }}
+            </v-btn>
+          </div>
+        </template>
+
+        <template #append>
+          <v-tooltip v-if="voteDisabledMessage" location="top">
+            <template #activator="{ props: tooltipProps }">
+              <span v-bind="tooltipProps">
+                <v-btn
+                  color="primary"
+                  variant="flat"
+                  size="small"
+                  :aria-label="`${voteButtonAriaLabel} ${issue.title}`"
+                  :disabled="isVoteDisabled"
+                  :loading="votePendingId === issue.id"
+                  @click="handleVote(issue.id)"
+                >
+                  {{ voteButtonLabel }}
+                </v-btn>
+              </span>
+            </template>
+            <span>{{ voteDisabledMessage }}</span>
+          </v-tooltip>
+          <v-btn
+            v-else
+            color="primary"
+            variant="flat"
+            size="small"
+            :aria-label="`${voteButtonAriaLabel} ${issue.title}`"
+            :disabled="isVoteDisabled"
+            :loading="votePendingId === issue.id"
+            @click="handleVote(issue.id)"
+          >
+            {{ voteButtonLabel }}
+          </v-btn>
+        </template>
+      </v-list-item>
+    </v-list>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+export interface FeedbackIssueDisplay {
+  id?: string
+  number?: number
+  title?: string
+  url?: string
+  votes?: number
+}
+
+const emit = defineEmits<{
+  (event: 'vote', issueId: string | undefined): void
+}>()
+
+type IssueIcon = string
+
+const props = defineProps<{
+  headingId: string
+  title: string
+  descriptionBlocId: string
+  issues: FeedbackIssueDisplay[]
+  loading: boolean
+  errorMessage: string | null
+  emptyStateLabel: string
+  voteButtonLabel: string
+  voteButtonAriaLabel: string
+  openIssueLabel: string
+  statusMessage?: string | null
+  remainingVotes: number | null
+  canVote: boolean
+  votePendingId?: string | null
+  voteDisabledWhenNoVotesMessage: string
+  voteDisabledWhenBlockedMessage: string
+  issueIcon: IssueIcon
+}>()
+
+const voteDisabledMessage = computed(() => {
+  if (!props.canVote) {
+    return props.voteDisabledWhenBlockedMessage
+  }
+
+  if (props.remainingVotes !== null && props.remainingVotes <= 0) {
+    return props.voteDisabledWhenNoVotesMessage
+  }
+
+  return null
+})
+
+const isVoteDisabled = computed(
+  () => !props.canVote || (props.remainingVotes !== null && props.remainingVotes <= 0),
+)
+
+const issueKey = (issue: FeedbackIssueDisplay) => {
+  if (issue.id) {
+    return issue.id
+  }
+
+  if (typeof issue.number === 'number') {
+    return `number-${issue.number}`
+  }
+
+  if (issue.title) {
+    return `title-${issue.title}`
+  }
+
+  return JSON.stringify(issue)
+}
+
+const handleVote = (issueId: string | undefined) => {
+  if (!issueId || isVoteDisabled.value) {
+    return
+  }
+
+  emit('vote', issueId)
+}
+</script>
+
+<style scoped lang="scss">
+.feedback-issue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__description {
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    border-radius: 1rem;
+    border: 1px dashed rgba(var(--v-theme-border-primary-strong), 0.4);
+    background-color: rgba(var(--v-theme-surface-glass), 0.6);
+    text-align: center;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__items {
+    border-radius: 1.5rem;
+    background-color: rgba(var(--v-theme-surface-glass-strong), 0.95);
+    box-shadow: 0 18px 45px rgba(var(--v-theme-shadow-primary-600), 0.14);
+  }
+
+  &__item {
+    border-bottom: 1px solid rgba(var(--v-theme-border-primary-strong), 0.15);
+    padding-block: 1.25rem;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  &__issue-avatar {
+    backdrop-filter: blur(8px);
+    box-shadow: 0 12px 26px rgba(var(--v-theme-shadow-primary-600), 0.12);
+  }
+
+  &__issue-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__issue-number {
+    font-weight: 600;
+    color: rgb(var(--v-theme-primary));
+  }
+
+  &__issue-title {
+    font-weight: 600;
+    font-size: 1.1rem;
+    margin: 0;
+    color: rgb(var(--v-theme-text-neutral-strong));
+  }
+
+  &__issue-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.35rem;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__issue-votes {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+  }
+}
+</style>

--- a/frontend/app/components/domains/feedback/FeedbackOpenSourceSection.vue
+++ b/frontend/app/components/domains/feedback/FeedbackOpenSourceSection.vue
@@ -1,0 +1,133 @@
+<template>
+  <section class="feedback-open-source" aria-labelledby="feedback-open-source-heading">
+    <v-container class="py-16">
+      <div class="feedback-open-source__header">
+        <p class="feedback-open-source__eyebrow">{{ eyebrow }}</p>
+        <h2 id="feedback-open-source-heading" class="feedback-open-source__title">
+          {{ title }}
+        </h2>
+        <TextContent :bloc-id="introBlocId" :ipsum-length="180" class="feedback-open-source__description" />
+      </div>
+
+      <v-row class="g-6 mt-6">
+        <v-col v-for="card in cards" :key="card.title" cols="12" md="6">
+          <v-card class="feedback-open-source__card" elevation="6" rounded="xl">
+            <div class="feedback-open-source__card-header">
+              <v-avatar size="44" class="feedback-open-source__card-icon" color="surface-primary-120">
+                <v-icon :icon="card.icon" size="26" color="primary" />
+              </v-avatar>
+              <h3 class="feedback-open-source__card-title">{{ card.title }}</h3>
+            </div>
+            <TextContent :bloc-id="card.descriptionBlocId" :ipsum-length="150" class="feedback-open-source__card-text" />
+            <v-btn
+              :href="card.cta.href"
+              :to="card.cta.to"
+              :aria-label="card.cta.ariaLabel"
+              :target="card.cta.target"
+              :rel="card.cta.rel"
+              color="primary"
+              variant="outlined"
+              append-icon="mdi-arrow-right"
+            >
+              {{ card.cta.label }}
+            </v-btn>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+type FeedbackCardCta = {
+  label: string
+  ariaLabel: string
+  href?: string
+  to?: string
+  target?: string
+  rel?: string
+}
+
+type FeedbackCard = {
+  icon: string
+  title: string
+  descriptionBlocId: string
+  cta: FeedbackCardCta
+}
+
+defineProps<{
+  eyebrow: string
+  title: string
+  introBlocId: string
+  cards: FeedbackCard[]
+}>()
+</script>
+
+<style scoped lang="scss">
+.feedback-open-source {
+  background: linear-gradient(
+      145deg,
+      rgba(var(--v-theme-surface-ice-050), 0.95),
+      rgba(var(--v-theme-surface-ice-100), 0.9)
+    ),
+    radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-end), 0.18), transparent 55%);
+
+  &__header {
+    max-width: 56rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-weight: 600;
+    color: rgb(var(--v-theme-primary));
+  }
+
+  &__title {
+    font-size: clamp(2rem, 3vw, 2.75rem);
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__description {
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__card {
+    padding: clamp(1.5rem, 2.5vw, 2rem);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    background: rgb(var(--v-theme-surface-glass));
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35);
+  }
+
+  &__card-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  &__card-icon {
+    backdrop-filter: blur(8px);
+    box-shadow: 0 14px 36px rgba(var(--v-theme-shadow-primary-600), 0.12);
+  }
+
+  &__card-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__card-text {
+    flex: 1;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+}
+</style>

--- a/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
+++ b/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
@@ -1,0 +1,397 @@
+<template>
+  <section :id="sectionId" class="feedback-form" :aria-labelledby="`${sectionId}-heading`">
+    <v-card class="feedback-form__card" elevation="8" rounded="xl">
+      <div class="feedback-form__header">
+        <v-avatar size="42" class="feedback-form__header-icon" color="surface-primary-120">
+          <v-icon :icon="categoryIcon" size="26" color="primary" />
+        </v-avatar>
+        <div>
+          <p class="feedback-form__eyebrow">{{ eyebrow }}</p>
+          <h3 :id="`${sectionId}-heading`" class="feedback-form__title">
+            {{ title }}
+          </h3>
+          <p class="feedback-form__subtitle">{{ subtitle }}</p>
+        </div>
+      </div>
+
+      <TextContent :bloc-id="introBlocId" :ipsum-length="170" class="feedback-form__intro" />
+
+      <v-alert
+        v-if="success"
+        type="success"
+        variant="tonal"
+        prominent
+        border="start"
+        class="mb-4"
+        role="status"
+      >
+        {{ successMessage }}
+      </v-alert>
+
+      <v-alert
+        v-else-if="errorMessage"
+        type="error"
+        variant="tonal"
+        prominent
+        border="start"
+        class="mb-4"
+        role="alert"
+      >
+        {{ errorMessage }}
+      </v-alert>
+
+      <v-alert
+        v-if="!hasSiteKey"
+        type="warning"
+        variant="tonal"
+        border="start"
+        class="mb-4"
+        role="status"
+      >
+        {{ missingCaptchaMessage }}
+      </v-alert>
+
+      <v-form ref="formRef" class="feedback-form__form" @submit.prevent="onSubmit">
+        <v-row dense>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="author"
+              :label="authorLabel"
+              :placeholder="authorPlaceholder"
+              :disabled="submitting"
+              autocomplete="nickname"
+              variant="outlined"
+              prepend-inner-icon="mdi-account"
+            />
+          </v-col>
+
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="titleInput"
+              :label="titleLabel"
+              :placeholder="titlePlaceholder"
+              :rules="titleRules"
+              :disabled="submitting"
+              required
+              variant="outlined"
+              prepend-inner-icon="mdi-format-title"
+              maxlength="140"
+            />
+          </v-col>
+
+          <v-col cols="12">
+            <v-textarea
+              v-model="message"
+              :label="messageLabel"
+              :placeholder="messagePlaceholder"
+              :rules="messageRules"
+              :counter="2000"
+              :disabled="submitting"
+              auto-grow
+              required
+              rows="6"
+              variant="outlined"
+              prepend-inner-icon="mdi-text-long"
+            />
+          </v-col>
+
+          <v-col cols="12">
+            <div class="feedback-form__captcha">
+              <VueHcaptcha
+                v-if="hasSiteKey"
+                ref="captchaRef"
+                :sitekey="siteKey"
+                :language="captchaLocale"
+                :theme="captchaTheme"
+                @verify="handleCaptchaVerify"
+                @expired="handleCaptchaExpired"
+                @error="handleCaptchaError"
+              />
+              <div v-else class="feedback-form__captcha-placeholder" aria-hidden="true">
+                <v-icon icon="mdi-shield-alert-outline" size="36" color="primary" />
+              </div>
+              <p v-if="captchaError" class="feedback-form__captcha-error" role="alert">
+                {{ captchaError }}
+              </p>
+            </div>
+          </v-col>
+
+          <v-col cols="12">
+            <div class="feedback-form__actions">
+              <v-btn
+                type="submit"
+                color="primary"
+                size="large"
+                :loading="submitting"
+                :disabled="submitting || !captchaToken || !hasSiteKey"
+                prepend-icon="mdi-send"
+              >
+                {{ submitLabel }}
+              </v-btn>
+              <v-btn
+                variant="text"
+                color="primary"
+                :disabled="submitting"
+                @click="resetForm"
+              >
+                {{ resetLabel }}
+              </v-btn>
+            </div>
+            <p class="feedback-form__privacy">{{ privacyNotice }}</p>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useTheme } from 'vuetify'
+import { VForm } from 'vuetify/components'
+import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
+import TextContent from '~/components/domains/content/TextContent.vue'
+
+export interface FeedbackFormSubmitPayload {
+  type: string
+  title: string
+  message: string
+  author: string
+  hCaptchaResponse: string
+  url: string
+}
+
+const props = defineProps<{
+  sectionId: string
+  eyebrow: string
+  title: string
+  subtitle: string
+  introBlocId: string
+  categoryIcon: string
+  categoryType: string
+  submitting: boolean
+  success: boolean
+  errorMessage: string | null
+  siteKey: string
+  authorLabel: string
+  authorPlaceholder: string
+  defaultAuthor: string
+  titleLabel: string
+  titlePlaceholder: string
+  messageLabel: string
+  messagePlaceholder: string
+  submitLabel: string
+  resetLabel: string
+  successMessage: string
+  missingCaptchaMessage: string
+  privacyNotice: string
+  captchaMissingMessage: string
+  captchaExpiredMessage: string
+  captchaFailedMessage: string
+  titleTooShortMessage: string
+  messageTooShortMessage: string
+  currentLocale: string
+  currentUrl: string
+}>()
+
+const emit = defineEmits<{
+  (event: 'submit', payload: FeedbackFormSubmitPayload): void
+  (event: 'reset-feedback'): void
+}>()
+
+const theme = useTheme()
+const formRef = ref<InstanceType<typeof VForm> | null>(null)
+const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
+
+const author = ref(props.defaultAuthor)
+const titleInput = ref('')
+const message = ref('')
+const captchaToken = ref('')
+const captchaError = ref<string | null>(null)
+
+const hasSiteKey = computed(() => props.siteKey?.length > 0)
+const siteKey = computed(() => props.siteKey)
+
+const captchaLocale = computed(() => (props.currentLocale.startsWith('fr') ? 'fr' : 'en'))
+const captchaTheme = computed(() => (theme.current.value.dark ? 'dark' : 'light'))
+
+watch(
+  () => props.defaultAuthor,
+  (nextAuthor) => {
+    if (!author.value) {
+      author.value = nextAuthor
+    }
+  }
+)
+
+watch(
+  () => props.success,
+  (isSuccess) => {
+    if (isSuccess) {
+      resetForm()
+    }
+  }
+)
+
+watch([author, titleInput, message], () => {
+  emit('reset-feedback')
+})
+
+const titleRules = [
+  (value: string) => (!!value && value.trim().length >= 4) || props.titleTooShortMessage,
+]
+
+const messageRules = [
+  (value: string) => (!!value && value.trim().length >= 20) || props.messageTooShortMessage,
+]
+
+const handleCaptchaVerify = (token: string) => {
+  captchaToken.value = token
+  captchaError.value = null
+}
+
+const handleCaptchaExpired = () => {
+  captchaToken.value = ''
+  captchaError.value = props.captchaExpiredMessage
+  captchaRef.value?.reset?.()
+}
+
+const handleCaptchaError = () => {
+  captchaToken.value = ''
+  captchaError.value = props.captchaFailedMessage
+  captchaRef.value?.reset?.()
+}
+
+const validateForm = async () => {
+  const validation = await formRef.value?.validate()
+
+  if (validation?.valid === false) {
+    return false
+  }
+
+  if (!captchaToken.value) {
+    captchaError.value = props.captchaMissingMessage
+    return false
+  }
+
+  return true
+}
+
+const onSubmit = async () => {
+  const isValid = await validateForm()
+
+  if (!isValid) {
+    return
+  }
+
+  emit('submit', {
+    type: props.categoryType,
+    title: titleInput.value.trim(),
+    message: message.value.trim(),
+    author: author.value.trim(),
+    hCaptchaResponse: captchaToken.value,
+    url: props.currentUrl,
+  })
+}
+
+const resetForm = () => {
+  author.value = props.defaultAuthor
+  titleInput.value = ''
+  message.value = ''
+  captchaToken.value = ''
+  captchaError.value = null
+  formRef.value?.resetValidation()
+  captchaRef.value?.reset?.()
+  emit('reset-feedback')
+}
+</script>
+
+<style scoped lang="scss">
+.feedback-form {
+  &__card {
+    padding: clamp(1.5rem, 3vw, 2.25rem);
+    background: rgb(var(--v-theme-surface-glass-strong));
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
+    box-shadow: 0 16px 48px rgba(var(--v-theme-shadow-primary-600), 0.16);
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  &__header-icon {
+    backdrop-filter: blur(8px);
+    box-shadow: 0 12px 32px rgba(var(--v-theme-shadow-primary-600), 0.12);
+  }
+
+  &__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+    margin-bottom: 0.25rem;
+  }
+
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__subtitle {
+    margin: 0.25rem 0 0;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__intro {
+    margin-bottom: 1.5rem;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__form {
+    margin-top: 1rem;
+  }
+
+  &__captcha {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  &__captcha-placeholder {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 302px;
+    height: 78px;
+    border-radius: 0.75rem;
+    border: 1px dashed rgba(var(--v-theme-border-primary-strong), 0.4);
+    background-color: rgba(var(--v-theme-surface-glass), 0.6);
+  }
+
+  &__captcha-error {
+    margin: 0;
+    color: rgb(var(--v-theme-error));
+    font-size: 0.9rem;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 0.5rem;
+  }
+
+  &__privacy {
+    margin-top: 0.75rem;
+    color: rgb(var(--v-theme-text-neutral-soft));
+    font-size: 0.85rem;
+  }
+}
+</style>

--- a/frontend/app/pages/feedback/index.vue
+++ b/frontend/app/pages/feedback/index.vue
@@ -1,0 +1,591 @@
+<template>
+  <div class="feedback-page">
+    <FeedbackHero
+      :eyebrow="t('feedback.hero.eyebrow')"
+      :title="t('feedback.hero.title')"
+      :subtitle="t('feedback.hero.subtitle')"
+      description-bloc-id="webpages:feedback:hero-description"
+      :primary-cta="heroPrimaryCta"
+      :secondary-cta="heroSecondaryCta"
+      :cta-group-label="t('feedback.hero.ctaGroupLabel')"
+      :highlights="heroHighlights"
+      :stats="heroStats"
+    />
+
+    <section id="feedback-tabs" class="feedback-tabs" aria-labelledby="feedback-tabs-heading">
+      <v-container class="py-16">
+        <header class="feedback-tabs__header">
+          <p class="feedback-tabs__eyebrow">{{ t('feedback.tabs.eyebrow') }}</p>
+          <h2 id="feedback-tabs-heading" class="feedback-tabs__title">
+            {{ t('feedback.tabs.title') }}
+          </h2>
+          <TextContent
+            bloc-id="webpages:feedback:tabs-intro"
+            :ipsum-length="200"
+            class="feedback-tabs__description"
+          />
+        </header>
+
+        <v-tabs
+          v-model="selectedTab"
+          class="feedback-tabs__tabs"
+          align-tabs="center"
+          grow
+          density="comfortable"
+          :aria-label="t('feedback.tabs.ariaLabel')"
+        >
+          <v-tab
+            v-for="tab in tabs"
+            :key="tab.value"
+            :value="tab.value"
+            class="feedback-tabs__tab"
+            :prepend-icon="tab.icon"
+            :aria-controls="`${tab.value.toLowerCase()}-panel`"
+          >
+            <span class="feedback-tabs__tab-label">{{ tab.label }}</span>
+            <span class="feedback-tabs__tab-caption">{{ tab.caption }}</span>
+          </v-tab>
+        </v-tabs>
+
+        <v-window v-model="selectedTab" class="feedback-tabs__window">
+          <v-window-item v-for="tab in tabs" :key="tab.value" :value="tab.value">
+            <v-row class="g-8 mt-8" align="stretch">
+              <v-col cols="12" md="6">
+                <FeedbackIssueList
+                  :heading-id="`${tab.value.toLowerCase()}-issues-heading`"
+                  :title="tab.issueTitle"
+                  :description-bloc-id="tab.descriptionBlocId"
+                  :issues="issuesByType[tab.value]"
+                  :loading="issueLoadingStates[tab.value]"
+                  :error-message="issueErrorMessages[tab.value]"
+                  :empty-state-label="tab.emptyMessage"
+                  :vote-button-label="t('feedback.voting.voteButton')"
+                  :vote-button-aria-label="t('feedback.voting.voteButtonAria')"
+                  :open-issue-label="t('feedback.voting.openIssue')"
+                  :status-message="voteStatusMessage"
+                  :remaining-votes="remainingVotes"
+                  :can-vote="canVote"
+                  :vote-pending-id="votingIssueId"
+                  :vote-disabled-when-no-votes-message="t('feedback.voting.noVotes')"
+                  :vote-disabled-when-blocked-message="t('feedback.voting.limitReached')"
+                  :issue-icon="tab.icon"
+                  @vote="(issueId) => handleVote(issueId, tab.value)"
+                />
+              </v-col>
+
+              <v-col cols="12" md="6">
+                <FeedbackSubmissionForm
+                  :section-id="`${tab.value.toLowerCase()}-form`"
+                  :eyebrow="tab.formEyebrow"
+                  :title="tab.formTitle"
+                  :subtitle="tab.formSubtitle"
+                  :intro-bloc-id="tab.formDescriptionBlocId"
+                  :category-icon="tab.icon"
+                  :category-type="tab.value"
+                  :submitting="submissionState.submitting"
+                  :success="submissionState.success && submittedCategory === tab.value"
+                  :error-message="submissionState.errorMessage"
+                  :site-key="siteKey"
+                  :author-label="t('feedback.form.fields.author.label')"
+                  :author-placeholder="t('feedback.form.fields.author.placeholder')"
+                  :default-author="t('feedback.form.fields.author.default')"
+                  :title-label="t('feedback.form.fields.title.label')"
+                  :title-placeholder="tab.formTitlePlaceholder"
+                  :message-label="t('feedback.form.fields.message.label')"
+                  :message-placeholder="tab.formMessagePlaceholder"
+                  :submit-label="t('feedback.form.actions.submit')"
+                  :reset-label="t('feedback.form.actions.reset')"
+                  :success-message="t('feedback.form.feedback.success')"
+                  :missing-captcha-message="t('feedback.form.feedback.missingSiteKey')"
+                  :privacy-notice="t('feedback.form.privacy')"
+                  :captcha-missing-message="t('feedback.form.errors.missingCaptcha')"
+                  :captcha-expired-message="t('feedback.form.errors.captchaExpired')"
+                  :captcha-failed-message="t('feedback.form.errors.captchaFailed')"
+                  :title-too-short-message="t('feedback.form.errors.title.length')"
+                  :message-too-short-message="t('feedback.form.errors.message.length')"
+                  :current-locale="currentLocale"
+                  :current-url="currentUrl"
+                  @submit="handleSubmitFeedback"
+                  @reset-feedback="clearSubmissionFeedback"
+                />
+              </v-col>
+            </v-row>
+          </v-window-item>
+        </v-window>
+      </v-container>
+    </section>
+
+    <FeedbackOpenSourceSection
+      :eyebrow="t('feedback.openSource.eyebrow')"
+      :title="t('feedback.openSource.title')"
+      intro-bloc-id="webpages:feedback:open-source-intro"
+      :cards="openSourceCards"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { FetchError } from 'ofetch'
+import FeedbackHero from '~/components/domains/feedback/FeedbackHero.vue'
+import FeedbackIssueList, {
+  type FeedbackIssueDisplay,
+} from '~/components/domains/feedback/FeedbackIssueList.vue'
+import FeedbackSubmissionForm, {
+  type FeedbackFormSubmitPayload,
+} from '~/components/domains/feedback/FeedbackSubmissionForm.vue'
+import FeedbackOpenSourceSection from '~/components/domains/feedback/FeedbackOpenSourceSection.vue'
+import TextContent from '~/components/domains/content/TextContent.vue'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+import type {
+  FeedbackIssueDto,
+  FeedbackRemainingVotesDto,
+  FeedbackVoteEligibilityDto,
+} from '~~/shared/api-client'
+
+definePageMeta({
+  ssr: true,
+})
+
+const { t, locale, availableLocales } = useI18n()
+const requestURL = useRequestURL()
+const runtimeConfig = useRuntimeConfig()
+const localePath = useLocalePath()
+
+const siteKey = computed(() => runtimeConfig.public.hcaptchaSiteKey ?? '')
+const currentUrl = computed(() => requestURL.href)
+const currentLocale = computed(() => locale.value)
+
+const tabs = computed(() => [
+  {
+    value: 'IDEA' as const,
+    label: String(t('feedback.tabs.idea.label')),
+    caption: String(t('feedback.tabs.idea.caption')),
+    icon: 'mdi-lightbulb-on-outline',
+    issueTitle: String(t('feedback.tabs.idea.issueTitle')),
+    descriptionBlocId: 'webpages:feedback:ideas-guidelines',
+    emptyMessage: String(t('feedback.issues.empty.idea')),
+    formEyebrow: String(t('feedback.form.sections.idea.eyebrow')),
+    formTitle: String(t('feedback.form.sections.idea.title')),
+    formSubtitle: String(t('feedback.form.sections.idea.subtitle')),
+    formDescriptionBlocId: 'webpages:feedback:idea-form-intro',
+    formTitlePlaceholder: String(t('feedback.form.sections.idea.titlePlaceholder')),
+    formMessagePlaceholder: String(t('feedback.form.sections.idea.messagePlaceholder')),
+  },
+  {
+    value: 'BUG' as const,
+    label: String(t('feedback.tabs.bug.label')),
+    caption: String(t('feedback.tabs.bug.caption')),
+    icon: 'mdi-bug-check-outline',
+    issueTitle: String(t('feedback.tabs.bug.issueTitle')),
+    descriptionBlocId: 'webpages:feedback:bugs-guidelines',
+    emptyMessage: String(t('feedback.issues.empty.bug')),
+    formEyebrow: String(t('feedback.form.sections.bug.eyebrow')),
+    formTitle: String(t('feedback.form.sections.bug.title')),
+    formSubtitle: String(t('feedback.form.sections.bug.subtitle')),
+    formDescriptionBlocId: 'webpages:feedback:bug-form-intro',
+    formTitlePlaceholder: String(t('feedback.form.sections.bug.titlePlaceholder')),
+    formMessagePlaceholder: String(t('feedback.form.sections.bug.messagePlaceholder')),
+  },
+])
+
+type FeedbackCategory = 'IDEA' | 'BUG'
+
+const selectedTab = ref<FeedbackCategory>('IDEA')
+
+const loadErrorLabel = computed(() => String(t('feedback.issues.loadError')))
+
+const issueErrorMessages = reactive<Record<FeedbackCategory, string | null>>({
+  IDEA: null,
+  BUG: null,
+})
+
+const issueLoadFailed = reactive<Record<FeedbackCategory, boolean>>({
+  IDEA: false,
+  BUG: false,
+})
+
+const fetchIssues = async (category: FeedbackCategory) => {
+  try {
+    const response = await $fetch<FeedbackIssueDto[]>('/api/feedback/issues', {
+      query: { type: category },
+    })
+
+    issueErrorMessages[category] = null
+    issueLoadFailed[category] = false
+    return response
+  } catch (error) {
+    console.warn('Falling back to empty feedback issues list', { category, error })
+    issueErrorMessages[category] = loadErrorLabel.value
+    issueLoadFailed[category] = true
+    return []
+  }
+}
+
+const ideaIssuesData = await useAsyncData<FeedbackIssueDto[]>(
+  'feedback-issues-idea',
+  () => fetchIssues('IDEA'),
+)
+
+const bugIssuesData = await useAsyncData<FeedbackIssueDto[]>(
+  'feedback-issues-bug',
+  () => fetchIssues('BUG'),
+)
+
+const remainingVotesData = await useAsyncData<FeedbackRemainingVotesDto>(
+  'feedback-remaining-votes',
+  async () => {
+    try {
+      return await $fetch('/api/feedback/votes/remaining')
+    } catch (error) {
+      console.warn('Unable to load remaining votes, falling back to unknown state', error)
+      return {}
+    }
+  },
+)
+
+const canVoteData = await useAsyncData<FeedbackVoteEligibilityDto>(
+  'feedback-can-vote',
+  async () => {
+    try {
+      return await $fetch('/api/feedback/votes/can')
+    } catch (error) {
+      console.warn('Unable to determine vote eligibility, assuming voting is allowed', error)
+      return { canVote: true }
+    }
+  },
+)
+
+const issuesByType = computed<Record<FeedbackCategory, FeedbackIssueDisplay[]>>(() => ({
+  IDEA: (ideaIssuesData.data.value ?? []) as FeedbackIssueDisplay[],
+  BUG: (bugIssuesData.data.value ?? []) as FeedbackIssueDisplay[],
+}))
+
+const issueLoadingStates = computed<Record<FeedbackCategory, boolean>>(() => ({
+  IDEA: ideaIssuesData.pending.value,
+  BUG: bugIssuesData.pending.value,
+}))
+
+const remainingVotes = computed(() => remainingVotesData.data.value?.remainingVotes ?? null)
+const canVote = computed(() => canVoteData.data.value?.canVote ?? true)
+
+const voteStatusMessage = computed(() => {
+  if (!canVote.value) {
+    return String(t('feedback.voting.limitReached'))
+  }
+
+  if (remainingVotes.value !== null) {
+    if (remainingVotes.value <= 0) {
+      return String(t('feedback.voting.noVotes'))
+    }
+
+    return String(t('feedback.voting.remaining', { count: remainingVotes.value }))
+  }
+
+  return null
+})
+
+const votingIssueId = ref<string | null>(null)
+
+const submissionState = reactive({
+  submitting: false,
+  success: false,
+  errorMessage: null as string | null,
+})
+
+const submittedCategory = ref<FeedbackCategory>('IDEA')
+
+const voteErrors = reactive<Record<FeedbackCategory, string | null>>({
+  IDEA: null,
+  BUG: null,
+})
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof FetchError) {
+    const data = error.data as { statusMessage?: string; message?: string } | null
+
+    if (data?.statusMessage) {
+      return data.statusMessage
+    }
+
+    if (data?.message) {
+      return data.message
+    }
+
+    if (error.message) {
+      return error.message
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  if (typeof error === 'string' && error.length > 0) {
+    return error
+  }
+
+  return String(t('feedback.common.genericError'))
+}
+
+const refreshVotesState = async () => {
+  await Promise.allSettled([remainingVotesData.refresh(), canVoteData.refresh()])
+}
+
+const handleVote = async (issueId: string | undefined, category: FeedbackCategory) => {
+  if (!issueId) {
+    return
+  }
+
+  votingIssueId.value = issueId
+  voteErrors[category] = null
+
+  try {
+    await $fetch('/api/feedback/vote', {
+      method: 'POST',
+      body: { issueId },
+    })
+
+    if (category === 'IDEA') {
+      await ideaIssuesData.refresh()
+    } else {
+      await bugIssuesData.refresh()
+    }
+
+    await refreshVotesState()
+  } catch (error) {
+    console.error('Failed to vote on feedback issue', error)
+    voteErrors[category] = extractErrorMessage(error)
+  } finally {
+    votingIssueId.value = null
+  }
+}
+
+watch(
+  () => voteErrors.IDEA,
+  (error) => {
+    if (error) {
+      issueErrorMessages.IDEA = error
+    } else if (!issueLoadFailed.IDEA) {
+      issueErrorMessages.IDEA = null
+    }
+  },
+)
+
+watch(
+  () => voteErrors.BUG,
+  (error) => {
+    if (error) {
+      issueErrorMessages.BUG = error
+    } else if (!issueLoadFailed.BUG) {
+      issueErrorMessages.BUG = null
+    }
+  },
+)
+
+const handleSubmitFeedback = async (payload: FeedbackFormSubmitPayload) => {
+  submissionState.submitting = true
+  submissionState.success = false
+  submissionState.errorMessage = null
+  submittedCategory.value = payload.type as FeedbackCategory
+
+  try {
+    await $fetch('/api/feedback', {
+      method: 'POST',
+      body: payload,
+    })
+
+    submissionState.success = true
+
+    if (payload.type === 'IDEA') {
+      await ideaIssuesData.refresh()
+    } else {
+      await bugIssuesData.refresh()
+    }
+
+    await refreshVotesState()
+  } catch (error) {
+    console.error('Failed to submit feedback', error)
+    submissionState.success = false
+    submissionState.errorMessage = extractErrorMessage(error)
+  } finally {
+    submissionState.submitting = false
+  }
+}
+
+const clearSubmissionFeedback = () => {
+  if (submissionState.success || submissionState.errorMessage) {
+    submissionState.success = false
+    submissionState.errorMessage = null
+  }
+}
+
+const heroPrimaryCta = computed(() => ({
+  label: String(t('feedback.hero.primaryCta.label')),
+  ariaLabel: String(t('feedback.hero.primaryCta.ariaLabel')),
+  href: '#feedback-tabs',
+  icon: 'mdi-arrow-down-bold',
+}))
+
+const heroSecondaryCta = computed(() => ({
+  label: String(t('feedback.hero.secondaryCta.label')),
+  ariaLabel: String(t('feedback.hero.secondaryCta.ariaLabel')),
+  href: 'https://github.com/open4good/open4goods/issues',
+  target: '_blank',
+  rel: 'noopener',
+  icon: 'mdi-open-in-new',
+}))
+
+const heroHighlights = computed(() => [
+  {
+    icon: 'mdi-account-group-outline',
+    title: String(t('feedback.hero.highlights.community.title')),
+    description: String(t('feedback.hero.highlights.community.description')),
+  },
+  {
+    icon: 'mdi-shield-check-outline',
+    title: String(t('feedback.hero.highlights.trust.title')),
+    description: String(t('feedback.hero.highlights.trust.description')),
+  },
+  {
+    icon: 'mdi-rocket-launch-outline',
+    title: String(t('feedback.hero.highlights.roadmap.title')),
+    description: String(t('feedback.hero.highlights.roadmap.description')),
+  },
+])
+
+const heroStats = computed(() => ({
+  eyebrow: String(t('feedback.hero.stats.eyebrow')),
+  title: String(t('feedback.hero.stats.title')),
+  description: String(t('feedback.hero.stats.description')),
+  items: [
+    { icon: 'mdi-progress-check', label: String(t('feedback.hero.stats.items.iterations')) },
+    { icon: 'mdi-vote-outline', label: String(t('feedback.hero.stats.items.votes')) },
+    { icon: 'mdi-database-eye-outline', label: String(t('feedback.hero.stats.items.transparency')) },
+  ],
+}))
+
+const openSourceCards = computed(() => [
+  {
+    icon: 'mdi-github',
+    title: String(t('feedback.openSource.cards.opensource.title')),
+    descriptionBlocId: 'webpages:feedback:open-source-card',
+    cta: {
+      label: String(t('feedback.openSource.cards.opensource.cta')),
+      ariaLabel: String(t('feedback.openSource.cards.opensource.ariaLabel')),
+      href: localePath('opensource'),
+    },
+  },
+  {
+    icon: 'mdi-database-search',
+    title: String(t('feedback.openSource.cards.opendata.title')),
+    descriptionBlocId: 'webpages:feedback:open-data-card',
+    cta: {
+      label: String(t('feedback.openSource.cards.opendata.cta')),
+      ariaLabel: String(t('feedback.openSource.cards.opendata.ariaLabel')),
+      href: localePath('opendata'),
+    },
+  },
+])
+
+const canonicalUrl = computed(() =>
+  new URL(resolveLocalizedRoutePath('feedback', locale.value), requestURL.origin).toString(),
+)
+
+const siteName = computed(() => String(t('siteIdentity.siteName')))
+const ogLocale = computed(() => locale.value.replace('-', '_'))
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+const ogImageAlt = computed(() => String(t('feedback.seo.imageAlt')))
+
+const alternateLinks = computed(() =>
+  availableLocales.map((availableLocale) => ({
+    rel: 'alternate' as const,
+    hreflang: availableLocale,
+    href: new URL(resolveLocalizedRoutePath('feedback', availableLocale), requestURL.origin).toString(),
+  })),
+)
+
+useSeoMeta({
+  title: () => String(t('feedback.seo.title')),
+  description: () => String(t('feedback.seo.description')),
+  ogTitle: () => String(t('feedback.seo.title')),
+  ogDescription: () => String(t('feedback.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+  ogSiteName: () => siteName.value,
+  ogLocale: () => ogLocale.value,
+  ogImageAlt: () => ogImageAlt.value,
+})
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+    ...alternateLinks.value,
+  ],
+}))
+</script>
+
+<style scoped lang="scss">
+.feedback-page {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.feedback-tabs {
+  background-color: rgb(var(--v-theme-surface-default));
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 54rem;
+  }
+
+  &__eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    font-weight: 600;
+    color: rgb(var(--v-theme-primary));
+  }
+
+  &__title {
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    font-weight: 700;
+    margin: 0;
+  }
+
+  &__description {
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__tabs {
+    margin-top: 2rem;
+    border-radius: 999px;
+    background-color: rgba(var(--v-theme-surface-glass), 0.8);
+    box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.25);
+  }
+
+  &__tab {
+    flex-direction: column;
+    text-transform: none;
+    font-weight: 600;
+    gap: 0.25rem;
+  }
+
+  &__tab-label {
+    font-size: 1.05rem;
+  }
+
+  &__tab-caption {
+    font-size: 0.85rem;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__window {
+    margin-top: 2.5rem;
+  }
+}
+</style>

--- a/frontend/server/api/feedback.post.ts
+++ b/frontend/server/api/feedback.post.ts
@@ -1,0 +1,126 @@
+import {
+  FeedbackSubmissionRequestDtoTypeEnum,
+  type FeedbackSubmissionResponseDto,
+} from '~~/shared/api-client'
+import { useFeedbackService } from '~~/shared/api-client/services/feedback.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails, logBackendError } from '../utils/log-backend-error'
+
+type FeedbackType = `${FeedbackSubmissionRequestDtoTypeEnum}`
+
+interface FeedbackFormPayload {
+  type?: FeedbackType
+  title?: string
+  message?: string
+  author?: string
+  url?: string
+  hCaptchaResponse?: string
+}
+
+const SUPPORTED_TYPES = new Set<FeedbackType>([
+  FeedbackSubmissionRequestDtoTypeEnum.Idea,
+  FeedbackSubmissionRequestDtoTypeEnum.Bug,
+])
+
+const sanitize = (value: string | undefined | null): string => value?.trim() ?? ''
+
+const normalizeType = (value: FeedbackType | undefined): FeedbackSubmissionRequestDtoTypeEnum | null => {
+  if (!value) {
+    return null
+  }
+
+  const upperCased = value.toUpperCase() as FeedbackType
+
+  if (!SUPPORTED_TYPES.has(upperCased)) {
+    return null
+  }
+
+  return upperCased as FeedbackSubmissionRequestDtoTypeEnum
+}
+
+const MIN_TITLE_LENGTH = 4
+const MAX_TITLE_LENGTH = 140
+const MIN_MESSAGE_LENGTH = 20
+const MAX_MESSAGE_LENGTH = 4000
+
+export default defineEventHandler(async (event): Promise<FeedbackSubmissionResponseDto> => {
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const body = await readBody<FeedbackFormPayload>(event)
+
+  const type = normalizeType(body.type)
+  const title = sanitize(body.title)
+  const message = sanitize(body.message)
+  const author = sanitize(body.author)
+  const url = sanitize(body.url)
+  const hCaptchaResponse = sanitize(body.hCaptchaResponse)
+
+  if (!type) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Feedback category is required.',
+    })
+  }
+
+  if (!title || title.length < MIN_TITLE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Please provide a concise title (at least 4 characters).',
+    })
+  }
+
+  if (title.length > MAX_TITLE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'The provided title is too long.',
+    })
+  }
+
+  if (!message || message.length < MIN_MESSAGE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Please describe your idea or issue in more detail.',
+    })
+  }
+
+  if (message.length > MAX_MESSAGE_LENGTH) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'The provided description is too long.',
+    })
+  }
+
+  if (!hCaptchaResponse) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'The hCaptcha token is missing.',
+    })
+  }
+
+  const feedbackService = useFeedbackService(domainLanguage)
+
+  try {
+    return await feedbackService.submitFeedback({
+      type,
+      title,
+      message,
+      author: author || undefined,
+      url: url || undefined,
+      hCaptchaResponse,
+    })
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    logBackendError({
+      namespace: 'feedback:submit',
+      details: backendError,
+    })
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/server/api/feedback/issues.get.ts
+++ b/frontend/server/api/feedback/issues.get.ts
@@ -1,0 +1,62 @@
+import { ListIssuesTypeEnum, type FeedbackIssueDto } from '~~/shared/api-client'
+import { useFeedbackService } from '~~/shared/api-client/services/feedback.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails, logBackendError } from '../../utils/log-backend-error'
+
+type SupportedIssueType = `${ListIssuesTypeEnum}`
+
+const SUPPORTED_TYPES = new Set<SupportedIssueType>([
+  ListIssuesTypeEnum.Idea,
+  ListIssuesTypeEnum.Bug,
+])
+
+const normalizeIssueType = (value: unknown): ListIssuesTypeEnum | undefined => {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined
+  }
+
+  const upperCased = value.toUpperCase()
+
+  if (SUPPORTED_TYPES.has(upperCased as SupportedIssueType)) {
+    return upperCased as ListIssuesTypeEnum
+  }
+
+  return undefined
+}
+
+export default defineEventHandler(async (event): Promise<FeedbackIssueDto[]> => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=120, s-maxage=120')
+
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+  const query = getQuery(event)
+
+  const typeParam = Array.isArray(query.type) ? query.type[0] : query.type
+  const normalizedType = normalizeIssueType(typeParam)
+
+  if (typeParam && !normalizedType) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Unsupported feedback issue type.',
+    })
+  }
+
+  const feedbackService = useFeedbackService(domainLanguage)
+
+  try {
+    return await feedbackService.listIssues(normalizedType)
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    logBackendError({
+      namespace: 'feedback:issues',
+      details: backendError,
+    })
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/server/api/feedback/vote.post.ts
+++ b/frontend/server/api/feedback/vote.post.ts
@@ -1,0 +1,44 @@
+import type { FeedbackVoteResponseDto } from '~~/shared/api-client'
+import { useFeedbackService } from '~~/shared/api-client/services/feedback.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails, logBackendError } from '../../utils/log-backend-error'
+
+interface VotePayload {
+  issueId?: string
+}
+
+const sanitize = (value: string | undefined | null): string => value?.trim() ?? ''
+
+export default defineEventHandler(async (event): Promise<FeedbackVoteResponseDto> => {
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const body = await readBody<VotePayload>(event)
+  const issueId = sanitize(body.issueId)
+
+  if (!issueId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'The issueId field is required to register a vote.',
+    })
+  }
+
+  const feedbackService = useFeedbackService(domainLanguage)
+
+  try {
+    return await feedbackService.voteOnIssue(issueId)
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    logBackendError({
+      namespace: 'feedback:votes:vote',
+      details: backendError,
+    })
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/server/api/feedback/votes/can.get.ts
+++ b/frontend/server/api/feedback/votes/can.get.ts
@@ -1,0 +1,30 @@
+import type { FeedbackVoteEligibilityDto } from '~~/shared/api-client'
+import { useFeedbackService } from '~~/shared/api-client/services/feedback.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails, logBackendError } from '../../../utils/log-backend-error'
+
+export default defineEventHandler(async (event): Promise<FeedbackVoteEligibilityDto> => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=60, s-maxage=60')
+
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const feedbackService = useFeedbackService(domainLanguage)
+
+  try {
+    return await feedbackService.canVote()
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    logBackendError({
+      namespace: 'feedback:votes:can',
+      details: backendError,
+    })
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/server/api/feedback/votes/remaining.get.ts
+++ b/frontend/server/api/feedback/votes/remaining.get.ts
@@ -1,0 +1,30 @@
+import type { FeedbackRemainingVotesDto } from '~~/shared/api-client'
+import { useFeedbackService } from '~~/shared/api-client/services/feedback.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails, logBackendError } from '../../../utils/log-backend-error'
+
+export default defineEventHandler(async (event): Promise<FeedbackRemainingVotesDto> => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=60, s-maxage=60')
+
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const feedbackService = useFeedbackService(domainLanguage)
+
+  try {
+    return await feedbackService.remainingVotes()
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    logBackendError({
+      namespace: 'feedback:votes:remaining',
+      details: backendError,
+    })
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/shared/api-client/services/feedback.services.ts
+++ b/frontend/shared/api-client/services/feedback.services.ts
@@ -1,0 +1,118 @@
+import {
+  CanVoteDomainLanguageEnum,
+  FeedbackApi,
+  FeedbackSubmissionRequestDtoTypeEnum,
+  ListIssuesDomainLanguageEnum,
+  ListIssuesTypeEnum,
+  RemainingVotesDomainLanguageEnum,
+  SubmitFeedbackDomainLanguageEnum,
+  VoteDomainLanguageEnum,
+} from '..'
+import type {
+  FeedbackSubmissionRequestDto,
+  FeedbackVoteResponseDto,
+  FeedbackIssueDto,
+  FeedbackRemainingVotesDto,
+  FeedbackSubmissionResponseDto,
+  FeedbackVoteEligibilityDto,
+} from '..'
+import type { DomainLanguage } from '../../utils/domain-language'
+import { createBackendApiConfig } from './createBackendApiConfig'
+
+type FeedbackType = FeedbackSubmissionRequestDtoTypeEnum
+
+const DOMAIN_LANGUAGE_TO_CAN_VOTE_MAP: Record<DomainLanguage, CanVoteDomainLanguageEnum> = {
+  fr: CanVoteDomainLanguageEnum.Fr,
+  en: CanVoteDomainLanguageEnum.En,
+}
+
+const DOMAIN_LANGUAGE_TO_LIST_MAP: Record<DomainLanguage, ListIssuesDomainLanguageEnum> = {
+  fr: ListIssuesDomainLanguageEnum.Fr,
+  en: ListIssuesDomainLanguageEnum.En,
+}
+
+const DOMAIN_LANGUAGE_TO_REMAINING_MAP: Record<DomainLanguage, RemainingVotesDomainLanguageEnum> = {
+  fr: RemainingVotesDomainLanguageEnum.Fr,
+  en: RemainingVotesDomainLanguageEnum.En,
+}
+
+const DOMAIN_LANGUAGE_TO_SUBMIT_MAP: Record<DomainLanguage, SubmitFeedbackDomainLanguageEnum> = {
+  fr: SubmitFeedbackDomainLanguageEnum.Fr,
+  en: SubmitFeedbackDomainLanguageEnum.En,
+}
+
+const DOMAIN_LANGUAGE_TO_VOTE_MAP: Record<DomainLanguage, VoteDomainLanguageEnum> = {
+  fr: VoteDomainLanguageEnum.Fr,
+  en: VoteDomainLanguageEnum.En,
+}
+
+export const FEEDBACK_TYPES: FeedbackType[] = [
+  FeedbackSubmissionRequestDtoTypeEnum.Idea,
+  FeedbackSubmissionRequestDtoTypeEnum.Bug,
+]
+
+/**
+ * Service wrapper around the Feedback API. Only usable from the server runtime.
+ */
+export const useFeedbackService = (domainLanguage: DomainLanguage) => {
+  const isVitest = typeof process !== 'undefined' && process.env?.VITEST === 'true'
+  const isServerRuntime = import.meta.server || isVitest
+  let api: FeedbackApi | undefined
+
+  const resolveApi = () => {
+    if (!isServerRuntime) {
+      throw new Error('useFeedbackService() is only available on the server runtime.')
+    }
+
+    if (!api) {
+      api = new FeedbackApi(createBackendApiConfig())
+    }
+
+    return api
+  }
+
+  const listIssues = async (type?: ListIssuesTypeEnum): Promise<FeedbackIssueDto[]> => {
+    return resolveApi().listIssues({
+      domainLanguage: DOMAIN_LANGUAGE_TO_LIST_MAP[domainLanguage],
+      ...(type ? { type } : {}),
+    })
+  }
+
+  const canVote = async (): Promise<FeedbackVoteEligibilityDto> => {
+    return resolveApi().canVote({
+      domainLanguage: DOMAIN_LANGUAGE_TO_CAN_VOTE_MAP[domainLanguage],
+    })
+  }
+
+  const remainingVotes = async (): Promise<FeedbackRemainingVotesDto> => {
+    return resolveApi().remainingVotes({
+      domainLanguage: DOMAIN_LANGUAGE_TO_REMAINING_MAP[domainLanguage],
+    })
+  }
+
+  const submitFeedback = async (
+    payload: FeedbackSubmissionRequestDto,
+  ): Promise<FeedbackSubmissionResponseDto> => {
+    return resolveApi().submitFeedback({
+      domainLanguage: DOMAIN_LANGUAGE_TO_SUBMIT_MAP[domainLanguage],
+      feedbackSubmissionRequestDto: payload,
+    })
+  }
+
+  const voteOnIssue = async (issueId: string): Promise<FeedbackVoteResponseDto> => {
+    return resolveApi().vote({
+      issueId,
+      domainLanguage: DOMAIN_LANGUAGE_TO_VOTE_MAP[domainLanguage],
+    })
+  }
+
+  return {
+    listIssues,
+    canVote,
+    remainingVotes,
+    submitFeedback,
+    voteOnIssue,
+  }
+}
+
+export type { FeedbackType }


### PR DESCRIPTION
## Summary
- add the `/feedback` page with hero, tabbed issue/idea lists, submission form, and open data section
- create server routes and a feedback service wrapper that rely on the generated OpenAPI client and throttle noisy backend errors
- handle backend outages gracefully by falling back to safe states for issues, remaining votes, and eligibility checks

## Testing
- pnpm lint *(warns about existing vue/no-v-html in TextContent.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68e3741b7bf88333a63af6c9d092b31d