### PR TITLE
Add feedback board locale content

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -360,6 +360,142 @@
       "privacy": "We only use your contact details to answer your request and never share them with third parties."
     }
   },
+  "feedback": {
+    "hero": {
+      "eyebrow": "Product feedback",
+      "title": "Shape Nudger with your ideas",
+      "subtitle": "Report bugs, suggest features and vote on the improvements you need next.",
+      "ctaGroupLabel": "Feedback actions",
+      "primaryCta": {
+        "label": "Browse the feedback board",
+        "ariaLabel": "Scroll to the Nudger feedback board"
+      },
+      "secondaryCta": {
+        "label": "Open GitHub issues",
+        "ariaLabel": "Open Nudger's GitHub issues in a new tab"
+      },
+      "highlights": {
+        "community": "Open collaboration with fellow Nudger contributors.",
+        "trust": "Transparent decisions shared with the whole community.",
+        "roadmap": "Iterative roadmap shaped by your priorities."
+      },
+      "stats": {
+        "eyebrow": "How it works",
+        "title": "A living roadmap",
+        "description": "Help us focus on improvements that matter most.",
+        "items": {
+          "iterations": "Weekly iterations on the most upvoted ideas.",
+          "votes": "Three votes per person to highlight key needs.",
+          "transparency": "Public updates for every discussion and decision."
+        }
+      }
+    },
+    "tabs": {
+      "eyebrow": "Community board",
+      "title": "Help us prioritise the roadmap",
+      "ariaLabel": "Feedback categories",
+      "idea": {
+        "label": "Ideas",
+        "caption": "Product improvements & new features",
+        "issueTitle": "Community ideas"
+      },
+      "bug": {
+        "label": "Bugs",
+        "caption": "Issues affecting the experience",
+        "issueTitle": "Reported bugs"
+      }
+    },
+    "issues": {
+      "empty": {
+        "idea": "No ideas yet. Be the first to share yours!",
+        "bug": "No bugs reported here right now. Thanks for keeping an eye out."
+      },
+      "loadError": "We couldn't load the feedback board. Please try again."
+    },
+    "voting": {
+      "voteButton": "Vote",
+      "voteButtonAria": "Vote for",
+      "openIssue": "Open discussion",
+      "noVotes": "You have no votes left right now.",
+      "limitReached": "You reached your voting limit for now.",
+      "remaining": "You have {count} votes remaining."
+    },
+    "form": {
+      "sections": {
+        "idea": {
+          "eyebrow": "Share an idea",
+          "title": "Imagine the next improvement",
+          "subtitle": "Explain how Nudger could better help you or your organisation.",
+          "titlePlaceholder": "e.g. Compare the carbon footprint of fridges",
+          "messagePlaceholder": "Describe your idea, the context and the impact you expect."
+        },
+        "bug": {
+          "eyebrow": "Report a bug",
+          "title": "Tell us what went wrong",
+          "subtitle": "The more details you share, the faster we can investigate and fix it.",
+          "titlePlaceholder": "e.g. Error 500 on the product page",
+          "messagePlaceholder": "List the steps to reproduce, what you expected and what happened."
+        }
+      },
+      "fields": {
+        "author": {
+          "label": "Display name",
+          "placeholder": "How should we credit you?",
+          "default": "Nudger community member"
+        },
+        "title": {
+          "label": "Title"
+        },
+        "message": {
+          "label": "Message"
+        }
+      },
+      "actions": {
+        "submit": "Send feedback",
+        "reset": "Clear form"
+      },
+      "feedback": {
+        "success": "Thank you! Your contribution has been recorded and will appear on the board soon.",
+        "missingSiteKey": "Captcha is not configured yet. Feedback submissions are temporarily disabled."
+      },
+      "errors": {
+        "missingCaptcha": "Please complete the captcha before sending your feedback.",
+        "captchaExpired": "Captcha expired, please try again.",
+        "captchaFailed": "Captcha verification failed. Please retry.",
+        "title": {
+          "length": "The title must contain at least 4 characters."
+        },
+        "message": {
+          "length": "The message must contain at least 20 characters."
+        }
+      },
+      "privacy": "Feedback is public—please avoid sharing personal or sensitive data."
+    },
+    "common": {
+      "genericError": "Something went wrong. Please try again."
+    },
+    "openSource": {
+      "eyebrow": "Open collaboration",
+      "title": "Explore our open source and open data",
+      "cards": {
+        "opensource": {
+          "title": "Contribute on GitHub",
+          "cta": "Visit the open source page",
+          "ariaLabel": "Go to the Nudger open source page"
+        },
+        "opendata": {
+          "title": "Analyse our open data",
+          "cta": "Visit the open data page",
+          "ariaLabel": "Go to the Nudger open data page"
+        }
+      }
+    },
+    "seo": {
+      "title": "Feedback & roadmap – Nudger community board",
+      "description": "Share ideas, report bugs and vote on Nudger's public roadmap for responsible shopping.",
+      "imageAlt": "Illustration of the Nudger community feedback board."
+    }
+  },
   "cms": {
     "page": {
       "loading": "Loading page…",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -361,6 +361,142 @@
       "privacy": "Vos coordonnées ne sont utilisées que pour répondre à votre message et ne sont jamais partagées."
     }
   },
+  "feedback": {
+    "hero": {
+      "eyebrow": "Retours utilisateurs",
+      "title": "Co-construisons Nudger avec vos idées",
+      "subtitle": "Signalez les bugs, proposez des évolutions et votez pour les priorités qui comptent.",
+      "ctaGroupLabel": "Actions de feedback",
+      "primaryCta": {
+        "label": "Découvrir le tableau de feedback",
+        "ariaLabel": "Faire défiler jusqu'au tableau de feedback Nudger"
+      },
+      "secondaryCta": {
+        "label": "Ouvrir les issues GitHub",
+        "ariaLabel": "Ouvrir les issues GitHub de Nudger dans un nouvel onglet"
+      },
+      "highlights": {
+        "community": "Collaboration ouverte avec une communauté engagée.",
+        "trust": "Décisions transparentes partagées avec tous.",
+        "roadmap": "Feuille de route vivante façonnée par vos idées."
+      },
+      "stats": {
+        "eyebrow": "En pratique",
+        "title": "Un backlog collaboratif",
+        "description": "Aidez-nous à concentrer l'équipe sur les améliorations utiles.",
+        "items": {
+          "iterations": "Itérations hebdomadaires sur les sujets les plus soutenus.",
+          "votes": "Votes limités pour mettre en avant les priorités clés.",
+          "transparency": "Suivi public et transparent de chaque proposition."
+        }
+      }
+    },
+    "tabs": {
+      "eyebrow": "Tableau communautaire",
+      "title": "Aidez-nous à prioriser la feuille de route",
+      "ariaLabel": "Catégories de feedback",
+      "idea": {
+        "label": "Idées",
+        "caption": "Fonctionnalités & améliorations",
+        "issueTitle": "Idées de la communauté"
+      },
+      "bug": {
+        "label": "Bugs",
+        "caption": "Anomalies de l'expérience",
+        "issueTitle": "Bugs signalés"
+      }
+    },
+    "issues": {
+      "empty": {
+        "idea": "Aucune idée pour le moment. Partagez la vôtre !",
+        "bug": "Aucun bug recensé ici pour l'instant. Merci de nous prévenir si vous en trouvez."
+      },
+      "loadError": "Impossible de charger le tableau de feedback. Merci de réessayer."
+    },
+    "voting": {
+      "voteButton": "Voter",
+      "voteButtonAria": "Voter pour",
+      "openIssue": "Ouvrir la discussion",
+      "noVotes": "Vous n'avez plus de vote disponible.",
+      "limitReached": "Vous avez atteint votre limite de votes pour le moment.",
+      "remaining": "Il vous reste {count} vote(s)."
+    },
+    "form": {
+      "sections": {
+        "idea": {
+          "eyebrow": "Proposer une idée",
+          "title": "Imaginez la prochaine évolution",
+          "subtitle": "Expliquez comment Nudger pourrait mieux vous aider.",
+          "titlePlaceholder": "Ex. Comparer l'empreinte carbone des frigos",
+          "messagePlaceholder": "Décrivez votre idée, le contexte et les bénéfices attendus."
+        },
+        "bug": {
+          "eyebrow": "Signaler un bug",
+          "title": "Décrivez le problème rencontré",
+          "subtitle": "Plus vous donnez de détails, plus nous pourrons corriger rapidement.",
+          "titlePlaceholder": "Ex. Erreur 500 sur la fiche produit",
+          "messagePlaceholder": "Précisez les étapes, le comportement attendu et ce qui s'est produit."
+        }
+      },
+      "fields": {
+        "author": {
+          "label": "Nom affiché",
+          "placeholder": "Sous quel nom souhaitez-vous apparaître ?",
+          "default": "Membre de la communauté Nudger"
+        },
+        "title": {
+          "label": "Titre"
+        },
+        "message": {
+          "label": "Message"
+        }
+      },
+      "actions": {
+        "submit": "Envoyer le feedback",
+        "reset": "Réinitialiser le formulaire"
+      },
+      "feedback": {
+        "success": "Merci ! Votre contribution est enregistrée et apparaîtra bientôt sur le tableau.",
+        "missingSiteKey": "Le captcha n'est pas encore configuré : l'envoi de feedback est temporairement indisponible."
+      },
+      "errors": {
+        "missingCaptcha": "Merci de compléter le captcha avant d'envoyer.",
+        "captchaExpired": "Le captcha a expiré, merci de recommencer.",
+        "captchaFailed": "La vérification du captcha a échoué. Merci de réessayer.",
+        "title": {
+          "length": "Le titre doit contenir au moins 4 caractères."
+        },
+        "message": {
+          "length": "Le message doit contenir au moins 20 caractères."
+        }
+      },
+      "privacy": "Les retours sont publics : n'indiquez pas de données personnelles sensibles."
+    },
+    "common": {
+      "genericError": "Une erreur inattendue est survenue. Merci de réessayer."
+    },
+    "openSource": {
+      "eyebrow": "Collaboration ouverte",
+      "title": "Explorez nos communs open source et open data",
+      "cards": {
+        "opensource": {
+          "title": "Contribuer sur GitHub",
+          "cta": "Voir la page open source",
+          "ariaLabel": "Aller vers la page open source de Nudger"
+        },
+        "opendata": {
+          "title": "Analyser nos données ouvertes",
+          "cta": "Voir la page open data",
+          "ariaLabel": "Aller vers la page open data de Nudger"
+        }
+      }
+    },
+    "seo": {
+      "title": "Feedback & roadmap – Communauté Nudger",
+      "description": "Partagez vos idées, signalez les bugs et votez pour les prochaines évolutions de Nudger.",
+      "imageAlt": "Illustration du tableau de feedback de la communauté Nudger."
+    }
+  },
   "cms": {
     "page": {
       "loading": "Chargement de la page…",


### PR DESCRIPTION
## Summary
- add feedback board copy to the English and French locale files for the upcoming feedback experience

## Testing
- pnpm lint
- CI=1 pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e385bf0c888333a0225fcbbd39633b