### PR TITLE
feat: replace feedback TextContent blocks with i18n strings

### DIFF
--- a/frontend/app/components/domains/feedback/FeedbackHero.vue
+++ b/frontend/app/components/domains/feedback/FeedbackHero.vue
@@ -13,11 +13,9 @@
             <p class="feedback-hero__subtitle">
               {{ subtitle }}
             </p>
-            <TextContent
-              :bloc-id="descriptionBlocId"
-              :ipsum-length="220"
-              class="feedback-hero__description"
-            />
+            <p class="feedback-hero__description">
+              {{ description }}
+            </p>
 
             <div class="feedback-hero__actions" role="group" :aria-label="ctaGroupLabel">
               <v-btn
@@ -90,7 +88,6 @@
 </template>
 
 <script setup lang="ts">
-import TextContent from '~/components/domains/content/TextContent.vue'
 
 type HeroLink = {
   label: string
@@ -124,7 +121,7 @@ defineProps<{
   eyebrow: string
   title: string
   subtitle: string
-  descriptionBlocId: string
+  description: string
   primaryCta?: HeroLink
   secondaryCta?: HeroLink
   ctaGroupLabel: string

--- a/frontend/app/components/domains/feedback/FeedbackIssueList.vue
+++ b/frontend/app/components/domains/feedback/FeedbackIssueList.vue
@@ -2,7 +2,9 @@
   <section :aria-labelledby="headingId" class="feedback-issue-list">
     <header class="feedback-issue-list__header">
       <h3 :id="headingId" class="feedback-issue-list__title">{{ title }}</h3>
-      <TextContent :bloc-id="descriptionBlocId" :ipsum-length="160" class="feedback-issue-list__description" />
+      <p class="feedback-issue-list__description">
+        {{ description }}
+      </p>
     </header>
 
     <v-alert v-if="statusMessage" type="info" variant="tonal" border="start" class="mb-4" role="status">
@@ -111,7 +113,6 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import TextContent from '~/components/domains/content/TextContent.vue'
 
 export interface FeedbackIssueDisplay {
   id?: string
@@ -130,7 +131,7 @@ type IssueIcon = string
 const props = defineProps<{
   headingId: string
   title: string
-  descriptionBlocId: string
+  description: string
   issues: FeedbackIssueDisplay[]
   loading: boolean
   errorMessage: string | null

--- a/frontend/app/components/domains/feedback/FeedbackOpenSourceSection.vue
+++ b/frontend/app/components/domains/feedback/FeedbackOpenSourceSection.vue
@@ -6,7 +6,9 @@
         <h2 id="feedback-open-source-heading" class="feedback-open-source__title">
           {{ title }}
         </h2>
-        <TextContent :bloc-id="introBlocId" :ipsum-length="180" class="feedback-open-source__description" />
+        <p class="feedback-open-source__description">
+          {{ description }}
+        </p>
       </div>
 
       <v-row class="g-6 mt-6">
@@ -18,7 +20,9 @@
               </v-avatar>
               <h3 class="feedback-open-source__card-title">{{ card.title }}</h3>
             </div>
-            <TextContent :bloc-id="card.descriptionBlocId" :ipsum-length="150" class="feedback-open-source__card-text" />
+            <p class="feedback-open-source__card-text">
+              {{ card.description }}
+            </p>
             <v-btn
               :href="card.cta.href"
               :to="card.cta.to"
@@ -39,7 +43,6 @@
 </template>
 
 <script setup lang="ts">
-import TextContent from '~/components/domains/content/TextContent.vue'
 
 type FeedbackCardCta = {
   label: string
@@ -53,14 +56,14 @@ type FeedbackCardCta = {
 type FeedbackCard = {
   icon: string
   title: string
-  descriptionBlocId: string
+  description: string
   cta: FeedbackCardCta
 }
 
 defineProps<{
   eyebrow: string
   title: string
-  introBlocId: string
+  description: string
   cards: FeedbackCard[]
 }>()
 </script>

--- a/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
+++ b/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
@@ -14,7 +14,9 @@
         </div>
       </div>
 
-      <TextContent :bloc-id="introBlocId" :ipsum-length="170" class="feedback-form__intro" />
+      <p class="feedback-form__intro">
+        {{ intro }}
+      </p>
 
       <v-alert
         v-if="success"
@@ -150,7 +152,6 @@ import { computed, ref, watch } from 'vue'
 import { useTheme } from 'vuetify'
 import { VForm } from 'vuetify/components'
 import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
-import TextContent from '~/components/domains/content/TextContent.vue'
 
 export interface FeedbackFormSubmitPayload {
   type: string
@@ -166,7 +167,7 @@ const props = defineProps<{
   eyebrow: string
   title: string
   subtitle: string
-  introBlocId: string
+  intro: string
   categoryIcon: string
   categoryType: string
   submitting: boolean

--- a/frontend/app/pages/feedback/index.vue
+++ b/frontend/app/pages/feedback/index.vue
@@ -4,7 +4,7 @@
       :eyebrow="t('feedback.hero.eyebrow')"
       :title="t('feedback.hero.title')"
       :subtitle="t('feedback.hero.subtitle')"
-      description-bloc-id="webpages:feedback:hero-description"
+      :description="t('feedback.hero.description')"
       :primary-cta="heroPrimaryCta"
       :secondary-cta="heroSecondaryCta"
       :cta-group-label="t('feedback.hero.ctaGroupLabel')"
@@ -19,11 +19,9 @@
           <h2 id="feedback-tabs-heading" class="feedback-tabs__title">
             {{ t('feedback.tabs.title') }}
           </h2>
-          <TextContent
-            bloc-id="webpages:feedback:tabs-intro"
-            :ipsum-length="200"
-            class="feedback-tabs__description"
-          />
+          <p class="feedback-tabs__description">
+            {{ t('feedback.tabs.description') }}
+          </p>
         </header>
 
         <v-tabs
@@ -54,7 +52,7 @@
                 <FeedbackIssueList
                   :heading-id="`${tab.value.toLowerCase()}-issues-heading`"
                   :title="tab.issueTitle"
-                  :description-bloc-id="tab.descriptionBlocId"
+                  :description="tab.description"
                   :issues="issuesByType[tab.value]"
                   :loading="issueLoadingStates[tab.value]"
                   :error-message="issueErrorMessages[tab.value]"
@@ -79,7 +77,7 @@
                   :eyebrow="tab.formEyebrow"
                   :title="tab.formTitle"
                   :subtitle="tab.formSubtitle"
-                  :intro-bloc-id="tab.formDescriptionBlocId"
+                  :intro="tab.formIntro"
                   :category-icon="tab.icon"
                   :category-type="tab.value"
                   :submitting="submissionState.submitting"
@@ -118,7 +116,7 @@
     <FeedbackOpenSourceSection
       :eyebrow="t('feedback.openSource.eyebrow')"
       :title="t('feedback.openSource.title')"
-      intro-bloc-id="webpages:feedback:open-source-intro"
+      :description="t('feedback.openSource.description')"
       :cards="openSourceCards"
     />
   </div>
@@ -136,7 +134,6 @@ import FeedbackSubmissionForm, {
   type FeedbackFormSubmitPayload,
 } from '~/components/domains/feedback/FeedbackSubmissionForm.vue'
 import FeedbackOpenSourceSection from '~/components/domains/feedback/FeedbackOpenSourceSection.vue'
-import TextContent from '~/components/domains/content/TextContent.vue'
 import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 import type {
   FeedbackIssueDto,
@@ -164,12 +161,12 @@ const tabs = computed(() => [
     caption: String(t('feedback.tabs.idea.caption')),
     icon: 'mdi-lightbulb-on-outline',
     issueTitle: String(t('feedback.tabs.idea.issueTitle')),
-    descriptionBlocId: 'webpages:feedback:ideas-guidelines',
+    description: String(t('feedback.tabs.idea.description')),
     emptyMessage: String(t('feedback.issues.empty.idea')),
     formEyebrow: String(t('feedback.form.sections.idea.eyebrow')),
     formTitle: String(t('feedback.form.sections.idea.title')),
     formSubtitle: String(t('feedback.form.sections.idea.subtitle')),
-    formDescriptionBlocId: 'webpages:feedback:idea-form-intro',
+    formIntro: String(t('feedback.form.sections.idea.intro')),
     formTitlePlaceholder: String(t('feedback.form.sections.idea.titlePlaceholder')),
     formMessagePlaceholder: String(t('feedback.form.sections.idea.messagePlaceholder')),
   },
@@ -179,12 +176,12 @@ const tabs = computed(() => [
     caption: String(t('feedback.tabs.bug.caption')),
     icon: 'mdi-bug-check-outline',
     issueTitle: String(t('feedback.tabs.bug.issueTitle')),
-    descriptionBlocId: 'webpages:feedback:bugs-guidelines',
+    description: String(t('feedback.tabs.bug.description')),
     emptyMessage: String(t('feedback.issues.empty.bug')),
     formEyebrow: String(t('feedback.form.sections.bug.eyebrow')),
     formTitle: String(t('feedback.form.sections.bug.title')),
     formSubtitle: String(t('feedback.form.sections.bug.subtitle')),
-    formDescriptionBlocId: 'webpages:feedback:bug-form-intro',
+    formIntro: String(t('feedback.form.sections.bug.intro')),
     formTitlePlaceholder: String(t('feedback.form.sections.bug.titlePlaceholder')),
     formMessagePlaceholder: String(t('feedback.form.sections.bug.messagePlaceholder')),
   },
@@ -470,7 +467,7 @@ const openSourceCards = computed(() => [
   {
     icon: 'mdi-github',
     title: String(t('feedback.openSource.cards.opensource.title')),
-    descriptionBlocId: 'webpages:feedback:open-source-card',
+    description: String(t('feedback.openSource.cards.opensource.description')),
     cta: {
       label: String(t('feedback.openSource.cards.opensource.cta')),
       ariaLabel: String(t('feedback.openSource.cards.opensource.ariaLabel')),
@@ -480,7 +477,7 @@ const openSourceCards = computed(() => [
   {
     icon: 'mdi-database-search',
     title: String(t('feedback.openSource.cards.opendata.title')),
-    descriptionBlocId: 'webpages:feedback:open-data-card',
+    description: String(t('feedback.openSource.cards.opendata.description')),
     cta: {
       label: String(t('feedback.openSource.cards.opendata.cta')),
       ariaLabel: String(t('feedback.openSource.cards.opendata.ariaLabel')),

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -365,6 +365,7 @@
       "eyebrow": "Product feedback",
       "title": "Shape Nudger with your ideas",
       "subtitle": "Report bugs, suggest features and vote on the improvements you need next.",
+      "description": "Your feedback steers our roadmap. Discover what others requested, upvote the most useful ideas and submit your own improvements.",
       "ctaGroupLabel": "Feedback actions",
       "primaryCta": {
         "label": "Browse the feedback board",
@@ -393,16 +394,19 @@
     "tabs": {
       "eyebrow": "Community board",
       "title": "Help us prioritise the roadmap",
+      "description": "Pick a category to explore ongoing discussions, vote for the topics that resonate with you, or open a new one.",
       "ariaLabel": "Feedback categories",
       "idea": {
         "label": "Ideas",
         "caption": "Product improvements & new features",
-        "issueTitle": "Community ideas"
+        "issueTitle": "Community ideas",
+        "description": "Suggest enhancements that would make Nudger more helpful for you or your organisation. We review every idea weekly."
       },
       "bug": {
         "label": "Bugs",
         "caption": "Issues affecting the experience",
-        "issueTitle": "Reported bugs"
+        "issueTitle": "Reported bugs",
+        "description": "Describe any malfunction or inaccurate behaviour you spotted. Precise reports help us fix issues faster."
       }
     },
     "issues": {
@@ -426,6 +430,7 @@
           "eyebrow": "Share an idea",
           "title": "Imagine the next improvement",
           "subtitle": "Explain how Nudger could better help you or your organisation.",
+          "intro": "Explain the context of your idea, why it matters and how it would improve Nudger for everyone.",
           "titlePlaceholder": "e.g. Compare the carbon footprint of fridges",
           "messagePlaceholder": "Describe your idea, the context and the impact you expect."
         },
@@ -433,6 +438,7 @@
           "eyebrow": "Report a bug",
           "title": "Tell us what went wrong",
           "subtitle": "The more details you share, the faster we can investigate and fix it.",
+          "intro": "Share the steps to reproduce the bug, what you expected and what actually happened so we can investigate quickly.",
           "titlePlaceholder": "e.g. Error 500 on the product page",
           "messagePlaceholder": "List the steps to reproduce, what you expected and what happened."
         }
@@ -477,14 +483,17 @@
     "openSource": {
       "eyebrow": "Open collaboration",
       "title": "Explore our open source and open data",
+      "description": "We publish our roadmap, code and datasets so anyone can audit, reuse or contribute to Nudger.",
       "cards": {
         "opensource": {
           "title": "Contribute on GitHub",
+          "description": "Browse our repositories, follow ongoing pull requests and submit your own contributions.",
           "cta": "Visit the open source page",
           "ariaLabel": "Go to the Nudger open source page"
         },
         "opendata": {
           "title": "Analyse our open data",
+          "description": "Download the datasets powering Nudger and reuse them in your research or projects.",
           "cta": "Visit the open data page",
           "ariaLabel": "Go to the Nudger open data page"
         }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -366,6 +366,7 @@
       "eyebrow": "Retours utilisateurs",
       "title": "Co-construisons Nudger avec vos idées",
       "subtitle": "Signalez les bugs, proposez des évolutions et votez pour les priorités qui comptent.",
+      "description": "Vos retours orientent notre feuille de route. Découvrez les demandes déjà déposées, soutenez celles qui vous parlent et proposez les vôtres.",
       "ctaGroupLabel": "Actions de feedback",
       "primaryCta": {
         "label": "Découvrir le tableau de feedback",
@@ -394,16 +395,19 @@
     "tabs": {
       "eyebrow": "Tableau communautaire",
       "title": "Aidez-nous à prioriser la feuille de route",
+      "description": "Choisissez une catégorie pour explorer les discussions en cours, voter pour les sujets qui vous concernent ou en ouvrir une nouvelle.",
       "ariaLabel": "Catégories de feedback",
       "idea": {
         "label": "Idées",
         "caption": "Fonctionnalités & améliorations",
-        "issueTitle": "Idées de la communauté"
+        "issueTitle": "Idées de la communauté",
+        "description": "Proposez des améliorations qui rendraient Nudger plus utile pour vous ou votre organisation. Nous passons chaque idée en revue chaque semaine."
       },
       "bug": {
         "label": "Bugs",
         "caption": "Anomalies de l'expérience",
-        "issueTitle": "Bugs signalés"
+        "issueTitle": "Bugs signalés",
+        "description": "Décrivez toute anomalie ou comportement inattendu observé. Des signalements précis nous aident à corriger plus vite."
       }
     },
     "issues": {
@@ -427,6 +431,7 @@
           "eyebrow": "Proposer une idée",
           "title": "Imaginez la prochaine évolution",
           "subtitle": "Expliquez comment Nudger pourrait mieux vous aider.",
+          "intro": "Présentez le contexte de votre idée, son importance et la manière dont elle améliorerait Nudger pour toutes et tous.",
           "titlePlaceholder": "Ex. Comparer l'empreinte carbone des frigos",
           "messagePlaceholder": "Décrivez votre idée, le contexte et les bénéfices attendus."
         },
@@ -434,6 +439,7 @@
           "eyebrow": "Signaler un bug",
           "title": "Décrivez le problème rencontré",
           "subtitle": "Plus vous donnez de détails, plus nous pourrons corriger rapidement.",
+          "intro": "Partagez les étapes pour reproduire le bug, ce que vous attendiez et ce qui s'est réellement produit afin que nous puissions enquêter rapidement.",
           "titlePlaceholder": "Ex. Erreur 500 sur la fiche produit",
           "messagePlaceholder": "Précisez les étapes, le comportement attendu et ce qui s'est produit."
         }
@@ -478,14 +484,17 @@
     "openSource": {
       "eyebrow": "Collaboration ouverte",
       "title": "Explorez nos communs open source et open data",
+      "description": "Nous publions notre feuille de route, notre code et nos jeux de données pour que chacun puisse auditer, réutiliser ou contribuer à Nudger.",
       "cards": {
         "opensource": {
           "title": "Contribuer sur GitHub",
+          "description": "Parcourez nos dépôts, suivez les pull requests en cours et soumettez vos propres contributions.",
           "cta": "Voir la page open source",
           "ariaLabel": "Aller vers la page open source de Nudger"
         },
         "opendata": {
           "title": "Analyser nos données ouvertes",
+          "description": "Téléchargez les jeux de données qui alimentent Nudger et réutilisez-les dans vos recherches ou projets.",
           "cta": "Voir la page open data",
           "ariaLabel": "Aller vers la page open data de Nudger"
         }


### PR DESCRIPTION
## Summary
- replace the feedback page TextContent usages with standard i18n strings across the hero, issue list, submission form and open source sections
- add English and French translations for the new feedback copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e38b91599c8333b16835a7233f8165