### PR TITLE
fix(frontend): add missing feedback highlight translations

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -376,9 +376,18 @@
         "ariaLabel": "Open Nudger's GitHub issues in a new tab"
       },
       "highlights": {
-        "community": "Open collaboration with fellow Nudger contributors.",
-        "trust": "Transparent decisions shared with the whole community.",
-        "roadmap": "Iterative roadmap shaped by your priorities."
+        "community": {
+          "title": "Co-create with the community",
+          "description": "Share your ideas, vote on priorities and collaborate with fellow Nudger contributors."
+        },
+        "trust": {
+          "title": "Transparency you can rely on",
+          "description": "Follow every discussion and decision to understand how your feedback shapes Nudger."
+        },
+        "roadmap": {
+          "title": "Impact-driven roadmap",
+          "description": "We focus each iteration on the improvements that gather the most support."
+        }
       },
       "stats": {
         "eyebrow": "How it works",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -377,9 +377,18 @@
         "ariaLabel": "Ouvrir les issues GitHub de Nudger dans un nouvel onglet"
       },
       "highlights": {
-        "community": "Collaboration ouverte avec une communauté engagée.",
-        "trust": "Décisions transparentes partagées avec tous.",
-        "roadmap": "Feuille de route vivante façonnée par vos idées."
+        "community": {
+          "title": "Co-construire avec la communauté",
+          "description": "Proposez vos idées, votez pour les priorités et échangez avec les autres contributrices et contributeurs Nudger."
+        },
+        "trust": {
+          "title": "Une transparence totale",
+          "description": "Suivez chaque échange et chaque décision pour voir comment vos retours transforment Nudger."
+        },
+        "roadmap": {
+          "title": "Une feuille de route guidée par l'impact",
+          "description": "Chaque itération se concentre sur les améliorations qui recueillent le plus de soutien."
+        }
       },
       "stats": {
         "eyebrow": "En pratique",


### PR DESCRIPTION
## Summary
- add structured titles and descriptions for the feedback hero highlights in English
- localize the same highlight copy for the French language pack so i18n lookups resolve

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e38e1982b483339625e0ad55a62d76