### PR TITLE
Add OpenData REST endpoints to front API

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -25,6 +25,12 @@
       <version>${global.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>opendata</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.open4goods</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/AppConfig.java
@@ -4,6 +4,8 @@ import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.CacheProperties;
 import org.open4goods.services.blog.config.BlogConfiguration;
 import org.open4goods.services.blog.service.BlogService;
+import org.open4goods.services.opendata.config.OpenDataConfig;
+import org.open4goods.services.opendata.service.OpenDataService;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
@@ -37,6 +39,7 @@ public class AppConfig {
     ProductRepository productRepository() {
         return new ProductRepository();
     }
+
 
     @Bean
     BlogService blogService(@Autowired XwikiFacadeService xwikiFacadeService, @Autowired BlogConfiguration blogConfig) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/ApiProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/ApiProperties.java
@@ -8,8 +8,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "front")
 public class ApiProperties {
 
-    /** The resource provider root path (where static resources will be hosted) */
+    /** The resource provider root path (where static resources will be hosted). */
     private String resourceProviderRootPath;
+
+    /** Absolute root path used to expose downloadable assets. */
+    private String resourceRootPath;
 
     public String getResourceProviderRootPath() {
         return resourceProviderRootPath;
@@ -17,6 +20,14 @@ public class ApiProperties {
 
     public void setResourceProviderRootPath(String resourceProviderRootPath) {
         this.resourceProviderRootPath = resourceProviderRootPath;
+    }
+
+    public String getResourceRootPath() {
+        return resourceRootPath;
+    }
+
+    public void setResourceRootPath(String resourceRootPath) {
+        this.resourceRootPath = resourceRootPath;
     }
 
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/OpenDataController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/OpenDataController.java
@@ -5,7 +5,7 @@ import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
 import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataDatasetDto;
 import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataOverviewDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
-import org.open4goods.nudgerfrontapi.service.OpenDataFrontService;
+import org.open4goods.nudgerfrontapi.service.OpenDataMappingService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -33,9 +33,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "OpenData", description = "Metadata describing the public GTIN and ISBN datasets.")
 public class OpenDataController {
 
-    private final OpenDataFrontService openDataFrontService;
+    private final OpenDataMappingService openDataFrontService;
 
-    public OpenDataController(OpenDataFrontService openDataFrontService) {
+    public OpenDataController(OpenDataMappingService openDataFrontService) {
         this.openDataFrontService = openDataFrontService;
     }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/OpenDataController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/OpenDataController.java
@@ -1,0 +1,119 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataDatasetDto;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataOverviewDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.OpenDataFrontService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing OpenData dataset metadata for the frontend.
+ */
+@RestController
+@RequestMapping("/opendata")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "OpenData", description = "Metadata describing the public GTIN and ISBN datasets.")
+public class OpenDataController {
+
+    private final OpenDataFrontService openDataFrontService;
+
+    public OpenDataController(OpenDataFrontService openDataFrontService) {
+        this.openDataFrontService = openDataFrontService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get OpenData overview",
+            description = "Return aggregated metadata about the available GTIN and ISBN datasets.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Overview returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = OpenDataOverviewDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<OpenDataOverviewDto> overview(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        OpenDataOverviewDto body = openDataFrontService.overview(domainLanguage);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIVE_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", openDataFrontService.resolvedLocaleTag(domainLanguage))
+                .body(body);
+    }
+
+    @GetMapping("/gtin")
+    @Operation(
+            summary = "Get GTIN dataset metadata",
+            description = "Return metadata describing the GTIN OpenData export.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataset returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = OpenDataDatasetDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<OpenDataDatasetDto> gtin(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        OpenDataDatasetDto body = openDataFrontService.gtin(domainLanguage);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIVE_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", openDataFrontService.resolvedLocaleTag(domainLanguage))
+                .body(body);
+    }
+
+    @GetMapping("/isbn")
+    @Operation(
+            summary = "Get ISBN dataset metadata",
+            description = "Return metadata describing the ISBN OpenData export.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Dataset returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = OpenDataDatasetDto.class))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<OpenDataDatasetDto> isbn(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        OpenDataDatasetDto body = openDataFrontService.isbn(domainLanguage);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIVE_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", openDataFrontService.resolvedLocaleTag(domainLanguage))
+                .body(body);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDatasetDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDatasetDto.java
@@ -1,0 +1,33 @@
+package org.open4goods.nudgerfrontapi.dto.opendata;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO describing a single OpenData dataset (either GTIN or ISBN).
+ */
+@Schema(description = "Detailed description of a single OpenData dataset.")
+public record OpenDataDatasetDto(
+        @Schema(description = "Identifier of the dataset.", allowableValues = {"GTIN", "ISBN"}, example = "GTIN")
+        String type,
+
+        @Schema(description = "Number of rows in the dataset formatted using the requested locale.", example = "150\u00a0000")
+        String recordCount,
+
+        @Schema(description = "Last update timestamp formatted using the requested locale.",
+                example = "12 mars 2024, 10:15:42", nullable = true)
+        String lastUpdated,
+
+        @Schema(description = "Human readable size of the dataset formatted using the requested locale.", example = "512\u00a0MB")
+        String fileSize,
+
+        @Schema(description = "Absolute URL that can be used to download the dataset.", format = "uri",
+                example = "https://nudger.fr/opendata/gtin-open-data.zip")
+        String downloadUrl,
+
+        @ArraySchema(schema = @Schema(description = "Column header available in the dataset.", example = "gtin"))
+        List<String> headers
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDownloadLimitsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDownloadLimitsDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.opendata;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing the download rate limits applied to the OpenData datasets.
+ */
+@Schema(description = "Download limits applied to OpenData dataset transfers.")
+public record OpenDataDownloadLimitsDto(
+        @Schema(description = "Maximum download speed per client expressed in kilobytes per second.", example = "256")
+        int downloadSpeedKb,
+
+        @Schema(description = "Human readable download speed formatted according to the requested locale.",
+                example = "256\u00a0kB/s")
+        String downloadSpeed,
+
+        @Schema(description = "Maximum number of concurrent downloads accepted by the platform.", example = "4")
+        int concurrentDownloads
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataOverviewDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataOverviewDto.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.dto.opendata;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Overview information about all available OpenData datasets.
+ */
+@Schema(description = "Aggregated information describing the full OpenData catalogue.")
+public record OpenDataOverviewDto(
+        @Schema(description = "Total number of products covered by all datasets, formatted using the requested locale.",
+                example = "12\u00a0345")
+        String totalProductCount,
+
+        @Schema(description = "Number of datasets available for download, formatted using the requested locale.",
+                example = "2")
+        String datasetCount,
+
+        @Schema(description = "Human readable size of all datasets combined, formatted using the requested locale.",
+                example = "1,5\u00a0GB")
+        String totalDatasetSize,
+
+        @Schema(description = "Download restrictions applied when fetching the datasets.")
+        OpenDataDownloadLimitsDto downloadLimits
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataFrontService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataFrontService.java
@@ -1,0 +1,208 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.io.File;
+import java.text.NumberFormat;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.List;
+import java.util.Locale;
+
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataDatasetDto;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataDownloadLimitsDto;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataOverviewDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.services.opendata.config.OpenDataConfig;
+import org.open4goods.services.opendata.service.OpenDataService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Service assembling OpenData DTOs for the frontend REST API.
+ */
+@Service
+public class OpenDataFrontService {
+
+    private static final String[] SIZE_UNITS = {"B", "kB", "MB", "GB", "TB", "PB", "EB"};
+
+    private final OpenDataService openDataService;
+    private final OpenDataConfig openDataConfig;
+    private final ApiProperties apiProperties;
+
+    public OpenDataFrontService(OpenDataService openDataService,
+                                OpenDataConfig openDataConfig,
+                                ApiProperties apiProperties) {
+        this.openDataService = openDataService;
+        this.openDataConfig = openDataConfig;
+        this.apiProperties = apiProperties;
+    }
+
+    /**
+     * Build an overview of the available datasets.
+     *
+     * @param domainLanguage caller requested language
+     * @return overview DTO with localised values
+     */
+    public OpenDataOverviewDto overview(DomainLanguage domainLanguage) {
+        Locale locale = resolveLocale(domainLanguage);
+
+        long isbnCount = openDataService.totalItemsISBN();
+        long gtinCount = openDataService.totalItemsGTIN();
+        long totalProducts = isbnCount + gtinCount;
+        int datasetCount = 2; // GTIN + ISBN datasets
+        long totalSize = safeLength(openDataConfig.isbnZipFile()) + safeLength(openDataConfig.gtinZipFile());
+
+        OpenDataDownloadLimitsDto limits = new OpenDataDownloadLimitsDto(
+                openDataConfig.getDownloadSpeedKb(),
+                formatDownloadSpeed(openDataConfig.getDownloadSpeedKb(), locale),
+                openDataConfig.getConcurrentDownloads());
+
+        return new OpenDataOverviewDto(
+                formatInteger(totalProducts, locale),
+                formatInteger(datasetCount, locale),
+                formatDataSize(totalSize, locale),
+                limits
+        );
+    }
+
+    /**
+     * Build DTO for the GTIN dataset.
+     *
+     * @param domainLanguage caller requested language
+     * @return dataset DTO with localised values
+     */
+    public OpenDataDatasetDto gtin(DomainLanguage domainLanguage) {
+        return dataset(domainLanguage,
+                "GTIN",
+                openDataService.totalItemsGTIN(),
+                openDataConfig.gtinZipFile(),
+                "/opendata/gtin-open-data.zip",
+                List.of(OpenDataService.GTIN_HEADER));
+    }
+
+    /**
+     * Build DTO for the ISBN dataset.
+     *
+     * @param domainLanguage caller requested language
+     * @return dataset DTO with localised values
+     */
+    public OpenDataDatasetDto isbn(DomainLanguage domainLanguage) {
+        return dataset(domainLanguage,
+                "ISBN",
+                openDataService.totalItemsISBN(),
+                openDataConfig.isbnZipFile(),
+                "/opendata/isbn-open-data.zip",
+                List.of(OpenDataService.ISBN_HEADER));
+    }
+
+    /**
+     * Resolve the {@link Locale} matching a {@link DomainLanguage}.
+     *
+     * @param domainLanguage requested language
+     * @return resolved locale (defaults to system locale when null)
+     */
+    public Locale resolveLocale(DomainLanguage domainLanguage) {
+        if (domainLanguage == null) {
+            return Locale.getDefault();
+        }
+        return Locale.forLanguageTag(domainLanguage.languageTag());
+    }
+
+    /**
+     * Return the resolved locale tag.
+     *
+     * @param domainLanguage requested language
+     * @return locale expressed as IETF BCP 47 tag
+     */
+    public String resolvedLocaleTag(DomainLanguage domainLanguage) {
+        return resolveLocale(domainLanguage).toLanguageTag();
+    }
+
+    private OpenDataDatasetDto dataset(DomainLanguage domainLanguage,
+                                       String type,
+                                       long recordCount,
+                                       File file,
+                                       String relativeDownloadPath,
+                                       List<String> headers) {
+        Locale locale = resolveLocale(domainLanguage);
+        return new OpenDataDatasetDto(
+                type,
+                formatInteger(recordCount, locale),
+                formatTimestamp(file, locale),
+                formatDataSize(safeLength(file), locale),
+                buildDownloadUrl(relativeDownloadPath),
+                List.copyOf(headers)
+        );
+    }
+
+    private long safeLength(File file) {
+        if (file == null || !file.exists()) {
+            return 0L;
+        }
+        return file.length();
+    }
+
+    private String formatInteger(long value, Locale locale) {
+        NumberFormat numberFormat = NumberFormat.getIntegerInstance(locale);
+        return numberFormat.format(value);
+    }
+
+    private String formatDataSize(long bytes, Locale locale) {
+        if (bytes <= 0) {
+            return NumberFormat.getIntegerInstance(locale).format(0) + " " + SIZE_UNITS[0];
+        }
+
+        double value = bytes;
+        int unitIndex = 0;
+        while (value >= 1000 && unitIndex < SIZE_UNITS.length - 1) {
+            value /= 1000;
+            unitIndex++;
+        }
+
+        NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
+        if (unitIndex == 0) {
+            numberFormat.setMaximumFractionDigits(0);
+        } else if (value < 10) {
+            numberFormat.setMaximumFractionDigits(1);
+            numberFormat.setMinimumFractionDigits(1);
+        } else {
+            numberFormat.setMaximumFractionDigits(0);
+        }
+
+        return numberFormat.format(value) + " " + SIZE_UNITS[unitIndex];
+    }
+
+    private String formatTimestamp(File file, Locale locale) {
+        if (file == null || !file.exists()) {
+            return null;
+        }
+        Instant instant = Instant.ofEpochMilli(file.lastModified());
+        ZonedDateTime dateTime = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
+                .withLocale(locale);
+        return formatter.format(dateTime);
+    }
+
+    private String formatDownloadSpeed(int downloadSpeedKb, Locale locale) {
+        NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
+        numberFormat.setMaximumFractionDigits(0);
+        return numberFormat.format(downloadSpeedKb) + " kB/s";
+    }
+
+    private String buildDownloadUrl(String relativePath) {
+        String root = apiProperties.getResourceRootPath();
+        if (!StringUtils.hasText(root)) {
+            root = apiProperties.getResourceProviderRootPath();
+        }
+        if (!StringUtils.hasText(root)) {
+            return relativePath;
+        }
+
+        String normalisedRoot = root.endsWith("/") ? root.substring(0, root.length() - 1) : root;
+        String normalisedPath = relativePath.startsWith("/") ? relativePath : "/" + relativePath;
+        return normalisedRoot + normalisedPath;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingService.java
@@ -24,7 +24,7 @@ import org.springframework.util.StringUtils;
  * Service assembling OpenData DTOs for the frontend REST API.
  */
 @Service
-public class OpenDataFrontService {
+public class OpenDataMappingService {
 
     private static final String[] SIZE_UNITS = {"B", "kB", "MB", "GB", "TB", "PB", "EB"};
 
@@ -32,7 +32,7 @@ public class OpenDataFrontService {
     private final OpenDataConfig openDataConfig;
     private final ApiProperties apiProperties;
 
-    public OpenDataFrontService(OpenDataService openDataService,
+    public OpenDataMappingService(OpenDataService openDataService,
                                 OpenDataConfig openDataConfig,
                                 ApiProperties apiProperties) {
         this.openDataService = openDataService;

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -17,6 +17,7 @@ springdoc:
 
 front:
   resourceProviderRootPath: "https://nudger.fr"
+  resourceRootPath: "https://nudger.fr"
   cache:
     path: ./cache
   contact:
@@ -54,6 +55,9 @@ management:
     web:
       exposure:
         include: health,info,metrics
+
+open-data-config:
+  generation-enabled: false
 
 team-config:
   cores:


### PR DESCRIPTION
## Summary
- depend on the OpenData service and configure resource and generation properties for the front API
- add DTOs plus a mapper service to localise counts, sizes and download links for OpenData exports
- expose new `/opendata`, `/opendata/gtin` and `/opendata/isbn` endpoints returning the formatted metadata

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68e3b89a4e248333879e7971c9f9ddae