### PR TITLE
Make feedback listings client-only and update vote state

### DIFF
--- a/frontend/app/components/domains/feedback/FeedbackIssueList.vue
+++ b/frontend/app/components/domains/feedback/FeedbackIssueList.vue
@@ -15,25 +15,30 @@
       {{ errorMessage }}
     </v-alert>
 
-    <v-skeleton-loader
-      v-if="loading && !errorMessage"
-      type="list-item-three-line"
-      class="mb-4"
-      :elevation="2"
-    />
-
-    <div v-if="!loading && !errorMessage && issues.length === 0" class="feedback-issue-list__empty" role="status">
-      <v-icon icon="mdi-emoticon-thought" size="36" color="primary" class="mb-2" />
-      <p class="mb-0">{{ emptyStateLabel }}</p>
-    </div>
-
-    <v-list
-      v-else
-      class="feedback-issue-list__items"
-      bg-color="transparent"
-      role="list"
-      density="comfortable"
+    <div
+      class="feedback-issue-list__content"
+      :aria-busy="loading && !errorMessage"
+      aria-live="polite"
     >
+      <div v-if="loading && !errorMessage" class="feedback-issue-list__loading" role="status">
+        <v-skeleton-loader
+          type="heading, text@2, list-item-three-line@3"
+          class="feedback-issue-list__loading-skeleton"
+        />
+      </div>
+
+      <div v-else-if="issues.length === 0" class="feedback-issue-list__empty" role="status">
+        <v-icon icon="mdi-emoticon-thought" size="36" color="primary" class="mb-2" />
+        <p class="mb-0">{{ emptyStateLabel }}</p>
+      </div>
+
+      <v-list
+        v-else
+        class="feedback-issue-list__items"
+        bg-color="transparent"
+        role="list"
+        density="comfortable"
+      >
       <v-list-item
         v-for="issue in issues"
         :key="issueKey(issue)"
@@ -107,7 +112,8 @@
           </v-btn>
         </template>
       </v-list-item>
-    </v-list>
+      </v-list>
+    </div>
   </section>
 </template>
 
@@ -234,6 +240,21 @@ const handleVote = (issueId: string | undefined) => {
     background-color: rgba(var(--v-theme-surface-glass), 0.6);
     text-align: center;
     color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__content {
+    position: relative;
+    min-height: 12rem;
+  }
+
+  &__loading {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__loading-skeleton {
+    border-radius: 1.5rem;
   }
 
   &__items {

--- a/frontend/app/pages/feedback/index.vue
+++ b/frontend/app/pages/feedback/index.vue
@@ -47,28 +47,38 @@
           <v-window-item v-for="tab in tabs" :key="tab.value" :value="tab.value">
             <v-row class="g-8 mt-8" align="stretch">
               <v-col cols="12" md="6">
-                <FeedbackIssueList
-                  :heading-id="`${tab.value.toLowerCase()}-issues-heading`"
-                  :title="tab.issueTitle"
-                  :description="tab.description"
-                  :issues="issuesByType[tab.value]"
-                  :loading="issueLoadingStates[tab.value]"
-                  :error-message="issueErrorMessages[tab.value]"
-                  :empty-state-label="tab.emptyMessage"
-                  :vote-button-label="t('feedback.voting.voteButton')"
-                  :vote-button-aria-label="t('feedback.voting.voteButtonAria')"
-                  :open-issue-label="t('feedback.voting.openIssue')"
-                  :status-message="voteStatusMessage"
-                  :remaining-votes="remainingVotes"
-                  :can-vote="canVote"
-                  :vote-pending-id="votingIssueId"
-                  :vote-disabled-when-no-votes-message="t('feedback.voting.noVotes')"
-                  :vote-disabled-when-blocked-message="t('feedback.voting.limitReached')"
-                  :issue-icon="tab.icon"
-                  :vote-completed-label="t('feedback.voting.voteCompleted')"
-                  :voted-issue-ids="votedIssueIds"
-                  @vote="(issueId) => handleVote(issueId, tab.value)"
-                />
+                <ClientOnly>
+                  <FeedbackIssueList
+                    :heading-id="`${tab.value.toLowerCase()}-issues-heading`"
+                    :title="tab.issueTitle"
+                    :description="tab.description"
+                    :issues="issuesByType[tab.value]"
+                    :loading="issueLoadingStates[tab.value]"
+                    :error-message="issueErrorMessages[tab.value]"
+                    :empty-state-label="tab.emptyMessage"
+                    :vote-button-label="t('feedback.voting.voteButton')"
+                    :vote-button-aria-label="t('feedback.voting.voteButtonAria')"
+                    :open-issue-label="t('feedback.voting.openIssue')"
+                    :status-message="voteStatusMessage"
+                    :remaining-votes="remainingVotes"
+                    :can-vote="canVote"
+                    :vote-pending-id="votingIssueId"
+                    :vote-disabled-when-no-votes-message="t('feedback.voting.noVotes')"
+                    :vote-disabled-when-blocked-message="t('feedback.voting.limitReached')"
+                    :issue-icon="tab.icon"
+                    :vote-completed-label="t('feedback.voting.voteCompleted')"
+                    :voted-issue-ids="votedIssueIds"
+                    @vote="(issueId) => handleVote(issueId, tab.value)"
+                  />
+
+                  <template #fallback>
+                    <v-skeleton-loader
+                      class="feedback-tabs__issues-fallback"
+                      max-width="420"
+                      type="heading, paragraph, list-item-two-line@3"
+                    />
+                  </template>
+                </ClientOnly>
               </v-col>
 
               <v-col cols="12" md="6">
@@ -222,11 +232,13 @@ const fetchIssues = async (category: FeedbackCategory) => {
 const ideaIssuesData = await useAsyncData<FeedbackIssueDto[]>(
   'feedback-issues-idea',
   () => fetchIssues('IDEA'),
+  { server: false, lazy: true },
 )
 
 const bugIssuesData = await useAsyncData<FeedbackIssueDto[]>(
   'feedback-issues-bug',
   () => fetchIssues('BUG'),
+  { server: false, lazy: true },
 )
 
 const remainingVotesData = await useAsyncData<FeedbackRemainingVotesDto>(
@@ -239,6 +251,7 @@ const remainingVotesData = await useAsyncData<FeedbackRemainingVotesDto>(
       return {}
     }
   },
+  { server: false, lazy: true },
 )
 
 const canVoteData = await useAsyncData<FeedbackVoteEligibilityDto>(
@@ -251,6 +264,7 @@ const canVoteData = await useAsyncData<FeedbackVoteEligibilityDto>(
       return { canVote: true }
     }
   },
+  { server: false, lazy: true },
 )
 
 const issuesByType = computed<Record<FeedbackCategory, FeedbackIssueDisplay[]>>(() => ({
@@ -346,6 +360,32 @@ const handleVote = async (issueId: string | undefined, category: FeedbackCategor
 
     if (!votedIssueIds.value.includes(issueId)) {
       votedIssueIds.value = [...votedIssueIds.value, issueId]
+    }
+
+    const currentRemainingVotes = remainingVotesData.data.value?.remainingVotes
+
+    if (typeof currentRemainingVotes === 'number') {
+      const nextRemainingVotes = Math.max(currentRemainingVotes - 1, 0)
+
+      if (!remainingVotesData.data.value) {
+        remainingVotesData.data.value = { remainingVotes: nextRemainingVotes }
+      } else {
+        remainingVotesData.data.value = {
+          ...remainingVotesData.data.value,
+          remainingVotes: nextRemainingVotes,
+        }
+      }
+
+      if (nextRemainingVotes <= 0) {
+        if (!canVoteData.data.value) {
+          canVoteData.data.value = { canVote: false }
+        } else {
+          canVoteData.data.value = {
+            ...canVoteData.data.value,
+            canVote: false,
+          }
+        }
+      }
     }
 
     if (category === 'IDEA') {
@@ -620,6 +660,11 @@ useHead(() => ({
 
   &__window {
     margin-top: 2.5rem;
+  }
+
+  &__issues-fallback {
+    width: 100%;
+    border-radius: 1rem;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- render the feedback issue lists inside a client-only wrapper with a skeleton fallback so SSR no longer waits on GitHub
- move issue and vote async data fetching to client-only mode and optimistically update remaining votes after casting a vote

## Testing
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68e3d8cfe6d883339f9084263e9d1a2c