### PR TITLE
Fix hydration mismatch on blog pagination info message

### DIFF
--- a/frontend/app/components/domains/blog/TheArticles.vue
+++ b/frontend/app/components/domains/blog/TheArticles.vue
@@ -25,7 +25,7 @@ const buildDateIsoString = (timestamp: number) => {
 const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()
-const currentPage = ref(1)
+const currentPage = computed(() => pagination.value.page || 1)
 const tagsLoading = ref(false)
 const articleListId = 'blog-articles-list'
 
@@ -47,14 +47,6 @@ const parseTagQuery = (rawTag: unknown) => {
 
   return trimmed.length > 0 ? trimmed : null
 }
-
-watch(
-  () => pagination.value.page,
-  (page) => {
-    currentPage.value = page || 1
-  },
-  { immediate: true }
-)
 
 const totalPages = computed(() => pagination.value.totalPages || 0)
 const totalElements = computed(() => pagination.value.totalElements || 0)


### PR DESCRIPTION
## Summary
- derive the current blog page directly from pagination metadata to keep SSR and CSR in sync
- remove the redundant watcher so the pagination helper text hydrates consistently

## Testing
- pnpm lint *(warns about existing vue/no-v-html usage in TextContent.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b81205c883338f9dbc8e0bd03198