### PR TITLE
feat: refresh opendata landing content

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataFaqSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataFaqSection.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import TextContent from '~/components/domains/content/TextContent.vue'
-
 interface FaqItem {
   id: string
   question: string
-  blocId: string
+  answer: string
 }
 
 defineProps<{
@@ -28,7 +26,8 @@ defineProps<{
             <span class="opendata-faq__question">{{ item.question }}</span>
           </v-expansion-panel-title>
           <v-expansion-panel-text>
-            <TextContent :bloc-id="item.blocId" :ipsum-length="240" />
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div class="opendata-faq__answer" v-html="item.answer" />
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -67,6 +66,24 @@ defineProps<{
   font-size: 1.05rem
   font-weight: 600
   color: rgba(var(--v-theme-text-neutral-strong), 0.95)
+
+.opendata-faq__answer
+  font-size: 0.95rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.opendata-faq__answer ul
+  margin: 0.5rem 0 0
+  padding-left: 1.2rem
+  list-style: disc
+
+.opendata-faq__answer li
+  margin-bottom: 0.25rem
+
+.opendata-faq__answer b
+  color: rgba(var(--v-theme-text-neutral-strong), 1)
 
 .v-expansion-panel-text
   background: rgba(var(--v-theme-surface-default), 1)

--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -8,6 +8,7 @@ interface HeroCta {
   variant?: 'flat' | 'outlined' | 'tonal' | 'text' | 'plain'
   color?: string
   appendIcon?: string
+  onClick?: (event: MouseEvent) => void
 }
 
 withDefaults(
@@ -51,6 +52,7 @@ withDefaults(
                 size="large"
                 class="opendata-hero__cta"
                 :append-icon="primaryCta.appendIcon ?? 'mdi-arrow-right'"
+                @click="primaryCta.onClick?.($event)"
               >
                 {{ primaryCta.label }}
               </v-btn>
@@ -64,6 +66,7 @@ withDefaults(
                 size="large"
                 class="opendata-hero__cta"
                 :append-icon="secondaryCta.appendIcon ?? 'mdi-arrow-right'"
+                @click="secondaryCta.onClick?.($event)"
               >
                 {{ secondaryCta.label }}
               </v-btn>

--- a/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
@@ -22,7 +22,7 @@ defineProps<{
               :href="licenseUrl"
               :aria-label="licenseAriaLabel"
               target="_blank"
-              rel="noopener"
+              rel="noopener nofollow"
               color="primary"
               variant="tonal"
               size="large"

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -201,7 +201,7 @@ const downloadOptions = computed(() => {
         ariaLabel: String(t('opendata.datasets.common.download.fast.cta.ariaLabel')),
         href: String(t('opendata.datasets.common.download.fast.cta.href')),
         target: '_blank',
-        rel: 'noopener',
+        rel: 'noopener nofollow',
       },
     },
     {
@@ -254,22 +254,22 @@ const faqItems = computed(() => [
   {
     id: 'what-is-gtin',
     question: String(t('opendata.datasets.gtin.faq.items.whatIs.question')),
-    blocId: 'webpages:opendata:gtin-faq-what-is',
+    answer: String(t('opendata.datasets.gtin.faq.items.whatIs.answer')),
   },
   {
     id: 'structure',
     question: String(t('opendata.datasets.gtin.faq.items.structure.question')),
-    blocId: 'webpages:opendata:gtin-faq-structure',
+    answer: String(t('opendata.datasets.gtin.faq.items.structure.answer')),
   },
   {
     id: 'use-cases',
     question: String(t('opendata.datasets.gtin.faq.items.uses.question')),
-    blocId: 'webpages:opendata:gtin-faq-uses',
+    answer: String(t('opendata.datasets.gtin.faq.items.uses.answer')),
   },
   {
     id: 'contribute',
     question: String(t('opendata.datasets.gtin.faq.items.contribute.question')),
-    blocId: 'webpages:opendata:gtin-faq-contribute',
+    answer: String(t('opendata.datasets.gtin.faq.items.contribute.answer')),
   },
 ])
 

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -200,7 +200,7 @@ const downloadOptions = computed(() => {
         ariaLabel: String(t('opendata.datasets.common.download.fast.cta.ariaLabel')),
         href: String(t('opendata.datasets.common.download.fast.cta.href')),
         target: '_blank',
-        rel: 'noopener',
+        rel: 'noopener nofollow',
       },
     },
     {
@@ -253,22 +253,22 @@ const faqItems = computed(() => [
   {
     id: 'what-is-isbn',
     question: String(t('opendata.datasets.isbn.faq.items.whatIs.question')),
-    blocId: 'webpages:opendata:isbn-faq-what-is',
+    answer: String(t('opendata.datasets.isbn.faq.items.whatIs.answer')),
   },
   {
     id: 'assignment',
     question: String(t('opendata.datasets.isbn.faq.items.assignment.question')),
-    blocId: 'webpages:opendata:isbn-faq-assignment',
+    answer: String(t('opendata.datasets.isbn.faq.items.assignment.answer')),
   },
   {
     id: 'formats',
     question: String(t('opendata.datasets.isbn.faq.items.formats.question')),
-    blocId: 'webpages:opendata:isbn-faq-formats',
+    answer: String(t('opendata.datasets.isbn.faq.items.formats.answer')),
   },
   {
     id: 'importance',
     question: String(t('opendata.datasets.isbn.faq.items.importance.question')),
-    blocId: 'webpages:opendata:isbn-faq-importance',
+    answer: String(t('opendata.datasets.isbn.faq.items.importance.answer')),
   },
 ])
 

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -270,10 +270,6 @@
       "primaryCta": {
         "label": "Explore the datasets",
         "ariaLabel": "Scroll to the open data datasets section"
-      },
-      "secondaryCta": {
-        "label": "View GTIN dataset",
-        "ariaLabel": "Navigate to the GTIN open data dataset page"
       }
     },
     "stats": {
@@ -281,7 +277,8 @@
       "placeholder": "—",
       "totalProducts": {
         "label": "Products covered",
-        "description": "Unique products referenced across all exports."
+        "description": "Unique products referenced across all exports.",
+        "approxMillions": "+ {value} Million"
       },
       "datasets": {
         "label": "Published datasets",
@@ -290,10 +287,6 @@
       "totalSize": {
         "label": "Combined size",
         "description": "Total compressed footprint of weekly exports."
-      },
-      "downloadSpeed": {
-        "label": "Download policy",
-        "description": "Direct downloads limited to {concurrent} concurrent sessions."
       }
     },
     "datasets": {
@@ -456,16 +449,20 @@
           "subtitle": "Understand how to work with the GTIN dataset.",
           "items": {
             "whatIs": {
-              "question": "What is a GTIN and why does it matter?"
+              "question": "What is a GTIN and why does it matter?",
+              "answer": "<p><b>The GTIN (Global Trade Item Number)</b> is the worldwide identifier used to track goods and services. It streamlines inventory management, logistics and commercial transactions across supply chains.</p>"
             },
             "structure": {
-              "question": "What information do you expose for each GTIN?"
+              "question": "What information do you expose for each GTIN?",
+              "answer": "<p>The dataset ships as a zipped CSV file. Key columns include:</p><ul><li>gtin, brand, model, name, last_updated, gs1_country, gtinType</li><li>offers_count, min_price, min_price_compensation, currency</li><li>categories and url</li></ul>"
             },
             "uses": {
-              "question": "How can organisations use this dataset?"
+              "question": "How can organisations use this dataset?",
+              "answer": "<p>E-commerce, data and research teams rely on this dataset to enrich catalogues, detect price gaps, map category taxonomies and feed product matching algorithms.</p>"
             },
             "contribute": {
-              "question": "How can I report an issue or contribute corrections?"
+              "question": "How can I report an issue or contribute corrections?",
+              "answer": "<p>Have GTIN data to share? Reach out to contribute your enrichments or flag corrections so we can keep the open dataset accurate together.</p>"
             }
           }
         }
@@ -576,16 +573,20 @@
           "subtitle": "Key concepts about the ISBN export.",
           "items": {
             "whatIs": {
-              "question": "What is an ISBN?"
+              "question": "What is an ISBN?",
+              "answer": "<p><b>The ISBN (International Standard Book Number)</b> uniquely identifies each edition of a book or related resource. It streamlines distribution, cataloguing and sales tracking.</p>"
             },
             "assignment": {
-              "question": "Who assigns ISBN codes?"
+              "question": "Who assigns ISBN codes?",
+              "answer": "<p>ISBNs are issued by national agencies mandated by the International ISBN Agency. Publishers request one for every new publication or format.</p>"
             },
             "formats": {
-              "question": "What formats are covered in the dataset?"
+              "question": "What formats are covered in the dataset?",
+              "answer": "<p>A single work can carry multiple ISBNs—paperback, hardcover, audiobook or digital. Our dataset links these variants to simplify cross-channel reconciliation.</p>"
             },
             "importance": {
-              "question": "Why is ISBN data valuable for the book industry?"
+              "question": "Why is ISBN data valuable for the book industry?",
+              "answer": "<p>Publishing an open ISBN dataset helps booksellers, libraries, researchers and cultural institutions track catalogues, monitor availability and increase title visibility.</p>"
             }
           }
         }
@@ -605,16 +606,20 @@
       "subtitle": "Understand our approach to open data.",
       "items": {
         "sources": {
-          "question": "Where do the datasets come from?"
+          "question": "Where do the datasets come from?",
+          "answer": "<p>The extracts provided by Nudger come from our product data aggregation work. We combine public sources, merchant catalogues and community contributions to offer the most complete snapshot of the market we can.</p>"
         },
         "definition": {
-          "question": "What do we mean by open data?"
+          "question": "What do we mean by open data?",
+          "answer": "<p>Open data refers to datasets that are accessible to everyone without restrictive licences and published in machine-readable formats. Anyone can reuse, remix and redistribute them, which fosters transparency, innovation and better decision making.</p>"
         },
         "importance": {
-          "question": "Why is open data important for commerce?"
+          "question": "Why is open data important for commerce?",
+          "answer": "<p>Sharing data boosts democratic transparency, sparks new products and services, and improves public decision making. Citizens, researchers, developers and institutions can work together to solve shared challenges by building on these insights.</p>"
         },
         "contributors": {
-          "question": "How can contributors help improve the datasets?"
+          "question": "How can contributors help improve the datasets?",
+          "answer": "<p>Open data comes from many actors: public administrations, international organisations, private companies and engaged communities. Every contribution strengthens the dataset and benefits everyone working toward more responsible consumption.</p>"
         }
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -271,10 +271,6 @@
       "primaryCta": {
         "label": "Découvrir les jeux de données",
         "ariaLabel": "Faire défiler jusqu'à la section des jeux de données open data"
-      },
-      "secondaryCta": {
-        "label": "Voir le dataset GTIN",
-        "ariaLabel": "Aller vers la page open data GTIN"
       }
     },
     "stats": {
@@ -282,7 +278,8 @@
       "placeholder": "—",
       "totalProducts": {
         "label": "Produits couverts",
-        "description": "Produits uniques recensés dans l'ensemble des exports."
+        "description": "Produits uniques recensés dans l'ensemble des exports.",
+        "approxMillions": "+ {value} Millions"
       },
       "datasets": {
         "label": "Jeux de données publiés",
@@ -291,10 +288,6 @@
       "totalSize": {
         "label": "Taille cumulée",
         "description": "Volume compressé total des exports hebdomadaires."
-      },
-      "downloadSpeed": {
-        "label": "Politique de téléchargement",
-        "description": "Téléchargements directs limités à {concurrent} sessions simultanées."
       }
     },
     "datasets": {
@@ -457,16 +450,20 @@
           "subtitle": "Tout savoir sur l'exploitation du dataset GTIN.",
           "items": {
             "whatIs": {
-              "question": "Qu'est-ce qu'un GTIN et à quoi sert-il ?"
+              "question": "Qu'est-ce qu'un GTIN et à quoi sert-il ?",
+              "answer": "<p><b>Le GTIN (Global Trade Item Number)</b> est un identifiant unique utilisé mondialement pour suivre les biens et services. Il facilite la gestion des stocks, la logistique et les transactions commerciales dans toutes les chaînes d’approvisionnement.</p>"
             },
             "structure": {
-              "question": "Quelles informations fournissez-vous pour chaque GTIN ?"
+              "question": "Quelles informations fournissez-vous pour chaque GTIN ?",
+              "answer": "<p>Le fichier est livré en CSV compressé (ZIP). Les principales colonnes incluent&nbsp;:</p><ul><li>gtin, brand, model, name, last_updated, gs1_country, gtinType</li><li>offers_count, min_price, min_price_compensation, currency</li><li>categories et url</li></ul>"
             },
             "uses": {
-              "question": "Comment les organisations peuvent-elles exploiter ce dataset ?"
+              "question": "Comment les organisations peuvent-elles exploiter ce dataset ?",
+              "answer": "<p>Les équipes e-commerce, data et recherche utilisent ce dataset pour enrichir leurs référentiels, détecter les écarts de prix, cartographier les catégories et nourrir leurs algorithmes de correspondance produit.</p>"
             },
             "contribute": {
-              "question": "Comment signaler une erreur ou proposer une correction ?"
+              "question": "Comment signaler une erreur ou proposer une correction ?",
+              "answer": "<p>Vous avez des données GTIN à partager&nbsp;? Contactez-nous pour proposer vos enrichissements ou signaler une correction. Ensemble, nous améliorons la qualité de l’information disponible en open data.</p>"
             }
           }
         }
@@ -577,16 +574,20 @@
           "subtitle": "Les notions essentielles autour de l'export ISBN.",
           "items": {
             "whatIs": {
-              "question": "Qu'est-ce qu'un ISBN ?"
+              "question": "Qu'est-ce qu'un ISBN ?",
+              "answer": "<p><b>L’ISBN (International Standard Book Number)</b> identifie de manière unique chaque édition de livre ou ressource assimilée. Il simplifie la distribution, le référencement bibliographique et le suivi des ventes.</p>"
             },
             "assignment": {
-              "question": "Qui attribue les codes ISBN ?"
+              "question": "Qui attribue les codes ISBN ?",
+              "answer": "<p>Les ISBN sont attribués par des agences nationales mandatées par l’International ISBN Agency. Les éditeurs déposent une demande pour chaque nouvelle publication ou format.</p>"
             },
             "formats": {
-              "question": "Quels formats figurent dans le dataset ?"
+              "question": "Quels formats figurent dans le dataset ?",
+              "answer": "<p>Un même ouvrage peut disposer de plusieurs ISBN&nbsp;: broché, relié, livre audio ou numérique. Notre base regroupe ces versions pour faciliter les rapprochements entre canaux de vente.</p>"
             },
             "importance": {
-              "question": "Pourquoi les données ISBN sont-elles précieuses pour la filière du livre ?"
+              "question": "Pourquoi les données ISBN sont-elles précieuses pour la filière du livre ?",
+              "answer": "<p>Fournir un dataset ISBN ouvert aide les libraires, bibliothèques, chercheurs et acteurs culturels à suivre l’offre éditoriale, mesurer la disponibilité et renforcer la visibilité des ouvrages.</p>"
             }
           }
         }
@@ -606,16 +607,20 @@
       "subtitle": "Comprendre notre approche de l'open data.",
       "items": {
         "sources": {
-          "question": "D'où proviennent les jeux de données ?"
+          "question": "D'où proviennent les jeux de données ?",
+          "answer": "<p>Les extractions fournies par Nudger sont issues de nos travaux d’agrégation de données produits. Nous réunissons les contributions publiques, les catalogues marchands et les enrichissements communautaires pour proposer une vision la plus complète possible du marché.</p>"
         },
         "definition": {
-          "question": "Que signifie pour nous « open data » ?"
+          "question": "Que signifie pour nous « open data » ?",
+          "answer": "<p>L’open data désigne des données rendues accessibles à toutes et tous, sans restriction d’accès, dans des formats librement exploitables. Elles peuvent être réutilisées, modifiées et redistribuées par n’importe qui, favorisant transparence, innovation et efficacité.</p>"
         },
         "importance": {
-          "question": "Pourquoi l'open data est-il important pour le commerce ?"
+          "question": "Pourquoi l'open data est-il important pour le commerce ?",
+          "answer": "<p>Partager les données contribue à la transparence démocratique, stimule l’innovation économique et améliore la prise de décision publique. Citoyens, chercheurs, développeurs et collectivités peuvent travailler ensemble pour résoudre des problèmes communs en s’appuyant sur ces informations.</p>"
         },
         "contributors": {
-          "question": "Comment contribuer à l'amélioration des jeux de données ?"
+          "question": "Comment contribuer à l'amélioration des jeux de données ?",
+          "answer": "<p>Les producteurs de données ouvertes sont variés&nbsp;: administrations publiques, organisations internationales, entreprises privées et communautés engagées. Chaque contribution renforce la qualité globale du dataset et bénéficie à l’ensemble des acteurs de la consommation responsable.</p>"
         }
       }
     },


### PR DESCRIPTION
## Summary
- remove the secondary hero CTA, add smooth scrolling on the primary CTA, drop the download policy stat, and format the product count as a rounded million value
- migrate the opendata, GTIN, and ISBN FAQ answers from CMS blocs to translated strings with inline markup
- add rel="nofollow" to external licence and data.gouv download links to improve SEO hygiene

## Testing
- pnpm lint *(reports existing vue/no-v-html warning in TextContent.vue)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e4bcc2b6fc8333ad85e365afc012ca