### PR TITLE
Adjust opendata hero CTA and metrics display

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -10,21 +10,34 @@ interface HeroCta {
   appendIcon?: string
 }
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     eyebrow?: string
     title: string
     subtitle: string
     descriptionBlocId: string
     primaryCta?: HeroCta
-    secondaryCta?: HeroCta
   }>(),
   {
     eyebrow: undefined,
     primaryCta: undefined,
-    secondaryCta: undefined,
   },
 )
+
+const handlePrimaryClick = (event: MouseEvent) => {
+  const href = props.primaryCta?.href
+  if (!href || !href.startsWith('#')) {
+    return
+  }
+
+  if (import.meta.client) {
+    event.preventDefault()
+    const target = document.querySelector(href)
+    if (target instanceof HTMLElement) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+}
 </script>
 
 <template>
@@ -51,21 +64,9 @@ withDefaults(
                 size="large"
                 class="opendata-hero__cta"
                 :append-icon="primaryCta.appendIcon ?? 'mdi-arrow-right'"
+                @click="handlePrimaryClick"
               >
                 {{ primaryCta.label }}
-              </v-btn>
-
-              <v-btn
-                v-if="secondaryCta"
-                :href="secondaryCta.href"
-                :aria-label="secondaryCta.ariaLabel"
-                :variant="secondaryCta.variant ?? 'tonal'"
-                :color="secondaryCta.color ?? 'primary'"
-                size="large"
-                class="opendata-hero__cta"
-                :append-icon="secondaryCta.appendIcon ?? 'mdi-arrow-right'"
-              >
-                {{ secondaryCta.label }}
               </v-btn>
             </div>
           </v-col>

--- a/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
@@ -22,7 +22,7 @@ defineProps<{
               :href="licenseUrl"
               :aria-label="licenseAriaLabel"
               target="_blank"
-              rel="noopener"
+              rel="noopener nofollow"
               color="primary"
               variant="tonal"
               size="large"

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -201,7 +201,7 @@ const downloadOptions = computed(() => {
         ariaLabel: String(t('opendata.datasets.common.download.fast.cta.ariaLabel')),
         href: String(t('opendata.datasets.common.download.fast.cta.href')),
         target: '_blank',
-        rel: 'noopener',
+        rel: 'noopener nofollow',
       },
     },
     {

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -200,7 +200,7 @@ const downloadOptions = computed(() => {
         ariaLabel: String(t('opendata.datasets.common.download.fast.cta.ariaLabel')),
         href: String(t('opendata.datasets.common.download.fast.cta.href')),
         target: '_blank',
-        rel: 'noopener',
+        rel: 'noopener nofollow',
       },
     },
     {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -270,10 +270,6 @@
       "primaryCta": {
         "label": "Explore the datasets",
         "ariaLabel": "Scroll to the open data datasets section"
-      },
-      "secondaryCta": {
-        "label": "View GTIN dataset",
-        "ariaLabel": "Navigate to the GTIN open data dataset page"
       }
     },
     "stats": {
@@ -281,7 +277,8 @@
       "placeholder": "—",
       "totalProducts": {
         "label": "Products covered",
-        "description": "Unique products referenced across all exports."
+        "description": "Unique products referenced across all exports.",
+        "millions": "+{value} million"
       },
       "datasets": {
         "label": "Published datasets",
@@ -290,10 +287,6 @@
       "totalSize": {
         "label": "Combined size",
         "description": "Total compressed footprint of weekly exports."
-      },
-      "downloadSpeed": {
-        "label": "Download policy",
-        "description": "Direct downloads limited to {concurrent} concurrent sessions."
       }
     },
     "datasets": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -271,10 +271,6 @@
       "primaryCta": {
         "label": "Découvrir les jeux de données",
         "ariaLabel": "Faire défiler jusqu'à la section des jeux de données open data"
-      },
-      "secondaryCta": {
-        "label": "Voir le dataset GTIN",
-        "ariaLabel": "Aller vers la page open data GTIN"
       }
     },
     "stats": {
@@ -282,7 +278,8 @@
       "placeholder": "—",
       "totalProducts": {
         "label": "Produits couverts",
-        "description": "Produits uniques recensés dans l'ensemble des exports."
+        "description": "Produits uniques recensés dans l'ensemble des exports.",
+        "millions": "+{value} millions"
       },
       "datasets": {
         "label": "Jeux de données publiés",
@@ -291,10 +288,6 @@
       "totalSize": {
         "label": "Taille cumulée",
         "description": "Volume compressé total des exports hebdomadaires."
-      },
-      "downloadSpeed": {
-        "label": "Politique de téléchargement",
-        "description": "Téléchargements directs limités à {concurrent} sessions simultanées."
       }
     },
     "datasets": {


### PR DESCRIPTION
## Summary
- remove the opendata hero secondary CTA and add smooth scrolling to the primary button
- display the total product count in millions, drop the download policy stat, and update related translations
- add nofollow to external outbound links across the opendata surfaces

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e4c4680b8c8333ba3d1a3021a3378c