### PR TITLE
feat: refresh opendata dataset layouts and metadata

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
@@ -1,17 +1,10 @@
 <script setup lang="ts">
 import TextContent from '~/components/domains/content/TextContent.vue'
 
-interface HeroStat {
-  label: string
-  value: string
-  icon?: string
-}
-
 defineProps<{
   eyebrow: string
   title: string
   descriptionBlocId: string
-  stats: HeroStat[]
 }>()
 </script>
 
@@ -23,13 +16,6 @@ defineProps<{
           <span class="dataset-hero__eyebrow">{{ eyebrow }}</span>
           <h1 id="dataset-hero-heading" class="dataset-hero__title">{{ title }}</h1>
           <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
-        </div>
-        <div class="dataset-hero__stats" role="list">
-          <div v-for="stat in stats" :key="stat.label" class="dataset-hero__stat" role="listitem">
-            <v-icon v-if="stat.icon" :icon="stat.icon" class="dataset-hero__stat-icon" size="28" />
-            <p class="dataset-hero__stat-value">{{ stat.value }}</p>
-            <p class="dataset-hero__stat-label">{{ stat.label }}</p>
-          </div>
         </div>
       </div>
     </v-container>
@@ -43,14 +29,17 @@ defineProps<{
   color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
 
 .dataset-hero__surface
-  display: grid
-  gap: clamp(1.75rem, 4vw, 3rem)
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: clamp(1.5rem, 3vw, 2.5rem)
 
 .dataset-hero__text
   display: flex
   flex-direction: column
   gap: 1rem
+  width: 100%
+  max-width: 760px
 
 .dataset-hero__eyebrow
   display: inline-flex
@@ -66,32 +55,5 @@ defineProps<{
   margin: 0
   font-size: clamp(2.25rem, 4.5vw, 3.25rem)
   line-height: 1.15
-
-.dataset-hero__stats
-  display: grid
-  gap: clamp(1rem, 2vw, 1.5rem)
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))
-
-.dataset-hero__stat
-  padding: 1.5rem
-  border-radius: 18px
-  background: rgba(var(--v-theme-hero-overlay-soft), 0.12)
-  border: 1px solid rgba(var(--v-theme-hero-overlay-soft), 0.25)
-  display: flex
-  flex-direction: column
-  gap: 0.5rem
-
-.dataset-hero__stat-icon
-  color: rgba(var(--v-theme-hero-overlay-soft), 0.95)
-
-.dataset-hero__stat-value
-  margin: 0
-  font-size: 1.5rem
-  font-weight: 700
-
-.dataset-hero__stat-label
-  margin: 0
-  font-size: 0.95rem
-  color: rgba(var(--v-theme-hero-overlay-soft), 0.85)
 </style>
 

--- a/frontend/app/components/domains/opendata/OpendataDatasetHighlights.vue
+++ b/frontend/app/components/domains/opendata/OpendataDatasetHighlights.vue
@@ -30,13 +30,13 @@ defineProps<{
         <p v-if="subtitle" class="opendata-datasets__subtitle">{{ subtitle }}</p>
       </div>
 
-      <v-row class="g-6" align="stretch">
+      <v-row class="g-6" align="stretch" justify="center">
         <v-col
           v-for="card in cards"
           :key="card.id"
           cols="12"
           md="6"
-          class="d-flex"
+          class="d-flex justify-center"
         >
           <v-card class="opendata-dataset-card" rounded="xl" elevation="6">
             <div class="opendata-dataset-card__icon" aria-hidden="true">
@@ -99,6 +99,7 @@ defineProps<{
   padding: clamp(1.75rem, 4vw, 2.5rem)
   background: linear-gradient(160deg, rgba(var(--v-theme-surface-primary-080), 0.8), rgba(var(--v-theme-surface-default), 1))
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
+  width: 100%
 
 .opendata-dataset-card__icon
   display: inline-flex

--- a/frontend/app/components/domains/opendata/OpendataDownloadComparison.vue
+++ b/frontend/app/components/domains/opendata/OpendataDownloadComparison.vue
@@ -39,13 +39,13 @@ defineProps<{
         <p v-if="subtitle" class="dataset-download__subtitle">{{ subtitle }}</p>
       </div>
 
-      <v-row class="g-6" align="stretch">
+      <v-row class="g-6" align="stretch" justify="center">
         <v-col
           v-for="option in options"
           :key="option.id"
           cols="12"
           md="6"
-          class="d-flex"
+          class="d-flex justify-center"
         >
           <v-card class="dataset-download__card" rounded="xl" elevation="4">
             <div v-if="option.badge" class="dataset-download__badge">{{ option.badge }}</div>
@@ -110,6 +110,7 @@ defineProps<{
   padding: clamp(1.75rem, 4vw, 2.75rem)
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
   background: rgba(var(--v-theme-surface-primary-050), 0.9)
+  width: 100%
 
 .dataset-download__badge
   align-self: flex-start

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -1,23 +1,9 @@
 <template>
   <div class="dataset-page">
-    <nav class="dataset-page__breadcrumb" aria-label="Breadcrumb">
-      <ol>
-        <li>
-          <NuxtLink :to="localePath('opendata')">
-            {{ t('opendata.datasets.gtin.breadcrumb.root') }}
-          </NuxtLink>
-        </li>
-        <li aria-current="page">
-          {{ t('opendata.datasets.gtin.breadcrumb.current') }}
-        </li>
-      </ol>
-    </nav>
-
     <OpendataDatasetHero
       :eyebrow="t('opendata.datasets.gtin.hero.eyebrow')"
       :title="t('opendata.datasets.gtin.hero.title')"
       description-bloc-id="webpages:opendata:gtin-hero-overview"
-      :stats="heroStats"
     />
 
     <v-progress-linear
@@ -118,7 +104,6 @@ definePageMeta({
 })
 
 const { t, locale } = useI18n()
-const localePath = useLocalePath()
 const requestURL = useRequestURL()
 
 interface DatasetPayload {
@@ -139,24 +124,6 @@ const dataset = computed(() => data.value?.dataset)
 const overview = computed(() => data.value?.overview)
 
 const placeholder = computed(() => String(t('opendata.datasets.common.placeholder')))
-
-const heroStats = computed(() => [
-  {
-    label: String(t('opendata.datasets.gtin.hero.stats.records')),
-    value: dataset.value?.recordCount ?? placeholder.value,
-    icon: 'mdi-format-list-numbered',
-  },
-  {
-    label: String(t('opendata.datasets.gtin.hero.stats.updated')),
-    value: dataset.value?.lastUpdated ?? placeholder.value,
-    icon: 'mdi-update',
-  },
-  {
-    label: String(t('opendata.datasets.gtin.hero.stats.size')),
-    value: dataset.value?.fileSize ?? placeholder.value,
-    icon: 'mdi-archive-outline',
-  },
-])
 
 const summaryItems = computed(() => [
   {
@@ -300,25 +267,6 @@ useHead(() => ({
   display: flex
   flex-direction: column
   gap: 0
-
-.dataset-page__breadcrumb
-  padding: 1.5rem 1rem 0
-
-.dataset-page__breadcrumb ol
-  display: flex
-  flex-wrap: wrap
-  gap: 0.5rem
-  list-style: none
-  margin: 0
-  padding: 0
-  font-size: 0.95rem
-
-.dataset-page__breadcrumb a
-  color: rgba(var(--v-theme-primary), 1)
-  text-decoration: none
-
-.dataset-page__breadcrumb li[aria-current='page']
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
 
 .dataset-page__loader
   margin: 0

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -1,23 +1,9 @@
 <template>
   <div class="dataset-page">
-    <nav class="dataset-page__breadcrumb" aria-label="Breadcrumb">
-      <ol>
-        <li>
-          <NuxtLink :to="localePath('opendata')">
-            {{ t('opendata.datasets.isbn.breadcrumb.root') }}
-          </NuxtLink>
-        </li>
-        <li aria-current="page">
-          {{ t('opendata.datasets.isbn.breadcrumb.current') }}
-        </li>
-      </ol>
-    </nav>
-
     <OpendataDatasetHero
       :eyebrow="t('opendata.datasets.isbn.hero.eyebrow')"
       :title="t('opendata.datasets.isbn.hero.title')"
       description-bloc-id="webpages:opendata:isbn-hero-overview"
-      :stats="heroStats"
     />
 
     <v-progress-linear
@@ -118,7 +104,6 @@ definePageMeta({
 })
 
 const { t, locale } = useI18n()
-const localePath = useLocalePath()
 const requestURL = useRequestURL()
 
 interface DatasetPayload {
@@ -138,24 +123,6 @@ const { data, pending, error, refresh } = await useAsyncData<DatasetPayload>('op
 const dataset = computed(() => data.value?.dataset)
 const overview = computed(() => data.value?.overview)
 const placeholder = computed(() => String(t('opendata.datasets.common.placeholder')))
-
-const heroStats = computed(() => [
-  {
-    label: String(t('opendata.datasets.isbn.hero.stats.records')),
-    value: dataset.value?.recordCount ?? placeholder.value,
-    icon: 'mdi-book-multiple-outline',
-  },
-  {
-    label: String(t('opendata.datasets.isbn.hero.stats.updated')),
-    value: dataset.value?.lastUpdated ?? placeholder.value,
-    icon: 'mdi-update',
-  },
-  {
-    label: String(t('opendata.datasets.isbn.hero.stats.size')),
-    value: dataset.value?.fileSize ?? placeholder.value,
-    icon: 'mdi-archive-outline',
-  },
-])
 
 const summaryItems = computed(() => [
   {
@@ -299,25 +266,6 @@ useHead(() => ({
   display: flex
   flex-direction: column
   gap: 0
-
-.dataset-page__breadcrumb
-  padding: 1.5rem 1rem 0
-
-.dataset-page__breadcrumb ol
-  display: flex
-  flex-wrap: wrap
-  gap: 0.5rem
-  list-style: none
-  margin: 0
-  padding: 0
-  font-size: 0.95rem
-
-.dataset-page__breadcrumb a
-  color: rgba(var(--v-theme-primary), 1)
-  text-decoration: none
-
-.dataset-page__breadcrumb li[aria-current='page']
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
 
 .dataset-page__loader
   margin: 0

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -361,9 +361,9 @@
         }
       },
       "gtin": {
-        "breadcrumb": {
-          "root": "Open data",
-          "current": "GTIN dataset"
+        "seo": {
+          "title": "GTIN open data – download the barcode catalogue",
+          "description": "Access Nudger's GTIN dataset with weekly updates, download options and schema details for your barcode data projects."
         },
         "hero": {
           "eyebrow": "GTIN export",
@@ -469,9 +469,9 @@
         }
       },
       "isbn": {
-        "breadcrumb": {
-          "root": "Open data",
-          "current": "ISBN dataset"
+        "seo": {
+          "title": "ISBN open data – download the book metadata export",
+          "description": "Retrieve Nudger's ISBN dataset with weekly refreshes, download mirrors and schema information for publishing analytics."
         },
         "hero": {
           "eyebrow": "ISBN export",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -362,9 +362,9 @@
         }
       },
       "gtin": {
-        "breadcrumb": {
-          "root": "Open data",
-          "current": "Dataset GTIN"
+        "seo": {
+          "title": "Données ouvertes GTIN – télécharger le catalogue de codes-barres",
+          "description": "Accédez à la base GTIN de Nudger, mise à jour chaque semaine, avec les options de téléchargement et le schéma détaillé pour vos projets data sur les codes-barres."
         },
         "hero": {
           "eyebrow": "Export GTIN",
@@ -470,9 +470,9 @@
         }
       },
       "isbn": {
-        "breadcrumb": {
-          "root": "Open data",
-          "current": "Dataset ISBN"
+        "seo": {
+          "title": "Données ouvertes ISBN – télécharger l'export de métadonnées livres",
+          "description": "Téléchargez la base ISBN de Nudger, actualisée chaque semaine, avec les miroirs de téléchargement et le schéma détaillé pour vos analyses du secteur du livre."
         },
         "hero": {
           "eyebrow": "Export ISBN",


### PR DESCRIPTION
## Summary
- center the opendata dataset highlight and download cards for consistent layouts
- simplify the dataset hero sections and drop breadcrumbs on the GTIN/ISBN pages
- add the missing GTIN/ISBN SEO translations in both English and French bundles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e606752a34833398ce8c5d356850cd