### PR TITLE
Improve SSR coverage and licensing on opendata dataset pages

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
@@ -31,7 +31,7 @@ defineProps<{
 .dataset-hero__surface
   display: flex
   flex-direction: column
-  align-items: center
+  align-items: stretch
   gap: clamp(1.5rem, 3vw, 2.5rem)
 
 .dataset-hero__text
@@ -39,7 +39,6 @@ defineProps<{
   flex-direction: column
   gap: 1rem
   width: 100%
-  max-width: 760px
 
 .dataset-hero__eyebrow
   display: inline-flex

--- a/frontend/app/components/domains/opendata/OpendataFaqSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataFaqSection.vue
@@ -23,7 +23,7 @@ defineProps<{
       </div>
 
       <v-expansion-panels variant="accordion" class="opendata-faq__panels">
-        <v-expansion-panel v-for="item in items" :key="item.id">
+        <v-expansion-panel v-for="item in items" :key="item.id" eager>
           <v-expansion-panel-title expand-icon="mdi-chevron-down">
             <span class="opendata-faq__question">{{ item.question }}</span>
           </v-expansion-panel-title>

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -34,12 +34,6 @@
       :items="summaryItems"
     />
 
-    <OpendataDownloadComparison
-      :title="t('opendata.datasets.gtin.download.title')"
-      :subtitle="t('opendata.datasets.gtin.download.subtitle')"
-      :options="downloadOptions"
-    />
-
     <section class="dataset-format" aria-labelledby="dataset-format-heading">
       <v-container max-width="lg">
         <div class="dataset-format__card">
@@ -79,6 +73,13 @@
         </v-table>
       </v-container>
     </section>
+
+
+    <OpendataDownloadComparison
+      :title="t('opendata.datasets.gtin.download.title')"
+      :subtitle="t('opendata.datasets.gtin.download.subtitle')"
+      :options="downloadOptions"
+    />
 
     <OpendataLicenseSection
       :title="t('opendata.license.title')"

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -80,6 +80,14 @@
       </v-container>
     </section>
 
+    <OpendataLicenseSection
+      :title="t('opendata.license.title')"
+      :description="t('opendata.license.description')"
+      :license-label="t('opendata.license.cta.label')"
+      :license-aria-label="t('opendata.license.cta.ariaLabel')"
+      :license-url="t('opendata.license.cta.href')"
+    />
+
     <OpendataFaqSection
       :title="t('opendata.datasets.gtin.faq.title')"
       :subtitle="t('opendata.datasets.gtin.faq.subtitle')"
@@ -98,6 +106,7 @@ import OpendataDatasetHero from '~/components/domains/opendata/OpendataDatasetHe
 import OpendataDatasetSummary from '~/components/domains/opendata/OpendataDatasetSummary.vue'
 import OpendataDownloadComparison from '~/components/domains/opendata/OpendataDownloadComparison.vue'
 import OpendataFaqSection from '~/components/domains/opendata/OpendataFaqSection.vue'
+import OpendataLicenseSection from '~/components/domains/opendata/OpendataLicenseSection.vue'
 
 definePageMeta({
   ssr: true,

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -34,11 +34,6 @@
       :items="summaryItems"
     />
 
-    <OpendataDownloadComparison
-      :title="t('opendata.datasets.isbn.download.title')"
-      :subtitle="t('opendata.datasets.isbn.download.subtitle')"
-      :options="downloadOptions"
-    />
 
     <section class="dataset-format" aria-labelledby="dataset-format-heading">
       <v-container max-width="lg">
@@ -79,6 +74,12 @@
         </v-table>
       </v-container>
     </section>
+
+    <OpendataDownloadComparison
+      :title="t('opendata.datasets.isbn.download.title')"
+      :subtitle="t('opendata.datasets.isbn.download.subtitle')"
+      :options="downloadOptions"
+    />
 
     <OpendataLicenseSection
       :title="t('opendata.license.title')"

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -80,6 +80,14 @@
       </v-container>
     </section>
 
+    <OpendataLicenseSection
+      :title="t('opendata.license.title')"
+      :description="t('opendata.license.description')"
+      :license-label="t('opendata.license.cta.label')"
+      :license-aria-label="t('opendata.license.cta.ariaLabel')"
+      :license-url="t('opendata.license.cta.href')"
+    />
+
     <OpendataFaqSection
       :title="t('opendata.datasets.isbn.faq.title')"
       :subtitle="t('opendata.datasets.isbn.faq.subtitle')"
@@ -98,6 +106,7 @@ import OpendataDatasetHero from '~/components/domains/opendata/OpendataDatasetHe
 import OpendataDatasetSummary from '~/components/domains/opendata/OpendataDatasetSummary.vue'
 import OpendataDownloadComparison from '~/components/domains/opendata/OpendataDownloadComparison.vue'
 import OpendataFaqSection from '~/components/domains/opendata/OpendataFaqSection.vue'
+import OpendataLicenseSection from '~/components/domains/opendata/OpendataLicenseSection.vue'
 
 definePageMeta({
   ssr: true,

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -368,7 +368,7 @@
         },
         "hero": {
           "eyebrow": "Export GTIN",
-          "title": "Données codes-barres pour les biens de consommation",
+          "title": "Base de données de codes-barres",
           "stats": {
             "records": "Produits",
             "updated": "Dernière mise à jour",
@@ -476,7 +476,7 @@
         },
         "hero": {
           "eyebrow": "Export ISBN",
-          "title": "Métadonnées complètes pour les livres",
+          "title": "Base de données livres (ISBN)",
           "stats": {
             "records": "Publications",
             "updated": "Dernière mise à jour",

--- a/frontend/shared/api-client/models/PageProductDto.ts
+++ b/frontend/shared/api-client/models/PageProductDto.ts
@@ -79,18 +79,6 @@ export interface PageProductDto {
     sort?: SortObject;
     /**
      * 
-     * @type {number}
-     * @memberof PageProductDto
-     */
-    numberOfElements?: number;
-    /**
-     * 
-     * @type {PageableObject}
-     * @memberof PageProductDto
-     */
-    pageable?: PageableObject;
-    /**
-     * 
      * @type {boolean}
      * @memberof PageProductDto
      */
@@ -101,6 +89,18 @@ export interface PageProductDto {
      * @memberof PageProductDto
      */
     last?: boolean;
+    /**
+     * 
+     * @type {PageableObject}
+     * @memberof PageProductDto
+     */
+    pageable?: PageableObject;
+    /**
+     * 
+     * @type {number}
+     * @memberof PageProductDto
+     */
+    numberOfElements?: number;
     /**
      * 
      * @type {boolean}
@@ -132,10 +132,10 @@ export function PageProductDtoFromJSONTyped(json: any, ignoreDiscriminator: bool
         'content': json['content'] == null ? undefined : ((json['content'] as Array<any>).map(ProductDtoFromJSON)),
         'number': json['number'] == null ? undefined : json['number'],
         'sort': json['sort'] == null ? undefined : SortObjectFromJSON(json['sort']),
-        'numberOfElements': json['numberOfElements'] == null ? undefined : json['numberOfElements'],
-        'pageable': json['pageable'] == null ? undefined : PageableObjectFromJSON(json['pageable']),
         'first': json['first'] == null ? undefined : json['first'],
         'last': json['last'] == null ? undefined : json['last'],
+        'pageable': json['pageable'] == null ? undefined : PageableObjectFromJSON(json['pageable']),
+        'numberOfElements': json['numberOfElements'] == null ? undefined : json['numberOfElements'],
         'empty': json['empty'] == null ? undefined : json['empty'],
     };
 }
@@ -157,10 +157,10 @@ export function PageProductDtoToJSONTyped(value?: PageProductDto | null, ignoreD
         'content': value['content'] == null ? undefined : ((value['content'] as Array<any>).map(ProductDtoToJSON)),
         'number': value['number'],
         'sort': SortObjectToJSON(value['sort']),
-        'numberOfElements': value['numberOfElements'],
-        'pageable': PageableObjectToJSON(value['pageable']),
         'first': value['first'],
         'last': value['last'],
+        'pageable': PageableObjectToJSON(value['pageable']),
+        'numberOfElements': value['numberOfElements'],
         'empty': value['empty'],
     };
 }


### PR DESCRIPTION
## Summary
- render FAQ text blocks server-side by eager mounting the expansion panels
- widen dataset hero copy to span the full container width
- add the shared open data license callout to the GTIN and ISBN dataset pages

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e60c0220a8833384a0f84230e324e8