### PR TITLE
feat(frontend): localize opendata faqs and add breadcrumb

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataDatasetHero.vue
@@ -5,6 +5,11 @@ defineProps<{
   eyebrow: string
   title: string
   descriptionBlocId: string
+  breadcrumb?: {
+    label: string
+    href: string
+    ariaLabel?: string
+  }
 }>()
 </script>
 
@@ -13,7 +18,17 @@ defineProps<{
     <v-container max-width="lg" class="py-12">
       <div class="dataset-hero__surface">
         <div class="dataset-hero__text">
-          <span class="dataset-hero__eyebrow">{{ eyebrow }}</span>
+          <div class="dataset-hero__meta-row">
+            <NuxtLink
+              v-if="breadcrumb"
+              :to="breadcrumb.href"
+              :aria-label="breadcrumb.ariaLabel ?? breadcrumb.label"
+              class="dataset-hero__breadcrumb"
+            >
+              {{ breadcrumb.label }}
+            </NuxtLink>
+            <span class="dataset-hero__eyebrow">{{ eyebrow }}</span>
+          </div>
           <h1 id="dataset-hero-heading" class="dataset-hero__title">{{ title }}</h1>
           <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
         </div>
@@ -39,6 +54,30 @@ defineProps<{
   flex-direction: column
   gap: 1rem
   width: 100%
+
+.dataset-hero__meta-row
+  display: flex
+  gap: 0.5rem
+  align-items: center
+  flex-wrap: wrap
+
+.dataset-hero__breadcrumb
+  display: inline-flex
+  align-items: center
+  padding: 0.35rem 0.9rem
+  border-radius: 999px
+  background: rgba(var(--v-theme-hero-overlay-soft), 0.32)
+  font-size: 0.85rem
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-hero-pill-on-dark), 1)
+  text-decoration: none
+  transition: background-color 0.2s ease, color 0.2s ease
+
+.dataset-hero__breadcrumb:hover,
+.dataset-hero__breadcrumb:focus-visible
+  background: rgba(var(--v-theme-hero-overlay-soft), 0.48)
+  color: rgba(var(--v-theme-hero-pill-on-dark), 1)
 
 .dataset-hero__eyebrow
   display: inline-flex

--- a/frontend/app/components/domains/opendata/OpendataFaqSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataFaqSection.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
-import TextContent from '~/components/domains/content/TextContent.vue'
-
 interface FaqItem {
   id: string
   question: string
-  blocId: string
+  answer: string
 }
 
 defineProps<{
@@ -28,7 +26,8 @@ defineProps<{
             <span class="opendata-faq__question">{{ item.question }}</span>
           </v-expansion-panel-title>
           <v-expansion-panel-text>
-            <TextContent :bloc-id="item.blocId" :ipsum-length="240" />
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div class="opendata-faq__answer" v-html="item.answer" />
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
@@ -67,6 +66,27 @@ defineProps<{
   font-size: 1.05rem
   font-weight: 600
   color: rgba(var(--v-theme-text-neutral-strong), 0.95)
+
+.opendata-faq__answer :deep(p)
+  margin: 0 0 1rem
+  font-size: 0.95rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.opendata-faq__answer :deep(p:last-child)
+  margin-bottom: 0
+
+.opendata-faq__answer :deep(ul)
+  margin: 0 0 1rem 1.25rem
+  padding: 0
+  list-style: disc
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.opendata-faq__answer :deep(li)
+  margin-bottom: 0.5rem
+  font-size: 0.95rem
+
+.opendata-faq__answer :deep(li:last-child)
+  margin-bottom: 0
 
 .v-expansion-panel-text
   background: rgba(var(--v-theme-surface-default), 1)

--- a/frontend/app/components/domains/team/TeamHero.vue
+++ b/frontend/app/components/domains/team/TeamHero.vue
@@ -26,6 +26,10 @@ const headingId = useId()
         <h1 :id="headingId" class="team-hero__title">{{ props.title }}</h1>
         <p class="team-hero__subtitle">{{ props.subtitle }}</p>
 
+        <div class="team-hero__content">
+          <TextContent :bloc-id="props.descriptionBlocId" :ipsum-length="220" />
+        </div>
+
 
       </div>
     </v-container>

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -4,6 +4,11 @@
       :eyebrow="t('opendata.datasets.gtin.hero.eyebrow')"
       :title="t('opendata.datasets.gtin.hero.title')"
       description-bloc-id="webpages:opendata:gtin-hero-overview"
+      :breadcrumb="{
+        label: String(t('opendata.datasets.common.breadcrumb.label')),
+        ariaLabel: String(t('opendata.datasets.common.breadcrumb.ariaLabel')),
+        href: localePath('opendata'),
+      }"
     />
 
     <v-progress-linear
@@ -114,6 +119,7 @@ definePageMeta({
 })
 
 const { t, locale } = useI18n()
+const localePath = useLocalePath()
 const requestURL = useRequestURL()
 
 interface DatasetPayload {
@@ -231,22 +237,32 @@ const faqItems = computed(() => [
   {
     id: 'what-is-gtin',
     question: String(t('opendata.datasets.gtin.faq.items.whatIs.question')),
-    blocId: 'webpages:opendata:gtin-faq-what-is',
+    answer: String(t('opendata.datasets.gtin.faq.items.whatIs.answer')),
   },
   {
-    id: 'structure',
-    question: String(t('opendata.datasets.gtin.faq.items.structure.question')),
-    blocId: 'webpages:opendata:gtin-faq-structure',
+    id: 'difference-ean',
+    question: String(t('opendata.datasets.gtin.faq.items.differenceEan.question')),
+    answer: String(t('opendata.datasets.gtin.faq.items.differenceEan.answer')),
   },
   {
-    id: 'use-cases',
-    question: String(t('opendata.datasets.gtin.faq.items.uses.question')),
-    blocId: 'webpages:opendata:gtin-faq-uses',
+    id: 'formats',
+    question: String(t('opendata.datasets.gtin.faq.items.formats.question')),
+    answer: String(t('opendata.datasets.gtin.faq.items.formats.answer')),
   },
   {
-    id: 'contribute',
-    question: String(t('opendata.datasets.gtin.faq.items.contribute.question')),
-    blocId: 'webpages:opendata:gtin-faq-contribute',
+    id: 'difference-upc',
+    question: String(t('opendata.datasets.gtin.faq.items.differenceUpc.question')),
+    answer: String(t('opendata.datasets.gtin.faq.items.differenceUpc.answer')),
+  },
+  {
+    id: 'ean-13',
+    question: String(t('opendata.datasets.gtin.faq.items.ean13.question')),
+    answer: String(t('opendata.datasets.gtin.faq.items.ean13.answer')),
+  },
+  {
+    id: 'logistics',
+    question: String(t('opendata.datasets.gtin.faq.items.logistics.question')),
+    answer: String(t('opendata.datasets.gtin.faq.items.logistics.answer')),
   },
 ])
 

--- a/frontend/app/pages/opendata/index.vue
+++ b/frontend/app/pages/opendata/index.vue
@@ -187,22 +187,22 @@ const faqItems = computed(() => [
   {
     id: 'sources',
     question: String(t('opendata.faq.items.sources.question')),
-    blocId: 'webpages:opendata:faq-sources',
+    answer: String(t('opendata.faq.items.sources.answer')),
   },
   {
     id: 'definition',
     question: String(t('opendata.faq.items.definition.question')),
-    blocId: 'webpages:opendata:faq-definition',
+    answer: String(t('opendata.faq.items.definition.answer')),
   },
   {
     id: 'importance',
     question: String(t('opendata.faq.items.importance.question')),
-    blocId: 'webpages:opendata:faq-importance',
+    answer: String(t('opendata.faq.items.importance.answer')),
   },
   {
     id: 'contributors',
     question: String(t('opendata.faq.items.contributors.question')),
-    blocId: 'webpages:opendata:faq-contributors',
+    answer: String(t('opendata.faq.items.contributors.answer')),
   },
 ])
 

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -4,6 +4,11 @@
       :eyebrow="t('opendata.datasets.isbn.hero.eyebrow')"
       :title="t('opendata.datasets.isbn.hero.title')"
       description-bloc-id="webpages:opendata:isbn-hero-overview"
+      :breadcrumb="{
+        label: String(t('opendata.datasets.common.breadcrumb.label')),
+        ariaLabel: String(t('opendata.datasets.common.breadcrumb.ariaLabel')),
+        href: localePath('opendata'),
+      }"
     />
 
     <v-progress-linear
@@ -114,6 +119,7 @@ definePageMeta({
 })
 
 const { t, locale } = useI18n()
+const localePath = useLocalePath()
 const requestURL = useRequestURL()
 
 interface DatasetPayload {
@@ -230,22 +236,37 @@ const faqItems = computed(() => [
   {
     id: 'what-is-isbn',
     question: String(t('opendata.datasets.isbn.faq.items.whatIs.question')),
-    blocId: 'webpages:opendata:isbn-faq-what-is',
+    answer: String(t('opendata.datasets.isbn.faq.items.whatIs.answer')),
+  },
+  {
+    id: 'meaning',
+    question: String(t('opendata.datasets.isbn.faq.items.meaning.question')),
+    answer: String(t('opendata.datasets.isbn.faq.items.meaning.answer')),
+  },
+  {
+    id: 'structure',
+    question: String(t('opendata.datasets.isbn.faq.items.structure.question')),
+    answer: String(t('opendata.datasets.isbn.faq.items.structure.answer')),
+  },
+  {
+    id: 'difference',
+    question: String(t('opendata.datasets.isbn.faq.items.difference.question')),
+    answer: String(t('opendata.datasets.isbn.faq.items.difference.answer')),
   },
   {
     id: 'assignment',
     question: String(t('opendata.datasets.isbn.faq.items.assignment.question')),
-    blocId: 'webpages:opendata:isbn-faq-assignment',
-  },
-  {
-    id: 'formats',
-    question: String(t('opendata.datasets.isbn.faq.items.formats.question')),
-    blocId: 'webpages:opendata:isbn-faq-formats',
+    answer: String(t('opendata.datasets.isbn.faq.items.assignment.answer')),
   },
   {
     id: 'importance',
     question: String(t('opendata.datasets.isbn.faq.items.importance.question')),
-    blocId: 'webpages:opendata:isbn-faq-importance',
+    answer: String(t('opendata.datasets.isbn.faq.items.importance.answer')),
+  },
+  {
+    id: 'non-book',
+    question: String(t('opendata.datasets.isbn.faq.items.nonBook.question')),
+    answer: String(t('opendata.datasets.isbn.faq.items.nonBook.answer')),
   },
 ])
 

--- a/frontend/i18n.config.ts
+++ b/frontend/i18n.config.ts
@@ -5,4 +5,5 @@ export default defineI18nConfig(() => ({
   availableLocales: ['en-US', 'fr-FR'],
   missingWarn: false,
   fallbackWarn: false,
+  warnHtmlMessage: false
 }))

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -327,6 +327,10 @@
       },
       "common": {
         "placeholder": "—",
+        "breadcrumb": {
+          "label": "opendata",
+          "ariaLabel": "Back to the open data overview"
+        },
         "summary": {
           "records": "Total records",
           "updated": "Last updated",
@@ -454,16 +458,28 @@
           "subtitle": "Understand how to work with the GTIN dataset.",
           "items": {
             "whatIs": {
-              "question": "What is a GTIN and why does it matter?"
+              "question": "What is a GTIN and why does it matter?",
+              "answer": "<p><strong>The GTIN (Global Trade Item Number)</strong> is a unique identifier used to recognise products worldwide. It comes in several formats (GTIN-12, GTIN-13, GTIN-14), each tailored to specific product types or regions. For example, GTIN-13 is commonly used in Europe, while GTIN-12 is more frequent in North America. Every GTIN ensures a product can be tracked, identified and catalogued anywhere in the world, enabling efficient stock and sales management.</p>"
             },
-            "structure": {
-              "question": "What information do you expose for each GTIN?"
+            "differenceEan": {
+              "question": "What is the difference between GTIN and EAN?",
+              "answer": "<p><strong>The EAN (European Article Number)</strong> used to be the standard identifier in Europe for marking products. Today the term GTIN has replaced EAN to standardise product codes globally. The EAN-13 is now a GTIN-13. In practice the change is mainly a matter of naming and the code structure remains the same. GTIN also covers other identifiers such as the UPC (Universal Product Code) used in North America.</p>"
             },
-            "uses": {
-              "question": "How can organisations use this dataset?"
+            "formats": {
+              "question": "What are the different GTIN formats?",
+              "answer": "<p><strong>The main GTIN formats</strong> are: GTIN-12 (commonly used in the United States and Canada under the name UPC), GTIN-13 (most common in Europe) and GTIN-14 (for logistic units). These different formats meet the specific needs of each region and supply chain. GTIN-14 is generally used to identify larger logistic units, such as cartons or pallets, rather than single items.</p>"
             },
-            "contribute": {
-              "question": "How can I report an issue or contribute corrections?"
+            "differenceUpc": {
+              "question": "What is the difference between GTIN and UPC?",
+              "answer": "<p><strong>The UPC (Universal Product Code)</strong> is a form of GTIN-12 mainly used in North America. The difference between GTIN and UPC is mostly regional usage: GTIN is the broader global term, while UPC refers to a specific code used in a North American context. Both systems are interoperable and, within the GTIN standard, UPC is recognised as a sub-category.</p>"
+            },
+            "ean13": {
+              "question": "What is the EAN-13 format?",
+              "answer": "<p><strong>The EAN-13</strong> is a barcode made up of 13 digits that identifies products internationally, mainly in Europe. EAN-13 is also called GTIN-13 and is widely used at points of sale to scan and track items. It includes a country prefix, a company code, a product code and a check digit that ensures the code is valid.</p>"
+            },
+            "logistics": {
+              "question": "How is GTIN used in logistics?",
+              "answer": "<p><strong>GTIN in logistics</strong> plays an essential role in identifying products across supply chains. For example, the GTIN-14 format makes it possible to identify shipping units such as cartons or pallets, which simplifies stock management and shipping operations. Using GTIN barcodes in logistics allows precise traceability of products throughout their lifecycle, from manufacturer to distributor.</p>"
             }
           }
         }
@@ -574,16 +590,32 @@
           "subtitle": "Key concepts about the ISBN export.",
           "items": {
             "whatIs": {
-              "question": "What is an ISBN?"
+              "question": "What is an ISBN?",
+              "answer": "<p>An ISBN (International Standard Book Number) is a unique number that identifies a book worldwide. It is essential for publishers, booksellers, libraries and any platform selling books. ISBNs make it easier to manage inventory, distribution and sales. Each book or edition of the same book has its own ISBN, ensuring unique identification in databases and catalogues. ISBNs are used for both printed books and e-books, helping readers find the exact title they need in library systems and online marketplaces.</p>"
+            },
+            "meaning": {
+              "question": "What does ISBN stand for?",
+              "answer": "<p>ISBN stands for <strong>“International Standard Book Number”</strong>, a standardised international number for books. It uniquely identifies a publication worldwide and simplifies the management of books in storage, distribution and sales systems. The ISBN system is used in many countries and is managed by national agencies. Each ISBN is assigned to a specific title and edition, preventing any confusion between different editions or formats of the same work (for example, between a hardback and a paperback edition).</p>"
+            },
+            "structure": {
+              "question": "How is an ISBN structured?",
+              "answer": "<p>An ISBN consists of 13 digits (or 10 in the former system) split into five segments. These segments include: a prefix (identifying the numbering system), a registration group (representing the country or language area), a publisher number, a title number (identifying a specific work) and a check digit that validates the structure of the ISBN. This structure allows rapid and accurate identification of books, simplifying their management worldwide. The move to ISBN-13 in 2007 aligned the system with global barcode standards, making book distribution even more efficient across retail and library networks.</p>"
+            },
+            "difference": {
+              "question": "What is the difference between ISBN-10 and ISBN-13?",
+              "answer": "<p>ISBN-10 was the original format used until 2007 and consisted of 10 digits. To align with the global EAN-13 barcode standards, the system moved to a 13-digit format: ISBN-13. This change standardised sales and distribution processes worldwide because ISBN-13 codes are compatible with commercial barcode systems used across industries. While ISBN-10 codes still exist for older works, new books published since 2007 exclusively use ISBN-13, which provides greater capacity for future identifiers.</p>"
             },
             "assignment": {
-              "question": "Who assigns ISBN codes?"
-            },
-            "formats": {
-              "question": "What formats are covered in the dataset?"
+              "question": "How is an ISBN assigned to a book?",
+              "answer": "<p>An ISBN is assigned by a national ISBN agency in each country, responsible for distributing and registering ISBN numbers. Publishers or authors contact this agency to obtain an ISBN for their book. When applying, they provide information about the work, such as the title, author, format and edition. Once assigned, the ISBN is unique to that edition and cannot be reused for another. This ensures efficient management of books in library, sales and distribution systems. It is essential for any work intended for wide circulation or sale.</p>"
             },
             "importance": {
-              "question": "Why is ISBN data valuable for the book industry?"
+              "question": "Why are ISBNs important?",
+              "answer": "<p>An ISBN is important because it provides a unique, standardised identifier for a book within management, sales and distribution systems. Without an ISBN, a book can be difficult to find in online catalogues or bookshops because distribution systems rely heavily on this identifier. ISBNs also facilitate indexing in library and bookstore databases, improving visibility and accessibility for readers. They are essential for a book to be widely distributed, whether in print or digital format.</p>"
+            },
+            "nonBook": {
+              "question": "Why do I sometimes find non-book products in the database?",
+              "answer": "<p>Sometimes an ISBN is used to identify something other than a book. Several situations can lead to this:</p><ul><li><strong>Lack of understanding of standards</strong>: Some sellers or platforms use the ISBN as a generic identifier, especially when the product is cultural or related to creative hobbies.</li><li><strong>Cost savings</strong>: In certain cases it is cheaper for a small manufacturer to reuse an existing ISBN code, even though it falls outside the standards.</li><li><strong>Code format confusion</strong>: Some marketplaces do not strictly validate standard codes and accept ISBNs for non-book products, which creates ambiguities.</li><li><strong>Reassignment or attribution error</strong>: ISBNs are sometimes used incorrectly for non-editorial products, especially when the manufacturer or distributor does not have an appropriate GTIN barcode.</li></ul>"
             }
           }
         }
@@ -603,16 +635,20 @@
       "subtitle": "Understand our approach to open data.",
       "items": {
         "sources": {
-          "question": "Where do the datasets come from?"
+          "question": "Where do the datasets come from?",
+          "answer": "<p>Extractions provided by Nudger stem from our work aggregating product data. We integrate a wide variety of sources that we group into several categories:</p><p><strong>Brand and manufacturer websites:</strong><br>We extract data directly from product sheets made available by brands and manufacturers.</p><p><strong>Institutional websites and open data:</strong> (base eprel, open food facts)<br>We integrate data from public or open repositories.</p><p><strong>Affiliate feeds and marketplaces:</strong> (awin, effinity, affilae, amazon, ..)<br>These come from promotional partnerships between Nudger and the platforms. We include a link in our extract so affiliate tracking applies when active offers exist for the product.</p><p>Nudger aggregates, normalises and resolves conflicts to publish factual, minimal product data. Building and sharing this database follows a commons mindset. We are convinced that sharing these datasets benefits every stakeholder in the consumption chain (manufacturers, retailers, researchers, citizens).</p><p>We are also mindful of intellectual property. Feel free to <a href=\"/contact\">contact us</a> with any question or if, as a data holder, you wish to opt out of this dataset.</p>"
         },
         "definition": {
-          "question": "What do we mean by open data?"
+          "question": "What do we mean by open data?",
+          "answer": "<p>Open data refers to data that is made accessible to everyone without access restrictions and in formats that can be freely reused. They can be reused, modified and redistributed by anyone for personal or professional purposes. The goal is to maximise access to information in order to encourage transparency, innovation and efficiency across sectors. Open data is often provided by public organisations, but some private companies have also started to publish portions of their data. A key aspect of open data is technical accessibility: data must be available in standard, machine-readable formats (such as CSV, JSON or XML) so they can be reused without major technical hurdles. By easing access to data, open data unlocks numerous applications, from mobile apps and visualisations to in-depth analyses.</p>"
         },
         "importance": {
-          "question": "Why is open data important for commerce?"
+          "question": "Why is open data important for commerce?",
+          "answer": "<p>Open data is crucial for promoting transparency and innovation. By making data accessible, it helps citizens better understand government decisions and participate in public debate with informed arguments. Companies can use these data to develop new products and services, stimulating economic growth. Open data also supports better decision-making because public information can be analysed to improve policies, reduce inefficiencies and make institutions more accountable. Finally, open data fosters collaboration between stakeholders—researchers, entrepreneurs, developers and local communities—who can work together to solve shared challenges creatively.</p>"
         },
         "contributors": {
-          "question": "How can contributors help improve the datasets?"
+          "question": "How can contributors help improve the datasets?",
+          "answer": "<p>Nudger aggregates, normalises and resolves conflicts to publish factual product data, but contributions remain essential. You can share additional sources, report issues in the datasets or suggest improvements. Collaborating with manufacturers, distributors, researchers and citizens helps us keep the exports accurate, up to date and useful for everyone.</p>"
         }
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -359,6 +359,10 @@
               "ariaLabel": "Lancer le téléchargement direct depuis Nudger"
             }
           }
+        },
+        "breadcrumb": {
+          "label": "opendata",
+          "ariaLabel": "Retour à la page opendata"
         }
       },
       "gtin": {
@@ -455,16 +459,28 @@
           "subtitle": "Tout savoir sur l'exploitation du dataset GTIN.",
           "items": {
             "whatIs": {
-              "question": "Qu'est-ce qu'un GTIN et à quoi sert-il ?"
+              "question": "Qu'est-ce qu'un GTIN ?",
+              "answer": "<p><strong>Le GTIN (Global Trade Item Number)</strong> est un identifiant unique utilisé pour identifier des produits à l'échelle mondiale. Il se présente sous plusieurs formats (GTIN-12, GTIN-13, GTIN-14), chaque format étant adapté à différents types de produits ou à des régions spécifiques. Par exemple, le GTIN-13 est couramment utilisé en Europe, tandis que le GTIN-12 est plus fréquent en Amérique du Nord. Chaque GTIN garantit qu’un produit peut être suivi, identifié et catalogué dans n'importe quelle partie du monde, assurant ainsi une gestion efficace des stocks et des ventes.</p>"
             },
-            "structure": {
-              "question": "Quelles informations fournissez-vous pour chaque GTIN ?"
+            "differenceEan": {
+              "question": "Quelle est la différence entre GTIN et EAN ?",
+              "answer": "<p><strong>L’EAN (European Article Number)</strong> était autrefois l'identifiant standard utilisé en Europe pour marquer les produits. Aujourd'hui, le terme GTIN a remplacé l’EAN afin de standardiser les codes de produit à l'échelle mondiale. L'EAN-13 est désormais un GTIN-13. En pratique, la transition de l'EAN au GTIN est surtout une question de nomenclature, et la structure du code reste la même. Le GTIN englobe également d'autres identifiants comme le UPC (Universal Product Code) utilisé en Amérique du Nord.</p>"
             },
-            "uses": {
-              "question": "Comment les organisations peuvent-elles exploiter ce dataset ?"
+            "formats": {
+              "question": "Quels sont les différents formats de GTIN ?",
+              "answer": "<p><strong>Les principaux formats de GTIN</strong> sont : GTIN-12 (couramment utilisé aux États-Unis et au Canada sous le nom de UPC), GTIN-13 (le plus courant en Europe), et GTIN-14 (pour les unités logistiques). Ces différents formats permettent de répondre aux besoins spécifiques de chaque région et chaque chaîne d'approvisionnement. Le format GTIN-14 est généralement utilisé pour l'identification d’unités logistiques plus grandes, comme des cartons ou des palettes, plutôt que pour des articles à l’unité.</p>"
             },
-            "contribute": {
-              "question": "Comment signaler une erreur ou proposer une correction ?"
+            "differenceUpc": {
+              "question": "Quelle est la différence entre GTIN et UPC ?",
+              "answer": "<p><strong>L'UPC (Universal Product Code)</strong> est une forme de GTIN-12, utilisé principalement en Amérique du Nord. La différence entre GTIN et UPC réside surtout dans leur utilisation régionale : le GTIN est un terme plus global, tandis que l’UPC se réfère à un code spécifique utilisé dans un contexte nord-américain. Toutefois, les deux systèmes sont interopérables, et dans le cadre de la norme GTIN, l’UPC est reconnu comme une sous-catégorie.</p>"
+            },
+            "ean13": {
+              "question": "Qu'est-ce que le format EAN-13 ?",
+              "answer": "<p><strong>L’EAN-13</strong> est un code-barres constitué de 13 chiffres qui identifie les produits au niveau international, principalement en Europe. L'EAN-13 est aussi appelé GTIN-13 et est largement utilisé dans les points de vente pour scanner et suivre les articles. Il inclut un préfixe de pays, un code d’entreprise, un code produit et une clé de contrôle qui garantit l'exactitude du code.</p>"
+            },
+            "logistics": {
+              "question": "Comment le GTIN est-il utilisé dans la logistique ?",
+              "answer": "<p><strong>Le GTIN dans la logistique</strong> joue un rôle essentiel pour identifier les produits à travers les chaînes d'approvisionnement. Par exemple, le format GTIN-14 permet d'identifier des unités d'expédition comme des cartons ou des palettes, et facilite ainsi la gestion des stocks et des expéditions. L’utilisation des codes-barres GTIN dans la logistique permet une traçabilité précise des produits tout au long de leur cycle de vie, du fabricant au distributeur.</p>"
             }
           }
         }
@@ -575,16 +591,32 @@
           "subtitle": "Les notions essentielles autour de l'export ISBN.",
           "items": {
             "whatIs": {
-              "question": "Qu'est-ce qu'un ISBN ?"
+              "question": "Qu'est-ce qu'un ISBN ?",
+              "answer": "<p>Un ISBN (International Standard Book Number) est un numéro unique qui permet d'identifier un livre à l'échelle mondiale. C’est un identifiant essentiel pour les éditeurs, librairies, bibliothèques, et toutes les plateformes de vente de livres. L'ISBN facilite la gestion des stocks, la distribution, et la vente des livres. Chaque livre ou édition d'un même livre dispose de son propre ISBN, garantissant une identification unique dans les bases de données et les catalogues. Les ISBN sont utilisés aussi bien pour les livres imprimés que pour les livres numériques (e-books), et permettent aux lecteurs de retrouver facilement l’ouvrage qu’ils cherchent, notamment dans les systèmes de bibliothèques et sur les plateformes de vente en ligne.</p>"
+            },
+            "meaning": {
+              "question": "Quelle est la signification d'ISBN ?",
+              "answer": "<p>ISBN signifie <strong>\"International Standard Book Number\"</strong>, un numéro international normalisé pour les livres. Ce numéro sert à identifier de manière unique une publication dans le monde entier. Il permet de simplifier la gestion des livres dans les systèmes de stockage, de distribution et de vente. Le système ISBN est utilisé dans de nombreux pays et est géré par des agences nationales. Chaque ISBN est attribué spécifiquement à un titre et à une édition particulière, ce qui permet une gestion précise et évite toute confusion entre différentes éditions ou formats d'un même ouvrage (par exemple, entre une version reliée et une version broché).</p>"
+            },
+            "structure": {
+            "question": "Comment un ISBN est-il structuré ?",
+              "answer": "<p>Un ISBN est composé de 13 chiffres (ou 10 dans l’ancien système), répartis en cinq segments. Ces segments incluent : un préfixe (qui identifie le système de numérotation), un groupe d’enregistrement (qui représente le pays ou la région linguistique), un numéro d'éditeur, un numéro de titre (qui identifie un ouvrage spécifique), et enfin, un chiffre de contrôle qui valide la structure de l’ISBN. Cette structure permet une identification rapide et précise des livres, facilitant leur gestion à l’échelle mondiale. Le passage à l'ISBN-13 en 2007 s'est aligné sur les normes mondiales des codes-barres, rendant la distribution des livres encore plus efficace à travers différents systèmes de commerce et de bibliothèque.</p>"
+            },
+            "difference": {
+            "question": "Quelle est la différence entre un ISBN-10 et un ISBN-13 ?",
+              "answer": "<p>L'ISBN-10 était le format d'origine utilisé jusqu'en 2007. Il se composait de 10 chiffres. Cependant, pour s'aligner avec les standards mondiaux des codes-barres EAN-13, le système est passé à un format à 13 chiffres, l'ISBN-13. Ce changement a permis de standardiser les processus de vente et de distribution à l’échelle mondiale, car les ISBN-13 sont compatibles avec les systèmes de codes-barres commerciaux utilisés dans divers secteurs. Bien que les ISBN-10 existent encore pour les anciens ouvrages, les nouveaux livres publiés depuis 2007 utilisent exclusivement le format ISBN-13, qui offre une plus grande capacité pour les identifications futures.</p>"
             },
             "assignment": {
-              "question": "Qui attribue les codes ISBN ?"
-            },
-            "formats": {
-              "question": "Quels formats figurent dans le dataset ?"
+              "question": "Comment un ISBN est-il attribué à un livre ?",
+              "answer": "<p>Un ISBN est attribué par une agence nationale ISBN dans chaque pays, qui gère la distribution et l'enregistrement des numéros ISBN. L'éditeur ou l'auteur doit contacter cette agence pour obtenir un ISBN pour son livre. Lors de la demande, des informations sur l'ouvrage sont fournies, telles que le titre, l’auteur, le format et l’édition. Une fois attribué, l'ISBN est unique pour cette édition et ne peut être réutilisé pour une autre. Cela garantit une gestion efficace des livres dans les systèmes de bibliothèques, de vente, et de distribution. Il est essentiel pour toute œuvre destinée à une large diffusion ou à la vente.</p>"
             },
             "importance": {
-              "question": "Pourquoi les données ISBN sont-elles précieuses pour la filière du livre ?"
+              "question": "Importance des ISBN ?",
+              "answer": "<p>Un code ISBN est important car il permet d'identifier un livre de manière unique et standardisée dans les systèmes de gestion, de vente, et de distribution. Sans ISBN, un livre peut être difficile à trouver dans les catalogues en ligne ou en librairie, car les systèmes de distribution reposent en grande partie sur cet identifiant. L'ISBN facilite aussi le référencement dans les bases de données des bibliothèques et des librairies, ce qui améliore sa visibilité et son accessibilité pour le public. Il est essentiel pour qu'un livre puisse être largement distribué, que ce soit sous format imprimé ou numérique.</p>"
+            },
+            "nonBook": {
+            "question": "Pourquoi je retrouve des produits (autres que des livres) dans la base ?",
+              "answer": "<p>Il arrive qu'un ISBN soit utilisé pour identifier autre chose qu'un livre. Cela peut se produire pour plusieurs raisons :</p><ul><li><strong>Manque de compréhension des standards</strong> : Certains vendeurs ou plateformes utilisent l'ISBN comme un identifiant générique, surtout si le produit est culturel ou lié aux loisirs créatifs.</li><li><strong>Économies de coût</strong> : Dans certains cas, il est plus économique pour un petit fabricant de réutiliser un code ISBN existant, bien que cela soit en dehors des normes.</li><li><strong>Confusion de formats de codes</strong> : Certaines plateformes de vente n’étant pas strictes sur la validation des codes standards, elles acceptent des ISBN pour des produits autres que des livres, ce qui crée des ambiguïtés.</li><li><strong>Réaffectation ou erreur d'attribution</strong> : L'ISBN est parfois utilisé incorrectement pour des produits non éditoriaux, surtout si le fabricant ou le distributeur n’a pas de code-barres GTIN adapté.</li></ul>"
             }
           }
         }
@@ -604,16 +636,20 @@
       "subtitle": "Comprendre notre approche de l'open data.",
       "items": {
         "sources": {
-          "question": "D'où proviennent les données ?"
+          "question": "Sources de données et contributions",
+          "answer": "<p>Les extractions fournies par Nudger sont issues de nos travaux d'aggrégation des données produits. Nous intégrons une grande variété de sources de données, que l'on peut classer en plusieurs types :</p><p><strong>Sites des marques et fabricants :</strong><br>Nous extrayons directement de la donnée à partir des fiches produits mises à disposition par les marques et fabricants.</p><p><strong>Sites institutionnels et données ouvertes :</strong> (base eprel, open food facts)<br>Nous intégrons des données issues de référentiels publics ou ouverts.</p><p><strong>Flux d'affiliation et plateformes marchandes :</strong> (awin, effinity, affilae, amazon, ..)<br>Dans le cadre de la relation contractuelle de promotion de Nudger et des plateformes. A ce titre, nous intégrons un lien dans notre extraction, permettant de faire jouer l'affiliation si des offres actives existent pour le produit.</p><p>Nudger aggrège, normalise et résout les conflits pour exposer des données factuelles et minimales sur les produits. La constitution et la mise à disposition de cette base sont opérées dans une logique de bien commun. Nous sommes également convaincus que le partage de ces données est au bénéfice de tous les acteurs de la chaîne de consommation (fabricants, distributeurs, chercheurs, citoyens).</p><p>Pour autant, nous sommes soucieux de respecter la propriété intellectuelle, aussi n'hésitez pas à <a href=\"/contact\">nous contacter</a> pour toute question, ou si en tant que dépositaire de données vous souhaitez vous opposer à votre participation à cette base.</p>"
         },
         "definition": {
-          "question": "Que signifie « open data » ?"
+          "question": "Qu'est-ce que l'open data ?",
+          "answer": "<p>L'open data, ou données ouvertes, désigne des données rendues accessibles à tous, sans restriction d’accès, et sous un format librement exploitable. Elles peuvent être réutilisées, modifiées, redistribuées par n’importe qui, à des fins personnelles ou professionnelles. L'objectif est de maximiser l'accès à l'information pour encourager la transparence, l'innovation et l'efficacité dans différents secteurs. L'open data est souvent fourni par des organismes publics, mais certaines entreprises privées commencent aussi à publier certaines de leurs données. Un aspect clé de l'open data est l'accessibilité technique : les données doivent être disponibles dans des formats standards et lisibles par des machines (comme les fichiers CSV, JSON ou XML) afin de permettre leur réutilisation sans obstacles techniques majeurs. En facilitant l'accès aux données, l'open data ouvre la voie à de nombreuses applications, comme la création d'applications mobiles, de visualisations ou d'analyses approfondies.</p>"
         },
         "importance": {
-          "question": "Pourquoi l'open data est-il important ?"
+          "question": "Pourquoi l'open data est-il important ?",
+          "answer": "<p>L'open data est crucial pour promouvoir la transparence et l’innovation. En rendant les données accessibles, il permet aux citoyens de mieux comprendre les décisions des gouvernements et de participer aux discussions publiques de manière informée. Les entreprises peuvent utiliser ces données pour développer de nouveaux produits et services, ce qui stimule la croissance économique. De plus, l'open data permet une meilleure prise de décision, car les données publiques peuvent être analysées pour améliorer les politiques publiques, réduire les inefficacités, et rendre les gouvernements plus responsables de leurs actions. L'open data favorise aussi la collaboration entre différentes parties prenantes, notamment les chercheurs, les entrepreneurs, les développeurs et les collectivités locales, qui peuvent travailler ensemble pour résoudre des problèmes communs en utilisant les données de manière créative.</p>"
         },
         "contributors": {
-          "question": "Qui produit et met à disposition les données ouvertes ?"
+            "question": "Qui produit et met à disposition les données ouvertes ?",
+          "answer": "<p>Les principales sources de données ouvertes sont généralement les gouvernements, les institutions publiques, les ONG et parfois des entreprises privées. Les gouvernements, à tous les niveaux (national, régional, municipal), sont des acteurs majeurs dans la production de données ouvertes, en publiant des informations relatives à des secteurs tels que l’éducation, la santé, l'environnement, et les finances publiques. Les organisations internationales comme l'ONU ou l'OCDE, ainsi que certaines agences spécialisées, sont aussi d'importants contributeurs. De plus, des entreprises privées dans le domaine de la technologie ou de l'innovation, choisissent parfois de publier leurs données pour encourager la collaboration ou améliorer leur transparence. Enfin, des projets communautaires et collaboratifs permettent également de collecter et de publier des données ouvertes, souvent autour de thématiques spécifiques comme l'écologie ou le développement durable.</p>"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add a breadcrumb pill in the dataset hero so GTIN/ISBN pages link back to the open data overview
- replace the opendata FAQs with localized i18n content in English and French instead of CMS blocs
- render the FAQ answers within the shared section component and restore the team hero description output

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e6150e9d4483339806cdbecf5a5896