### PR TITLE
feat(frontend): add favicon metadata

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,17 @@ export default defineNuxtConfig({
   dir: {
     public: 'app/public',
   },
+  app: {
+    head: {
+      link: [
+        { rel: 'icon', type: 'image/png', href: '/favicon-96x96.png', sizes: '96x96' },
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        { rel: 'shortcut icon', href: '/favicon.ico' },
+        { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
+        { rel: 'manifest', href: '/site.webmanifest' },
+      ],
+    },
+  },
   devtools: {
     enabled: process.env.NODE_ENV !== 'production',
     timeline: {


### PR DESCRIPTION
## Summary
- register the provided favicon, touch icon, and manifest links in the global Nuxt head configuration

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e623c54ae88333ad1d2e7871fa6f47