### PR TITLE
Fix local auth cookies for HTTP preview

### DIFF
--- a/frontend/server/routes/auth/login.post.ts
+++ b/frontend/server/routes/auth/login.post.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
-import type { CookieSerializeOptions } from 'cookie-es'
 import { FetchError } from 'ofetch'
+import { buildAuthCookieOptions } from '~~/server/utils/auth-cookie-options'
 
 interface LoginResponse { accessToken: string; refreshToken: string }
 interface LoginBody { username: string; password: string }
@@ -17,14 +17,7 @@ export default defineEventHandler(async (event: H3Event) => {
       method: 'POST',
       body,
     })
-    const secure = process.env.NODE_ENV === 'production'
-    const sameSite: 'lax' | 'none' = secure ? 'none' : 'lax'
-    const cookieOptions: CookieSerializeOptions = {
-      httpOnly: true,
-      sameSite,
-      secure,
-      path: '/',
-    }
+    const cookieOptions = buildAuthCookieOptions(event)
     setCookie(event, config.tokenCookieName, tokens.accessToken, cookieOptions)
     setCookie(event, config.refreshCookieName, tokens.refreshToken, cookieOptions)
     // Return tokens so the client can decode and update its state immediately

--- a/frontend/server/routes/auth/logout.post.ts
+++ b/frontend/server/routes/auth/logout.post.ts
@@ -1,12 +1,14 @@
 import type { H3Event } from 'h3'
 import { FetchError } from 'ofetch'
+import { buildAuthCookieOptions } from '~~/server/utils/auth-cookie-options'
 
 const clearAuthCookies = (
   event: H3Event,
   config: { tokenCookieName: string; refreshCookieName: string }
 ) => {
-  deleteCookie(event, config.tokenCookieName, { path: '/' })
-  deleteCookie(event, config.refreshCookieName, { path: '/' })
+  const cookieOptions = buildAuthCookieOptions(event)
+  deleteCookie(event, config.tokenCookieName, cookieOptions)
+  deleteCookie(event, config.refreshCookieName, cookieOptions)
 }
 
 export default defineEventHandler(async (event: H3Event) => {

--- a/frontend/server/routes/auth/refresh.post.ts
+++ b/frontend/server/routes/auth/refresh.post.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
-import type { CookieSerializeOptions } from 'cookie-es'
 import { FetchError } from 'ofetch'
+import { buildAuthCookieOptions } from '~~/server/utils/auth-cookie-options'
 
 /**
  * Proxy endpoint to renew access and refresh tokens using the backend API.
@@ -20,14 +20,7 @@ export default defineEventHandler(async (event: H3Event) => {
       headers: { cookie: `${config.refreshCookieName}=${refreshToken}` },
     })
 
-    const secure = process.env.NODE_ENV === 'production'
-    const sameSite: 'lax' | 'none' = secure ? 'none' : 'lax'
-    const cookieOptions: CookieSerializeOptions = {
-      httpOnly: true,
-      sameSite,
-      secure,
-      path: '/',
-    }
+    const cookieOptions = buildAuthCookieOptions(event)
     setCookie(event, config.tokenCookieName, tokens.accessToken, cookieOptions)
     setCookie(event, config.refreshCookieName, tokens.refreshToken, cookieOptions)
     // Return tokens to allow the client to update the auth store reactively

--- a/frontend/server/utils/auth-cookie-options.spec.ts
+++ b/frontend/server/utils/auth-cookie-options.spec.ts
@@ -1,0 +1,37 @@
+import type { H3Event } from 'h3'
+import { describe, expect, it } from 'vitest'
+
+import { buildAuthCookieOptions } from './auth-cookie-options'
+
+const createEvent = (headers: Record<string, string> = {}, encrypted = false): H3Event => ({
+  node: {
+    req: {
+      headers,
+      connection: encrypted ? { encrypted: true } : undefined,
+    },
+  },
+} as unknown as H3Event)
+
+describe('buildAuthCookieOptions', () => {
+  it('returns lax cookies for HTTP requests to support local development', () => {
+    const options = buildAuthCookieOptions(createEvent())
+
+    expect(options).toMatchObject({
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+      path: '/',
+    })
+  })
+
+  it('enforces secure cookies when the request is served over HTTPS', () => {
+    const options = buildAuthCookieOptions(createEvent({ 'x-forwarded-proto': 'https' }, true))
+
+    expect(options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'none',
+      path: '/',
+    })
+  })
+})

--- a/frontend/server/utils/auth-cookie-options.ts
+++ b/frontend/server/utils/auth-cookie-options.ts
@@ -1,0 +1,19 @@
+import type { CookieSerializeOptions } from 'cookie-es'
+import type { H3Event } from 'h3'
+import { getRequestProtocol } from 'h3'
+
+/**
+ * Builds consistent cookie options for authentication cookies.
+ * Ensures Secure/SameSite flags align with the current request protocol so
+ * local HTTP previews keep working while HTTPS deployments remain protected.
+ */
+export const buildAuthCookieOptions = (event: H3Event): CookieSerializeOptions => {
+  const secure = getRequestProtocol(event) === 'https'
+
+  return {
+    httpOnly: true,
+    sameSite: secure ? 'none' : 'lax',
+    secure,
+    path: '/',
+  }
+}


### PR DESCRIPTION
## Summary
- derive authentication cookie flags from the incoming request protocol so local HTTP previews keep login cookies
- reuse the new helper across login, refresh and logout routes for consistent behaviour
- add unit coverage to lock the Secure/SameSite combination

## Testing
- pnpm vitest run server/utils/auth-cookie-options.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e621be935083339ec77294a33daa88