### PR TITLE
Add affiliation partner caching service to front API

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/NudgerFrontApiApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "org.open4goods")
 @ConfigurationPropertiesScan("org.open4goods.nudgerfrontapi.config.properties")
 @EnableCaching
+@EnableScheduling
 /**
  * Spring Boot application entry point for the frontend API.
  */

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/AffiliationPartnersProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/AffiliationPartnersProperties.java
@@ -1,0 +1,55 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration properties describing the affiliation partners backend used by the frontend API.
+ */
+@Validated
+@ConfigurationProperties("front.affiliation-partners")
+public class AffiliationPartnersProperties {
+
+    /**
+     * Base URL of the backend exposing affiliation partners information.
+     */
+    @NotBlank(message = "front.affiliation-partners.api-base-url must be provided")
+    private String apiBaseUrl;
+
+    /**
+     * Path appended to the base URL to retrieve the partners collection.
+     */
+    @NotBlank(message = "front.affiliation-partners.partners-path must be provided")
+    private String partnersPath = "/partners";
+
+    /**
+     * API key forwarded in the {@code Authorization} header when calling the backend.
+     */
+    @NotBlank(message = "front.affiliation-partners.api-key must be provided")
+    private String apiKey;
+
+    public String getApiBaseUrl() {
+        return apiBaseUrl;
+    }
+
+    public void setApiBaseUrl(String apiBaseUrl) {
+        this.apiBaseUrl = apiBaseUrl;
+    }
+
+    public String getPartnersPath() {
+        return partnersPath;
+    }
+
+    public void setPartnersPath(String partnersPath) {
+        this.partnersPath = partnersPath;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
@@ -1,0 +1,69 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.open4goods.model.affiliation.AffiliationPartner;
+import org.open4goods.model.constants.UrlConstants;
+import org.open4goods.nudgerfrontapi.config.properties.AffiliationPartnersProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Service responsible for retrieving affiliation partners from the back-office API and caching them in memory.
+ */
+@Service
+public class AffiliationPartnerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AffiliationPartnerService.class);
+    private static final ParameterizedTypeReference<List<AffiliationPartner>> PARTNERS_TYPE =
+            new ParameterizedTypeReference<>() { };
+
+    private final RestClient restClient;
+    private final AffiliationPartnersProperties properties;
+    private final AtomicReference<List<AffiliationPartner>> partners = new AtomicReference<>(List.of());
+
+    public AffiliationPartnerService(RestClient.Builder restClientBuilder, AffiliationPartnersProperties properties) {
+        this.properties = properties;
+        this.restClient = restClientBuilder.baseUrl(properties.getApiBaseUrl())
+                .defaultHeader(UrlConstants.APIKEY_PARAMETER, properties.getApiKey())
+                .build();
+    }
+
+    /**
+     * Returns the latest affiliation partners snapshot.
+     *
+     * @return immutable list of affiliation partners
+     */
+    public List<AffiliationPartner> getPartners() {
+        return partners.get();
+    }
+
+    @PostConstruct
+    public void preloadPartners() {
+        refreshPartners();
+    }
+
+    /**
+     * Refreshes the cached list of affiliation partners from the back-office API.
+     * Retains the previous value when the HTTP call fails.
+     */
+    @Scheduled(fixedDelayString = "PT1H")
+    public void refreshPartners() {
+        try {
+            List<AffiliationPartner> fetched = restClient.get().uri(properties.getPartnersPath()).retrieve()
+                    .body(PARTNERS_TYPE);
+            List<AffiliationPartner> immutablePartners = fetched == null ? List.of() : List.copyOf(fetched);
+            partners.set(immutablePartners);
+            LOGGER.info("Loaded {} affiliation partners from backend.", immutablePartners.size());
+        }
+        catch (Exception exception) {
+            LOGGER.warn("Failed to refresh affiliation partners. Preserving {} cached partners. Error: {}",
+                    partners.get().size(), exception.getMessage(), exception);
+        }
+    }
+}

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -27,6 +27,10 @@ front:
     cors-allowed-hosts: ${FRONT_SECURITY_CORS_ALLOWED_HOSTS:"http://localhost:8082"}
     jwt-secret: ${FRONT_SECURITY_JWT_SECRET:CHANGE_ME_TO_A_LONG_SECRET_VALUE_32_BYTES_MIN}
     shared-token: ${FRONT_SECURITY_SHARED_TOKEN:CHANGE_ME_SHARED_TOKEN}
+
+  affiliation-partners:
+    api-base-url: ${FRONT_AFFILIATION_PARTNERS_API_BASE_URL:https://api.open4goods.org}
+    api-key: ${FRONT_AFFILIATION_PARTNERS_API_KEY:CHANGE_ME_AFFILIATION_PARTNER_API_KEY}
     
   rate-limit:
     anonymous: 100

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerServiceTest.java
@@ -1,0 +1,95 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.affiliation.AffiliationPartner;
+import org.open4goods.model.constants.UrlConstants;
+import org.open4goods.nudgerfrontapi.config.properties.AffiliationPartnersProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class AffiliationPartnerServiceTest {
+
+    private static final String BASE_URL = "https://backend.example";
+    private static final String PARTNERS_PATH = "/partners";
+
+    private AffiliationPartnerService service;
+    private MockRestServiceServer mockServer;
+
+    @BeforeEach
+    void setUp() {
+        AffiliationPartnersProperties properties = new AffiliationPartnersProperties();
+        properties.setApiBaseUrl(BASE_URL);
+        properties.setApiKey("secret");
+        properties.setPartnersPath(PARTNERS_PATH);
+
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        service = new AffiliationPartnerService(builder, properties);
+    }
+
+    @Test
+    void refreshPartnersLoadsLatestSnapshot() {
+        mockServer.expect(requestTo(BASE_URL + PARTNERS_PATH))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(UrlConstants.APIKEY_PARAMETER, "secret"))
+                .andRespond(withSuccess("""
+                        [
+                          {
+                            "id": "p1",
+                            "name": "Partner 1",
+                            "logoUrl": "https://logo.example/p1.svg",
+                            "affiliationLink": "https://aff.example/p1",
+                            "portalUrl": "https://portal.example/p1",
+                            "countryCodes": ["FR", "DE"]
+                          }
+                        ]
+                        """, MediaType.APPLICATION_JSON));
+
+        service.refreshPartners();
+
+        List<AffiliationPartner> partners = service.getPartners();
+        assertThat(partners).hasSize(1);
+        AffiliationPartner partner = partners.getFirst();
+        assertThat(partner.getId()).isEqualTo("p1");
+        assertThat(partner.getName()).isEqualTo("Partner 1");
+        mockServer.verify();
+    }
+
+    @Test
+    void refreshPartnersPreservesPreviousSnapshotOnFailure() {
+        mockServer.expect(requestTo(BASE_URL + PARTNERS_PATH))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        [
+                          {"id": "p1"},
+                          {"id": "p2"}
+                        ]
+                        """, MediaType.APPLICATION_JSON));
+
+        service.refreshPartners();
+        mockServer.verify();
+
+        List<AffiliationPartner> initialPartners = service.getPartners();
+
+        mockServer.reset();
+        mockServer.expect(requestTo(BASE_URL + PARTNERS_PATH))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withServerError());
+
+        service.refreshPartners();
+
+        assertThat(service.getPartners()).isSameAs(initialPartners);
+        mockServer.verify();
+    }
+}

--- a/services/feedservice/src/main/java/org/open4goods/services/feedservice/service/FeedService.java
+++ b/services/feedservice/src/main/java/org/open4goods/services/feedservice/service/FeedService.java
@@ -58,7 +58,7 @@ public class FeedService {
         	p.setId(ds.getName());
         	p.setName(ds.getName());
         	p.setLogoUrl(ds.getLogo());
-        	p.setAffiliationLink(ds.getPortalUrl());
+        	p.setAffiliationLink(ds.getAffiliatedPortalUrl());
         	partners.add(p);
         }
     }


### PR DESCRIPTION
## Summary
- add configuration properties for the affiliation partners backend and expose new YAML configuration entries
- enable scheduling and introduce a service that caches affiliation partners with hourly refreshes
- cover the new service with unit tests for successful refreshes and failure fallback behaviour

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68e674d3cb948333bdc5649d2e43fb2f