### PR TITLE
feat: expose ecosystem and mentor partner directories

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/EcosystemPartnersProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/EcosystemPartnersProperties.java
@@ -1,0 +1,94 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration properties exposing the list of ecosystem partners rendered by the frontend.
+ */
+@Validated
+@ConfigurationProperties(prefix = "front.partners.ecosystem")
+public class EcosystemPartnersProperties {
+
+    /**
+     * Ecosystem partner entries configured in application properties.
+     */
+    @Valid
+    private List<Partner> partners = new ArrayList<>();
+
+    public List<Partner> getPartners() {
+        return partners;
+    }
+
+    public void setPartners(List<Partner> partners) {
+        this.partners = partners == null ? new ArrayList<>() : new ArrayList<>(partners);
+    }
+
+    /**
+     * Single ecosystem partner entry.
+     */
+    public static class Partner {
+
+        /**
+         * Display name of the ecosystem partner.
+         */
+        @NotBlank(message = "front.partners.ecosystem.partners[].name must be provided")
+        private String name;
+
+        /**
+         * XWiki bloc identifier linking to partner content.
+         */
+        @NotBlank(message = "front.partners.ecosystem.partners[].bloc-id must be provided")
+        private String blocId;
+
+        /**
+         * Public website URL of the partner.
+         */
+        @NotBlank(message = "front.partners.ecosystem.partners[].url must be provided")
+        private String url;
+
+        /**
+         * Relative image URL rendered in the frontend.
+         */
+        @NotBlank(message = "front.partners.ecosystem.partners[].image-url must be provided")
+        private String imageUrl;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getBlocId() {
+            return blocId;
+        }
+
+        public void setBlocId(String blocId) {
+            this.blocId = blocId;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
+
+        public void setImageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/MentorPartnersProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/MentorPartnersProperties.java
@@ -1,0 +1,94 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration properties exposing the mentor partners highlighted by the frontend.
+ */
+@Validated
+@ConfigurationProperties(prefix = "front.partners.mentors")
+public class MentorPartnersProperties {
+
+    /**
+     * Mentor partner entries configured in application properties.
+     */
+    @Valid
+    private List<Partner> partners = new ArrayList<>();
+
+    public List<Partner> getPartners() {
+        return partners;
+    }
+
+    public void setPartners(List<Partner> partners) {
+        this.partners = partners == null ? new ArrayList<>() : new ArrayList<>(partners);
+    }
+
+    /**
+     * Single mentor partner entry.
+     */
+    public static class Partner {
+
+        /**
+         * Display name of the mentor partner.
+         */
+        @NotBlank(message = "front.partners.mentors.partners[].name must be provided")
+        private String name;
+
+        /**
+         * XWiki bloc identifier linking to partner content.
+         */
+        @NotBlank(message = "front.partners.mentors.partners[].bloc-id must be provided")
+        private String blocId;
+
+        /**
+         * Public website URL of the partner.
+         */
+        @NotBlank(message = "front.partners.mentors.partners[].url must be provided")
+        private String url;
+
+        /**
+         * Relative image URL rendered in the frontend.
+         */
+        @NotBlank(message = "front.partners.mentors.partners[].image-url must be provided")
+        private String imageUrl;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getBlocId() {
+            return blocId;
+        }
+
+        public void setBlocId(String blocId) {
+            this.blocId = blocId;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getImageUrl() {
+            return imageUrl;
+        }
+
+        public void setImageUrl(String imageUrl) {
+            this.imageUrl = imageUrl;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/partner/StaticPartnerDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/partner/StaticPartnerDto.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.dto.partner;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO describing a static partner configured from application properties.
+ */
+public record StaticPartnerDto(
+        @Schema(description = "Display name of the partner.", example = "French Tech Ouest")
+        String name,
+
+        @Schema(description = "XWiki bloc identifier containing the partner content.",
+                example = "pages:ecosystem:french-tech")
+        String blocId,
+
+        @Schema(description = "Public URL pointing to the partner website.",
+                example = "https://www.ft-brestbretagneouest.bzh/")
+        String url,
+
+        @Schema(description = "Relative path to the partner image served by the frontend.",
+                example = "/images/ecosystem/frenchTech.jpeg")
+        String imageUrl) {
+}

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -34,6 +34,37 @@ front:
   rate-limit:
     anonymous: 100
     authenticated: 1000
+
+  partners:
+    ecosystem:
+      partners:
+        - name: French Tech Ouest
+          blocId: 'pages:ecosystem:french-tech'
+          url: https://www.ft-brestbretagneouest.bzh/
+          imageUrl: /images/ecosystem/frenchTech.jpeg
+        - name: Village by CA Finistère
+          blocId: 'pages:ecosystem:village-ca-finistere'
+          url: https://levillagebycafinistere.com/
+          imageUrl: /images/ecosystem/village-ca-finistere.jpeg
+        - name: IRT B<>Com
+          blocId: 'pages:ecosystem:irt-b-com'
+          url: https://b-com.com/
+          imageUrl: /images/ecosystem/irt-b-com.jpeg
+
+    mentors:
+      partners:
+        - name: Moovance
+          blocId: 'pages:partners:moovance'
+          url: https://www.moovance.fr/
+          imageUrl: /images/mentors/moovance.jpeg
+        - name: France Mobilités
+          blocId: 'pages:partners:france-mobilites'
+          url: https://www.francemobilites.fr/
+          imageUrl: /images/mentors/france-mobilites.jpeg
+        - name: Région Bretagne
+          blocId: 'pages:partners:region-bretagne'
+          url: https://www.bretagne.bzh/
+          imageUrl: /images/mentors/region-bretagne.jpeg
     
 
 

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/PartnerControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/PartnerControllerTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.nudgerfrontapi.config.properties.EcosystemPartnersProperties;
+import org.open4goods.nudgerfrontapi.config.properties.MentorPartnersProperties;
 import org.open4goods.nudgerfrontapi.dto.partner.AffiliationPartnerDto;
 import org.open4goods.nudgerfrontapi.service.AffiliationPartnerService;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -30,9 +32,29 @@ class PartnerControllerTest {
     @Mock
     private AffiliationPartnerService affiliationPartnerService;
 
+    private EcosystemPartnersProperties ecosystemPartnersProperties;
+    private MentorPartnersProperties mentorPartnersProperties;
+
     @BeforeEach
     void setUp() {
-        PartnerController controller = new PartnerController(affiliationPartnerService);
+        ecosystemPartnersProperties = new EcosystemPartnersProperties();
+        EcosystemPartnersProperties.Partner ecosystemPartner = new EcosystemPartnersProperties.Partner();
+        ecosystemPartner.setName("French Tech Ouest");
+        ecosystemPartner.setBlocId("pages:ecosystem:french-tech");
+        ecosystemPartner.setUrl("https://www.ft-brestbretagneouest.bzh/");
+        ecosystemPartner.setImageUrl("/images/ecosystem/frenchTech.jpeg");
+        ecosystemPartnersProperties.setPartners(List.of(ecosystemPartner));
+
+        mentorPartnersProperties = new MentorPartnersProperties();
+        MentorPartnersProperties.Partner mentorPartner = new MentorPartnersProperties.Partner();
+        mentorPartner.setName("Moovance");
+        mentorPartner.setBlocId("pages:partners:moovance");
+        mentorPartner.setUrl("https://www.moovance.fr/");
+        mentorPartner.setImageUrl("/images/mentors/moovance.jpeg");
+        mentorPartnersProperties.setPartners(List.of(mentorPartner));
+
+        PartnerController controller = new PartnerController(affiliationPartnerService,
+                ecosystemPartnersProperties, mentorPartnersProperties);
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setMessageConverters(new MappingJackson2HttpMessageConverter())
                 .build();
@@ -52,6 +74,28 @@ class PartnerControllerTest {
                 .andExpect(header().string("X-Locale", "fr"))
                 .andExpect(jsonPath("$[0].id").value("p1"))
                 .andExpect(jsonPath("$[0].faviconUrl").value("https://cdn.example/favicon?url=Partner"));
+    }
+
+    @Test
+    void shouldExposeEcosystemPartnersFromProperties() throws Exception {
+        mockMvc.perform(get("/partners/ecosystem").param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$[0].name").value("French Tech Ouest"))
+                .andExpect(jsonPath("$[0].blocId").value("pages:ecosystem:french-tech"))
+                .andExpect(jsonPath("$[0].url").value("https://www.ft-brestbretagneouest.bzh/"))
+                .andExpect(jsonPath("$[0].imageUrl").value("/images/ecosystem/frenchTech.jpeg"));
+    }
+
+    @Test
+    void shouldExposeMentorPartnersFromProperties() throws Exception {
+        mockMvc.perform(get("/partners/mentors").param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$[0].name").value("Moovance"))
+                .andExpect(jsonPath("$[0].blocId").value("pages:partners:moovance"))
+                .andExpect(jsonPath("$[0].url").value("https://www.moovance.fr/"))
+                .andExpect(jsonPath("$[0].imageUrl").value("/images/mentors/moovance.jpeg"));
     }
 }
 


### PR DESCRIPTION
## Summary
- add configuration properties for ecosystem and mentor partners and a DTO for static partner responses
- extend PartnerController with /partners/ecosystem and /partners/mentors endpoints backed by the new properties
- seed application.yml and controller tests with representative partner data

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68e7863d2be88333869be4775081a3a7