### PR TITLE
Handle manual affiliation redirects

### DIFF
--- a/frontend/server/api/contrib/[token].spec.ts
+++ b/frontend/server/api/contrib/[token].spec.ts
@@ -127,6 +127,35 @@ describe('server/api/contrib/[token]', () => {
     expect(response).toEqual({ statusCode: 301, location: 'https://example.test/post' })
   })
 
+  it('propagates the Location header from manual redirect responses', async () => {
+    resolveRedirectMock.mockResolvedValue({
+      statusCode: 301,
+      location: 'https://example.test/manual',
+    })
+
+    const event = {
+      node: {
+        req: {
+          method: 'GET',
+          headers: {
+            host: 'nudger.example',
+          },
+        },
+      },
+      context: { params: { token: 'token-manual' } },
+    } as unknown as Parameters<ContribRouteHandler>[0]
+
+    const response = await handler(event)
+
+    expect(resolveRedirectMock).toHaveBeenCalledWith({
+      token: 'token-manual',
+      method: 'GET',
+      userAgent: undefined,
+    })
+    expect(response.statusCode).toBe(301)
+    expect(response.location).toBe('https://example.test/manual')
+  })
+
   it('throws a 405 error when using an unsupported HTTP method', async () => {
     const event = {
       node: {

--- a/frontend/shared/api-client/services/affiliation.services.ts
+++ b/frontend/shared/api-client/services/affiliation.services.ts
@@ -62,9 +62,15 @@ export const useAffiliationService = (domainLanguage: DomainLanguage) => {
 
     try {
       if (method === 'POST') {
-        await apiInstance.redirectPostRaw({ token, domainLanguage: language, userAgent })
+        await apiInstance.redirectPostRaw(
+          { token, domainLanguage: language, userAgent },
+          (requestContext) => ({ ...requestContext.init, redirect: 'manual' }),
+        )
       } else {
-        await apiInstance.redirectGetRaw({ token, domainLanguage: language, userAgent })
+        await apiInstance.redirectGetRaw(
+          { token, domainLanguage: language, userAgent },
+          (requestContext) => ({ ...requestContext.init, redirect: 'manual' }),
+        )
       }
 
       throw new Error('Expected a redirect response from the affiliation endpoint.')

--- a/frontend/shared/api-client/services/affiliation.services.ts
+++ b/frontend/shared/api-client/services/affiliation.services.ts
@@ -64,12 +64,18 @@ export const useAffiliationService = (domainLanguage: DomainLanguage) => {
       if (method === 'POST') {
         await apiInstance.redirectPostRaw(
           { token, domainLanguage: language, userAgent },
-          (requestContext) => ({ ...requestContext.init, redirect: 'manual' }),
+          async (requestContext) => ({
+            ...requestContext.init,
+            redirect: 'manual',
+          }),
         )
       } else {
         await apiInstance.redirectGetRaw(
           { token, domainLanguage: language, userAgent },
-          (requestContext) => ({ ...requestContext.init, redirect: 'manual' }),
+          async (requestContext) => ({
+            ...requestContext.init,
+            redirect: 'manual',
+          }),
         )
       }
 


### PR DESCRIPTION
## Summary
- ensure the affiliation service performs GET and POST redirect requests with manual fetch handling so 301 responses surface instead of throwing
- extend the contrib redirect route spec to cover manual redirect responses and Location propagation

## Testing
- pnpm vitest run "server/api/contrib/[token].spec.ts"


------
https://chatgpt.com/codex/tasks/task_e_68e7ca860c188333951ab0e434dc4a10