### PR TITLE
feat: refine partners page layout

### DIFF
--- a/frontend/app/components/domains/partners/PartnersAffiliationSection.vue
+++ b/frontend/app/components/domains/partners/PartnersAffiliationSection.vue
@@ -6,9 +6,6 @@
     <v-container class="py-12 px-4" max-width="xl">
       <header class="partners-affiliation__header d-flex flex-column gap-4">
         <div class="partners-affiliation__titles">
-          <p class="text-overline text-uppercase mb-2 text-neutral-soft">
-            {{ eyebrow }}
-          </p>
           <div class="d-flex flex-column gap-2">
             <h2 :id="headingId" class="text-h4 text-wrap font-weight-bold">
               {{ title }}
@@ -40,6 +37,7 @@
           :height="carouselHeight"
           :cycle="slides.length > 1"
           :show-arrows="slides.length > 1"
+          :hide-delimiters="true"
           :hide-delimiter-background="true"
           :interval="6000"
           :pause-on-hover="true"
@@ -59,8 +57,12 @@
                   <v-card
                     v-bind="hoverProps"
                     class="partners-affiliation__card-surface"
-                    :elevation="isHovering ? 8 : 2"
+                    :elevation="isHovering ? 6 : 1"
                     rounded="lg"
+                    :href="partner.affiliationLink ?? undefined"
+                    :target="partner.affiliationLink ? '_blank' : undefined"
+                    :rel="partner.affiliationLink ? 'noopener nofollow' : undefined"
+                    :aria-label="linkAriaLabel(partner)"
                   >
                     <div class="partners-affiliation__card-media">
                       <v-img
@@ -76,18 +78,10 @@
                       <h3 class="text-subtitle-1 font-weight-medium mb-1 text-center">
                         {{ partner.name }}
                       </h3>
-                      <v-btn
-                        :href="partner.affiliationLink"
-                        target="_blank"
-                        rel="noopener nofollow"
-                        color="primary"
-                        variant="text"
-                        size="small"
-                        class="partners-affiliation__cta"
-                      >
+                      <div class="partners-affiliation__cta" aria-hidden="true">
                         {{ linkLabel }}
                         <v-icon icon="mdi-open-in-new" size="16" class="ms-1" />
-                      </v-btn>
+                      </div>
                     </div>
                   </v-card>
                 </v-hover>
@@ -119,7 +113,6 @@ import type { AffiliationPartnerDto } from '~~/shared/api-client'
 const props = defineProps<{
   title: string
   subtitle: string
-  eyebrow: string
   partners: AffiliationPartnerDto[]
   searchLabel: string
   searchPlaceholder: string
@@ -188,6 +181,12 @@ const logoSize = computed(() => (display.smAndUp.value ? 96 : 80))
 
 const logoAlt = (partner: AffiliationPartnerDto) =>
   partner.name ? `${partner.name} logo` : ''
+
+const linkAriaLabel = (partner: AffiliationPartnerDto) => {
+  const name = partner.name?.trim()
+
+  return name ? `${props.linkLabel} – ${name}` : props.linkLabel
+}
 </script>
 
 <style scoped lang="scss">
@@ -211,7 +210,7 @@ const logoAlt = (partner: AffiliationPartnerDto) =>
   }
 
   &__search {
-    max-width: 420px;
+    width: min(100%, 560px);
     margin: 0 auto;
   }
 
@@ -247,6 +246,9 @@ const logoAlt = (partner: AffiliationPartnerDto) =>
     align-items: center;
     gap: 0.75rem;
     transition: transform 200ms ease, box-shadow 200ms ease;
+    cursor: pointer;
+    color: inherit;
+    text-decoration: none;
 
     &:hover {
       transform: translateY(-4px);
@@ -274,6 +276,10 @@ const logoAlt = (partner: AffiliationPartnerDto) =>
   }
 
   &__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
     text-transform: none;
     font-weight: 600;
   }

--- a/frontend/app/components/domains/partners/PartnersStaticCarouselSection.vue
+++ b/frontend/app/components/domains/partners/PartnersStaticCarouselSection.vue
@@ -2,9 +2,6 @@
   <section :class="['partners-static', `partners-static--${toneClass}`]" :aria-labelledby="headingId">
     <v-container class="py-12 px-4" max-width="xl">
       <header class="partners-static__header">
-        <p class="text-overline text-uppercase mb-2 text-neutral-soft">
-          {{ eyebrow }}
-        </p>
         <h2 :id="headingId" class="text-h4 text-wrap font-weight-bold mb-3">
           {{ title }}
         </h2>
@@ -16,11 +13,12 @@
       <div v-if="slides.length > 0" class="partners-static__carousel">
         <v-carousel
           v-model="activeSlide"
-          :cycle="slides.length > 1"
-          :interval="6500"
+          :cycle="shouldShowControls"
+          :interval="shouldShowControls ? 6500 : undefined"
           :pause-on-hover="true"
+          :hide-delimiters="true"
           :hide-delimiter-background="true"
-          :show-arrows="slides.length > 1"
+          :show-arrows="shouldShowControls"
           :aria-label="carouselAriaLabel"
           :height="display.mdAndUp.value ? 420 : 460"
         >
@@ -34,7 +32,7 @@
                 :key="partner.name ?? partner.blocId ?? slideIndex"
                 class="partners-static__card"
               >
-                <v-card class="partners-static__card-surface" elevation="4" rounded="xl">
+                <v-card class="partners-static__card-surface" elevation="0" rounded="xl">
                   <div v-if="partner.imageUrl" class="partners-static__card-media">
                     <v-img
                       :src="partner.imageUrl"
@@ -102,7 +100,6 @@ const props = withDefaults(
   defineProps<{
     title: string
     subtitle: string
-    eyebrow: string
     partners: StaticPartnerDto[]
     carouselAriaLabel: string
     emptyStateLabel: string
@@ -150,6 +147,10 @@ watch(slides, () => {
 })
 
 const toneClass = computed(() => props.tone)
+
+const shouldShowControls = computed(
+  () => normalizedPartners.value.length > itemsPerSlide.value,
+)
 
 const imageAlt = (partner: StaticPartnerDto) =>
   partner.name ? `${partner.name} visual` : ''

--- a/frontend/app/pages/partners/index.vue
+++ b/frontend/app/pages/partners/index.vue
@@ -47,7 +47,6 @@
     <PartnersAffiliationSection
       :title="t('partners.affiliation.title')"
       :subtitle="t('partners.affiliation.subtitle')"
-      :eyebrow="t('partners.affiliation.eyebrow')"
       :partners="affiliationPartners"
       :search-label="t('partners.affiliation.search.label')"
       :search-placeholder="t('partners.affiliation.search.placeholder')"
@@ -59,7 +58,6 @@
     <PartnersStaticCarouselSection
       :title="t('partners.ecosystem.title')"
       :subtitle="t('partners.ecosystem.subtitle')"
-      :eyebrow="t('partners.ecosystem.eyebrow')"
       :partners="ecosystemPartners"
       :carousel-aria-label="t('partners.ecosystem.carouselAriaLabel')"
       :empty-state-label="t('partners.ecosystem.empty')"
@@ -71,7 +69,6 @@
       tone="muted"
       :title="t('partners.mentors.title')"
       :subtitle="t('partners.mentors.subtitle')"
-      :eyebrow="t('partners.mentors.eyebrow')"
       :partners="mentorPartners"
       :carousel-aria-label="t('partners.mentors.carouselAriaLabel')"
       :empty-state-label="t('partners.mentors.empty')"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -190,7 +190,6 @@
       "loadFailed": "We could not load partner data. Please try again."
     },
     "affiliation": {
-      "eyebrow": "Our partners",
       "title": "They trust Nudger",
       "subtitle": "Explore the merchants who work with us through affiliation and discover their offers.",
       "search": {
@@ -202,7 +201,6 @@
       "linkLabel": "Visit this partner"
     },
     "ecosystem": {
-      "eyebrow": "Ecosystem",
       "title": "Nudger grows within a dynamic ecosystem",
       "subtitle": "These organisations collaborate with us to build public-interest digital services.",
       "empty": "Our ecosystem partners will appear here soon.",
@@ -211,7 +209,6 @@
       "fallbackDescription": "Content about this partner will be published soon."
     },
     "mentors": {
-      "eyebrow": "Mentors",
       "title": "They support us",
       "subtitle": "Entrepreneurship is never simple. These mentors share their experience with kindness.",
       "empty": "Mentor profiles will arrive shortly.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -191,7 +191,6 @@
       "loadFailed": "Impossible de charger les partenaires. Merci de réessayer."
     },
     "affiliation": {
-      "eyebrow": "Nos partenaires",
       "title": "Ils nous font confiance",
       "subtitle": "Découvrez les marchands qui collaborent avec nous et explorez leurs offres.",
       "search": {
@@ -203,7 +202,6 @@
       "linkLabel": "Visiter ce partenaire"
     },
     "ecosystem": {
-      "eyebrow": "Écosystème",
       "title": "Nudger s'inscrit dans un écosystème dynamique",
       "subtitle": "Au travers d'échanges ou de partenartiats directs, ils contribuent à la trajectoire de Nudger",
       "empty": "Les partenaires de l'écosystème seront bientôt listés ici.",
@@ -212,7 +210,6 @@
       "fallbackDescription": "Le contenu de ce partenaire sera publié prochainement."
     },
     "mentors": {
-      "eyebrow": "Mentors",
       "title": "Ils nous aident",
       "subtitle": "Entreprendre n'est jamais simple. Ces mentors partagent leur expérience avec bienveillance.",
       "empty": "Les profils mentors seront ajoutés prochainement.",


### PR DESCRIPTION
## Summary
- widen the affiliation search input and make each partner card open its external link while hiding carousel delimiters
- remove the ecosystem and mentor eyebrow headings and associated i18n strings from the partners page
- simplify static partner carousels by hiding dots, removing card elevation, and disabling controls when not needed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e8aff531a48333b7b2a785759280ac