### PR TITLE
Adjust dark theme surface background to black

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -127,7 +127,7 @@ export default defineNuxtConfig({
                 'hero-overlay-strong': '#FFFFFF',
                 'hero-overlay-soft': '#FFFFFF',
                 'hero-pill-on-dark': '#FFFFFF',
-                'surface-default': '#0F172A',
+                'surface-default': '#000000',
                 'surface-muted': '#111827',
                 'surface-alt': '#1E293B',
                 'surface-glass': '#1E293B',


### PR DESCRIPTION
## Summary
- update the dark theme surface-default color to pure black so dark mode menus use a true black background

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e8c22ab1b48333922b2b7e737aca84