### PR TITLE
Ensure hero menu bar uses surface default background

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -27,6 +27,7 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 
 <style lang="sass" scoped>
 .main-menu-app-bar
+  background-color: rgb(var(--v-theme-surface-default)) !important
   color: rgb(var(--v-theme-text-neutral-strong))
 
 @media (max-width: 959px)

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -127,7 +127,7 @@ export default defineNuxtConfig({
                 'hero-overlay-strong': '#FFFFFF',
                 'hero-overlay-soft': '#FFFFFF',
                 'hero-pill-on-dark': '#FFFFFF',
-                'surface-default': '#0F172A',
+                'surface-default': '#000000',
                 'surface-muted': '#111827',
                 'surface-alt': '#1E293B',
                 'surface-glass': '#1E293B',


### PR DESCRIPTION
## Summary
- override the hero menu app bar background to use the surface-default token so dark mode uses the updated black swatch

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e8c22ab1b48333922b2b7e737aca84