### PR TITLE
Use Vuetify theme.change in ThemeToggle

### DIFF
--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -78,7 +78,7 @@ const storedPreference = useStorage<ThemeName>(
 
 const applyTheme = (value: ThemeName) => {
   if (theme.global.name.value !== value) {
-    theme.global.name.value = value
+    theme.change(value)
   }
 
   if (storedPreference.value !== value) {


### PR DESCRIPTION
## Summary
- swap the ThemeToggle helper to call `theme.change` instead of mutating `theme.global.name.value` directly while keeping the guard in place to avoid Vuetify warnings

## Testing
- pnpm dev *(fails to reach remote beta.front-api.nudger.fr from CI container but allows verifying the theme toggle locally)*

------
https://chatgpt.com/codex/tasks/task_e_68e8c75fa5548333a8262c322346adc8