### PR TITLE
Fix dark theme navigation and team hero colors

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -28,7 +28,6 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 <style lang="sass" scoped>
 .main-menu-app-bar
   color: rgb(var(--v-theme-text-neutral-strong))
-  background-color: rgb(var(--v-theme-surface-default))
 
 @media (max-width: 959px)
   .main-menu-app-bar

--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -28,6 +28,7 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 <style lang="sass" scoped>
 .main-menu-app-bar
   color: rgb(var(--v-theme-text-neutral-strong))
+  background-color: rgb(var(--v-theme-surface-default))
 
 @media (max-width: 959px)
   .main-menu-app-bar

--- a/frontend/app/components/domains/team/TeamHero.vue
+++ b/frontend/app/components/domains/team/TeamHero.vue
@@ -41,7 +41,7 @@ const headingId = useId()
   position: relative
   overflow: hidden
   background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.95), rgba(var(--v-theme-hero-gradient-end), 0.9))
-  color: rgb(var(--v-theme-on-primary))
+  color: rgb(var(--v-theme-hero-pill-on-dark))
 
   &__wrapper
     margin: 0 auto
@@ -62,6 +62,10 @@ const headingId = useId()
 
   &__content :deep(.text-content)
     padding: 0
+
+  &__content :deep(.text-content),
+  &__content :deep(.xwiki-sandbox)
+    color: rgb(var(--v-theme-hero-pill-on-dark))
 
   &__content :deep(.xwiki-sandbox)
     font-size: clamp(1rem, 1.6vw, 1.15rem)

--- a/frontend/shared/api-client/models/PageProductDto.ts
+++ b/frontend/shared/api-client/models/PageProductDto.ts
@@ -79,18 +79,6 @@ export interface PageProductDto {
     sort?: SortObject;
     /**
      * 
-     * @type {boolean}
-     * @memberof PageProductDto
-     */
-    first?: boolean;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof PageProductDto
-     */
-    last?: boolean;
-    /**
-     * 
      * @type {number}
      * @memberof PageProductDto
      */
@@ -101,6 +89,18 @@ export interface PageProductDto {
      * @memberof PageProductDto
      */
     pageable?: PageableObject;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PageProductDto
+     */
+    first?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof PageProductDto
+     */
+    last?: boolean;
     /**
      * 
      * @type {boolean}
@@ -132,10 +132,10 @@ export function PageProductDtoFromJSONTyped(json: any, ignoreDiscriminator: bool
         'content': json['content'] == null ? undefined : ((json['content'] as Array<any>).map(ProductDtoFromJSON)),
         'number': json['number'] == null ? undefined : json['number'],
         'sort': json['sort'] == null ? undefined : SortObjectFromJSON(json['sort']),
-        'first': json['first'] == null ? undefined : json['first'],
-        'last': json['last'] == null ? undefined : json['last'],
         'numberOfElements': json['numberOfElements'] == null ? undefined : json['numberOfElements'],
         'pageable': json['pageable'] == null ? undefined : PageableObjectFromJSON(json['pageable']),
+        'first': json['first'] == null ? undefined : json['first'],
+        'last': json['last'] == null ? undefined : json['last'],
         'empty': json['empty'] == null ? undefined : json['empty'],
     };
 }
@@ -157,10 +157,10 @@ export function PageProductDtoToJSONTyped(value?: PageProductDto | null, ignoreD
         'content': value['content'] == null ? undefined : ((value['content'] as Array<any>).map(ProductDtoToJSON)),
         'number': value['number'],
         'sort': SortObjectToJSON(value['sort']),
-        'first': value['first'],
-        'last': value['last'],
         'numberOfElements': value['numberOfElements'],
         'pageable': PageableObjectToJSON(value['pageable']),
+        'first': value['first'],
+        'last': value['last'],
         'empty': value['empty'],
     };
 }


### PR DESCRIPTION
## Summary
- ensure the main navigation bar explicitly uses the surface-default design token so it renders black in dark mode
- switch the team hero copy to the hero-pill-on-dark token and cascade it to CMS content for consistent readability

## Testing
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68e8cc70c7108333aaa0a89dc465d83e