### PR TITLE
Align hero menu background with app bar

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -1,6 +1,6 @@
 <template>
   <menu id="container-main-menu" class="d-none d-md-block">
-  <!-- Desktop menu -->
+    <!-- Desktop menu -->
     <div class="d-flex justify-end align-center ga-4">
       <v-list class="d-flex justify-end font-weight-bold">
         <v-list-item
@@ -107,6 +107,9 @@ const navigateToPage = (path: string): void => {
 </script>
 
 <style scoped lang="sass">
+#container-main-menu
+  background-color: rgb(var(--v-theme-surface-default))
+
 .main-menu-items
   color: rgb(var(--v-theme-text-neutral-strong))
   font-size: 1rem


### PR DESCRIPTION
## Summary
- set the hero menu container background to reuse the `surface-default` theme token so it matches the main menu bar in dark mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8d360cd5483339de53d5a17ac093f