### PR TITLE
feat: expose complete product facets in DTO mapping

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
@@ -1,0 +1,33 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import org.open4goods.model.price.Currency;
+import org.open4goods.model.product.ProductCondition;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Representation of an aggregated offer price.
+ */
+public record ProductAggregatedPriceDto(
+        @Schema(description = "Datasource providing the offer", example = "amazon.fr")
+        String datasourceName,
+        @Schema(description = "Displayed offer title")
+        String offerName,
+        @Schema(description = "Target URL of the offer", example = "https://example.org/product/123")
+        String url,
+        @Schema(description = "Compensation paid when the offer is converted", example = "0.5")
+        Double compensation,
+        @Schema(description = "State of the product for this offer")
+        ProductCondition productState,
+        @Schema(description = "Affiliation token when available")
+        String affiliationToken,
+        @Schema(description = "Price value")
+        Double price,
+        @Schema(description = "Currency of the price")
+        Currency currency,
+        @Schema(description = "Timestamp of the price in epoch milliseconds")
+        Long timeStamp,
+        @Schema(description = "Human friendly representation of the price", nullable = true)
+        String shortPrice
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiDescriptionDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiDescriptionDto.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Represents a single AI generated text with its timestamp.
+ */
+public record ProductAiDescriptionDto(
+        @Schema(description = "Timestamp in epoch milliseconds when the description was generated")
+        long timestamp,
+        @Schema(description = "Generated textual content")
+        String content
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiReviewDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiReviewDto.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * DTO exposing AI review information of a product to the frontend.
  */
 public record ProductAiReviewDto(
-        @Schema(description = "AI-generated review that will be aligned with the requested domainLanguage once localisation is active.")
+        @Schema(description = "Language key used to resolve the AI review", example = "fr")
+        String language,
+        @Schema(description = "AI-generated review content")
         AiReview review,
         @Schema(description = "Source weighting for the review content", nullable = true)
         Map<String, Integer> sources,
@@ -19,4 +21,6 @@ public record ProductAiReviewDto(
         @Schema(description = "Total tokens consumed by the AI generation", nullable = true)
         Integer totalTokens,
         @Schema(description = "Creation timestamp ms", example = "1690972800000", nullable = true)
-        Long createdMs) {}
+        Long createdMs
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiTextsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAiTextsDto.java
@@ -1,11 +1,16 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
+import java.util.Map;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * AI generated descriptions facet.
+ * AI generated descriptions facet resolved using the requested domain language.
  */
 public record ProductAiTextsDto(
-        @Schema(description = "AI description aligned with the requested domainLanguage once localisation is available.")
-        String description
-) {}
+        @Schema(description = "Language key used to resolve the AI descriptions", example = "fr")
+        String language,
+        @Schema(description = "AI generated descriptions keyed by prompt identifier")
+        Map<String, ProductAiDescriptionDto> descriptions
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeDto.java
@@ -1,0 +1,22 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Representation of a general product attribute.
+ */
+public record ProductAttributeDto(
+        @Schema(description = "Attribute name", example = "screen_size")
+        String name,
+        @Schema(description = "Attribute value", example = "55")
+        String value,
+        @Schema(description = "Numeric interpretation when available", nullable = true)
+        Double numericValue,
+        @Schema(description = "Icecat taxonomy identifiers associated to the attribute")
+        Set<Integer> icecatTaxonomyIds,
+        @Schema(description = "Attributes values contributed by datasources")
+        Set<ProductSourcedAttributeDto> sources
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributesDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Aggregated attributes detected for the product.
+ */
+public record ProductAttributesDto(
+        @Schema(description = "Referential attributes keyed by the official attribute key")
+        Map<String, String> referentialAttributes,
+        @Schema(description = "Indexed attributes keyed by their identifier")
+        Map<String, ProductIndexedAttributeDto> indexedAttributes,
+        @Schema(description = "All attributes keyed by their identifier")
+        Map<String, ProductAttributeDto> allAttributes,
+        @Schema(description = "Concatenated human readable characteristics")
+        String characteristics
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
@@ -1,23 +1,33 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
-import org.open4goods.model.product.ExternalIds;
+import java.util.Set;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * Basic product metadata facet.
+ * Basic product metadata facet aggregating immutable identifiers and lifecycle
+ * timestamps.
  */
 public record ProductBaseDto(
-        @Schema(description = "Product GTIN", example = "7612345678901")
+        @Schema(description = "Product GTIN as stored in the catalogue", example = "7612345678901")
         long gtin,
-        @Schema(description = "Creation timestamp", example = "1693000000000")
+        @Schema(description = "Creation timestamp expressed in epoch milliseconds", example = "1693000000000")
         long creationDate,
-        @Schema(description = "Last change timestamp", example = "1693590000000")
+        @Schema(description = "Last modification timestamp expressed in epoch milliseconds", example = "1693590000000")
         long lastChange,
-        @Schema(description = "Associated vertical", example = "electronics")
+        @Schema(description = "Associated vertical identifier", example = "electronics")
         String vertical,
-        @Schema(description = "External identifiers")
-        ExternalIds externalIds,
+        @Schema(description = "External identifiers assigned to the product")
+        ProductExternalIdsDto externalIds,
         @Schema(description = "Google taxonomy identifier", example = "123")
-        Integer googleTaxonomyId
-) {}
+        Integer googleTaxonomyId,
+        @Schema(description = "Whether the product is excluded from vertical representation")
+        boolean excluded,
+        @Schema(description = "Reasons explaining why the product is excluded")
+        Set<String> excludedCauses,
+        @Schema(description = "Information inferred from the GTIN itself")
+        ProductGtinInfoDto gtinInfo,
+        @Schema(description = "Path of the preferred cover image if available")
+        String coverImagePath
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductCardinalityDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductCardinalityDto.java
@@ -1,0 +1,22 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Cardinality statistics associated with a score.
+ */
+public record ProductCardinalityDto(
+        @Schema(description = "Minimal value encountered")
+        Double min,
+        @Schema(description = "Maximal value encountered")
+        Double max,
+        @Schema(description = "Average value across the population")
+        Double avg,
+        @Schema(description = "Number of elements composing the population")
+        Integer count,
+        @Schema(description = "Sum of the values")
+        Double sum,
+        @Schema(description = "Current value")
+        Double value
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDatasourcesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDatasourcesDto.java
@@ -1,0 +1,21 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Datasource level information related to the product.
+ */
+public record ProductDatasourcesDto(
+        @Schema(description = "Codes assigned to the product by each datasource")
+        Map<String, Long> datasourceCodes,
+        @Schema(description = "Categories assigned by the contributing datasources")
+        Map<String, String> categoriesByDatasource,
+        @Schema(description = "Union of datasource categories")
+        Set<String> datasourceCategories,
+        @Schema(description = "Datasource categories excluding the shortest one")
+        Set<String> datasourceCategoriesWithoutShortest
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -8,62 +8,78 @@ import java.util.stream.Collectors;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * DTO representing a product view returned by the API.
+ * DTO representing a comprehensive product view returned by the API.
  */
 public record ProductDto(
         @Schema(description = "Product GTIN, it is the unique identifier", example = "7612345678901")
         long gtin,
         @Schema(description = "Basic product metadata")
         ProductBaseDto base,
+        @Schema(description = "Identity facet exposing brand, model and alternate identifiers")
+        ProductIdentityDto identity,
         @Schema(description = "Localised textual information resolved using the domainLanguage query parameter when available.")
         ProductNamesDto names,
+        @Schema(description = "Structured attributes aggregated from all datasources")
+        ProductAttributesDto attributes,
         @Schema(description = "Associated media resources")
         ProductResourcesDto resources,
+        @Schema(description = "Datasource related information")
+        ProductDatasourcesDto datasources,
+        @Schema(description = "Score and ranking related information")
+        ProductScoresDto scores,
+        @Schema(description = "Ecoscore derived rankings")
+        ProductRankingDto ranking,
         @Schema(description = "AI generated texts localised according to the requested domainLanguage when implemented.")
         ProductAiTextsDto aiTexts,
         @Schema(description = "AI-generated review matching the requested domainLanguage when localisation is enabled.")
         ProductAiReviewDto aiReview,
-        @Schema(description = "Product offers with textual content meant to align with the requested domainLanguage in the future.")
+        @Schema(description = "Product offers and pricing information")
         ProductOffersDto offers
 ) {
 
-	/**
-	 * Available facets on ProductsDto
-	 */
+        /**
+         * Available facets on ProductsDto.
+         */
         public enum ProductDtoComponent {
                 base,
+                identity,
                 names,
+                attributes,
                 resources,
+                datasources,
+                scores,
+                ranking,
+                aiTexts,
                 aiReview,
                 offers
         }
 
-	/**
-	 * Allowed sort values on Products. (must exactly match elastic mapping)
-	 */
+        /**
+         * Allowed sort values on Products. (must exactly match elastic mapping)
+         */
         public enum ProductDtoSortableFields {
                 price("price.minPrice.price"),
                 offersCount("offersCount");
 
-		private final String text;
+                private final String text;
 
-		ProductDtoSortableFields(String text) {
-			this.text = text;
-		}
+                ProductDtoSortableFields(String text) {
+                        this.text = text;
+                }
 
-		public String getText() {
-			return text;
-		}
+                public String getText() {
+                        return text;
+                }
 
-		@Override
-		public String toString() {
-			return text;
-		}
+                @Override
+                public String toString() {
+                        return text;
+                }
 
-		/**
-		 * Optional: parse from the text value.
-		 */
-		private static final Map<String, ProductDtoSortableFields> LOOKUP = Arrays.stream(values()).collect(Collectors.toMap(ProductDtoSortableFields::getText, e -> e));
+                /**
+                 * Optional: parse from the text value.
+                 */
+                private static final Map<String, ProductDtoSortableFields> LOOKUP = Arrays.stream(values()).collect(Collectors.toMap(ProductDtoSortableFields::getText, e -> e));
 
                 public static Optional<ProductDtoSortableFields> fromText(String text) {
                         return Optional.ofNullable(LOOKUP.get(text));

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductExternalIdsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductExternalIdsDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Exposes the various external identifiers attached to a product.
+ */
+public record ProductExternalIdsDto(
+        @Schema(description = "Amazon Standard Identification Number", example = "B012345678")
+        String asin,
+        @Schema(description = "Icecat identifier", example = "12345")
+        String icecat,
+        @Schema(description = "Known manufacturer part numbers")
+        Set<String> mpn,
+        @Schema(description = "Known stock keeping units")
+        Set<String> sku
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductGtinInfoDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductGtinInfoDto.java
@@ -1,0 +1,16 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import org.open4goods.model.product.BarcodeType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Holds information inferred from the product GTIN.
+ */
+public record ProductGtinInfoDto(
+        @Schema(description = "UPC type derived from the GTIN")
+        BarcodeType upcType,
+        @Schema(description = "Manufacturer country inferred from the GTIN prefix", example = "FR")
+        String country
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIdentityDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIdentityDto.java
@@ -1,0 +1,36 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Captures the brand/model identity of the product together with the different
+ * alternative identifiers detected across datasources.
+ */
+public record ProductIdentityDto(
+        @Schema(description = "Preferred brand extracted from referential attributes", example = "Sony")
+        String brand,
+        @Schema(description = "Preferred model extracted from referential attributes", example = "WH-1000XM5")
+        String model,
+        @Schema(description = "Best human readable name synthesised from brand and model when available", example = "Sony WH-1000XM5")
+        String bestName,
+        @Schema(description = "Randomly selected model amongst the known alternatives", example = "WH-1000XM5B")
+        String randomModel,
+        @Schema(description = "Shortest known model value", example = "XM5")
+        String shortestModel,
+        @Schema(description = "Whether alternate identifiers are available")
+        boolean hasAlternateIds,
+        @Schema(description = "Human readable list of alternate identifiers", example = "WH1000XM5, XM5")
+        String alternateIdsText,
+        @Schema(description = "Set of alternative model identifiers discovered across datasources")
+        Set<String> akaModels,
+        @Schema(description = "Alternative brand values keyed by datasource")
+        Map<String, String> akaBrandsByDatasource,
+        @Schema(description = "Distinct set of alternative brand values")
+        Set<String> akaBrands,
+        @Schema(description = "GTIN rendered as string to preserve leading zeros", example = "07612345678901")
+        String gtinAsString
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIndexedAttributeDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIndexedAttributeDto.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Indexed attribute representation used by the frontend.
+ */
+public record ProductIndexedAttributeDto(
+        @Schema(description = "Attribute name", example = "color")
+        String name,
+        @Schema(description = "Attribute value", example = "black")
+        String value,
+        @Schema(description = "Numeric interpretation when available", nullable = true, example = "12.5")
+        Double numericValue,
+        @Schema(description = "Boolean interpretation when available", nullable = true)
+        Boolean booleanValue
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -1,21 +1,35 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
+import java.util.List;
+import java.util.Set;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * Localised textual information.
+ * Localised textual information resolved against the requested domain language.
  */
 public record ProductNamesDto(
-        @Schema(description = "H1 title expected to align with the requested domainLanguage when localisation is available.")
+        @Schema(description = "Canonical product URL for the resolved language", example = "https://example.org/products/123")
+        String url,
+        @Schema(description = "H1 title for the requested language", example = "Casque Bluetooth haut de gamme")
         String h1Title,
-        @Schema(description = "Meta description aligned to the requested domainLanguage once localisation is wired.")
+        @Schema(description = "Meta description aligned with the requested language")
         String metaDescription,
-        @Schema(description = "OpenGraph title prepared for domainLanguage-driven localisation.")
+        @Schema(description = "OpenGraph title for social sharing")
         String ogTitle,
-        @Schema(description = "OpenGraph description prepared for domainLanguage-driven localisation.")
+        @Schema(description = "OpenGraph description for social sharing")
         String ogDescription,
-        @Schema(description = "Twitter title mirroring the requested domainLanguage in the future.")
+        @Schema(description = "Twitter card title")
         String twitterTitle,
-        @Schema(description = "Twitter description mirroring the requested domainLanguage in the future.")
-        String twitterDescription
-) {}
+        @Schema(description = "Twitter card description")
+        String twitterDescription,
+        @Schema(description = "Offer names aggregated across datasources")
+        Set<String> offerNames,
+        @Schema(description = "Longest detected offer name", nullable = true)
+        String longestOfferName,
+        @Schema(description = "Shortest detected offer name", nullable = true)
+        String shortestOfferName,
+        @Schema(description = "All names and descriptions excluding the shortest offer name")
+        List<String> namesAndDescriptionsWithoutShortestName
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
@@ -1,5 +1,38 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
-public class ProductOffersDto {
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.open4goods.model.product.ProductCondition;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Pricing and offer information for a product.
+ */
+public record ProductOffersDto(
+        @Schema(description = "Number of offers aggregated for this product", example = "12")
+        Integer offersCount,
+        @Schema(description = "Whether the catalogue exposes occasion offers for this product")
+        boolean hasOccasions,
+        @Schema(description = "Best price across all conditions", nullable = true)
+        ProductAggregatedPriceDto bestPrice,
+        @Schema(description = "Best price for new offers", nullable = true)
+        ProductAggregatedPriceDto bestNewOffer,
+        @Schema(description = "Best price for occasion offers", nullable = true)
+        ProductAggregatedPriceDto bestOccasionOffer,
+        @Schema(description = "Aggregated offers grouped by product condition")
+        Map<ProductCondition, List<ProductAggregatedPriceDto>> offersByCondition,
+        @Schema(description = "Price history for brand new products", nullable = true)
+        ProductPriceHistoryDto newHistory,
+        @Schema(description = "Price history for second hand products", nullable = true)
+        ProductPriceHistoryDto occasionHistory,
+        @Schema(description = "Price evolution trends per condition", nullable = true)
+        Map<ProductCondition, Integer> trends,
+        @Schema(description = "Available product conditions")
+        Set<ProductCondition> conditions,
+        @Schema(description = "Gap between current best price and historical lowest price", nullable = true)
+        Double historyPriceGap
+) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceHistoryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceHistoryDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Aggregated view of price history for a specific product condition.
+ */
+public record ProductPriceHistoryDto(
+        @Schema(description = "Full history entries sorted chronologically")
+        List<ProductPriceHistoryEntryDto> entries,
+        @Schema(description = "Lowest recorded price in history", nullable = true)
+        ProductPriceHistoryEntryDto lowest,
+        @Schema(description = "Highest recorded price in history", nullable = true)
+        ProductPriceHistoryEntryDto highest,
+        @Schema(description = "Average price over the recorded history", nullable = true)
+        Double average
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceHistoryEntryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceHistoryEntryDto.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Entry representing a price history point.
+ */
+public record ProductPriceHistoryEntryDto(
+        @Schema(description = "Timestamp of the history entry in epoch milliseconds")
+        Long timestamp,
+        @Schema(description = "Price recorded at the given timestamp")
+        Double price
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductRankingDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductRankingDto.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Ranking information derived from ecoscore comparisons.
+ */
+public record ProductRankingDto(
+        @Schema(description = "Global ranking position", example = "120")
+        Long globalPosition,
+        @Schema(description = "Number of items considered in the global ranking", example = "5000")
+        Long globalCount,
+        @Schema(description = "GTIN of the best ranked product in the global ranking", nullable = true)
+        Long globalBest,
+        @Schema(description = "GTIN of the product ranked immediately above", nullable = true)
+        Long globalBetter,
+        @Schema(description = "Specialised ranking position", example = "12")
+        Long specializedPosition,
+        @Schema(description = "Number of items considered in the specialised ranking", example = "120")
+        Long specializedCount,
+        @Schema(description = "Identifier of the best product in the specialised ranking", nullable = true)
+        String specializedBest,
+        @Schema(description = "Identifier of the product ranked immediately above in the specialised ranking", nullable = true)
+        String specializedBetter
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourceDto.java
@@ -1,0 +1,52 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Set;
+
+import org.open4goods.model.resource.ResourceStatus;
+import org.open4goods.model.resource.ResourceTag;
+import org.open4goods.model.resource.ResourceType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO mirroring {@link org.open4goods.model.resource.Resource} content for API consumption.
+ */
+public record ProductResourceDto(
+        @Schema(description = "Resource URL", example = "https://cdn.example.org/images/1.jpg")
+        String url,
+        @Schema(description = "Detected MIME type", example = "image/jpeg")
+        String mimeType,
+        @Schema(description = "Last update timestamp in epoch milliseconds")
+        Long timeStamp,
+        @Schema(description = "Cache key used by the media pipeline")
+        String cacheKey,
+        @Schema(description = "Whether the resource has been evicted from the catalogue")
+        boolean evicted,
+        @Schema(description = "Whether the resource has been processed")
+        boolean processed,
+        @Schema(description = "Status assigned by the ingestion pipeline", nullable = true)
+        ResourceStatus status,
+        @Schema(description = "Size in bytes when known", example = "102400")
+        Long fileSize,
+        @Schema(description = "File name extracted from the URL", example = "image.jpg")
+        String fileName,
+        @Schema(description = "File extension", example = "jpg")
+        String extension,
+        @Schema(description = "MD5 checksum when available")
+        String md5,
+        @Schema(description = "Resource type")
+        ResourceType resourceType,
+        @Schema(description = "Additional image metadata", nullable = true)
+        ProductResourceImageInfoDto imageInfo,
+        @Schema(description = "Additional PDF metadata", nullable = true)
+        ProductResourcePdfInfoDto pdfInfo,
+        @Schema(description = "Group identifier used to cluster similar images", nullable = true)
+        Integer group,
+        @Schema(description = "Datasource providing the resource", example = "amazon.fr")
+        String datasourceName,
+        @Schema(description = "Tags describing the resource")
+        Set<String> tags,
+        @Schema(description = "Hard tags describing the resource nature")
+        Set<ResourceTag> hardTags
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourceImageInfoDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourceImageInfoDto.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Image metadata exported with the resource facet.
+ */
+public record ProductResourceImageInfoDto(
+        @Schema(description = "Image height in pixels", example = "1080")
+        Integer height,
+        @Schema(description = "Image width in pixels", example = "1920")
+        Integer width,
+        @Schema(description = "Perceptual hash value when available")
+        Long pHashValue,
+        @Schema(description = "Number of bits used for the perceptual hash")
+        Integer pHashLength
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcePdfInfoDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcePdfInfoDto.java
@@ -1,0 +1,32 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * PDF metadata exported with the resource facet.
+ */
+public record ProductResourcePdfInfoDto(
+        @Schema(description = "Title extracted from the PDF metadata", example = "User manual")
+        String metadataTitle,
+        @Schema(description = "Title extracted from the PDF content", example = "Operating instructions")
+        String extractedTitle,
+        @Schema(description = "Number of pages contained in the document", example = "48")
+        Integer numberOfPages,
+        @Schema(description = "Author declared in the metadata", example = "Example Corp")
+        String author,
+        @Schema(description = "Subject declared in the metadata")
+        String subject,
+        @Schema(description = "Keywords declared in the metadata")
+        String keywords,
+        @Schema(description = "Creation timestamp in epoch milliseconds")
+        Long creationDate,
+        @Schema(description = "Last modification timestamp in epoch milliseconds")
+        Long modificationDate,
+        @Schema(description = "Producer declared in the metadata")
+        String producer,
+        @Schema(description = "Detected language", example = "fr")
+        String language,
+        @Schema(description = "Confidence score associated with the detected language", example = "0.95")
+        Double languageConfidence
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
@@ -5,15 +5,22 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * Media resources associated with a product.
+ * Media resources associated with the product.
  */
 public record ProductResourcesDto(
-        @Schema(description = "Image URLs", type = "array")
-        List<String> images,
-        @Schema(description = "Video URLs", type = "array")
-        List<String> videos,
-        @Schema(description = "PDF URLs", type = "array")
-        List<String> pdfs,
-        @Schema(description = "Cover image URL")
-        String coverPath
-) {}
+        @Schema(description = "All resources attached to the product")
+        List<ProductResourceDto> resources,
+        @Schema(description = "Images grouped and ranked by relevance")
+        List<ProductResourceDto> images,
+        @Schema(description = "Images collected before processing")
+        List<ProductResourceDto> unprocessedImages,
+        @Schema(description = "List of unprocessed image URLs for quick previews")
+        List<String> unprocessedImagesUrl,
+        @Schema(description = "Video resources extracted from datasources")
+        List<ProductResourceDto> videos,
+        @Schema(description = "PDF resources extracted from datasources")
+        List<ProductResourceDto> pdfs,
+        @Schema(description = "External cover automatically computed from resources", example = "https://cdn.example.org/cover.jpg")
+        String externalCover
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
@@ -1,0 +1,40 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Detailed representation of a score attached to the product.
+ */
+public record ProductScoreDto(
+        @Schema(description = "Score name", example = "ENERGY")
+        String name,
+        @Schema(description = "Whether the score is virtual")
+        Boolean virtual,
+        @Schema(description = "Raw score value", nullable = true)
+        Double value,
+        @Schema(description = "Absolute cardinality information", nullable = true)
+        ProductCardinalityDto absolute,
+        @Schema(description = "Relative cardinality information", nullable = true)
+        ProductCardinalityDto relativ,
+        @Schema(description = "Additional metadata")
+        Map<String, String> metadatas,
+        @Schema(description = "Ranking of the product for this score", nullable = true)
+        Integer ranking,
+        @Schema(description = "GTIN of the product with the lowest score", nullable = true)
+        Long lowestScoreId,
+        @Schema(description = "GTIN of the product with the highest score", nullable = true)
+        Long highestScoreId,
+        @Schema(description = "Percentage representation of the score on a 0-100 scale", nullable = true)
+        Long percent,
+        @Schema(description = "Score scaled on 0-20", nullable = true)
+        Long on20,
+        @Schema(description = "Absolute value formatted as text", nullable = true)
+        String absoluteValue,
+        @Schema(description = "Relative value formatted as text", nullable = true)
+        String relativeValue,
+        @Schema(description = "Letter grade representation", nullable = true)
+        String letter
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoresDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoresDto.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Score information facet.
+ */
+public record ProductScoresDto(
+        @Schema(description = "All scores keyed by their identifier")
+        Map<String, ProductScoreDto> scores,
+        @Schema(description = "Scores computed from real measurements")
+        List<ProductScoreDto> realScores,
+        @Schema(description = "Scores computed virtually")
+        List<ProductScoreDto> virtualScores,
+        @Schema(description = "Ecoscore when available", nullable = true)
+        ProductScoreDto ecoscore,
+        @Schema(description = "Score identifiers where the product ranks amongst the worst")
+        Set<String> worstScores,
+        @Schema(description = "Score identifiers where the product ranks amongst the best")
+        Set<String> bestScores
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductSourcedAttributeDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductSourcedAttributeDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Attribute value contributed by a specific datasource.
+ */
+public record ProductSourcedAttributeDto(
+        @Schema(description = "Datasource providing the attribute", example = "example-shop")
+        String datasourceName,
+        @Schema(description = "Attribute value", example = "55")
+        String value,
+        @Schema(description = "Attribute language when provided", example = "fr", nullable = true)
+        String language,
+        @Schema(description = "Icecat taxonomy identifier for the attribute", nullable = true)
+        Integer icecatTaxonomyId,
+        @Schema(description = "Attribute label provided by the datasource", nullable = true)
+        String name
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -1,22 +1,69 @@
 package org.open4goods.nudgerfrontapi.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import org.open4goods.model.Localisable;
+import org.open4goods.model.ai.AiDescriptions;
 import org.open4goods.model.exceptions.ResourceNotFoundException;
+import org.open4goods.model.price.AggregatedPrice;
+import org.open4goods.model.price.AggregatedPrices;
+import org.open4goods.model.price.PriceHistory;
 import org.open4goods.model.product.AiReviewHolder;
+import org.open4goods.model.product.ExternalIds;
+import org.open4goods.model.product.GtinInfo;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.attribute.ProductAttributes;
+import org.open4goods.model.product.ProductCondition;
+import org.open4goods.model.product.Score;
+import org.open4goods.model.product.EcoScoreRanking;
+import org.open4goods.model.resource.ImageInfo;
+import org.open4goods.model.resource.PdfInfo;
+import org.open4goods.model.resource.Resource;
+import org.open4goods.model.attribute.IndexedAttribute;
+import org.open4goods.model.attribute.ProductAttribute;
+import org.open4goods.model.attribute.SourcedAttribute;
+import org.open4goods.model.rating.Cardinality;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAiDescriptionDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductAiReviewDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductAiTextsDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAggregatedPriceDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAttributeDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAttributesDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductBaseDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductCardinalityDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDatasourcesDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
+import org.open4goods.nudgerfrontapi.dto.product.ProductExternalIdsDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductGtinInfoDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductIdentityDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductIndexedAttributeDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductNamesDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductOffersDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductPriceHistoryDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductPriceHistoryEntryDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductRankingDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductResourcesDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductResourceDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductResourceImageInfoDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductResourcePdfInfoDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductScoreDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductScoresDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductSourcedAttributeDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -39,115 +86,266 @@ import jakarta.servlet.http.HttpServletRequest;
 public class ProductMappingService {
 
     private static final Logger logger = LoggerFactory.getLogger(ProductMappingService.class);
+    private static final String DEFAULT_LANGUAGE_KEY = "default";
 
     private final ProductRepository repository;
 
     public ProductMappingService(ProductRepository repository) {
-    	this.repository = repository;
+        this.repository = repository;
     }
 
     /**
-     *
-     * @param gtin
-     * @param local
-     * @param includes
-     * @return
+     * Retrieve and map a product.
      */
-    public ProductDto getProduct(long gtin, Locale local, Set<String> includes, DomainLanguage domainLanguage)
+    public ProductDto getProduct(long gtin, Locale locale, Set<String> includes, DomainLanguage domainLanguage)
             throws ResourceNotFoundException {
-        Product p = repository.getById(gtin);
-
-        ProductDto pdto = mapProduct(p, local, includes, domainLanguage);
-        return pdto;
+        Product product = repository.getById(gtin);
+        return mapProduct(product, locale, includes, domainLanguage);
     }
 
-        private ProductDto mapProduct(  Product p, Locale local, Set<String> includes, DomainLanguage domainLanguage) {
-        ProductBaseDto base = null;
-        ProductNamesDto names = null;
-        ProductResourcesDto resources = null;
-        ProductAiTextsDto aiTexts = null;
-        ProductAiReviewDto aiReview = null;
-        ProductOffersDto offers = null;
+    private ProductDto mapProduct(Product product, Locale locale, Set<String> includes, DomainLanguage domainLanguage) {
+        EnumSet<ProductDtoComponent> components = resolveComponents(includes);
 
-        if (null != includes) {
-                for (String include : includes) {
-                        ProductDtoComponent component = ProductDtoComponent.valueOf(include);
-
-                        switch (component) {
-                                case base -> base = mapBase(p);
-                                case names -> names = mapNames(p, local);
-                                case resources -> resources = mapResources(p);
-                                case aiReview -> aiReview = mapAiReview(p, local);
-                                case offers -> offers = mapOffers(p, local);
-                                default -> throw new IllegalArgumentException("Missing component mapper for: " + include);
-                        }
-                }
-        }
+        ProductBaseDto base = components.contains(ProductDtoComponent.base) ? mapBase(product) : null;
+        ProductIdentityDto identity = components.contains(ProductDtoComponent.identity) ? mapIdentity(product) : null;
+        ProductNamesDto names = components.contains(ProductDtoComponent.names) ? mapNames(product, domainLanguage, locale) : null;
+        ProductAttributesDto attributes = components.contains(ProductDtoComponent.attributes) ? mapAttributes(product) : null;
+        ProductResourcesDto resources = components.contains(ProductDtoComponent.resources) ? mapResources(product) : null;
+        ProductDatasourcesDto datasources = components.contains(ProductDtoComponent.datasources) ? mapDatasources(product) : null;
+        ProductScoresDto scores = components.contains(ProductDtoComponent.scores) ? mapScores(product) : null;
+        ProductRankingDto ranking = components.contains(ProductDtoComponent.ranking) ? mapRanking(product) : null;
+        ProductAiTextsDto aiTexts = components.contains(ProductDtoComponent.aiTexts) ? mapAiTexts(product, domainLanguage, locale) : null;
+        ProductAiReviewDto aiReview = components.contains(ProductDtoComponent.aiReview) ? mapAiReview(product, domainLanguage, locale) : null;
+        ProductOffersDto offers = components.contains(ProductDtoComponent.offers) ? mapOffers(product) : null;
 
         return new ProductDto(
-                p.getId(),
+                product.getId(),
                 base,
+                identity,
                 names,
+                attributes,
                 resources,
+                datasources,
+                scores,
+                ranking,
                 aiTexts,
                 aiReview,
                 offers);
+    }
+
+    private EnumSet<ProductDtoComponent> resolveComponents(Set<String> includes) {
+        if (includes == null || includes.isEmpty()) {
+            return EnumSet.allOf(ProductDtoComponent.class);
         }
-
-
-    private ProductOffersDto mapOffers(Product p, Locale local) {
-                return null;
+        EnumSet<ProductDtoComponent> resolved = EnumSet.noneOf(ProductDtoComponent.class);
+        for (String include : includes) {
+            if (include == null || include.isBlank()) {
+                continue;
+            }
+            try {
+                resolved.add(ProductDtoComponent.valueOf(include.trim()));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException("Unknown component requested: " + include, ex);
+            }
         }
+        return resolved.isEmpty() ? EnumSet.allOf(ProductDtoComponent.class) : resolved;
+    }
 
-        private ProductBaseDto mapBase(Product p) {
-                return new ProductBaseDto(
-                                p.getId(),
-                                p.getCreationDate(),
-                                p.getLastChange(),
-                                p.getVertical(),
-                                p.getExternalIds(),
-                                p.getGoogleTaxonomyId());
-        }
+    private ProductBaseDto mapBase(Product product) {
+        return new ProductBaseDto(
+                product.getId(),
+                product.getCreationDate(),
+                product.getLastChange(),
+                product.getVertical(),
+                mapExternalIds(product.getExternalIds()),
+                product.getGoogleTaxonomyId(),
+                product.isExcluded(),
+                product.getExcludedCauses() == null ? Collections.emptySet() : new LinkedHashSet<>(product.getExcludedCauses()),
+                mapGtinInfo(product.getGtinInfos()),
+                product.getCoverImagePath());
+    }
 
-        private ProductNamesDto mapNames(Product p, Locale local) {
-                if (p.getNames() == null) {
-                        return null;
-                }
-                return new ProductNamesDto(
-                                p.getNames().getH1Title().i18n(local.getLanguage()),
-                                p.getNames().getMetaDescription().i18n(local.getLanguage()),
-                                p.getNames().getProductMetaOpenGraphTitle().i18n(local.getLanguage()),
-                                p.getNames().getProductMetaOpenGraphDescription().i18n(local.getLanguage()),
-                                p.getNames().getProductMetaTwitterTitle().i18n(local.getLanguage()),
-                                p.getNames().getProductMetaTwitterDescription().i18n(local.getLanguage()));
-        }
+    private ProductIdentityDto mapIdentity(Product product) {
+        Map<String, String> akaBrandsByDatasource = product.getAkaBrands() == null
+                ? Collections.emptyMap()
+                : new LinkedHashMap<>(product.getAkaBrands());
+        Set<String> akaBrands = product.akaBrands() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(product.akaBrands());
+        Set<String> akaModels = product.getAkaModels() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(product.getAkaModels());
 
-        private ProductResourcesDto mapResources(Product p) {
-                return new ProductResourcesDto(
-                                p.unprocessedImagesUrl(),
-                                p.videos().stream().map(r -> r.getUrl()).toList(),
-                                p.pdfs().stream().map(r -> r.getUrl()).toList(),
-                                p.externalCover());
-        }
+        return new ProductIdentityDto(
+                product.brand(),
+                product.model(),
+                product.bestName(),
+                safeCall(product::randomModel),
+                safeCall(product::shortestModel),
+                product.hasAlternateIds(),
+                product.alternateIdsAsText(),
+                akaModels,
+                akaBrandsByDatasource,
+                akaBrands,
+                product.gtin());
+    }
 
-
-	/**
-     * AI Review component mapping
-     * @param p
-     * @param local
-     * @return
-     */
-    private ProductAiReviewDto mapAiReview(Product p, Locale local) {
-        if (p == null || p.getReviews() == null) {
+    private ProductNamesDto mapNames(Product product, DomainLanguage domainLanguage, Locale locale) {
+        if (product.getNames() == null) {
             return null;
         }
+        List<String> namesWithoutShortest = safeCall(product::namesAndDescriptionsWithoutShortestName);
 
-        AiReviewHolder holder = p.getReviews().i18n(local.getLanguage());
-        if (holder == null) {
-            return null;
+        return new ProductNamesDto(
+                resolveLocalisedString(product.getNames().getUrl(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getH1Title(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getMetaDescription(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getProductMetaOpenGraphTitle(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getProductMetaOpenGraphDescription(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getProductMetaTwitterTitle(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getProductMetaTwitterDescription(), domainLanguage, locale),
+                product.getOfferNames() == null ? Collections.emptySet() : new LinkedHashSet<>(product.getOfferNames()),
+                safeCall(product::longestOfferName),
+                safeCall(product::shortestOfferName),
+                namesWithoutShortest == null ? Collections.emptyList() : namesWithoutShortest);
+    }
+
+    private ProductAttributesDto mapAttributes(Product product) {
+        ProductAttributes attributes = product.getAttributes();
+        if (attributes == null) {
+            return new ProductAttributesDto(Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), product.caracteristics());
+        }
+        Map<String, ProductIndexedAttributeDto> indexed;
+        if (attributes.getIndexed() == null) {
+            indexed = Collections.emptyMap();
+        } else {
+            indexed = new LinkedHashMap<>();
+            attributes.getIndexed().forEach((key, value) -> indexed.put(key, mapIndexedAttribute(value)));
+        }
+        Map<String, ProductAttributeDto> all;
+        if (attributes.getAll() == null) {
+            all = Collections.emptyMap();
+        } else {
+            all = new LinkedHashMap<>();
+            attributes.getAll().forEach((key, value) -> all.put(key, mapProductAttribute(value)));
+        }
+        Map<String, String> referential;
+        if (attributes.getReferentielAttributes() == null) {
+            referential = Collections.emptyMap();
+        } else {
+            referential = new LinkedHashMap<>();
+            attributes.getReferentielAttributes().forEach((key, value) -> referential.put(key.toString(), value));
         }
 
+        return new ProductAttributesDto(referential, indexed, all, product.caracteristics());
+    }
+
+    private ProductResourcesDto mapResources(Product product) {
+        List<ProductResourceDto> resources = product.getResources() == null
+                ? Collections.emptyList()
+                : product.getResources().stream().map(this::mapResource).toList();
+        List<ProductResourceDto> images = product.images() == null
+                ? Collections.emptyList()
+                : product.images().stream().map(this::mapResource).toList();
+        List<ProductResourceDto> unprocessedImages = product.unprocessedimages() == null
+                ? Collections.emptyList()
+                : product.unprocessedimages().stream().map(this::mapResource).toList();
+        List<String> unprocessedImagesUrl = product.unprocessedImagesUrl() == null
+                ? Collections.emptyList()
+                : product.unprocessedImagesUrl();
+        List<ProductResourceDto> videos = product.videos() == null
+                ? Collections.emptyList()
+                : product.videos().stream().map(this::mapResource).toList();
+        List<ProductResourceDto> pdfs = product.pdfs() == null
+                ? Collections.emptyList()
+                : product.pdfs().stream().map(this::mapResource).toList();
+
+        return new ProductResourcesDto(resources, images, unprocessedImages, unprocessedImagesUrl, videos, pdfs, product.externalCover());
+    }
+
+    private ProductDatasourcesDto mapDatasources(Product product) {
+        Map<String, Long> datasourceCodes = product.getDatasourceCodes() == null
+                ? Collections.emptyMap()
+                : new LinkedHashMap<>(product.getDatasourceCodes());
+        Map<String, String> categoriesByDatasource = product.getCategoriesByDatasources() == null
+                ? Collections.emptyMap()
+                : new LinkedHashMap<>(product.getCategoriesByDatasources());
+        Set<String> datasourceCategories = product.getDatasourceCategories() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(product.getDatasourceCategories());
+        List<String> categoriesWithoutShortest = safeCall(product::datasourceCategoriesWithoutShortest);
+        Set<String> datasourceCategoriesWithoutShortest = categoriesWithoutShortest == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(categoriesWithoutShortest);
+
+        return new ProductDatasourcesDto(datasourceCodes, categoriesByDatasource, datasourceCategories, datasourceCategoriesWithoutShortest);
+    }
+
+    private ProductScoresDto mapScores(Product product) {
+        Map<String, ProductScoreDto> scores = product.getScores() == null
+                ? Collections.emptyMap()
+                : product.getScores().entrySet().stream()
+                        .collect(Collectors.toMap(Entry::getKey,
+                                entry -> mapScore(entry.getValue()),
+                                (left, right) -> right,
+                                LinkedHashMap::new));
+        List<ProductScoreDto> realScores = product.realScores() == null
+                ? Collections.emptyList()
+                : product.realScores().stream().map(this::mapScore).toList();
+        List<ProductScoreDto> virtualScores = product.virtualScores() == null
+                ? Collections.emptyList()
+                : product.virtualScores().stream().map(this::mapScore).toList();
+        ProductScoreDto ecoscore = product.ecoscore() == null ? null : mapScore(product.ecoscore());
+        Set<String> worstScores = product.getWorsesScores() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(product.getWorsesScores());
+        Set<String> bestScores = product.getBestsScores() == null
+                ? Collections.emptySet()
+                : new LinkedHashSet<>(product.getBestsScores());
+
+        return new ProductScoresDto(scores, realScores, virtualScores, ecoscore, worstScores, bestScores);
+    }
+
+    private ProductRankingDto mapRanking(Product product) {
+        EcoScoreRanking ranking = product.getRanking();
+        if (ranking == null) {
+            return null;
+        }
+        return new ProductRankingDto(
+                ranking.getGlobalPosition(),
+                ranking.getGlobalCount(),
+                ranking.getGlobalBest(),
+                ranking.getGlobalBetter(),
+                ranking.getSpecializedPosition(),
+                ranking.getSpecializedCount(),
+                ranking.getSpecializedBest(),
+                ranking.getSpecializedBetter());
+    }
+
+    private ProductAiTextsDto mapAiTexts(Product product, DomainLanguage domainLanguage, Locale locale) {
+        ResolvedLocalisedValue<AiDescriptions> resolved = resolveLocalised(product.getGenaiTexts(), domainLanguage, locale);
+        if (resolved.value() == null) {
+            return null;
+        }
+        Map<String, ProductAiDescriptionDto> descriptions = Optional.ofNullable(resolved.value().getDescriptions())
+                .orElse(Collections.emptyMap())
+                .entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .collect(Collectors.toMap(Entry::getKey,
+                        entry -> new ProductAiDescriptionDto(entry.getValue().getTs(), entry.getValue().getContent()),
+                        (left, right) -> right,
+                        LinkedHashMap::new));
+        return new ProductAiTextsDto(resolved.key(), descriptions);
+    }
+
+    private ProductAiReviewDto mapAiReview(Product product, DomainLanguage domainLanguage, Locale locale) {
+        ResolvedLocalisedValue<AiReviewHolder> resolved = resolveLocalised(product.getReviews(), domainLanguage, locale);
+        if (resolved.value() == null) {
+            return null;
+        }
+        AiReviewHolder holder = resolved.value();
         return new ProductAiReviewDto(
+                resolved.key(),
                 holder.getReview(),
                 holder.getSources(),
                 holder.isEnoughData(),
@@ -155,32 +353,338 @@ public class ProductMappingService {
                 holder.getCreatedMs());
     }
 
+    private ProductOffersDto mapOffers(Product product) {
+        AggregatedPrices aggregatedPrices = product.getPrice();
+        ProductAggregatedPriceDto bestPrice = mapAggregatedPrice(product.bestPrice());
+        ProductAggregatedPriceDto bestNew = aggregatedPrices == null ? null : mapAggregatedPrice(aggregatedPrices.bestNewOffer());
+        ProductAggregatedPriceDto bestOccasion = aggregatedPrices == null ? null : mapAggregatedPrice(aggregatedPrices.bestOccasionOffer());
+
+        Map<ProductCondition, List<ProductAggregatedPriceDto>> offersByCondition = Collections.emptyMap();
+        ProductPriceHistoryDto newHistory = null;
+        ProductPriceHistoryDto occasionHistory = null;
+        Map<ProductCondition, Integer> trends = Collections.emptyMap();
+        Set<ProductCondition> conditions = Collections.emptySet();
+        Double historyPriceGap = null;
+
+        if (aggregatedPrices != null) {
+            offersByCondition = aggregatedPrices.getConditions() == null
+                    ? Collections.emptyMap()
+                    : aggregatedPrices.getConditions().stream()
+                            .collect(Collectors.toMap(
+                                    condition -> condition,
+                                    condition -> aggregatedPrices.sortedOffers(condition).stream()
+                                            .map(this::mapAggregatedPrice)
+                                            .collect(Collectors.toList()),
+                                    (left, right) -> right,
+                                    () -> new EnumMap<>(ProductCondition.class)));
+            newHistory = mapPriceHistory(aggregatedPrices.getNewPricehistory());
+            occasionHistory = mapPriceHistory(aggregatedPrices.getOccasionPricehistory());
+            trends = aggregatedPrices.getTrends() == null
+                    ? Collections.emptyMap()
+                    : new EnumMap<>(aggregatedPrices.getTrends());
+            conditions = aggregatedPrices.getConditions() == null
+                    ? EnumSet.noneOf(ProductCondition.class)
+                    : aggregatedPrices.getConditions().isEmpty()
+                            ? EnumSet.noneOf(ProductCondition.class)
+                            : EnumSet.copyOf(aggregatedPrices.getConditions());
+            historyPriceGap = aggregatedPrices.historyPriceGap();
+        }
+
+        return new ProductOffersDto(
+                product.getOffersCount(),
+                product.hasOccasions(),
+                bestPrice,
+                bestNew,
+                bestOccasion,
+                offersByCondition,
+                newHistory,
+                occasionHistory,
+                trends,
+                conditions,
+                historyPriceGap);
+    }
 
     public Page<ProductDto> getProducts(Pageable pageable, Locale locale, Set<String> includes,
                                         AggregationRequestDto aggregation, DomainLanguage domainLanguage) {
 
-                // TODO implement aggregation handling once search service is ready
-                SearchHits<Product> response = repository.get(pageable);
-                List<ProductDto> items = response
-                                .map(e -> e.getContent())
-                                .map(e -> mapProduct(e, locale, includes, domainLanguage))
-                                .toList();
+        SearchHits<Product> response = repository.get(pageable);
+        List<ProductDto> items = response
+                .map(hit -> hit.getContent())
+                .map(product -> mapProduct(product, locale, includes, domainLanguage))
+                .toList();
 
-		return  new PageImpl<ProductDto>(items, pageable, response.getTotalHits());
+        return new PageImpl<>(items, pageable, response.getTotalHits());
     }
 
-
-
-	public Page<ProductReviewDto> getReviews(long gtin, Pageable pageable) throws ResourceNotFoundException {
+    public Page<ProductReviewDto> getReviews(long gtin, Pageable pageable) throws ResourceNotFoundException {
         List<ProductReviewDto> reviews = new ArrayList<>();
         return new PageImpl<>(reviews, pageable, 0);
     }
 
-
     public void createReview(long gtin, String captchaResponse, HttpServletRequest request)
             throws ResourceNotFoundException, SecurityException {
-        // Ensure the product exists
         repository.getById(gtin);
         logger.info("AI review generation requested for product {}", gtin);
+    }
+
+    private ProductExternalIdsDto mapExternalIds(ExternalIds externalIds) {
+        if (externalIds == null) {
+            return null;
+        }
+        return new ProductExternalIdsDto(
+                externalIds.getAsin(),
+                externalIds.getIcecat(),
+                externalIds.getMpn() == null ? Collections.emptySet() : new LinkedHashSet<>(externalIds.getMpn()),
+                externalIds.getSku() == null ? Collections.emptySet() : new LinkedHashSet<>(externalIds.getSku()));
+    }
+
+    private ProductGtinInfoDto mapGtinInfo(GtinInfo gtinInfo) {
+        if (gtinInfo == null) {
+            return null;
+        }
+        return new ProductGtinInfoDto(gtinInfo.getUpcType(), gtinInfo.getCountry());
+    }
+
+    private ProductIndexedAttributeDto mapIndexedAttribute(IndexedAttribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return new ProductIndexedAttributeDto(
+                attribute.getName(),
+                attribute.getValue(),
+                attribute.getNumericValue(),
+                attribute.getBoolValue());
+    }
+
+    private ProductAttributeDto mapProductAttribute(ProductAttribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        Set<ProductSourcedAttributeDto> sources = attribute.getSource() == null
+                ? Collections.emptySet()
+                : attribute.getSource().stream()
+                        .map(this::mapSourcedAttribute)
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+        return new ProductAttributeDto(
+                attribute.getName(),
+                attribute.getValue(),
+                attribute.getNumericValue(),
+                attribute.getIcecatTaxonomyIds() == null ? Collections.emptySet() : new LinkedHashSet<>(attribute.getIcecatTaxonomyIds()),
+                sources);
+    }
+
+    private ProductSourcedAttributeDto mapSourcedAttribute(SourcedAttribute attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return new ProductSourcedAttributeDto(
+                attribute.getDataSourcename(),
+                attribute.getValue(),
+                null,
+                attribute.getIcecatTaxonomyId(),
+                attribute.getName());
+    }
+
+    private ProductResourceDto mapResource(Resource resource) {
+        if (resource == null) {
+            return null;
+        }
+        return new ProductResourceDto(
+                resource.getUrl(),
+                resource.getMimeType(),
+                resource.getTimeStamp(),
+                resource.getCacheKey(),
+                resource.isEvicted(),
+                resource.isProcessed(),
+                resource.getStatus(),
+                resource.getFileSize(),
+                resource.getFileName(),
+                resource.getExtension(),
+                resource.getMd5(),
+                resource.getResourceType(),
+                mapImageInfo(resource.getImageInfo()),
+                mapPdfInfo(resource.getPdfInfo()),
+                resource.getGroup(),
+                resource.getDatasourceName(),
+                resource.getTags() == null ? Collections.emptySet() : new LinkedHashSet<>(resource.getTags()),
+                resource.getHardTags() == null ? Collections.emptySet() : new LinkedHashSet<>(resource.getHardTags()));
+    }
+
+    private ProductResourceImageInfoDto mapImageInfo(ImageInfo imageInfo) {
+        if (imageInfo == null) {
+            return null;
+        }
+        return new ProductResourceImageInfoDto(
+                imageInfo.getHeight(),
+                imageInfo.getWidth(),
+                imageInfo.getpHashValue(),
+                imageInfo.getpHashLength());
+    }
+
+    private ProductResourcePdfInfoDto mapPdfInfo(PdfInfo pdfInfo) {
+        if (pdfInfo == null) {
+            return null;
+        }
+        return new ProductResourcePdfInfoDto(
+                pdfInfo.getMetadataTitle(),
+                pdfInfo.getExtractedTitle(),
+                pdfInfo.getNumberOfPages(),
+                pdfInfo.getAuthor(),
+                pdfInfo.getSubject(),
+                pdfInfo.getKeywords(),
+                pdfInfo.getCreationDate(),
+                pdfInfo.getModificationDate(),
+                pdfInfo.getProducer(),
+                pdfInfo.getLanguage(),
+                pdfInfo.getLanguageConfidence());
+    }
+
+    private ProductAggregatedPriceDto mapAggregatedPrice(AggregatedPrice price) {
+        if (price == null) {
+            return null;
+        }
+        return new ProductAggregatedPriceDto(
+                price.getDatasourceName(),
+                price.getOfferName(),
+                price.getUrl(),
+                price.getCompensation(),
+                price.getProductState(),
+                price.getAffiliationToken(),
+                price.getPrice(),
+                price.getCurrency(),
+                price.getTimeStamp(),
+                safeCall(price::shortPrice));
+    }
+
+    private ProductPriceHistoryDto mapPriceHistory(List<PriceHistory> history) {
+        if (history == null || history.isEmpty()) {
+            return null;
+        }
+        List<ProductPriceHistoryEntryDto> entries = history.stream()
+                .map(this::mapPriceHistoryEntry)
+                .collect(Collectors.toList());
+        PriceHistory lowest = history.stream().min((left, right) -> Double.compare(left.price(), right.price())).orElse(null);
+        PriceHistory highest = history.stream().max((left, right) -> Double.compare(left.price(), right.price())).orElse(null);
+        Double average = history.stream().mapToDouble(PriceHistory::price).average().orElse(Double.NaN);
+        if (Double.isNaN(average)) {
+            average = null;
+        }
+        return new ProductPriceHistoryDto(
+                entries,
+                mapPriceHistoryEntry(lowest),
+                mapPriceHistoryEntry(highest),
+                average);
+    }
+
+    private ProductPriceHistoryEntryDto mapPriceHistoryEntry(PriceHistory entry) {
+        if (entry == null) {
+            return null;
+        }
+        return new ProductPriceHistoryEntryDto(entry.timestamp(), entry.price());
+    }
+
+    private ProductScoreDto mapScore(Score score) {
+        if (score == null) {
+            return null;
+        }
+        return new ProductScoreDto(
+                score.getName(),
+                score.getVirtual(),
+                score.getValue(),
+                mapCardinality(score.getAbsolute()),
+                mapCardinality(score.getRelativ()),
+                score.getMetadatas(),
+                score.getRanking(),
+                score.getLowestScoreId(),
+                score.getHighestScoreId(),
+                safeCall(score::percent),
+                safeCall(score::on20),
+                safeCall(score::absValue),
+                safeCall(score::relValue),
+                safeCall(score::letter));
+    }
+
+    private ProductCardinalityDto mapCardinality(Cardinality cardinality) {
+        if (cardinality == null) {
+            return null;
+        }
+        return new ProductCardinalityDto(
+                cardinality.getMin(),
+                cardinality.getMax(),
+                cardinality.getAvg(),
+                cardinality.getCount(),
+                cardinality.getSum(),
+                cardinality.getValue());
+    }
+
+    private String resolveLocalisedString(Localisable<String, String> localisable, DomainLanguage domainLanguage, Locale locale) {
+        ResolvedLocalisedValue<String> resolved = resolveLocalised(localisable, domainLanguage, locale);
+        return resolved.value();
+    }
+
+    private <T> ResolvedLocalisedValue<T> resolveLocalised(Localisable<String, T> localisable, DomainLanguage domainLanguage, Locale locale) {
+        if (localisable == null || localisable.isEmpty()) {
+            return new ResolvedLocalisedValue<>(null, null);
+        }
+        for (String key : candidateLanguageKeys(domainLanguage, locale)) {
+            if (localisable.containsKey(key)) {
+                T value = localisable.get(key);
+                if (value != null) {
+                    return new ResolvedLocalisedValue<>(key, value);
+                }
+            }
+        }
+        Optional<Entry<String, T>> fallback = localisable.entrySet().stream()
+                .filter(entry -> entry.getValue() != null)
+                .findFirst();
+        return fallback.map(entry -> new ResolvedLocalisedValue<>(entry.getKey(), entry.getValue()))
+                .orElseGet(() -> new ResolvedLocalisedValue<>(null, null));
+    }
+
+    private Set<String> candidateLanguageKeys(DomainLanguage domainLanguage, Locale locale) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        if (domainLanguage != null) {
+            String iso = domainLanguage.name();
+            String tag = domainLanguage.languageTag();
+            String normalizedTag = tag.replace('_', '-');
+            keys.add(iso);
+            keys.add(iso.toLowerCase(Locale.ROOT));
+            keys.add(iso.toUpperCase(Locale.ROOT));
+            keys.add(tag);
+            keys.add(tag.toLowerCase(Locale.ROOT));
+            keys.add(normalizedTag);
+            keys.add(normalizedTag.toLowerCase(Locale.ROOT));
+            if (normalizedTag.contains("-")) {
+                String base = normalizedTag.substring(0, normalizedTag.indexOf('-'));
+                keys.add(base);
+                keys.add(base.toLowerCase(Locale.ROOT));
+            }
+        }
+        if (locale != null) {
+            String language = locale.getLanguage();
+            if (language != null && !language.isBlank()) {
+                keys.add(language);
+                keys.add(language.toLowerCase(Locale.ROOT));
+            }
+            String localeTag = locale.toLanguageTag();
+            if (localeTag != null && !localeTag.isBlank()) {
+                keys.add(localeTag);
+                keys.add(localeTag.toLowerCase(Locale.ROOT));
+            }
+        }
+        keys.add(DEFAULT_LANGUAGE_KEY);
+        return keys;
+    }
+
+    private <T> T safeCall(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception ex) {
+            logger.debug("Computed helper failed: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    private record ResolvedLocalisedValue<T>(String key, T value) {
     }
 }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -76,7 +76,7 @@ class ProductControllerIT {
     void includeParameterFiltersFields() throws Exception {
         long gtin = 321L;
         given(service.getProduct(anyLong(), any(Locale.class), anySet(), any(DomainLanguage.class)))
-                .willReturn(new ProductDto(0L, null, null, null, null, null, null));
+                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null));
 
         mockMvc.perform(get("/products/{gtin}", gtin)
                         .param("include", "gtin")
@@ -103,7 +103,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointReturnsPage() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")
@@ -118,7 +118,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointAcceptsAggregationParameter() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")


### PR DESCRIPTION
## Summary
- redesign `ProductDto` to expose identity, attributes, resources, datasource, scoring, and pricing facets alongside AI outputs
- add dedicated DTOs for the new facets with Swagger annotations and localisation-ready fields
- overhaul `ProductMappingService` to populate every facet from `Product`, honouring `DomainLanguage`, and adjust controller tests

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68ea5d7073b88333b215071ef102c7f9