### PR TITLE
Refine product DTO contract

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDatasourcesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDatasourcesDto.java
@@ -1,7 +1,6 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
 import java.util.Map;
-import java.util.Set;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -10,12 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 public record ProductDatasourcesDto(
         @Schema(description = "Codes assigned to the product by each datasource")
-        Map<String, Long> datasourceCodes,
-        @Schema(description = "Categories assigned by the contributing datasources")
-        Map<String, String> categoriesByDatasource,
-        @Schema(description = "Union of datasource categories")
-        Set<String> datasourceCategories,
-        @Schema(description = "Datasource categories excluding the shortest one")
-        Set<String> datasourceCategoriesWithoutShortest
+        Map<String, Long> datasourceCodes
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ProductDto(
         @Schema(description = "Product GTIN, it is the unique identifier", example = "7612345678901")
         long gtin,
+        @Schema(description = "Canonical product URL previously exposed as names.url", example = "https://example.org/products/123")
+        String slug,
         @Schema(description = "Basic product metadata")
         ProductBaseDto base,
         @Schema(description = "Identity facet exposing brand, model and alternate identifiers")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIdentityDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIdentityDto.java
@@ -20,17 +20,11 @@ public record ProductIdentityDto(
         String randomModel,
         @Schema(description = "Shortest known model value", example = "XM5")
         String shortestModel,
-        @Schema(description = "Whether alternate identifiers are available")
-        boolean hasAlternateIds,
-        @Schema(description = "Human readable list of alternate identifiers", example = "WH1000XM5, XM5")
-        String alternateIdsText,
         @Schema(description = "Set of alternative model identifiers discovered across datasources")
         Set<String> akaModels,
         @Schema(description = "Alternative brand values keyed by datasource")
         Map<String, String> akaBrandsByDatasource,
         @Schema(description = "Distinct set of alternative brand values")
-        Set<String> akaBrands,
-        @Schema(description = "GTIN rendered as string to preserve leading zeros", example = "07612345678901")
-        String gtinAsString
+        Set<String> akaBrands
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -1,6 +1,5 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
-import java.util.List;
 import java.util.Set;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,8 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Localised textual information resolved against the requested domain language.
  */
 public record ProductNamesDto(
-        @Schema(description = "Canonical product URL for the resolved language", example = "https://example.org/products/123")
-        String url,
         @Schema(description = "H1 title for the requested language", example = "Casque Bluetooth haut de gamme")
         String h1Title,
         @Schema(description = "Meta description aligned with the requested language")
@@ -19,17 +16,11 @@ public record ProductNamesDto(
         String ogTitle,
         @Schema(description = "OpenGraph description for social sharing")
         String ogDescription,
-        @Schema(description = "Twitter card title")
-        String twitterTitle,
-        @Schema(description = "Twitter card description")
-        String twitterDescription,
         @Schema(description = "Offer names aggregated across datasources")
         Set<String> offerNames,
         @Schema(description = "Longest detected offer name", nullable = true)
         String longestOfferName,
         @Schema(description = "Shortest detected offer name", nullable = true)
-        String shortestOfferName,
-        @Schema(description = "All names and descriptions excluding the shortest offer name")
-        List<String> namesAndDescriptionsWithoutShortestName
+        String shortestOfferName
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
@@ -2,8 +2,6 @@ package org.open4goods.nudgerfrontapi.dto.product;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
 import org.open4goods.model.product.ProductCondition;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -30,8 +28,6 @@ public record ProductOffersDto(
         ProductPriceHistoryDto occasionHistory,
         @Schema(description = "Price evolution trends per condition", nullable = true)
         Map<ProductCondition, Integer> trends,
-        @Schema(description = "Available product conditions")
-        Set<ProductCondition> conditions,
         @Schema(description = "Gap between current best price and historical lowest price", nullable = true)
         Double historyPriceGap
 ) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductResourcesDto.java
@@ -8,14 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Media resources associated with the product.
  */
 public record ProductResourcesDto(
-        @Schema(description = "All resources attached to the product")
-        List<ProductResourceDto> resources,
         @Schema(description = "Images grouped and ranked by relevance")
         List<ProductResourceDto> images,
-        @Schema(description = "Images collected before processing")
-        List<ProductResourceDto> unprocessedImages,
-        @Schema(description = "List of unprocessed image URLs for quick previews")
-        List<String> unprocessedImagesUrl,
         @Schema(description = "Video resources extracted from datasources")
         List<ProductResourceDto> videos,
         @Schema(description = "PDF resources extracted from datasources")

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -76,7 +76,7 @@ class ProductControllerIT {
     void includeParameterFiltersFields() throws Exception {
         long gtin = 321L;
         given(service.getProduct(anyLong(), any(Locale.class), anySet(), any(DomainLanguage.class)))
-                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null));
+                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null));
 
         mockMvc.perform(get("/products/{gtin}", gtin)
                         .param("include", "gtin")
@@ -103,7 +103,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointReturnsPage() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")
@@ -118,7 +118,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointAcceptsAggregationParameter() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")


### PR DESCRIPTION
## Summary
- remove deprecated identity, names, datasource, and offers fields from the product payload
- expose the canonical product URL as a root-level slug and slim the resources facet to images, videos, and PDFs
- align the mapping service and controller tests with the trimmed DTOs

## Testing
- `mvn --offline -pl front-api -am test`


------
https://chatgpt.com/codex/tasks/task_e_68ea76fdf8948333b80c9f2d0151b01e