### PR TITLE
feat: localize GTIN metadata and prefix cover images

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -74,6 +74,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>77.1</version>
+    </dependency>
+
+    <dependency>
         <groupId>org.open4goods</groupId>
         <artifactId>xwiki-spring-boot-starter</artifactId>
         <version>${global.version}</version>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
@@ -27,7 +27,7 @@ public record ProductBaseDto(
         Set<String> excludedCauses,
         @Schema(description = "Information inferred from the GTIN itself")
         ProductGtinInfoDto gtinInfo,
-        @Schema(description = "Path of the preferred cover image if available")
+        @Schema(description = "Absolute URL of the preferred cover image if available")
         String coverImagePath
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductGtinInfoDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductGtinInfoDto.java
@@ -10,7 +10,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ProductGtinInfoDto(
         @Schema(description = "UPC type derived from the GTIN")
         BarcodeType upcType,
-        @Schema(description = "Manufacturer country inferred from the GTIN prefix", example = "FR")
-        String country
+        @Schema(description = "Manufacturer country code inferred from the GTIN prefix", example = "FR")
+        String countryCode,
+        @Schema(description = "Manufacturer country name localised with the requested domainLanguage", example = "France")
+        String countryName,
+        @Schema(description = "URL of the country flag icon matching the manufacturer country", example = "/images/flags/fr.png")
+        String countryFlagUrl
 ) {
 }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -1,7 +1,6 @@
 package org.open4goods.nudgerfrontapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,7 +15,9 @@ import org.open4goods.model.Localisable;
 import org.open4goods.model.ai.AiReview;
 import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.model.product.AiReviewHolder;
+import org.open4goods.model.product.GtinInfo;
 import org.open4goods.model.product.Product;
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -25,11 +26,14 @@ class ProductMappingServiceTest {
 
     private ProductRepository repository;
     private ProductMappingService service;
+    private ApiProperties apiProperties;
 
     @BeforeEach
     void setUp() {
         repository = mock(ProductRepository.class);
-        service = new ProductMappingService(repository);
+        apiProperties = new ApiProperties();
+        apiProperties.setResourceRootPath("https://static.example");
+        service = new ProductMappingService(repository, apiProperties);
     }
 
     @Test
@@ -60,6 +64,10 @@ class ProductMappingServiceTest {
         Product product = new Product(gtin);
         product.setCreationDate(1L);
         product.setLastChange(2L);
+        product.setCoverImagePath("/covers/main.jpg");
+        GtinInfo gtinInfo = new GtinInfo();
+        gtinInfo.setCountry("FR");
+        product.setGtinInfos(gtinInfo);
 
         when(repository.getById(gtin)).thenReturn(product);
 
@@ -67,6 +75,11 @@ class ProductMappingServiceTest {
 
         assertThat(dto.base()).isNotNull();
         assertThat(dto.base().gtin()).isEqualTo(gtin);
+        assertThat(dto.base().coverImagePath()).isEqualTo("https://static.example/covers/main.jpg");
+        assertThat(dto.base().gtinInfo()).isNotNull();
+        assertThat(dto.base().gtinInfo().countryCode()).isEqualTo("FR");
+        assertThat(dto.base().gtinInfo().countryName()).isEqualTo("France");
+        assertThat(dto.base().gtinInfo().countryFlagUrl()).isEqualTo("/images/flags/fr.png");
     }
 
 


### PR DESCRIPTION
## Summary
- rename GTIN metadata field to expose the country code together with the localised name and flag URL
- prefix product cover images with the configured resource root while wiring ApiProperties into the mapping service
- add the ICU dependency and extend mapping tests to cover the new behaviour

## Testing
- mvn -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68ea7c268a148333836bcb4564f3e4ce