### PR TITLE
feat(front-api): expose taxonomy navigation endpoints

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleCategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleCategoriesController.java
@@ -1,0 +1,252 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.util.List;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategorySummaryDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleCategoryNavigationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing navigation endpoints over the Google taxonomy tree used by the frontend.
+ */
+@RestController
+@RequestMapping("/categories/taxonomy")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Categories", description = "Explore Google taxonomy categories and their associated vertical configurations.")
+public class GoogleCategoriesController {
+
+    private final GoogleCategoryNavigationService navigationService;
+
+    public GoogleCategoriesController(GoogleCategoryNavigationService navigationService) {
+        this.navigationService = navigationService;
+    }
+
+    /**
+     * Retrieve a taxonomy category by its Google taxonomy identifier.
+     */
+    @GetMapping("/{taxonomyId}")
+    @Operation(
+            summary = "Get taxonomy category by id",
+            description = "Return a taxonomy category enriched with breadcrumbs, children and associated vertical configuration.",
+            parameters = {
+                    @Parameter(name = "taxonomyId", in = ParameterIn.PATH, required = true,
+                            description = "Google taxonomy identifier of the category to retrieve.",
+                            schema = @Schema(type = "integer", example = "1234")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Category returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = GoogleCategoryDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Category not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<GoogleCategoryDto> getCategoryById(
+            @PathVariable("taxonomyId") Integer taxonomyId,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getCategoryById(taxonomyId, domainLanguage)
+                .map(dto -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(dto))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Retrieve the taxonomy root category without providing a slug path.
+     */
+    @GetMapping("/path")
+    @Operation(
+            summary = "Get taxonomy root category",
+            description = "Return the root taxonomy node enriched with breadcrumbs, children and associated vertical configuration.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Category returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = GoogleCategoryDto.class)))
+            }
+    )
+    public ResponseEntity<GoogleCategoryDto> getRootCategory(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getCategoryByPath(null, domainLanguage)
+                .map(dto -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(dto))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Retrieve a taxonomy category by its slug path.
+     */
+    @GetMapping("/path/{categoryPath:.+}")
+    @Operation(
+            summary = "Get taxonomy category by slug path",
+            description = "Return a taxonomy category referenced by its slug path relative to the taxonomy root.",
+            parameters = {
+                    @Parameter(name = "categoryPath", in = ParameterIn.PATH, required = true,
+                            description = "Slug path of the taxonomy category (e.g. electronics/televisions).",
+                            schema = @Schema(type = "string")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Category returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = GoogleCategoryDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Category not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<GoogleCategoryDto> getCategoryByPath(
+            @PathVariable(name = "categoryPath") String categoryPath,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getCategoryByPath(categoryPath, domainLanguage)
+                .map(dto -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(dto))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Retrieve the immediate children of a taxonomy category by id.
+     */
+    @GetMapping("/{taxonomyId}/children")
+    @Operation(
+            summary = "List taxonomy children by id",
+            description = "Return the immediate children of a taxonomy node identified by its Google taxonomy id.",
+            parameters = {
+                    @Parameter(name = "taxonomyId", in = ParameterIn.PATH, required = true,
+                            description = "Google taxonomy identifier of the parent category.",
+                            schema = @Schema(type = "integer", example = "1234")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Children returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = GoogleCategorySummaryDto.class)))),
+                    @ApiResponse(responseCode = "404", description = "Category not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<List<GoogleCategorySummaryDto>> getChildrenById(
+            @PathVariable("taxonomyId") Integer taxonomyId,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getChildrenById(taxonomyId, domainLanguage)
+                .map(children -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(children))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Retrieve the immediate children of a taxonomy category by slug path.
+     */
+    @GetMapping("/path/children")
+    @Operation(
+            summary = "List root taxonomy children",
+            description = "Return the immediate children of the taxonomy root node.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Children returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = GoogleCategorySummaryDto.class))))
+            }
+    )
+    public ResponseEntity<List<GoogleCategorySummaryDto>> getRootChildren(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getChildrenByPath(null, domainLanguage)
+                .map(children -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(children))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/path/{categoryPath:.+}/children")
+    @Operation(
+            summary = "List taxonomy children by slug path",
+            description = "Return the immediate children of a taxonomy node referenced by its slug path.",
+            parameters = {
+                    @Parameter(name = "categoryPath", in = ParameterIn.PATH, required = true,
+                            description = "Slug path of the taxonomy category (e.g. electronics/televisions).",
+                            schema = @Schema(type = "string")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Children returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = GoogleCategorySummaryDto.class)))),
+                    @ApiResponse(responseCode = "404", description = "Category not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<List<GoogleCategorySummaryDto>> getChildrenByPath(
+            @PathVariable(name = "categoryPath") String categoryPath,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        return navigationService.getChildrenByPath(categoryPath, domainLanguage)
+                .map(children -> ResponseEntity.ok()
+                        .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                        .header("X-Locale", domainLanguage.languageTag())
+                        .body(children))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryBreadcrumbDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryBreadcrumbDto.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Breadcrumb element describing a taxonomy node along the path to a category.
+ */
+public record GoogleCategoryBreadcrumbDto(
+        @Schema(description = "Google taxonomy identifier for the breadcrumb node.", example = "1234")
+        Integer taxonomyId,
+        @Schema(description = "Display name of the breadcrumb node localised with the requested language.", example = "Téléviseurs")
+        String name,
+        @Schema(description = "Slugified segment representing the node in URLs.", example = "televiseurs")
+        String slug,
+        @Schema(description = "Full slug path from the taxonomy root to this node.", example = "electronique/televiseurs")
+        String path
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryDto.java
@@ -1,0 +1,41 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Detailed representation of a Google taxonomy node enriched with vertical data and navigation helpers.
+ */
+public record GoogleCategoryDto(
+        @Schema(description = "Google taxonomy identifier of the category.", example = "1234")
+        Integer taxonomyId,
+        @Schema(description = "Display name of the category in the requested language.", example = "Téléviseurs")
+        String name,
+        @Schema(description = "All available localised names keyed by language.")
+        Map<String, String> names,
+        @Schema(description = "Slug corresponding to the category for the requested language.", example = "televiseurs")
+        String slug,
+        @Schema(description = "Slug path from the taxonomy root to this category.", example = "electronique/televiseurs")
+        String path,
+        @Schema(description = "Individual slug segments that compose the full path.")
+        List<String> pathSegments,
+        @Schema(description = "Indicates whether the category has children filtered to nodes exposing verticals.")
+        boolean hasChildren,
+        @Schema(description = "True when the category does not have any children in the taxonomy tree.")
+        boolean leaf,
+        @Schema(description = "True when a vertical configuration is directly associated with the category.")
+        boolean hasVertical,
+        @Schema(description = "True when the category or one of its descendants exposes a vertical configuration.")
+        boolean hasVerticals,
+        @Schema(description = "Summary of the associated vertical configuration, when available.")
+        VerticalConfigDto vertical,
+        @Schema(description = "Breadcrumb elements describing the navigation path to this category.")
+        List<GoogleCategoryBreadcrumbDto> breadcrumbs,
+        @Schema(description = "Immediate child categories filtered to nodes exposing verticals.")
+        List<GoogleCategorySummaryDto> children,
+        @Schema(description = "Descendant categories carrying a vertical configuration but not listed as direct children.")
+        List<GoogleCategorySummaryDto> descendantVerticals
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategorySummaryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategorySummaryDto.java
@@ -1,0 +1,35 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Lightweight view of a taxonomy node used when rendering children or descendants.
+ */
+public record GoogleCategorySummaryDto(
+        @Schema(description = "Google taxonomy identifier uniquely identifying the node.", example = "1234")
+        Integer taxonomyId,
+        @Schema(description = "Display name of the category in the requested language.", example = "Téléviseurs")
+        String name,
+        @Schema(description = "All available localised names keyed by language.")
+        Map<String, String> names,
+        @Schema(description = "Slug corresponding to the node for the requested language.", example = "televiseurs")
+        String slug,
+        @Schema(description = "Slug path from the taxonomy root to this node.", example = "electronique/televiseurs")
+        String path,
+        @Schema(description = "Individual slug segments building the full path.")
+        List<String> pathSegments,
+        @Schema(description = "Indicates whether the node has any child categories.")
+        boolean hasChildren,
+        @Schema(description = "Indicates whether the node is a leaf in the taxonomy tree.")
+        boolean leaf,
+        @Schema(description = "True when a vertical configuration is linked to this node.")
+        boolean hasVertical,
+        @Schema(description = "True when this node or one of its descendants carries a vertical configuration.")
+        boolean hasVerticals,
+        @Schema(description = "Vertical configuration summary associated with the node, when available.")
+        VerticalConfigDto vertical
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleCategoryNavigationService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleCategoryNavigationService.java
@@ -1,0 +1,140 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.open4goods.model.vertical.ProductCategory;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategorySummaryDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.verticals.GoogleTaxonomyService;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service exposing navigation helpers over the Google taxonomy tree for the frontend API.
+ */
+@Service
+public class GoogleCategoryNavigationService {
+
+    private final GoogleTaxonomyService googleTaxonomyService;
+    private final CategoryMappingService categoryMappingService;
+
+    public GoogleCategoryNavigationService(GoogleTaxonomyService googleTaxonomyService,
+                                           CategoryMappingService categoryMappingService) {
+        this.googleTaxonomyService = googleTaxonomyService;
+        this.categoryMappingService = categoryMappingService;
+    }
+
+    /**
+     * Resolve a taxonomy node by its Google taxonomy identifier and convert it to a DTO.
+     *
+     * @param taxonomyId     identifier of the taxonomy node
+     * @param domainLanguage requested localisation context
+     * @return optional DTO representing the taxonomy node
+     */
+    public Optional<GoogleCategoryDto> getCategoryById(Integer taxonomyId, DomainLanguage domainLanguage) {
+        return resolveById(taxonomyId)
+                .map(category -> categoryMappingService.toGoogleCategoryDto(category, domainLanguage));
+    }
+
+    /**
+     * Resolve a taxonomy node by its slug path and convert it to a DTO.
+     *
+     * @param path           slug path relative to the taxonomy root
+     * @param domainLanguage requested localisation context
+     * @return optional DTO representing the taxonomy node
+     */
+    public Optional<GoogleCategoryDto> getCategoryByPath(String path, DomainLanguage domainLanguage) {
+        return resolveByPath(path, domainLanguage)
+                .map(category -> categoryMappingService.toGoogleCategoryDto(category, domainLanguage));
+    }
+
+    /**
+     * Retrieve the immediate children of a taxonomy node identified by its taxonomy id.
+     *
+     * @param taxonomyId     identifier of the parent taxonomy node
+     * @param domainLanguage requested localisation context
+     * @return optional list of child summaries
+     */
+    public Optional<List<GoogleCategorySummaryDto>> getChildrenById(Integer taxonomyId,
+                                                                    DomainLanguage domainLanguage) {
+        return resolveById(taxonomyId)
+                .map(category -> categoryMappingService.toGoogleCategoryChildren(category, domainLanguage));
+    }
+
+    /**
+     * Retrieve the immediate children of a taxonomy node identified by its slug path.
+     *
+     * @param path           slug path relative to the taxonomy root
+     * @param domainLanguage requested localisation context
+     * @return optional list of child summaries
+     */
+    public Optional<List<GoogleCategorySummaryDto>> getChildrenByPath(String path,
+                                                                      DomainLanguage domainLanguage) {
+        return resolveByPath(path, domainLanguage)
+                .map(category -> categoryMappingService.toGoogleCategoryChildren(category, domainLanguage));
+    }
+
+    private Optional<ProductCategory> resolveById(Integer taxonomyId) {
+        if (taxonomyId == null || taxonomyId == 0) {
+            return Optional.of(googleTaxonomyService.getCategories().asRootNode());
+        }
+        return Optional.ofNullable(googleTaxonomyService.byId(taxonomyId));
+    }
+
+    private Optional<ProductCategory> resolveByPath(String path, DomainLanguage domainLanguage) {
+        String normalized = normalizePath(path);
+        if (normalized.isEmpty()) {
+            return Optional.of(googleTaxonomyService.getCategories().asRootNode());
+        }
+
+        for (String languageKey : candidateLanguageKeys(domainLanguage)) {
+            Map<String, ProductCategory> nodes = googleTaxonomyService.getCategories().paths(languageKey);
+            if (nodes == null || nodes.isEmpty()) {
+                continue;
+            }
+            ProductCategory category = nodes.get(normalized);
+            if (category != null) {
+                return Optional.of(category);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String normalizePath(String path) {
+        if (path == null) {
+            return "";
+        }
+        String normalized = path.trim();
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private Set<String> candidateLanguageKeys(DomainLanguage domainLanguage) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        String iso = domainLanguage.name();
+        String tag = domainLanguage.languageTag();
+        keys.add(iso);
+        keys.add(iso.toLowerCase(Locale.ROOT));
+        keys.add(tag);
+        keys.add(tag.replace('_', '-'));
+        keys.add(tag.replace('-', '_'));
+        int separator = tag.indexOf('-');
+        if (separator > 0) {
+            keys.add(tag.substring(0, separator));
+        }
+        return keys;
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/GoogleCategoriesControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/GoogleCategoriesControllerTest.java
@@ -1,0 +1,153 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryBreadcrumbDto;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategorySummaryDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleCategoryNavigationService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Controller tests covering the Google taxonomy navigation endpoints.
+ */
+@ExtendWith(MockitoExtension.class)
+class GoogleCategoriesControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private GoogleCategoryNavigationService navigationService;
+
+    @BeforeEach
+    void setUp() {
+        GoogleCategoriesController controller = new GoogleCategoriesController(navigationService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    private GoogleCategoryDto sampleCategoryDto() {
+        VerticalConfigDto vertical = new VerticalConfigDto(
+                "tv",
+                true,
+                1234,
+                5678,
+                1,
+                "/images/verticals/tv-small.jpg",
+                "/images/verticals/tv-medium.jpg",
+                "/images/verticals/tv-large.jpg",
+                "Téléviseurs",
+                "Description",
+                "televiseurs");
+
+        GoogleCategorySummaryDto child = new GoogleCategorySummaryDto(
+                567,
+                "Téléviseurs LED",
+                Map.of("fr", "Téléviseurs LED"),
+                "televiseurs-led",
+                "televiseurs/televiseurs-led",
+                List.of("televiseurs", "televiseurs-led"),
+                false,
+                true,
+                true,
+                true,
+                vertical);
+
+        GoogleCategoryBreadcrumbDto breadcrumb = new GoogleCategoryBreadcrumbDto(
+                1234,
+                "Téléviseurs",
+                "televiseurs",
+                "televiseurs");
+
+        return new GoogleCategoryDto(
+                1234,
+                "Téléviseurs",
+                Map.of("fr", "Téléviseurs"),
+                "televiseurs",
+                "televiseurs",
+                List.of("televiseurs"),
+                true,
+                false,
+                true,
+                true,
+                vertical,
+                List.of(breadcrumb),
+                List.of(child),
+                List.of());
+    }
+
+    @Test
+    void getCategoryByIdReturnsPayload() throws Exception {
+        GoogleCategoryDto dto = sampleCategoryDto();
+        given(navigationService.getCategoryById(eq(1234), any(DomainLanguage.class)))
+                .willReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/categories/taxonomy/{taxonomyId}", 1234)
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$.taxonomyId").value(1234))
+                .andExpect(jsonPath("$.children").isArray());
+    }
+
+    @Test
+    void getCategoryByIdReturns404WhenMissing() throws Exception {
+        given(navigationService.getCategoryById(eq(9999), any(DomainLanguage.class)))
+                .willReturn(Optional.empty());
+
+        mockMvc.perform(get("/categories/taxonomy/{taxonomyId}", 9999)
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getCategoryByPathReturnsPayload() throws Exception {
+        GoogleCategoryDto dto = sampleCategoryDto();
+        given(navigationService.getCategoryByPath(eq("televiseurs"), any(DomainLanguage.class)))
+                .willReturn(Optional.of(dto));
+
+        mockMvc.perform(get("/categories/taxonomy/path/{categoryPath}", "televiseurs")
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.path").value("televiseurs"));
+    }
+
+    @Test
+    void getChildrenByIdReturnsList() throws Exception {
+        GoogleCategorySummaryDto child = sampleCategoryDto().children().get(0);
+        given(navigationService.getChildrenById(eq(1234), any(DomainLanguage.class)))
+                .willReturn(Optional.of(List.of(child)));
+
+        mockMvc.perform(get("/categories/taxonomy/{taxonomyId}/children", 1234)
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].taxonomyId").value(child.taxonomyId()));
+    }
+
+    @Test
+    void getChildrenByPathReturns404WhenCategoryMissing() throws Exception {
+        given(navigationService.getChildrenByPath(eq("unknown"), any(DomainLanguage.class)))
+                .willReturn(Optional.empty());
+
+        mockMvc.perform(get("/categories/taxonomy/path/{categoryPath}/children", "unknown")
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
- add a GoogleCategoriesController that serves taxonomy nodes by id, slug path, and lazy-loaded children while keeping the existing /category endpoints intact
- introduce GoogleCategory* DTOs and a GoogleCategoryNavigationService to expose breadcrumbs, localized paths, and linked verticals
- extend CategoryMappingService to map ProductCategory trees and add standalone controller tests for the new API

## Testing
- mvn --offline clean install

------
https://chatgpt.com/codex/tasks/task_e_68ea63f04d488333a686b05cc0677f85