### PR TITLE
Add full slug and secure offer URLs in product API

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
@@ -17,8 +17,8 @@ public record ProductAggregatedPriceDto(
         String url,
         @Schema(description = "Compensation paid when the offer is converted", example = "0.5")
         Double compensation,
-        @Schema(description = "State of the product for this offer")
-        ProductCondition productState,
+        @Schema(description = "Condition of the product for this offer")
+        ProductCondition condition,
         @Schema(description = "Affiliation token when available")
         String affiliationToken,
         @Schema(description = "Price value")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -15,6 +15,8 @@ public record ProductDto(
         long gtin,
         @Schema(description = "Canonical product URL previously exposed as names.url", example = "https://example.org/products/123")
         String slug,
+        @Schema(description = "Fully qualified slug composed of the vertical home URL and the product slug", example = "/telephones-reconditionnes/fairphone-4")
+        String fullSlug,
         @Schema(description = "Basic product metadata")
         ProductBaseDto base,
         @Schema(description = "Identity facet exposing brand, model and alternate identifiers")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
@@ -28,7 +28,7 @@ public class AffiliationPartnerService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AffiliationPartnerService.class);
     private static final ParameterizedTypeReference<List<AffiliationPartner>> PARTNERS_TYPE =
             new ParameterizedTypeReference<>() { };
-	private static final String CONTRIB_ENDPOINT = "/contrib/";
+    public static final String CONTRIB_ENDPOINT = "/contrib/";
 
     private final RestClient restClient;
     private final AffiliationPartnersProperties properties;

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -76,7 +76,7 @@ class ProductControllerIT {
     void includeParameterFiltersFields() throws Exception {
         long gtin = 321L;
         given(service.getProduct(anyLong(), any(Locale.class), anySet(), any(DomainLanguage.class)))
-                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null));
+                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null, null));
 
         mockMvc.perform(get("/products/{gtin}", gtin)
                         .param("include", "gtin")
@@ -103,7 +103,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointReturnsPage() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")
@@ -118,7 +118,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointAcceptsAggregationParameter() throws Exception {
-        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
+        var page = new PageImpl<>(List.of(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null, null)), PageRequest.of(0, 20), 1);
         given(service.getProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class))).willReturn(page);
 
         mockMvc.perform(get("/products")

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -17,23 +18,37 @@ import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.model.product.AiReviewHolder;
 import org.open4goods.model.product.GtinInfo;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.price.AggregatedPrice;
+import org.open4goods.model.price.AggregatedPrices;
+import org.open4goods.model.price.Currency;
+import org.open4goods.model.product.ProductCondition;
+import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
 
 class ProductMappingServiceTest {
 
     private ProductRepository repository;
     private ProductMappingService service;
     private ApiProperties apiProperties;
+    private CategoryMappingService categoryMappingService;
+    private VerticalsConfigService verticalsConfigService;
+    private AffiliationService affiliationService;
 
     @BeforeEach
     void setUp() {
         repository = mock(ProductRepository.class);
         apiProperties = new ApiProperties();
         apiProperties.setResourceRootPath("https://static.example");
-        service = new ProductMappingService(repository, apiProperties);
+        categoryMappingService = mock(CategoryMappingService.class);
+        verticalsConfigService = mock(VerticalsConfigService.class);
+        affiliationService = mock(AffiliationService.class);
+        service = new ProductMappingService(repository, apiProperties, categoryMappingService,
+                verticalsConfigService, affiliationService);
     }
 
     @Test
@@ -80,6 +95,65 @@ class ProductMappingServiceTest {
         assertThat(dto.base().gtinInfo().countryCode()).isEqualTo("FR");
         assertThat(dto.base().gtinInfo().countryName()).isEqualTo("France");
         assertThat(dto.base().gtinInfo().countryFlagUrl()).isEqualTo("/images/flags/fr.webp");
+    }
+
+    @Test
+    void getProductComputesFullSlugWhenVerticalHomeUrlExists() throws Exception {
+        long gtin = 12L;
+        Product product = new Product(gtin);
+        product.setVertical("electronics");
+        Localisable<String, String> urlLocalisable = new Localisable<>();
+        urlLocalisable.put("en", "fairphone-4");
+        product.getNames().setUrl(urlLocalisable);
+
+        when(repository.getById(gtin)).thenReturn(product);
+        VerticalConfig verticalConfig = new VerticalConfig();
+        verticalConfig.setId("electronics");
+        VerticalConfigDto configDto = new VerticalConfigDto("electronics", true, null, null, 1,
+                null, null, null, null, null, "telephones-reconditionnes");
+        when(verticalsConfigService.getConfigById("electronics")).thenReturn(verticalConfig);
+        when(categoryMappingService.toVerticalConfigDto(verticalConfig, DomainLanguage.en)).thenReturn(configDto);
+
+        ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("base"), DomainLanguage.en);
+
+        assertThat(dto.slug()).isEqualTo("fairphone-4");
+        assertThat(dto.fullSlug()).isEqualTo("/telephones-reconditionnes/fairphone-4");
+    }
+
+    @Test
+    void offersUrlsAreEncryptedAndConditionRenamed() throws Exception {
+        long gtin = 55L;
+        Product product = new Product(gtin);
+        AggregatedPrice aggregatedPrice = new AggregatedPrice();
+        aggregatedPrice.setDatasourceName("amazon");
+        aggregatedPrice.setUrl("https://example.com/product");
+        aggregatedPrice.setOfferName("Eco Phone");
+        aggregatedPrice.setCompensation(0.2);
+        aggregatedPrice.setProductState(ProductCondition.NEW);
+        aggregatedPrice.setAffiliationToken("raw-token");
+        aggregatedPrice.setPrice(199.99);
+        aggregatedPrice.setCurrency(Currency.EUR);
+        aggregatedPrice.setTimeStamp(123L);
+
+        AggregatedPrices aggregatedPrices = new AggregatedPrices();
+        aggregatedPrices.setOffers(Set.of(aggregatedPrice));
+        aggregatedPrices.setMinPrice(aggregatedPrice);
+        aggregatedPrices.setConditions(EnumSet.of(ProductCondition.NEW));
+        aggregatedPrices.setTrends(null);
+
+        product.setPrice(aggregatedPrices);
+        product.setOffersCount(1);
+
+        when(repository.getById(gtin)).thenReturn(product);
+        when(affiliationService.encryptAffiliationLink("amazon", "https://example.com/product")).thenReturn("encrypted-token");
+
+        ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("offers"), DomainLanguage.en);
+
+        assertThat(dto.offers()).isNotNull();
+        assertThat(dto.offers().bestPrice()).isNotNull();
+        assertThat(dto.offers().bestPrice().url()).isEqualTo("/contrib/encrypted-token");
+        assertThat(dto.offers().bestPrice().condition()).isEqualTo(ProductCondition.NEW);
+        assertThat(dto.offers().bestPrice().affiliationToken()).isEqualTo("raw-token");
     }
 
 


### PR DESCRIPTION
## Summary
- add the `fullSlug` field to product payloads and compute it from the vertical home URL
- expose the affiliation contrib endpoint for reuse and wrap offer URLs with encrypted redirects
- update product mapping tests and controller tests to cover new slug field and offer URL changes

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68eb564d49388333a72f852acce1c726