### PR TITLE
docs: improve service documentation and metadata

### DIFF
--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -183,13 +183,13 @@ public record OfferDto(
 ## 9. Documentation
 
 Follow java / spring documentation best practices :
-* Use javadoc at class and at level field
+* Use javadoc at class, field and method level
 * Use inline code comments to leverage human
 * Keep README.md and AGENTS.md up to date
 
-### 9.1 Front service documentation baseline
+### 9.1 documentation baseline
 
-* Every service class under `src/main/java/org/open4goods/nudgerfrontapi/service/**` MUST expose detailed Javadoc at class level
+* Every class MUST expose detailed Javadoc at class level
   and for each public or private method. Mention parameters, return values and error handling when relevant.
 * Add light inline comments when business rules are non obvious. Prefer short, focused comments over redundant prose.
 

--- a/front-api/AGENTS.md
+++ b/front-api/AGENTS.md
@@ -184,8 +184,21 @@ public record OfferDto(
 
 Follow java / spring documentation best practices :
 * Use javadoc at class and at level field
-* Use inline code comments to leverage human 
+* Use inline code comments to leverage human
 * Keep README.md and AGENTS.md up to date
+
+### 9.1 Front service documentation baseline
+
+* Every service class under `src/main/java/org/open4goods/nudgerfrontapi/service/**` MUST expose detailed Javadoc at class level
+  and for each public or private method. Mention parameters, return values and error handling when relevant.
+* Add light inline comments when business rules are non obvious. Prefer short, focused comments over redundant prose.
+
+### 9.2 Spring configuration metadata
+
+* Whenever a `@ConfigurationProperties` class is created or updated, mirror its structure in
+  `src/main/resources/META-INF/additional-spring-configuration-metadata.json` so IDE auto-completion stays accurate.
+* Nested collections should use the `[].property` notation (e.g. `front.partners.mentors.partners[].name`). Include
+  defaults and descriptions when available.
 
 ---
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationService.java
@@ -111,6 +111,12 @@ public class AffiliationService {
         }
     }
 
+    /**
+     * Trim and normalise the user agent while preventing Elasticsearch field explosion.
+     *
+     * @param userAgent raw header value provided by the client
+     * @return sanitised user agent or {@code null} when blank
+     */
     private String sanitiseUserAgent(String userAgent) {
         if (!StringUtils.hasText(userAgent)) {
             return null;

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactMailService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactMailService.java
@@ -10,6 +10,10 @@ import jakarta.mail.internet.MimeMessage;
 
 /**
  * Thin wrapper around {@link JavaMailSender} dedicated to contact form emails.
+ * <p>
+ * Keeping the SMTP interaction encapsulated simplifies mocking in tests and
+ * keeps controller/service logic focused on validation rules.
+ * </p>
  */
 @Service
 public class ContactMailService {
@@ -34,6 +38,7 @@ public class ContactMailService {
     public void send(String to, String body, String subject, String from) throws Exception {
         MimeMessage message = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message);
+        // Keep the helper configuration local to avoid leaking message state across calls.
         helper.setTo(to);
         helper.setText(body);
         helper.setSubject(subject);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Service;
 
 /**
  * Service orchestrating contact form submissions: captcha verification and email dispatching.
+ * <p>
+ * Splitting responsibilities between captcha validation and email rendering allows unit tests to
+ * cover error scenarios without hitting external infrastructure.
+ * </p>
  */
 @Service
 public class ContactService {
@@ -33,6 +37,7 @@ public class ContactService {
      */
     public void submit(ContactRequestDto request, String clientIp) throws Exception {
         hcaptchaService.verifyRecaptcha(clientIp, request.captchaResponse());
+        // Prefix the subject to keep a consistent format in the shared inbox.
         contactMailService.send(contactProperties.getEmail(), request.message(), SUBJECT_PREFIX + request.name(),
                 request.email());
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
@@ -17,6 +17,10 @@ import org.xwiki.rest.model.jaxb.Page;
 
 /**
  * Service responsible for retrieving XWiki {@link FullPage} instances and mapping them to {@link FullPageDto}.
+ * <p>
+ * The service centralises DTO conversions so the rest of the application can work with a
+ * simplified representation that hides XWiki specific dependencies.
+ * </p>
  */
 @Service
 public class XwikiFullPageService {
@@ -39,6 +43,12 @@ public class XwikiFullPageService {
         return mapToDto(fullPage);
     }
 
+    /**
+     * Convert the XWiki {@link FullPage} aggregate to its DTO counterpart.
+     *
+     * @param fullPage entity returned by the XWiki facade
+     * @return flattened DTO compatible with the REST contract
+     */
     private FullPageDto mapToDto(FullPage fullPage) {
         Page wikiPage = fullPage.getWikiPage();
         Map<String, String> properties = fullPage.getProperties();
@@ -46,6 +56,7 @@ public class XwikiFullPageService {
             properties = Collections.emptyMap();
         }
 
+        // Fetch HTML content separately because the REST descriptor only exposes metadata.
         String htmlContent = xwikiFacadeService.getxWikiHtmlService().getHtmlClassWebPage(fullPage.getWikiPage().getId());
         return new FullPageDto(
         		htmlContent,
@@ -85,6 +96,12 @@ public class XwikiFullPageService {
         );
     }
 
+    /**
+     * Convert an {@link Calendar} instance into an ISO 8601 string while gracefully handling non Gregorian calendars.
+     *
+     * @param calendar source calendar
+     * @return ISO representation or {@code null} when the source is null
+     */
     private String toIsoString(Calendar calendar) {
         if (calendar == null) {
             return null;

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/auth/JwtService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/auth/JwtService.java
@@ -15,6 +15,10 @@ import org.springframework.stereotype.Service;
 
 /**
  * Utility service to issue and validate JWT tokens for the frontend API.
+ * <p>
+ * The service wraps Spring Security's encoder/decoder beans and centralises claim construction so controllers
+ * and filters keep a single source of truth for token lifetimes and payloads.
+ * </p>
  */
 @Service
 public class JwtService {
@@ -29,12 +33,18 @@ public class JwtService {
         this.properties = properties;
     }
 
+    /**
+     * Expose the current security properties (mainly used for configuration endpoints).
+     */
     public SecurityProperties getProperties() {
         return properties;
     }
 
     /**
      * Generate an access token for the given authentication.
+     *
+     * @param auth authenticated principal
+     * @return signed JWT containing the principal username and authorities
      */
     public String generateAccessToken(Authentication auth) {
         Instant now = Instant.now();
@@ -52,6 +62,9 @@ public class JwtService {
 
     /**
      * Generate a refresh token for the given authentication.
+     *
+     * @param auth authenticated principal
+     * @return signed JWT usable to request a new access token
      */
     public String generateRefreshToken(Authentication auth) {
         Instant now = Instant.now();
@@ -67,6 +80,9 @@ public class JwtService {
 
     /**
      * Validate a token and return the authentication subject.
+     *
+     * @param token refresh token value
+     * @return subject embedded in the token after successful validation
      */
     public String validateRefreshToken(String token) {
         return decoder.decode(token).getSubject();

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/AffiliationTrackingException.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/AffiliationTrackingException.java
@@ -5,6 +5,12 @@ package org.open4goods.nudgerfrontapi.service.exception;
  */
 public class AffiliationTrackingException extends RuntimeException {
 
+    /**
+     * Create an exception describing why affiliation tracking failed.
+     *
+     * @param message human readable explanation of the failure
+     * @param cause   root cause thrown by the persistence or serialisation layer
+     */
     public AffiliationTrackingException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/InvalidAffiliationTokenException.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/InvalidAffiliationTokenException.java
@@ -5,10 +5,21 @@ package org.open4goods.nudgerfrontapi.service.exception;
  */
 public class InvalidAffiliationTokenException extends RuntimeException {
 
+    /**
+     * Create an exception describing why an affiliation token is invalid.
+     *
+     * @param message human readable explanation of the validation failure
+     */
     public InvalidAffiliationTokenException(String message) {
         super(message);
     }
 
+    /**
+     * Create an exception describing why an affiliation token is invalid.
+     *
+     * @param message human readable explanation of the validation failure
+     * @param cause   underlying cause of the failure
+     */
     public InvalidAffiliationTokenException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,6 +1,11 @@
 {
   "groups": [
     {
+      "name": "front",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.ApiProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.ApiProperties"
+    },
+    {
       "name": "front.security",
       "type": "org.open4goods.nudgerfrontapi.config.properties.SecurityProperties",
       "sourceType": "org.open4goods.nudgerfrontapi.config.properties.SecurityProperties"
@@ -14,9 +19,39 @@
       "name": "front.rate-limit",
       "type": "org.open4goods.nudgerfrontapi.config.properties.RateLimitProperties",
       "sourceType": "org.open4goods.nudgerfrontapi.config.properties.RateLimitProperties"
+    },
+    {
+      "name": "front.affiliation-partners",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.AffiliationPartnersProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.AffiliationPartnersProperties"
+    },
+    {
+      "name": "front.contact",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.ContactProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.ContactProperties"
+    },
+    {
+      "name": "front.partners.ecosystem",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.EcosystemPartnersProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.EcosystemPartnersProperties"
+    },
+    {
+      "name": "front.partners.mentors",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.MentorPartnersProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.MentorPartnersProperties"
+    },
+    {
+      "name": "team-config",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.TeamProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.TeamProperties"
     }
   ],
   "properties": [
+    {
+      "name": "front.resource-root-path",
+      "type": "java.lang.String",
+      "description": "Base URL used by the frontend to fetch generated assets (images, documents, ...)."
+    },
     {
       "name": "front.security.enabled",
       "type": "java.lang.Boolean",
@@ -25,21 +60,18 @@
     },
     {
       "name": "front.security.cors-allowed-hosts",
-      "type": "java.lang.String",
-      "description": "Comma-separated list of origins allowed for CORS requests.",
-      "defaultValue": "http://localhost:8082"
+      "type": "java.util.List<java.lang.String>",
+      "description": "List of origins allowed for CORS requests."
     },
     {
       "name": "front.security.jwt-secret",
       "type": "java.lang.String",
-      "description": "Secret key used to sign JWT tokens.",
-      "defaultValue": "changeMe"
+      "description": "Secret key used to sign JWT tokens."
     },
     {
       "name": "front.security.shared-token",
       "type": "java.lang.String",
-      "description": "Shared secret expected in the X-Shared-Token header for authenticated requests.",
-      "defaultValue": "changeMeSharedToken"
+      "description": "Shared secret expected in the X-Shared-Token header for authenticated requests."
     },
     {
       "name": "front.security.access-token-expiry",
@@ -70,6 +102,127 @@
       "type": "java.lang.Integer",
       "description": "Maximum requests per minute for authenticated users.",
       "defaultValue": 1000
+    },
+    {
+      "name": "front.affiliation-partners.api-base-url",
+      "type": "java.lang.String",
+      "description": "Base URL of the affiliation partner back-office API."
+    },
+    {
+      "name": "front.affiliation-partners.partners-path",
+      "type": "java.lang.String",
+      "description": "Path appended to the base URL to retrieve the partners collection.",
+      "defaultValue": "/partners"
+    },
+    {
+      "name": "front.affiliation-partners.api-key",
+      "type": "java.lang.String",
+      "description": "API key forwarded when calling the affiliation partner backend."
+    },
+    {
+      "name": "front.contact.email",
+      "type": "java.lang.String",
+      "description": "Recipient email address for contact form submissions."
+    },
+    {
+      "name": "front.partners.ecosystem.partners",
+      "type": "java.util.List",
+      "description": "Configured ecosystem partners displayed on the public site."
+    },
+    {
+      "name": "front.partners.ecosystem.partners[].name",
+      "type": "java.lang.String",
+      "description": "Display name of the ecosystem partner."
+    },
+    {
+      "name": "front.partners.ecosystem.partners[].bloc-id",
+      "type": "java.lang.String",
+      "description": "XWiki bloc identifier linked to the partner content."
+    },
+    {
+      "name": "front.partners.ecosystem.partners[].url",
+      "type": "java.lang.String",
+      "description": "Public website URL of the partner."
+    },
+    {
+      "name": "front.partners.ecosystem.partners[].image-url",
+      "type": "java.lang.String",
+      "description": "Relative image URL rendered for the partner logo."
+    },
+    {
+      "name": "front.partners.mentors.partners",
+      "type": "java.util.List",
+      "description": "Configured mentor partners displayed on the public site."
+    },
+    {
+      "name": "front.partners.mentors.partners[].name",
+      "type": "java.lang.String",
+      "description": "Display name of the mentor partner."
+    },
+    {
+      "name": "front.partners.mentors.partners[].bloc-id",
+      "type": "java.lang.String",
+      "description": "XWiki bloc identifier linked to the mentor content."
+    },
+    {
+      "name": "front.partners.mentors.partners[].url",
+      "type": "java.lang.String",
+      "description": "Public website URL of the mentor partner."
+    },
+    {
+      "name": "front.partners.mentors.partners[].image-url",
+      "type": "java.lang.String",
+      "description": "Relative image URL rendered for the mentor partner logo."
+    },
+    {
+      "name": "team-config.cores",
+      "type": "java.util.List",
+      "description": "Core eco-nudger team members."
+    },
+    {
+      "name": "team-config.cores[].name",
+      "type": "java.lang.String",
+      "description": "Full name of the core team member."
+    },
+    {
+      "name": "team-config.cores[].linked-in-url",
+      "type": "java.lang.String",
+      "description": "LinkedIn profile URL of the core team member."
+    },
+    {
+      "name": "team-config.cores[].image-url",
+      "type": "java.lang.String",
+      "description": "Relative URL for the core team member portrait."
+    },
+    {
+      "name": "team-config.cores[].bloc-id",
+      "type": "java.lang.String",
+      "description": "XWiki bloc identifier providing the member biography."
+    },
+    {
+      "name": "team-config.contributors",
+      "type": "java.util.List",
+      "description": "Extended contributors supporting the core team."
+    },
+    {
+      "name": "team-config.contributors[].name",
+      "type": "java.lang.String",
+      "description": "Full name of the contributor."
+    },
+    {
+      "name": "team-config.contributors[].linked-in-url",
+      "type": "java.lang.String",
+      "description": "LinkedIn profile URL of the contributor."
+    },
+    {
+      "name": "team-config.contributors[].image-url",
+      "type": "java.lang.String",
+      "description": "Relative URL for the contributor portrait."
+    },
+    {
+      "name": "team-config.contributors[].bloc-id",
+      "type": "java.lang.String",
+      "description": "XWiki bloc identifier providing the contributor biography."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand class and method Javadoc across the nudger front API services and add targeted inline comments
- update the service-layer guide to mandate thorough Javadoc and metadata coverage
- document every configuration property group in additional-spring-configuration-metadata.json for IDE support

## Testing
- mvn -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68eb964a7c7c8333a71910f20156785d