### PR TITLE
feat(frontend): add dynamic category detail route

### DIFF
--- a/frontend/app/composables/categories/useCategories.spec.ts
+++ b/frontend/app/composables/categories/useCategories.spec.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useCategories composable', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(async () => {
+    vi.resetModules()
+    fetchMock.mockReset()
+    vi.stubGlobal('$fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('loads category details, stores the active id and retains subsets', async () => {
+    const categoriesResponse = [
+      {
+        id: 'category-1',
+        verticalHomeUrl: '/dish-washers',
+      },
+    ]
+    const detailResponse = {
+      id: 'category-1',
+      verticalHomeTitle: 'Dish washers',
+      subsets: [
+        {
+          id: 'subset-1',
+          title: 'Eco friendly',
+        },
+      ],
+    }
+
+    fetchMock.mockImplementation((request, init) => {
+      if (request === '/api/categories') {
+        expect(init).toEqual({ params: { onlyEnabled: true } })
+        return Promise.resolve(categoriesResponse)
+      }
+
+      if (request === '/api/categories/category-1') {
+        expect(init).toBeUndefined()
+        return Promise.resolve(detailResponse)
+      }
+
+      throw new Error(`Unexpected request: ${String(request)}`)
+    })
+
+    const { useCategories } = await import('./useCategories')
+    const { selectCategoryBySlug, currentCategory, activeCategoryId } = useCategories()
+
+    const detail = await selectCategoryBySlug('dish-washers')
+
+    expect(activeCategoryId.value).toBe('category-1')
+    expect(detail).toEqual(detailResponse)
+    expect(currentCategory.value?.subsets).toEqual(detailResponse.subsets)
+  })
+
+  it('raises a CategoryNotFoundError when the slug cannot be resolved', async () => {
+    fetchMock.mockResolvedValueOnce([])
+
+    const { useCategories } = await import('./useCategories')
+    const { selectCategoryBySlug, error, currentCategory, activeCategoryId } = useCategories()
+
+    await expect(selectCategoryBySlug('unknown-slug')).rejects.toMatchObject({
+      name: 'CategoryNotFoundError',
+      message: 'Category not found',
+    })
+
+    expect(error.value).toBe('Category not found')
+    expect(currentCategory.value).toBeNull()
+    expect(activeCategoryId.value).toBeNull()
+  })
+})

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -52,9 +52,9 @@
         </v-card-text>
       </v-card>
 
-      <v-row v-if="category.verticalSubsets?.length" class="category-page__subsets">
+      <v-row v-if="category.subsets?.length" class="category-page__subsets">
         <v-col
-          v-for="subset in category.verticalSubsets"
+          v-for="subset in category.subsets"
           :key="subset.id ?? subset.title ?? subset.caption"
           cols="12"
           md="6"
@@ -168,18 +168,18 @@ const ogImage = computed(() => {
 })
 const ogLocale = computed(() => locale.value.replace('-', '_'))
 
-useSeoMeta(() => ({
-  title: seoTitle.value,
-  description: seoDescription.value,
-  ogTitle: ogTitle.value,
-  ogDescription: ogDescription.value,
-  ogUrl: canonicalUrl.value,
+useSeoMeta({
+  title: () => seoTitle.value,
+  description: () => seoDescription.value,
+  ogTitle: () => ogTitle.value,
+  ogDescription: () => ogDescription.value,
+  ogUrl: () => canonicalUrl.value,
   ogType: 'website',
-  ogImage: ogImage.value,
-  ogSiteName: siteName.value,
-  ogLocale: ogLocale.value,
-  ogImageAlt: category.value?.verticalHomeTitle ?? siteName.value,
-}))
+  ogImage: () => ogImage.value,
+  ogSiteName: () => siteName.value,
+  ogLocale: () => ogLocale.value,
+  ogImageAlt: () => category.value?.verticalHomeTitle ?? siteName.value,
+})
 
 useHead(() => ({
   link: [

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -1,0 +1,205 @@
+<template>
+  <v-container class="py-10 category-page">
+    <v-alert
+      v-if="errorMessage"
+      type="error"
+      variant="tonal"
+      border="start"
+      class="mb-6"
+    >
+      {{ errorMessage }}
+    </v-alert>
+
+    <v-skeleton-loader
+      v-else-if="pageLoading"
+      type="image, article"
+      class="mb-6"
+    />
+
+    <div v-else-if="category" class="category-page__content">
+      <v-row class="align-center mb-8" justify="space-between">
+        <v-col cols="12" md="6">
+          <h1 class="text-h3 text-md-h2 font-weight-bold mb-4">
+            {{ category.verticalHomeTitle }}
+          </h1>
+          <p v-if="category.verticalHomeDescription" class="text-body-1">
+            {{ category.verticalHomeDescription }}
+          </p>
+        </v-col>
+        <v-col v-if="heroImage" cols="12" md="5">
+          <v-img
+            :src="heroImage"
+            :alt="category.verticalHomeTitle ?? siteName"
+            height="320"
+            cover
+            class="rounded-lg"
+          />
+        </v-col>
+      </v-row>
+
+      <v-card
+        v-if="category.verticalMetaDescription"
+        variant="outlined"
+        class="mb-8"
+      >
+        <v-card-title class="text-h5">
+          {{ category.verticalMetaTitle ?? category.verticalHomeTitle }}
+        </v-card-title>
+        <v-card-text>
+          <p class="text-body-1">
+            {{ category.verticalMetaDescription }}
+          </p>
+        </v-card-text>
+      </v-card>
+
+      <v-row v-if="category.verticalSubsets?.length" class="category-page__subsets">
+        <v-col
+          v-for="subset in category.verticalSubsets"
+          :key="subset.id ?? subset.title ?? subset.caption"
+          cols="12"
+          md="6"
+          lg="4"
+        >
+          <v-card variant="outlined" class="h-100 d-flex flex-column">
+            <v-img
+              v-if="subset.image"
+              :src="subset.image"
+              :alt="subset.title ?? subset.caption ?? ''"
+              height="180"
+              cover
+            />
+            <v-card-title class="text-h6">
+              {{ subset.title ?? subset.caption }}
+            </v-card-title>
+            <v-card-text class="d-flex flex-column gap-3">
+              <p v-if="subset.description" class="text-body-2">
+                {{ subset.description }}
+              </p>
+              <NuxtLink
+                v-if="subset.url && subset.caption"
+                :to="subset.url"
+                class="text-body-2 font-weight-medium"
+              >
+                {{ subset.caption }}
+              </NuxtLink>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </div>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { useCategories } from '~/composables/categories/useCategories'
+
+const route = useRoute()
+const { locale, t } = useI18n()
+const requestURL = useRequestURL()
+
+const rawParam = route.params.categorySlug
+const slug = Array.isArray(rawParam) ? rawParam[0] ?? '' : rawParam ?? ''
+const slugPattern = /^[a-z-]+$/
+
+if (!slugPattern.test(slug)) {
+  throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+
+const { currentCategory, loading, error: categoriesError, selectCategoryBySlug } = useCategories()
+
+const { data: categoryData } = await useAsyncData(
+  `category-detail-${slug}`,
+  async () => {
+    try {
+      return await selectCategoryBySlug(slug)
+    } catch (err) {
+      if (err instanceof Error && err.name === 'CategoryNotFoundError') {
+        throw createError({ statusCode: 404, statusMessage: err.message, cause: err })
+      }
+
+      throw err
+    }
+  },
+  { server: true, immediate: true },
+)
+
+const category = computed(() => categoryData.value ?? currentCategory.value ?? null)
+const pageLoading = computed(() => loading.value && !category.value)
+const errorMessage = computed(() => categoriesError.value)
+
+const heroImage = computed(() => {
+  if (!category.value) {
+    return null
+  }
+
+  return (
+    category.value.imageLarge ??
+    category.value.imageMedium ??
+    category.value.imageSmall ??
+    null
+  )
+})
+
+const siteName = computed(() => String(t('siteIdentity.siteName')))
+const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
+const seoTitle = computed(
+  () => category.value?.verticalMetaTitle ?? category.value?.verticalHomeTitle ?? siteName.value,
+)
+const seoDescription = computed(
+  () => category.value?.verticalMetaDescription ?? category.value?.verticalHomeDescription ?? '',
+)
+const ogTitle = computed(
+  () => category.value?.verticalMetaOpenGraphTitle ?? seoTitle.value,
+)
+const ogDescription = computed(
+  () => category.value?.verticalMetaOpenGraphDescription ?? seoDescription.value,
+)
+const ogImage = computed(() => {
+  if (!heroImage.value) {
+    return undefined
+  }
+
+  try {
+    return new URL(heroImage.value, requestURL.origin).toString()
+  } catch (error) {
+    console.error('Invalid hero image URL', error)
+    return undefined
+  }
+})
+const ogLocale = computed(() => locale.value.replace('-', '_'))
+
+useSeoMeta(() => ({
+  title: seoTitle.value,
+  description: seoDescription.value,
+  ogTitle: ogTitle.value,
+  ogDescription: ogDescription.value,
+  ogUrl: canonicalUrl.value,
+  ogType: 'website',
+  ogImage: ogImage.value,
+  ogSiteName: siteName.value,
+  ogLocale: ogLocale.value,
+  ogImageAlt: category.value?.verticalHomeTitle ?? siteName.value,
+}))
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+  ],
+}))
+</script>
+
+<style scoped lang="sass">
+.category-page
+  min-height: 70vh
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 2rem
+
+  &__subsets
+    gap: 1.5rem
+
+  .v-card-text
+    flex-grow: 1
+</style>

--- a/frontend/server/api/categories/[id].ts
+++ b/frontend/server/api/categories/[id].ts
@@ -1,0 +1,34 @@
+import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
+import type { VerticalConfigFullDto } from '~~/shared/api-client'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+
+export default defineEventHandler(async (event): Promise<VerticalConfigFullDto> => {
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600, s-maxage=3600')
+
+  const categoryIdParam = getRouterParam(event, 'id')
+  if (!categoryIdParam) {
+    throw createError({ statusCode: 400, statusMessage: 'Category id is required' })
+  }
+
+  const categoryId = decodeURIComponent(categoryIdParam)
+
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const categoriesService = useCategoriesService(domainLanguage)
+
+  try {
+    return await categoriesService.getCategoryById(categoryId)
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error fetching category detail:', backendError.logMessage, backendError)
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/shared/api-client/services/categories.services.ts
+++ b/frontend/shared/api-client/services/categories.services.ts
@@ -1,5 +1,5 @@
 import { CategoriesApi } from '..'
-import type { VerticalConfigDto } from '..'
+import type { VerticalConfigDto, VerticalConfigFullDto } from '..'
 import type { DomainLanguage } from '../../utils/domain-language'
 import { createBackendApiConfig } from './createBackendApiConfig'
 
@@ -37,5 +37,21 @@ export const useCategoriesService = (domainLanguage: DomainLanguage) => {
     }
   }
 
-  return { getCategories }
+  /**
+   * Fetch a category detail by id
+   * @param categoryId - Identifier of the category to fetch
+   * @returns Promise<VerticalConfigFullDto>
+   */
+  const getCategoryById = async (
+    categoryId: string,
+  ): Promise<VerticalConfigFullDto> => {
+    try {
+      return await resolveApi().category({ categoryId, domainLanguage })
+    } catch (error) {
+      console.error('Error fetching category detail:', error)
+      throw error
+    }
+  }
+
+  return { getCategories, getCategoryById }
 }


### PR DESCRIPTION
## Summary
- add a Nuxt server proxy for `/api/categories/:id` backed by the generated client
- extend the categories composable to persist the active category and fetch detailed data
- introduce a slug-driven category page that renders backend metadata and subsets with SEO tags

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ebed2867a48333bf34ba36d3cbbf62