### PR TITLE
Enforce ESLint restriction on client service imports

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -27,6 +27,29 @@ const sharedOverrides = [
   {
     ignores: ['shared/api-client/**', 'src/api/**'],
   },
+  {
+    files: [
+      'app/**/*.{ts,vue}',
+      'app.config.ts',
+      'i18n.config.ts',
+      'nuxt.config.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              regex: '^~~/shared/api-client/services/(?!auth\\.services(?:$|/))',
+              allowTypeImports: true,
+              message:
+                'Use the Nuxt server route + composable pattern instead of importing generated backend services directly into client code.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]
 
 const config = await resolveConfig()


### PR DESCRIPTION
## Summary
- enable `no-restricted-imports` for Nuxt client entry files
- block value imports from generated backend services while allowing the approved auth helper
- document the lint error message to point developers to the server route + composable pattern

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ecbb2031248333a1d2a1d5103ed5c1