### PR TITLE
feat(frontend): forward forwarded host header via server fetch

### DIFF
--- a/frontend/app/plugins/__tests__/server-fetch-forwarded-host.spec.ts
+++ b/frontend/app/plugins/__tests__/server-fetch-forwarded-host.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { installForwardedHostFetch } from '../server-fetch-forwarded-host.server'
+
+const useRequestHeadersMock = vi.hoisted(() => vi.fn())
+
+vi.mock('#app', async () => {
+  const actual = await vi.importActual<typeof import('#app')>('#app')
+
+  return {
+    ...actual,
+    useRequestHeaders: useRequestHeadersMock,
+  }
+})
+
+describe('server fetch forwarded host plugin', () => {
+  const originalGlobalFetch = globalThis.$fetch
+
+  const createBaseFetch = () => {
+    const fetchSpy = vi
+      .fn(async (_input: Parameters<typeof $fetch>[0], init?: RequestInit) => ({ init }))
+      .mockName('base$fetch')
+    const rawSpy = vi
+      .fn(async (_input: Parameters<typeof $fetch.raw>[0], init?: RequestInit) => ({ init }))
+      .mockName('base$fetch.raw')
+
+    const baseFetch = fetchSpy as unknown as typeof $fetch
+    baseFetch.raw = rawSpy as unknown as typeof $fetch.raw
+    baseFetch.create = vi.fn(() => baseFetch).mockName('base$fetch.create') as unknown as typeof baseFetch.create
+
+    return { baseFetch, fetchSpy, rawSpy }
+  }
+
+  afterEach(() => {
+    useRequestHeadersMock.mockReset()
+    globalThis.$fetch = originalGlobalFetch
+  })
+
+  it('wraps $fetch to forward the normalized host header', async () => {
+    const { baseFetch, fetchSpy, rawSpy } = createBaseFetch()
+    const nuxtApp = { $fetch: baseFetch }
+
+    globalThis.$fetch = baseFetch
+
+    useRequestHeadersMock.mockReturnValue({
+      'x-forwarded-host': 'Example.COM:3000, backup.example',
+      host: undefined,
+    })
+
+    installForwardedHostFetch(nuxtApp)
+
+    expect(useRequestHeadersMock).toHaveBeenCalledWith(['x-forwarded-host', 'host'])
+
+    const wrappedFetch = nuxtApp.$fetch as typeof $fetch
+
+    await wrappedFetch('https://service.test', { headers: { 'x-custom-header': 'value' } })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    const forwardedInit = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined
+    const forwardedHeaders = new Headers((forwardedInit?.headers ?? {}) as HeadersInit)
+
+    expect(forwardedHeaders.get('x-forwarded-host')).toBe('example.com:3000')
+    expect(forwardedHeaders.get('host')).toBe('example.com:3000')
+    expect(forwardedHeaders.get('x-custom-header')).toBe('value')
+    expect(globalThis.$fetch).toBe(nuxtApp.$fetch)
+
+    await wrappedFetch.raw('https://service.test/raw')
+    const rawCall = rawSpy.mock.calls[0]?.[1] as RequestInit | undefined
+    const rawHeaders = new Headers((rawCall?.headers ?? {}) as HeadersInit)
+    expect(rawHeaders.get('x-forwarded-host')).toBe('example.com:3000')
+    expect(rawHeaders.get('host')).toBe('example.com:3000')
+  })
+})

--- a/frontend/app/plugins/server-fetch-forwarded-host.server.ts
+++ b/frontend/app/plugins/server-fetch-forwarded-host.server.ts
@@ -1,0 +1,74 @@
+import { useRequestHeaders } from '#app'
+
+const HEADER_NAME = 'x-forwarded-host'
+
+const normalizeForwardedHost = (rawValue: string | string[] | undefined): string | null => {
+  if (!rawValue) {
+    return null
+  }
+
+  const value = Array.isArray(rawValue) ? rawValue[0] : rawValue
+  if (!value) {
+    return null
+  }
+  const normalized = value.split(',')[0]?.trim().toLowerCase()
+
+  return normalized ? normalized : null
+}
+
+const withForwardedHost = (forwardedHost: string, init?: RequestInit): RequestInit => {
+  const headers = new Headers(init?.headers ?? {})
+
+  headers.set(HEADER_NAME, forwardedHost)
+  headers.set('host', forwardedHost)
+
+  return { ...init, headers }
+}
+
+const wrapFetchWithForwardedHost = (baseFetch: typeof $fetch, forwardedHost: string): typeof $fetch => {
+  const forwardedFetch = (async (input: Parameters<typeof $fetch>[0], init?: RequestInit) => {
+    const options = withForwardedHost(forwardedHost, init)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return baseFetch(input as any, options as any)
+  }) as typeof $fetch
+
+  if (typeof baseFetch.raw === 'function') {
+    forwardedFetch.raw = (async (input: Parameters<typeof $fetch.raw>[0], init?: RequestInit) => {
+      const options = withForwardedHost(forwardedHost, init)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return baseFetch.raw(input as any, options as any)
+    }) as typeof $fetch.raw
+  }
+
+  if (typeof baseFetch.create === 'function') {
+    forwardedFetch.create = ((defaults?: Parameters<typeof baseFetch.create>[0]) => {
+      const created = baseFetch.create(defaults as never)
+      return wrapFetchWithForwardedHost(created, forwardedHost)
+    }) as typeof baseFetch.create
+  }
+
+  return forwardedFetch
+}
+
+type FetchCapableNuxtApp = { $fetch: typeof $fetch }
+
+export const installForwardedHostFetch = (nuxtApp: FetchCapableNuxtApp): void => {
+  const requestHeaders = useRequestHeaders(['x-forwarded-host', 'host'])
+  const forwardedHost =
+    normalizeForwardedHost(requestHeaders['x-forwarded-host']) ?? normalizeForwardedHost(requestHeaders.host)
+
+  if (!forwardedHost) {
+    return
+  }
+
+  const globalScope = globalThis as typeof globalThis & { $fetch?: typeof $fetch }
+  const baseFetch = (nuxtApp.$fetch ?? globalScope.$fetch ?? $fetch) as typeof $fetch
+  const forwardedFetch = wrapFetchWithForwardedHost(baseFetch, forwardedHost)
+
+  nuxtApp.$fetch = forwardedFetch
+  globalScope.$fetch = forwardedFetch
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  installForwardedHostFetch(nuxtApp as unknown as FetchCapableNuxtApp)
+})


### PR DESCRIPTION
## Summary
- add a server-only plugin that wraps `$fetch` to inject the normalized forwarded host header for SSR calls
- cover the plugin with a Vitest spec that verifies the header is propagated through wrapped `$fetch` and `$fetch.raw`

## Testing
- pnpm vitest run server-fetch-forwarded-host
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ecbe158d7c833383444a03486dcc2e