### PR TITLE
Ensure frontend API fetches forward host headers

### DIFF
--- a/frontend/app/components/shared/dev/debugs/The-debug.vue
+++ b/frontend/app/components/shared/dev/debugs/The-debug.vue
@@ -25,11 +25,14 @@ interface DebugResponse {
 
 const loading = ref(false)
 const debugData = ref<DebugResponse | null>(null)
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const fetchDebugData = async () => {
   loading.value = true
   try {
-    const response = await $fetch<DebugResponse>('/api/blog/test')
+    const response = await $fetch<DebugResponse>('/api/blog/test', {
+      headers: requestHeaders,
+    })
     debugData.value = response
   } catch (error) {
     console.error('Error fetching debug data:', error)

--- a/frontend/app/composables/blog/useBlog.ts
+++ b/frontend/app/composables/blog/useBlog.ts
@@ -11,6 +11,7 @@ export const useBlog = () => {
     'blog-articles',
     () => [],
   )
+  const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
   const currentArticle = useState<BlogPostDto | null>(
     'blog-current-article',
     () => null,
@@ -59,6 +60,7 @@ export const useBlog = () => {
 
       // Use our server API as proxy instead of calling external API directly
       const response = await $fetch<PageDto>('/api/blog/articles', {
+        headers: requestHeaders,
         params: {
           pageNumber: sanitizedPage - 1,
           pageSize: sanitizedSize,
@@ -123,7 +125,9 @@ export const useBlog = () => {
 
   const fetchTags = async () => {
     try {
-      const response = await $fetch<BlogTagDto[]>('/api/blog/tags')
+      const response = await $fetch<BlogTagDto[]>('/api/blog/tags', {
+        headers: requestHeaders,
+      })
       tags.value = response ?? []
     } catch (err) {
       console.error('Error in fetchTags:', err)
@@ -146,7 +150,11 @@ export const useBlog = () => {
     error.value = null
 
     try {
-      const article = await $fetch<BlogPostDto>(`/api/blog/articles/${slug}`)
+      const article = await $fetch<BlogPostDto>(`/api/blog/articles/${slug}`,
+        {
+          headers: requestHeaders,
+        },
+      )
       currentArticle.value = article
       return article
     } catch (err) {

--- a/frontend/app/composables/categories/useCategories.ts
+++ b/frontend/app/composables/categories/useCategories.ts
@@ -9,6 +9,7 @@ export const useCategories = () => {
     'categories-list',
     () => [],
   )
+  const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
   const loading = useState(
     'categories-loading',
     () => false,
@@ -38,6 +39,7 @@ export const useCategories = () => {
 
     try {
       const response = await $fetch<VerticalConfigDto[]>('/api/categories', {
+        headers: requestHeaders,
         params: { onlyEnabled },
       })
 
@@ -94,6 +96,9 @@ export const useCategories = () => {
 
       const detail = await $fetch<VerticalConfigFullDto>(
         `/api/categories/${encodeURIComponent(matchingCategory.id)}`,
+        {
+          headers: requestHeaders,
+        },
       )
 
       currentCategory.value = detail

--- a/frontend/app/composables/cms/useFullPage.ts
+++ b/frontend/app/composables/cms/useFullPage.ts
@@ -22,7 +22,12 @@ export const useFullPage = async (
       }
 
       const encodedId = encodeURIComponent(id)
-      return await $fetch<CmsFullPage>(`/api/pages/${encodedId}`)
+      const headers = useRequestHeaders(['host', 'x-forwarded-host'])
+      return await $fetch<CmsFullPage>(`/api/pages/${encodedId}`,
+        {
+          headers,
+        },
+      )
     },
     {
       server: true,

--- a/frontend/app/composables/content/useContentBloc.ts
+++ b/frontend/app/composables/content/useContentBloc.ts
@@ -20,7 +20,12 @@ export const useContentBloc = async (
         return null
       }
 
-      return $fetch<XwikiContentBlocDto>(`/api/blocs/${id}`)
+      const headers = useRequestHeaders(['host', 'x-forwarded-host'])
+      return $fetch<XwikiContentBlocDto>(`/api/blocs/${id}`,
+        {
+          headers,
+        },
+      )
     },
     {
       server: true,

--- a/frontend/app/pages/contact/index.vue
+++ b/frontend/app/pages/contact/index.vue
@@ -50,6 +50,7 @@ const { t, locale, availableLocales } = useI18n()
 const runtimeConfig = useRuntimeConfig()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const siteKey = computed(() => runtimeConfig.public.hcaptchaSiteKey ?? '')
 const submitting = ref(false)
@@ -180,6 +181,10 @@ const handleFormSubmit = async (payload: ContactFormPayload) => {
   try {
     const response = await $fetch<ContactResponseDto>('/api/contact', {
       method: 'POST',
+      headers: {
+        ...requestHeaders,
+        'content-type': 'application/json',
+      },
       body: payload,
     })
 

--- a/frontend/app/pages/contrib/[token].vue
+++ b/frontend/app/pages/contrib/[token].vue
@@ -83,6 +83,7 @@ const route = useRoute()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
 const { t } = useI18n()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const token = computed(() => {
   const param = route.params.token
@@ -102,7 +103,11 @@ const fetchRedirect = async () => {
   }
 
   const encodedToken = encodeURIComponent(token.value)
-  return $fetch<AffiliationRedirectResponse>(`/api/contrib/${encodedToken}`)
+  return $fetch<AffiliationRedirectResponse>(`/api/contrib/${encodedToken}`,
+    {
+      headers: requestHeaders,
+    },
+  )
 }
 
 const { data, pending, error } = await useAsyncData<AffiliationRedirectResponse>(

--- a/frontend/app/pages/feedback/index.vue
+++ b/frontend/app/pages/feedback/index.vue
@@ -160,6 +160,7 @@ const { t, locale, availableLocales } = useI18n()
 const requestURL = useRequestURL()
 const runtimeConfig = useRuntimeConfig()
 const localePath = useLocalePath()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const siteKey = computed(() => runtimeConfig.public.hcaptchaSiteKey ?? '')
 const currentUrl = computed(() => requestURL.href)
@@ -215,6 +216,7 @@ const issueLoadFailed = reactive<Record<FeedbackCategory, boolean>>({
 const fetchIssues = async (category: FeedbackCategory) => {
   try {
     const response = await $fetch<FeedbackIssueDto[]>('/api/feedback/issues', {
+      headers: requestHeaders,
       query: { type: category },
     })
 
@@ -267,7 +269,10 @@ const loadRemainingVotes = async () => {
   try {
     remainingVotesState.value = await $fetch('/api/feedback/votes/remaining', {
       query: buildVotesQuery(),
-      headers: { 'cache-control': 'no-cache' },
+      headers: {
+        ...requestHeaders,
+        'cache-control': 'no-cache',
+      },
     })
   } catch (error) {
     console.warn('Unable to load remaining votes, falling back to unknown state', error)
@@ -283,7 +288,10 @@ const loadVoteEligibility = async () => {
   try {
     canVoteState.value = await $fetch('/api/feedback/votes/can', {
       query: buildVotesQuery(),
-      headers: { 'cache-control': 'no-cache' },
+      headers: {
+        ...requestHeaders,
+        'cache-control': 'no-cache',
+      },
     })
   } catch (error) {
     console.warn('Unable to determine vote eligibility, assuming voting is allowed', error)
@@ -380,6 +388,7 @@ const handleVote = async (issueId: string | undefined, category: FeedbackCategor
   try {
     await $fetch('/api/feedback/vote', {
       method: 'POST',
+      headers: requestHeaders,
       body: { issueId },
     })
 
@@ -455,6 +464,7 @@ const handleSubmitFeedback = async (payload: FeedbackFormSubmitPayload) => {
   try {
     const response = await $fetch<FeedbackSubmissionResponseDto>('/api/feedback', {
       method: 'POST',
+      headers: requestHeaders,
       body: payload,
     })
 

--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -121,6 +121,7 @@ definePageMeta({
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 interface DatasetPayload {
   dataset: OpenDataDatasetDto
@@ -129,8 +130,12 @@ interface DatasetPayload {
 
 const { data, pending, error, refresh } = await useAsyncData<DatasetPayload>('opendata-gtin', async () => {
   const [dataset, overview] = await Promise.all([
-    $fetch<OpenDataDatasetDto>('/api/opendata/gtin'),
-    $fetch<OpenDataOverviewDto>('/api/opendata'),
+    $fetch<OpenDataDatasetDto>('/api/opendata/gtin', {
+      headers: requestHeaders,
+    }),
+    $fetch<OpenDataOverviewDto>('/api/opendata', {
+      headers: requestHeaders,
+    }),
   ])
 
   return { dataset, overview }

--- a/frontend/app/pages/opendata/index.vue
+++ b/frontend/app/pages/opendata/index.vue
@@ -84,9 +84,12 @@ definePageMeta({
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const { data, pending, error, refresh } = await useAsyncData<OpenDataOverviewDto>('opendata-overview', () =>
-  $fetch<OpenDataOverviewDto>('/api/opendata'),
+  $fetch<OpenDataOverviewDto>('/api/opendata', {
+    headers: requestHeaders,
+  }),
 )
 
 const formatProductCount = (count?: string | number | null) => {

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -121,6 +121,7 @@ definePageMeta({
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 interface DatasetPayload {
   dataset: OpenDataDatasetDto
@@ -129,8 +130,12 @@ interface DatasetPayload {
 
 const { data, pending, error, refresh } = await useAsyncData<DatasetPayload>('opendata-isbn', async () => {
   const [dataset, overview] = await Promise.all([
-    $fetch<OpenDataDatasetDto>('/api/opendata/isbn'),
-    $fetch<OpenDataOverviewDto>('/api/opendata'),
+    $fetch<OpenDataDatasetDto>('/api/opendata/isbn', {
+      headers: requestHeaders,
+    }),
+    $fetch<OpenDataOverviewDto>('/api/opendata', {
+      headers: requestHeaders,
+    }),
   ])
 
   return { dataset, overview }

--- a/frontend/app/pages/partners/index.vue
+++ b/frontend/app/pages/partners/index.vue
@@ -110,14 +110,21 @@ const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
 const heroHeadingId = useId()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const { data, pending, error, refresh } = await useAsyncData<PartnersPageData>(
   'partners-data',
   async () => {
     const [affiliation, ecosystem, mentors] = await Promise.all([
-      $fetch<AffiliationPartnerDto[]>('/api/partners/affiliation'),
-      $fetch<StaticPartnerDto[]>('/api/partners/ecosystem'),
-      $fetch<StaticPartnerDto[]>('/api/partners/mentors'),
+      $fetch<AffiliationPartnerDto[]>('/api/partners/affiliation', {
+        headers: requestHeaders,
+      }),
+      $fetch<StaticPartnerDto[]>('/api/partners/ecosystem', {
+        headers: requestHeaders,
+      }),
+      $fetch<StaticPartnerDto[]>('/api/partners/mentors', {
+        headers: requestHeaders,
+      }),
     ])
 
     return {

--- a/frontend/app/pages/team/index.vue
+++ b/frontend/app/pages/team/index.vue
@@ -75,9 +75,12 @@ const PARTNERS_BLOC_ID = 'pages:team:partenaires:'
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const { data, pending, error, refresh } = await useAsyncData<TeamProperties>('team-roster', () =>
-  $fetch<TeamProperties>('/api/team')
+  $fetch<TeamProperties>('/api/team', {
+    headers: requestHeaders,
+  })
 )
 
 const coreMembers = computed(() => data.value?.cores ?? [])


### PR DESCRIPTION
## Summary
- forward the original host headers with every Nuxt $fetch call that targets server API routes so SSR preserves the resolved domain language
- update category, blog, content, partners, open data, feedback, contact, team, and contrib flows to share the forwarding helper
- align the developer debug tool with the same header propagation to keep behaviour consistent

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68eccda1b200833383ae0b34921fd846