### PR TITLE
feat: redirect GTIN routes via backend lookup

### DIFF
--- a/frontend/app/pages/[gtin].vue
+++ b/frontend/app/pages/[gtin].vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="gtin-redirect" />
+</template>
+
+<script setup lang="ts">
+import type { ProductDto } from '~~/shared/api-client'
+import { extractGtinParam, isValidGtinParam } from '~~/shared/utils/_gtin'
+import { resolveGtinRedirectTarget } from '~/utils/_gtin-redirect'
+
+definePageMeta({
+  validate: (route) => isValidGtinParam(route.params.gtin),
+})
+
+const route = useRoute()
+const rawGtin = extractGtinParam(route.params.gtin)
+
+if (!rawGtin) {
+  throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+
+const targetPath = await resolveGtinRedirectTarget(rawGtin, {
+  fetchProduct: (gtin: string) =>
+    $fetch<ProductDto>(`/api/products/${gtin}`, {
+      headers: requestHeaders,
+    }),
+  createError,
+})
+
+await navigateTo(targetPath, { replace: true, redirectCode: 301 })
+</script>
+
+<style scoped>
+.gtin-redirect {
+  display: none;
+}
+</style>

--- a/frontend/app/utils/_gtin-redirect.spec.ts
+++ b/frontend/app/utils/_gtin-redirect.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ResolveGtinRedirectDependencies } from './_gtin-redirect'
+import { resolveGtinRedirectTarget } from './_gtin-redirect'
+
+describe('app/utils/_gtin-redirect', () => {
+  const createDependencies = (
+    overrides: Partial<ResolveGtinRedirectDependencies> = {}
+  ): ResolveGtinRedirectDependencies => {
+    const fetchProduct = vi.fn()
+    const createError = vi.fn(
+      (input: { statusCode: number; statusMessage: string; cause?: unknown }) =>
+        Object.assign(new Error(input.statusMessage), {
+          ...input,
+          isCreateError: true,
+        })
+    )
+
+    return {
+      fetchProduct,
+      createError,
+      ...overrides,
+    }
+  }
+
+  it('returns the canonical fullSlug path when the product exists', async () => {
+    const dependencies = createDependencies({
+      fetchProduct: vi.fn().mockResolvedValue({ fullSlug: 'produits/example-product' }),
+    })
+
+    const target = await resolveGtinRedirectTarget('123456', dependencies)
+
+    expect(dependencies.fetchProduct).toHaveBeenCalledWith('123456')
+    expect(target).toBe('/produits/example-product')
+  })
+
+  it('strips query strings and fragments from the slug', async () => {
+    const dependencies = createDependencies({
+      fetchProduct: vi.fn().mockResolvedValue({ fullSlug: '/produits/example?ref=123#section' }),
+    })
+
+    const target = await resolveGtinRedirectTarget('123456', dependencies)
+
+    expect(target).toBe('/produits/example')
+  })
+
+  it('throws a 404 error when the backend does not find the product', async () => {
+    const backendError = { statusCode: 404 }
+    const dependencies = createDependencies({
+      fetchProduct: vi.fn().mockRejectedValue(backendError),
+    })
+
+    await expect(resolveGtinRedirectTarget('123456', dependencies)).rejects.toMatchObject({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+      isCreateError: true,
+    })
+
+    expect(dependencies.createError).toHaveBeenCalledWith({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+      cause: backendError,
+    })
+  })
+
+  it('throws a 404 when the product does not expose a fullSlug', async () => {
+    const dependencies = createDependencies({
+      fetchProduct: vi.fn().mockResolvedValue({ fullSlug: '' }),
+    })
+
+    await expect(resolveGtinRedirectTarget('123456', dependencies)).rejects.toMatchObject({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+      isCreateError: true,
+    })
+
+    expect(dependencies.createError).toHaveBeenCalledWith({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+    })
+  })
+})

--- a/frontend/app/utils/_gtin-redirect.ts
+++ b/frontend/app/utils/_gtin-redirect.ts
@@ -1,0 +1,51 @@
+import type { ProductDto } from '~~/shared/api-client'
+
+export interface ResolveGtinRedirectDependencies {
+  fetchProduct: (gtin: string) => Promise<ProductDto>
+  createError: (input: { statusCode: number; statusMessage: string; cause?: unknown }) => Error
+}
+
+export const resolveGtinRedirectTarget = async (
+  gtin: string,
+  { fetchProduct, createError }: ResolveGtinRedirectDependencies
+): Promise<string> => {
+  let product: ProductDto
+  try {
+    product = await fetchProduct(gtin)
+  } catch (error) {
+    const statusCode =
+      (error as { statusCode?: number })?.statusCode ??
+      (error as { response?: { status?: number } })?.response?.status
+
+    if (statusCode === 404) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: 'Product not found',
+        cause: error,
+      })
+    }
+
+    throw error
+  }
+
+  const normalizedFullSlug = product.fullSlug?.trim()
+
+  if (!normalizedFullSlug) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+    })
+  }
+
+  const [maybeBareSlug] = normalizedFullSlug.split(/[?#]/, 1)
+  const bareFullSlug = (maybeBareSlug ?? '').trim()
+
+  if (!bareFullSlug) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Product not found',
+    })
+  }
+
+  return bareFullSlug.startsWith('/') ? bareFullSlug : `/${bareFullSlug}`
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -237,6 +237,16 @@ export default defineNuxtConfig({
   },
   hooks: {
     'pages:extend'(pages) {
+      const normalizePath = (file?: string) => file?.split('\\').join('/')
+
+      const gtinRedirectPage = pages.find((page) =>
+        normalizePath(page.file)?.endsWith('/app/pages/[gtin].vue')
+      )
+
+      if (gtinRedirectPage) {
+        gtinRedirectPage.path = '/:gtin(\\d{6,})'
+      }
+
       const wikiSourcePage = pages.find(page => page.file?.includes('/app/pages/xwiki-fullpage.vue'))
 
       if (!wikiSourcePage) {

--- a/frontend/shared/utils/_gtin.spec.ts
+++ b/frontend/shared/utils/_gtin.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractGtinParam, isValidGtinParam } from './_gtin'
+
+describe('shared/utils/_gtin', () => {
+  describe('isValidGtinParam', () => {
+    it('accepts strings with at least six digits', () => {
+      expect(isValidGtinParam('123456')).toBe(true)
+      expect(isValidGtinParam('9876543210')).toBe(true)
+    })
+
+    it('rejects non-strings and short values', () => {
+      expect(isValidGtinParam(123456 as unknown as string)).toBe(false)
+      expect(isValidGtinParam('12345')).toBe(false)
+      expect(isValidGtinParam('12345a')).toBe(false)
+    })
+  })
+
+  describe('extractGtinParam', () => {
+    it('returns the GTIN from valid strings', () => {
+      expect(extractGtinParam('123456')).toBe('123456')
+    })
+
+    it('returns the first GTIN from arrays', () => {
+      expect(extractGtinParam(['foo', '654321', '987654'])).toBe('654321')
+    })
+
+    it('returns null for invalid inputs', () => {
+      expect(extractGtinParam(undefined)).toBeNull()
+      expect(extractGtinParam('123')).toBeNull()
+      expect(extractGtinParam(['abc', '12345'])).toBeNull()
+    })
+  })
+})

--- a/frontend/shared/utils/_gtin.ts
+++ b/frontend/shared/utils/_gtin.ts
@@ -1,0 +1,20 @@
+export const GTIN_PARAM_PATTERN = /^\d{6,}$/
+
+export const isValidGtinParam = (value: unknown): value is string => {
+  return typeof value === 'string' && GTIN_PARAM_PATTERN.test(value)
+}
+
+export const extractGtinParam = (value: unknown): string | null => {
+  if (typeof value === 'string' && GTIN_PARAM_PATTERN.test(value)) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    const match = value.find(
+      (item): item is string => typeof item === 'string' && GTIN_PARAM_PATTERN.test(item)
+    )
+    return match ?? null
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add a dedicated /[gtin] page that validates numeric GTINs and redirects via backend lookups
- introduce reusable helpers and tests for GTIN parsing and redirect target resolution

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm build
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ed08b66a6c8333ba2c977b1845d303