### PR TITLE
Add aggregated search response for products

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationBucketDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationBucketDto.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Represents a single bucket produced by a search aggregation.
+ */
+public record AggregationBucketDto(
+        @Schema(description = "Bucket identifier. For numeric histograms this is the lower bound.")
+        String key,
+        @Schema(description = "Upper bound when the bucket represents a numeric range.")
+        Double to,
+        @Schema(description = "Number of matching products contained in the bucket.")
+        long count,
+        @Schema(description = "Whether this bucket corresponds to documents missing the aggregated field.")
+        boolean missing) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
@@ -21,8 +21,6 @@ public record AggregationRequestDto(
             ProductDtoAggregatableFields field,
             @Schema(description = "Aggregation type", implementation = AggType.class)
             AggType type,
-            @Schema(description = "Sub aggregation")
-            Agg subAgg,
             @Schema(description = "Minimum value for range aggregations")
             Double min,
             @Schema(description = "Maximum value for range aggregations")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
@@ -26,7 +26,9 @@ public record AggregationRequestDto(
             @Schema(description = "Minimum value for range aggregations")
             Double min,
             @Schema(description = "Maximum value for range aggregations")
-            Double max) {
+            Double max,
+            @Schema(description = "Maximum number of buckets to return. For range aggregations this represents the desired bucket count.")
+            Integer buckets) {
     }
 
     /** Supported aggregation types. */

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationResponseDto.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Container describing the aggregations computed for a search query.
+ */
+public record AggregationResponseDto(
+        @Schema(description = "Aggregation name mirroring the request payload.")
+        String name,
+        @Schema(description = "Aggregated field")
+        ProductDtoAggregatableFields field,
+        @Schema(description = "Aggregation type", implementation = AggregationRequestDto.AggType.class)
+        AggregationRequestDto.AggType type,
+        @Schema(description = "Buckets yielded by the aggregation")
+        List<AggregationBucketDto> buckets,
+        @Schema(description = "Minimum observed value when applicable")
+        Double min,
+        @Schema(description = "Maximum observed value when applicable")
+        Double max) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/ProductSearchResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/ProductSearchResponseDto.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.dto.PageDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * API payload combining paginated products with aggregation buckets for chart rendering.
+ */
+public record ProductSearchResponseDto(
+        @Schema(description = "Paginated products matching the search criteria")
+        PageDto<ProductDto> products,
+        @Schema(description = "Aggregation buckets computed for the current query")
+        List<AggregationResponseDto> aggregations) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
@@ -1,0 +1,263 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.open4goods.model.product.Product;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationBucketDto;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.Agg;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.AggType;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationResponseDto;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.HistogramAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.HistogramBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket;
+import co.elastic.clients.elasticsearch._types.aggregations.MissingAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StatsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+
+/**
+ * Dedicated search service tailored for the frontend API.
+ *
+ * <p>
+ * The implementation mirrors the behaviour of the historical {@code verticalSearch}
+ * method located in the commons module while remaining self contained. It
+ * supports vertical scoping, textual queries and aggregation descriptors defined
+ * by {@link AggregationRequestDto} so the Nuxt frontend can build charts with a
+ * single API call.
+ * </p>
+ */
+@Service
+public class SearchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchService.class);
+    private static final String MISSING_BUCKET = "ES-UNKNOWN";
+    private static final int DEFAULT_BUCKET_COUNT = 10;
+    private static final int DEFAULT_TERMS_SIZE = 50;
+
+    private final ProductRepository repository;
+    private final VerticalsConfigService verticalsConfigService;
+
+    public SearchService(ProductRepository repository, VerticalsConfigService verticalsConfigService) {
+        this.repository = repository;
+        this.verticalsConfigService = verticalsConfigService;
+    }
+
+    /**
+     * Executes a product search and computes aggregation buckets tailored for the frontend.
+     *
+     * @param pageable         pagination information requested by the caller
+     * @param verticalId       optional vertical identifier used to scope the search
+     * @param query            optional free text query applied on offer names
+     * @param aggregationQuery optional aggregation definition mirroring the Nuxt contract
+     * @return a {@link SearchResult} bundling {@link SearchHits} and aggregation metadata
+     */
+    public SearchResult search(Pageable pageable, String verticalId, String query, AggregationRequestDto aggregationQuery) {
+        Criteria criteria = repository.getRecentPriceQuery();
+
+        if (StringUtils.hasText(verticalId) && verticalsConfigService.getConfigById(verticalId) != null) {
+            criteria = criteria.and(new Criteria("vertical").is(verticalId));
+        } else if (StringUtils.hasText(verticalId)) {
+            LOGGER.warn("Requested vertical {} not found. Returning empty result set.", verticalId);
+            criteria = criteria.and(new Criteria("vertical").is("__unknown__"));
+        }
+
+        String sanitizedQuery = sanitize(query);
+        if (StringUtils.hasText(sanitizedQuery)) {
+            criteria = criteria.and(new Criteria("offerNames").matches(sanitizedQuery));
+        }
+
+        CriteriaQuery criteriaQuery = new CriteriaQuery(criteria);
+        criteriaQuery.setPageable(pageable);
+
+        List<AggregationDescriptor> descriptors = new ArrayList<>();
+        var nativeQueryBuilder = new org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder()
+                .withQuery(criteriaQuery)
+                .withPageable(pageable);
+
+        if (aggregationQuery != null && aggregationQuery.aggs() != null) {
+            for (Agg agg : aggregationQuery.aggs()) {
+                if (!isValidAggregation(agg)) {
+                    continue;
+                }
+                switch (agg.type()) {
+                case terms -> descriptors.add(configureTermsAggregation(nativeQueryBuilder, agg));
+                case range -> descriptors.add(configureRangeAggregation(nativeQueryBuilder, agg));
+                default -> LOGGER.warn("Unsupported aggregation type {}", agg.type());
+                }
+            }
+        }
+
+        SearchHits<Product> hits = repository.search(nativeQueryBuilder.build(), ProductRepository.MAIN_INDEX_NAME);
+        List<AggregationResponseDto> aggregations = extractAggregationResults(hits, descriptors);
+        return new SearchResult(hits, List.copyOf(aggregations));
+    }
+
+    private boolean isValidAggregation(Agg agg) {
+        return agg != null && StringUtils.hasText(agg.name()) && agg.field() != null && agg.type() != null;
+    }
+
+    private AggregationDescriptor configureTermsAggregation(org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder builder,
+            Agg agg) {
+        int size = agg.buckets() != null && agg.buckets() > 0 ? agg.buckets() : DEFAULT_TERMS_SIZE;
+        builder.withAggregation(agg.name(), Aggregation.of(a -> a.terms(t -> t.field(agg.field().getText())
+                .size(size)
+                .missing(MISSING_BUCKET))));
+        return AggregationDescriptor.forTerms(agg);
+    }
+
+    private AggregationDescriptor configureRangeAggregation(org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder builder,
+            Agg agg) {
+        int buckets = agg.buckets() != null && agg.buckets() > 0 ? agg.buckets() : DEFAULT_BUCKET_COUNT;
+        double interval = computeInterval(agg.min(), agg.max(), buckets);
+
+        String histogramName = agg.name();
+        String missingName = agg.name() + "_missing";
+        String statsName = agg.name() + "_stats";
+
+        builder.withAggregation(histogramName,
+                Aggregation.of(a -> a.histogram(h -> h.field(agg.field().getText())
+                        .interval(interval)
+                        .minDocCount(1))))
+                .withAggregation(missingName, Aggregation.of(a -> a.missing(m -> m.field(agg.field().getText()))))
+                .withAggregation(statsName, Aggregation.of(a -> a.stats(s -> s.field(agg.field().getText()))));
+
+        return AggregationDescriptor.forRange(agg, interval, histogramName, missingName, statsName);
+    }
+
+    private double computeInterval(Double min, Double max, int buckets) {
+        double effectiveMin = min != null ? min : 0d;
+        double effectiveMax = max != null ? max : effectiveMin + buckets;
+        if (effectiveMax <= effectiveMin) {
+            effectiveMax = effectiveMin + buckets;
+        }
+        double span = effectiveMax - effectiveMin;
+        double interval = span / Math.max(1, buckets);
+        if (interval <= 0d) {
+            interval = Math.max(1d, Math.abs(effectiveMax));
+        }
+        return interval;
+    }
+
+    private List<AggregationResponseDto> extractAggregationResults(SearchHits<Product> hits, List<AggregationDescriptor> descriptors) {
+        if (descriptors.isEmpty() || hits == null || hits.getAggregations() == null) {
+            return Collections.emptyList();
+        }
+
+        if (!(hits.getAggregations() instanceof ElasticsearchAggregations aggregations)) {
+            return Collections.emptyList();
+        }
+
+        List<AggregationResponseDto> responses = new ArrayList<>();
+        for (AggregationDescriptor descriptor : descriptors) {
+            if (descriptor.type == AggType.terms) {
+                responses.add(extractTermsAggregation(aggregations, descriptor));
+            } else if (descriptor.type == AggType.range) {
+                responses.add(extractRangeAggregation(aggregations, descriptor));
+            }
+        }
+        return responses;
+    }
+
+    private AggregationResponseDto extractTermsAggregation(ElasticsearchAggregations aggregations, AggregationDescriptor descriptor) {
+        var aggregation = aggregations.get(descriptor.histogramName);
+        if (aggregation == null) {
+            return new AggregationResponseDto(descriptor.request.name(), descriptor.request.field(), descriptor.type, List.of(), null, null);
+        }
+
+        var aggregate = aggregation.aggregation().getAggregate();
+        List<AggregationBucketDto> buckets = new ArrayList<>();
+        if (aggregate.isSterms()) {
+            StringTermsAggregate terms = aggregate.sterms();
+            for (StringTermsBucket bucket : terms.buckets().array()) {
+                buckets.add(new AggregationBucketDto(bucket.key().stringValue(), null, bucket.docCount(), Objects.equals(bucket.key().stringValue(), MISSING_BUCKET)));
+            }
+        } else if (aggregate.isLterms()) {
+            LongTermsAggregate terms = aggregate.lterms();
+            for (LongTermsBucket bucket : terms.buckets().array()) {
+                String key = Long.toString(bucket.key());
+                buckets.add(new AggregationBucketDto(key, null, bucket.docCount(), Objects.equals(key, MISSING_BUCKET)));
+            }
+        }
+        buckets.sort((a, b) -> Long.compare(b.count(), a.count()));
+        return new AggregationResponseDto(descriptor.request.name(), descriptor.request.field(), descriptor.type, buckets, null, null);
+    }
+
+    private AggregationResponseDto extractRangeAggregation(ElasticsearchAggregations aggregations, AggregationDescriptor descriptor) {
+        var histogramAgg = aggregations.get(descriptor.histogramName);
+        var missingAgg = aggregations.get(descriptor.missingName);
+        var statsAgg = aggregations.get(descriptor.statsName);
+
+        List<AggregationBucketDto> buckets = new ArrayList<>();
+        Double min = null;
+        Double max = null;
+        if (statsAgg != null && statsAgg.aggregation().getAggregate().isStats()) {
+            StatsAggregate stats = statsAgg.aggregation().getAggregate().stats();
+            min = stats.min();
+            max = stats.max();
+        }
+
+        if (histogramAgg != null && histogramAgg.aggregation().getAggregate().isHistogram()) {
+            HistogramAggregate histogram = histogramAgg.aggregation().getAggregate().histogram();
+            for (HistogramBucket bucket : histogram.buckets().array()) {
+                double from = bucket.key();
+                double to = from + descriptor.interval;
+                buckets.add(new AggregationBucketDto(Double.toString(from), to, bucket.docCount(), false));
+            }
+        }
+
+        if (missingAgg != null && missingAgg.aggregation().getAggregate().isMissing()) {
+            MissingAggregate missing = missingAgg.aggregation().getAggregate().missing();
+            if (missing.docCount() > 0) {
+                buckets.add(new AggregationBucketDto(MISSING_BUCKET, null, missing.docCount(), true));
+            }
+        }
+
+        return new AggregationResponseDto(descriptor.request.name(), descriptor.request.field(), descriptor.type, buckets, min, max);
+    }
+
+    private String sanitize(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String sanitized = value.replaceAll("[^\\p{IsAlphabetic}\\p{IsDigit}\\s]", " ");
+        sanitized = sanitized.replaceAll("\\s+", " ").trim();
+        return sanitized;
+    }
+
+    /**
+     * Wrapper holding the {@link SearchHits} and the aggregation response DTOs.
+     */
+    public record SearchResult(SearchHits<Product> hits, List<AggregationResponseDto> aggregations) {
+    }
+
+    private record AggregationDescriptor(Agg request, AggType type, double interval, String histogramName, String missingName,
+            String statsName) {
+
+        private static AggregationDescriptor forTerms(Agg request) {
+            return new AggregationDescriptor(request, request.type(), 0d, request.name(), null, null);
+        }
+
+        private static AggregationDescriptor forRange(Agg request, double interval, String histogramName, String missingName,
+                String statsName) {
+            return new AggregationDescriptor(request, request.type(), interval, histogramName, missingName, statsName);
+        }
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdviceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/advice/PaginationLinkAdviceTest.java
@@ -1,0 +1,53 @@
+package org.open4goods.nudgerfrontapi.controller.advice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.PageDto;
+import org.open4goods.nudgerfrontapi.dto.PageMetaDto;
+import org.open4goods.nudgerfrontapi.dto.search.ProductSearchResponseDto;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Tests for {@link PaginationLinkAdvice}.
+ */
+class PaginationLinkAdviceTest {
+
+    private final PaginationLinkAdvice advice = new PaginationLinkAdvice();
+
+    @Test
+    void shouldAddPaginationLinksForSearchResponse() {
+        ProductSearchResponseDto body = new ProductSearchResponseDto(
+                new PageDto<>(new PageMetaDto(1, 20, 100, 5), List.of()),
+                List.of());
+
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest("GET", "/products");
+        servletRequest.setScheme("http");
+        servletRequest.setServerName("localhost");
+        servletRequest.setServerPort(80);
+        servletRequest.setQueryString("pageNumber=1&pageSize=20");
+
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+
+        Object written = advice.beforeBodyWrite(body, null, MediaType.APPLICATION_JSON, null, request, response);
+
+        assertThat(written).isSameAs(body);
+
+        List<String> linkHeaders = response.getHeaders().get(HttpHeaders.LINK);
+        assertThat(linkHeaders).isNotNull();
+        assertThat(String.join(",", linkHeaders))
+                .contains("rel=\"first\"")
+                .contains("rel=\"last\"")
+                .contains("rel=\"prev\"")
+                .contains("rel=\"next\"");
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -33,6 +33,7 @@ import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.verticals.VerticalsConfigService;
 
+
 class ProductMappingServiceTest {
 
     private ProductRepository repository;
@@ -42,6 +43,7 @@ class ProductMappingServiceTest {
     private VerticalsConfigService verticalsConfigService;
     private AffiliationService affiliationService;
     private IcecatService icecatService;
+    private SearchService searchService;
 
     @BeforeEach
     void setUp() {
@@ -52,8 +54,9 @@ class ProductMappingServiceTest {
         verticalsConfigService = mock(VerticalsConfigService.class);
         affiliationService = mock(AffiliationService.class);
         icecatService = mock(IcecatService.class);
+        searchService = mock(SearchService.class);
         service = new ProductMappingService(repository, apiProperties, categoryMappingService,
-                verticalsConfigService, affiliationService, icecatService);
+                verticalsConfigService, searchService, affiliationService, icecatService);
     }
 
     @Test

--- a/frontend/shared/api-client/models/PageProductDto.ts
+++ b/frontend/shared/api-client/models/PageProductDto.ts
@@ -79,6 +79,18 @@ export interface PageProductDto {
     sort?: SortObject;
     /**
      * 
+     * @type {PageableObject}
+     * @memberof PageProductDto
+     */
+    pageable?: PageableObject;
+    /**
+     * 
+     * @type {number}
+     * @memberof PageProductDto
+     */
+    numberOfElements?: number;
+    /**
+     * 
      * @type {boolean}
      * @memberof PageProductDto
      */
@@ -89,18 +101,6 @@ export interface PageProductDto {
      * @memberof PageProductDto
      */
     last?: boolean;
-    /**
-     * 
-     * @type {number}
-     * @memberof PageProductDto
-     */
-    numberOfElements?: number;
-    /**
-     * 
-     * @type {PageableObject}
-     * @memberof PageProductDto
-     */
-    pageable?: PageableObject;
     /**
      * 
      * @type {boolean}
@@ -132,10 +132,10 @@ export function PageProductDtoFromJSONTyped(json: any, ignoreDiscriminator: bool
         'content': json['content'] == null ? undefined : ((json['content'] as Array<any>).map(ProductDtoFromJSON)),
         'number': json['number'] == null ? undefined : json['number'],
         'sort': json['sort'] == null ? undefined : SortObjectFromJSON(json['sort']),
+        'pageable': json['pageable'] == null ? undefined : PageableObjectFromJSON(json['pageable']),
+        'numberOfElements': json['numberOfElements'] == null ? undefined : json['numberOfElements'],
         'first': json['first'] == null ? undefined : json['first'],
         'last': json['last'] == null ? undefined : json['last'],
-        'numberOfElements': json['numberOfElements'] == null ? undefined : json['numberOfElements'],
-        'pageable': json['pageable'] == null ? undefined : PageableObjectFromJSON(json['pageable']),
         'empty': json['empty'] == null ? undefined : json['empty'],
     };
 }
@@ -157,10 +157,10 @@ export function PageProductDtoToJSONTyped(value?: PageProductDto | null, ignoreD
         'content': value['content'] == null ? undefined : ((value['content'] as Array<any>).map(ProductDtoToJSON)),
         'number': value['number'],
         'sort': SortObjectToJSON(value['sort']),
+        'pageable': PageableObjectToJSON(value['pageable']),
+        'numberOfElements': value['numberOfElements'],
         'first': value['first'],
         'last': value['last'],
-        'numberOfElements': value['numberOfElements'],
-        'pageable': PageableObjectToJSON(value['pageable']),
         'empty': value['empty'],
     };
 }


### PR DESCRIPTION
## Summary
- add a dedicated search service mirroring the legacy verticalSearch behaviour while exposing chart-friendly aggregation results
- return a ProductSearchResponseDto from GET /products with optional verticalId/query filters and updated aggregation DTOs
- update pagination advice and tests so pagination headers and controller checks work with the new response envelope

## Testing
- mvn --offline test

------
https://chatgpt.com/codex/tasks/task_e_68ed1043dfe08333ba1ecb409eb47071