### PR TITLE
Handle bare aggregation arrays in ProductController

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -252,8 +252,16 @@ public class ProductController {
 
                 AggregationRequestDto aggDto = null;
                 if (aggs != null) {
+                        String trimmedAggs = aggs.trim();
                         try {
-                                aggDto = objectMapper.readValue(aggs, AggregationRequestDto.class);
+                                if (trimmedAggs.startsWith("[")) {
+                                        List<AggregationRequestDto.Agg> parsedAggs = objectMapper
+                                                        .readerForListOf(AggregationRequestDto.Agg.class)
+                                                        .readValue(trimmedAggs);
+                                        aggDto = new AggregationRequestDto(parsedAggs);
+                                } else {
+                                        aggDto = objectMapper.readValue(trimmedAggs, AggregationRequestDto.class);
+                                }
                         } catch (JsonProcessingException e) {
                                 ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
                                 pd.setTitle("Invalid aggregation parameter");


### PR DESCRIPTION
## Summary
- allow the product search endpoint to parse aggregation payloads supplied either as an object or a bare array
- keep the existing bad request response when the aggregation payload cannot be parsed
- extend the ProductController integration tests to cover both aggregation payload formats

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68ed215fc72c8333b0b39bfa220e1b36