### PR TITLE
Add structured filters to product search

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
@@ -1,0 +1,108 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes the filters that can be applied when searching for products.
+ *
+ * <p>The structure mirrors the JSON payload accepted by the {@code filters}
+ * query parameter on {@code GET /products}. Clients can combine multiple
+ * clauses. Each clause is evaluated with an AND semantics on the Elasticsearch
+ * query.</p>
+ */
+public record FilterRequestDto(
+        @Schema(description = "Collection of filter clauses. When omitted no additional filtering is applied.")
+        List<Filter> filters) {
+
+    /**
+     * Describes a single filter clause sent by the client.
+     */
+    public record Filter(
+            @Schema(description = "Field targeted by the filter.", implementation = FilterField.class)
+            FilterField field,
+            @Schema(description = "Filtering strategy to apply.", implementation = FilterOperator.class)
+            FilterOperator operator,
+            @Schema(description = "Exact values accepted when the operator is <code>term</code>. Multiple values are combined with OR semantics.",
+                    example = "[\"Fairphone\",\"Samsung\"]")
+            List<String> terms,
+            @Schema(description = "Inclusive lower bound used when the operator is <code>range</code>.", example = "100.0")
+            Double min,
+            @Schema(description = "Inclusive upper bound used when the operator is <code>range</code>.", example = "500.0")
+            Double max) {
+    }
+
+    /**
+     * Supported fields for product filtering along with the mapping to the Elasticsearch index.
+     */
+    public enum FilterField {
+        @Schema(description = "Filter on the minimum price of the product", example = "price")
+        price("price.minPrice.price", FilterValueType.numeric),
+        @Schema(description = "Filter on the number of offers available", example = "offersCount")
+        offersCount("offersCount", FilterValueType.numeric),
+        @Schema(description = "Filter on the condition of the offers (e.g. NEW, USED)", example = "condition")
+        condition("price.conditions", FilterValueType.keyword),
+        @Schema(description = "Filter on the product brand reported by datasources", example = "brand")
+        brand("attributes.referentielAttributes.BRAND", FilterValueType.keyword),
+        @Schema(description = "Filter on the country resolved from the GTIN prefix", example = "country")
+        country("gtinInfos.country", FilterValueType.keyword),
+        @Schema(description = "Filter on the datasources contributing to the aggregation", example = "datasource")
+        datasource("datasourceCodes", FilterValueType.keyword);
+
+        private final String fieldPath;
+        private final FilterValueType valueType;
+
+        FilterField(String fieldPath, FilterValueType valueType) {
+            this.fieldPath = fieldPath;
+            this.valueType = valueType;
+        }
+
+        /**
+         * @return Elasticsearch field backing the filter.
+         */
+        public String fieldPath() {
+            return fieldPath;
+        }
+
+        /**
+         * @return type of values supported by the field.
+         */
+        public FilterValueType valueType() {
+            return valueType;
+        }
+
+        /**
+         * Determine whether the field supports the requested operator.
+         *
+         * @param operator operator requested by the client
+         * @return {@code true} when the operator is compatible with the field type
+         */
+        public boolean supports(FilterOperator operator) {
+            return switch (valueType) {
+            case keyword -> operator == FilterOperator.term;
+            case numeric -> operator == FilterOperator.range || operator == FilterOperator.term;
+            };
+        }
+    }
+
+    /**
+     * Supported operator types for the filters.
+     */
+    public enum FilterOperator {
+        @Schema(description = "Matches documents where the field equals one of the provided terms.")
+        term,
+        @Schema(description = "Matches documents where the field is within the inclusive range defined by min and/or max.")
+        range
+    }
+
+    /**
+     * Describes the nature of values supported by a filter field.
+     */
+    public enum FilterValueType {
+        @Schema(description = "The field expects exact string values.")
+        keyword,
+        @Schema(description = "The field expects numeric values and supports range queries.")
+        numeric
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -73,6 +73,7 @@ import org.open4goods.nudgerfrontapi.dto.product.ProductScoresDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductSourcedAttributeDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductVideoDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.ProductSearchResponseDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -517,12 +518,14 @@ public class ProductMappingService {
      * @param domainLanguage   requested domain language
      * @param verticalId       optional vertical identifier
      * @param query            optional free text query
+     * @param filters         optional search filters applied on the Elasticsearch query
      * @return response payload containing paginated products and aggregations
      */
     public ProductSearchResponseDto searchProducts(Pageable pageable, Locale locale, Set<String> includes,
-            AggregationRequestDto aggregation, DomainLanguage domainLanguage, String verticalId, String query) {
+            AggregationRequestDto aggregation, DomainLanguage domainLanguage, String verticalId, String query,
+            FilterRequestDto filters) {
 
-        SearchService.SearchResult result = searchService.search(pageable, verticalId, query, aggregation);
+        SearchService.SearchResult result = searchService.search(pageable, verticalId, query, aggregation, filters);
         SearchHits<Product> hits = result.hits();
 
         List<ProductDto> items = hits.getSearchHits().stream()

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -1,10 +1,12 @@
 package org.open4goods.nudgerfrontapi.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -20,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.open4goods.model.RolesConstants;
 import org.open4goods.model.ai.AiReview;
 import org.open4goods.nudgerfrontapi.controller.api.ProductController;
@@ -28,8 +31,13 @@ import org.open4goods.nudgerfrontapi.dto.PageMetaDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
 import org.open4goods.nudgerfrontapi.dto.product.ProductReviewDto;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationBucketDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationResponseDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.Filter;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterField;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
 import org.open4goods.nudgerfrontapi.dto.search.ProductSearchResponseDto;
 import org.open4goods.nudgerfrontapi.dto.RequestMetadata;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
@@ -113,7 +121,7 @@ class ProductControllerIT {
         var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
-        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class), nullable(String.class), nullable(String.class)))
+        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
                 .willReturn(responseDto);
 
         mockMvc.perform(get("/products")
@@ -133,7 +141,7 @@ class ProductControllerIT {
         AggregationResponseDto aggregation = new AggregationResponseDto("offers", ProductDtoAggregatableFields.offersCount,
                 AggregationRequestDto.AggType.terms, List.of(), null, null);
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of(aggregation));
-        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class), nullable(String.class), nullable(String.class)))
+        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
                 .willReturn(responseDto);
 
         mockMvc.perform(get("/products")
@@ -143,6 +151,55 @@ class ProductControllerIT {
                         .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.aggregations").isArray());
+    }
+
+    @Test
+    void productsEndpointParsesFiltersAndPropagatesToService() throws Exception {
+        var product = new ProductDto(42L, null, null, null, null, null, null, null, null, null, null, null);
+        PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
+        AggregationBucketDto bucket = new AggregationBucketDto("NEW", null, 1L, false);
+        AggregationResponseDto aggregation = new AggregationResponseDto("offers", ProductDtoAggregatableFields.offersCount,
+                AggregationRequestDto.AggType.terms, List.of(bucket), null, null);
+        ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of(aggregation));
+        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
+                .willReturn(responseDto);
+
+        String filtersJson = "{\"filters\":[{\"field\":\"price\",\"operator\":\"range\",\"min\":100.0,\"max\":400.0},{\"field\":\"condition\",\"operator\":\"term\",\"terms\":[\"NEW\",\"USED\"]}]}";
+
+        mockMvc.perform(get("/products")
+                        .param("filters", filtersJson)
+                        .param("domainLanguage", "FR")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.products.data").isArray())
+                .andExpect(jsonPath("$.aggregations[0].buckets[0].key").value("NEW"))
+                .andExpect(jsonPath("$.aggregations[0].buckets[0].count").value(1));
+
+        ArgumentCaptor<FilterRequestDto> captor = ArgumentCaptor.forClass(FilterRequestDto.class);
+        then(service).should().searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(DomainLanguage.class),
+                nullable(String.class), nullable(String.class), captor.capture());
+
+        FilterRequestDto captured = captor.getValue();
+        assertThat(captured.filters()).hasSize(2);
+        assertThat(captured.filters()).extracting(Filter::field).contains(FilterField.price, FilterField.condition);
+        assertThat(captured.filters()).filteredOn(filter -> filter.field() == FilterField.price)
+                .first()
+                .satisfies(filter -> {
+                    assertThat(filter.operator()).isEqualTo(FilterOperator.range);
+                    assertThat(filter.min()).isEqualTo(100.0);
+                    assertThat(filter.max()).isEqualTo(400.0);
+                });
+    }
+
+    @Test
+    void productsEndpointReturns400OnInvalidFilters() throws Exception {
+        mockMvc.perform(get("/products")
+                        .param("filters", "{invalid")
+                        .param("domainLanguage", "FR")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -1,0 +1,108 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.Agg;
+import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.AggType;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.Filter;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterField;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsImpl;
+import org.springframework.data.elasticsearch.core.TotalHitsRelation;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+
+/**
+ * Unit tests for {@link SearchService} focusing on filter application.
+ */
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @Mock
+    private ProductRepository repository;
+
+    @Mock
+    private VerticalsConfigService verticalsConfigService;
+
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp() {
+        searchService = new SearchService(repository, verticalsConfigService);
+    }
+
+    @Test
+    void searchAppliesFiltersAndKeepsAggregations() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Criteria baseCriteria = new Criteria("offersCount").greaterThan(0);
+        when(repository.getRecentPriceQuery()).thenReturn(baseCriteria);
+        when(verticalsConfigService.getConfigById("electronics")).thenReturn(new VerticalConfig());
+
+        Product product = new Product(1L);
+        SearchHit<Product> searchHit = new SearchHit<>(ProductRepository.MAIN_INDEX_NAME, "1", null, 1f, null,
+                Map.of(), Map.of(), null, null, List.of(), product);
+        Aggregate aggregate = Aggregate.of(a -> a.sterms(st -> st.buckets(b -> b.array(List.of(
+                StringTermsBucket.of(bucket -> bucket.key(FieldValue.of(fv -> fv.stringValue("NEW"))).docCount(1L)))))));
+        ElasticsearchAggregations aggregations = new ElasticsearchAggregations(Map.of("byOffers", aggregate));
+        SearchHits<Product> searchHits = new SearchHitsImpl<>(1L, TotalHitsRelation.EQUAL_TO, 1f, Duration.ZERO, null, null,
+                List.of(searchHit), aggregations, null, null);
+        when(repository.search(any(NativeQuery.class), eq(ProductRepository.MAIN_INDEX_NAME))).thenReturn(searchHits);
+
+        Filter priceFilter = new Filter(FilterField.price, FilterOperator.range, null, 100.0, 400.0);
+        Filter conditionFilter = new Filter(FilterField.condition, FilterOperator.term, List.of("NEW"), null, null);
+        FilterRequestDto filters = new FilterRequestDto(List.of(priceFilter, conditionFilter));
+
+        Agg aggregation = new Agg("byOffers", org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields.offersCount,
+                AggType.terms, null, null, 5);
+        AggregationRequestDto aggregationRequest = new AggregationRequestDto(List.of(aggregation));
+
+        SearchService.SearchResult result = searchService.search(pageable, "electronics", "eco", aggregationRequest, filters);
+
+        assertThat(result.hits().getSearchHits()).hasSize(1);
+        assertThat(result.aggregations()).hasSize(1);
+        assertThat(result.aggregations().get(0).buckets()).hasSize(1);
+        assertThat(result.aggregations().get(0).buckets().get(0).count()).isEqualTo(1L);
+
+        ArgumentCaptor<NativeQuery> queryCaptor = ArgumentCaptor.forClass(NativeQuery.class);
+        org.mockito.Mockito.verify(repository).search(queryCaptor.capture(), eq(ProductRepository.MAIN_INDEX_NAME));
+        NativeQuery builtQuery = queryCaptor.getValue();
+        Criteria builtCriteria = ((CriteriaQuery) builtQuery.getSpringDataQuery()).getCriteria();
+        var fieldNames = builtCriteria.getCriteriaChain().stream()
+                .map(criteria -> criteria.getField() == null ? null : criteria.getField().getName())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        assertThat(fieldNames).contains("price.minPrice.price");
+        assertThat(fieldNames).contains("price.conditions");
+    }
+}


### PR DESCRIPTION
## Summary
- add a typed `filters` query parameter to the `/products` endpoint and surface parsing errors
- introduce `FilterRequestDto` and propagate filter clauses through `ProductMappingService` into the Elasticsearch query
- extend `SearchService` to translate filter clauses into criteria and cover the flow with controller and service tests

## Testing
- `mvn --offline -pl front-api test`


------
https://chatgpt.com/codex/tasks/task_e_68ed20e3d6f88333b7add3c274a7e66b