### PR TITLE
Add bad request response to product search OpenAPI spec

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -334,6 +334,9 @@ public class ProductController {
                                             schema = @Schema(type = "string", example = "fr-FR"))
                             },
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductSearchResponseDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid request parameters",
+                            content = @Content(mediaType = "application/problem+json",
+                                    schema = @Schema(implementation = ProblemDetail.class))),
                     @ApiResponse(responseCode = "401", description = "Authentication required"),
                     @ApiResponse(responseCode = "403", description = "Access forbidden"),
                     @ApiResponse(responseCode = "500", description = "Internal server error")

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/docs/OpenApiDocsIT.java
@@ -42,6 +42,7 @@ class OpenApiDocsIT {
                 .with(httpBasic("user", "pass"))
                 .header("X-Shared-Token", SHARED_TOKEN))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.openapi").exists());
+                .andExpect(jsonPath("$.openapi").exists())
+                .andExpect(jsonPath("$.paths['/products'].get.responses['400']").exists());
     }
 }


### PR DESCRIPTION
## Summary
- document the ProductController products endpoint with a 400 ProblemDetail response for validation failures
- extend the OpenAPI integration test to assert the new bad request response is exposed in the generated specification

## Testing
- mvn --offline -pl front-api -am test


------
https://chatgpt.com/codex/tasks/task_e_68ee0623a374833395743965d089dac9