### PR TITLE
Fix home category slide navigation URLs

### DIFF
--- a/frontend/app/components/domains/home/sections/The-section-items-slide.vue
+++ b/frontend/app/components/domains/home/sections/The-section-items-slide.vue
@@ -32,12 +32,27 @@ const categoryImages = computed(() => {
     .filter((category: VerticalConfigDto): category is VerticalConfigDto & {
       imageSmall: string;
       verticalHomeTitle: string;
-    } => Boolean(category.imageSmall) && Boolean(category.verticalHomeTitle))
-    .map((category: VerticalConfigDto & { imageSmall: string; verticalHomeTitle: string }) => {
-      return {
-        imageSmall: category.imageSmall,
-        verticalHomeTitle: category.verticalHomeTitle
-      };
-    });
+      verticalHomeUrl: string;
+    } =>
+      Boolean(category.imageSmall) &&
+      Boolean(category.verticalHomeTitle) &&
+      Boolean(category.verticalHomeUrl))
+    .map(
+      (
+        category: VerticalConfigDto & {
+          imageSmall: string;
+          verticalHomeTitle: string;
+          verticalHomeUrl: string;
+        }
+      ) => {
+        const sanitizedSlug = category.verticalHomeUrl.replace(/^\/+/, "");
+
+        return {
+          imageSmall: category.imageSmall,
+          verticalHomeTitle: category.verticalHomeTitle,
+          href: `/${sanitizedSlug}`
+        };
+      }
+    );
 });
 </script>

--- a/frontend/app/components/shared/slides/The-slide.spec.ts
+++ b/frontend/app/components/shared/slides/The-slide.spec.ts
@@ -10,14 +10,17 @@ describe('TheSlide', () => {
     {
       imageSmall: 'https://example.com/image1.jpg',
       verticalHomeTitle: 'category1',
+      href: '/category1',
     },
     {
       imageSmall: 'https://example.com/image2.jpg',
       verticalHomeTitle: 'category2',
+      href: '/category2',
     },
     {
       imageSmall: 'https://example.com/image3.jpg',
       verticalHomeTitle: 'category3',
+      href: '/category3',
     },
   ]
 
@@ -28,6 +31,14 @@ describe('TheSlide', () => {
         height: 150,
         width: 150,
         ...props,
+      },
+      global: {
+        stubs: {
+          NuxtLink: {
+            template: `<a :href="typeof to === 'string' ? to : to?.path"><slot /></a>`,
+            props: ['to'],
+          },
+        },
       },
     })
 
@@ -96,7 +107,7 @@ describe('TheSlide', () => {
       expect(images.length).toBeGreaterThan(0)
     })
 
-    it('should render cards as clickable', async () => {
+    it('should render cards as clickable images', async () => {
       wrapper = await createWrapper()
 
       const images = wrapper.findAll('.v-img')
@@ -108,44 +119,21 @@ describe('TheSlide', () => {
       })
     })
 
-    it('should toggle selection when card is clicked', async () => {
+    it('should expose SSR-friendly links for each card', async () => {
       wrapper = await createWrapper()
 
-      const images = wrapper.findAll('.v-img')
-      expect(images.length).toBeGreaterThan(0)
-
-      const firstImage = images[0]
-      expect(firstImage).toBeDefined()
-      if (!firstImage) return
-
-      // Click on the first image should trigger navigation
-      await firstImage.trigger('click')
-      await wrapper.vm.$nextTick()
-
-      // Image should still exist after click
-      expect(firstImage.exists()).toBe(true)
+      const anchors = wrapper.findAll('a')
+      expect(anchors).toHaveLength(mockItems.length)
+      expect(anchors[0]?.attributes('href')).toBe(mockItems[0]?.href)
     })
 
-    it('should handle multiple card clicks', async () => {
+    it('should render correct href for each card', async () => {
       wrapper = await createWrapper()
 
-      const images = wrapper.findAll('.v-img')
-
-      // Click on first image
-      if (images[0]) {
-        await images[0].trigger('click')
-        await wrapper.vm.$nextTick()
-      }
-
-      // Click on second image
-      if (images[1]) {
-        await images[1].trigger('click')
-        await wrapper.vm.$nextTick()
-      }
-
-      // Both operations should complete without errors
-      expect(images[0]?.exists()).toBe(true)
-      expect(images[1]?.exists()).toBe(true)
+      const anchors = wrapper.findAll('a')
+      anchors.forEach((anchor, index) => {
+        expect(anchor.attributes('href')).toBe(mockItems[index]?.href)
+      })
     })
   })
 

--- a/frontend/app/components/shared/slides/The-slide.vue
+++ b/frontend/app/components/shared/slides/The-slide.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { useRouter } from "vue-router";
 
 interface SlideItem {
   imageSmall: string;
   verticalHomeTitle: string;
+  href: string;
 }
 
-const router = useRouter();
 const selectedImage = ref(null);
 
 withDefaults(
@@ -23,10 +22,6 @@ withDefaults(
 
 const loadedImages = ref<Set<number>>(new Set());
 
-const handleClick = (verticalHomeTitle: string) => {
-  router.push(`/produits?category=${verticalHomeTitle}`);
-};
-
 const onImageLoad = (index: number) => {
   loadedImages.value.add(index);
 };
@@ -38,20 +33,19 @@ const onImageLoad = (index: number) => {
       v-for="(item, index) in items"
       :key="index"
     >
-    <div>
-      <v-img
-        :src="item.imageSmall"
-        :height="height"
-        :width="width"
-        cover
-        class="cursor-pointer"
-        @click.stop="() => handleClick(item.verticalHomeTitle)"
-        @load="() => onImageLoad(index)"
-      />
-      <div v-if="loadedImages.has(index)" class="text-center pa-2 text-caption">
-        {{ item.verticalHomeTitle }}
-      </div>
-    </div>
+      <NuxtLink :to="item.href" class="d-inline-flex flex-column align-center text-decoration-none">
+        <v-img
+          :src="item.imageSmall"
+          :height="height"
+          :width="width"
+          cover
+          class="cursor-pointer"
+          @load="() => onImageLoad(index)"
+        />
+        <div v-if="loadedImages.has(index)" class="text-center pa-2 text-caption text-high-emphasis">
+          {{ item.verticalHomeTitle }}
+        </div>
+      </NuxtLink>
     </v-slide-group-item>
   </v-slide-group>
 </template>


### PR DESCRIPTION
## Summary
- build home section slide links from the vertical slug and expose them to the slide component
- render slide cards as NuxtLink anchors so navigation works without client-side router pushes
- expand The-slide unit tests to cover SSR-friendly link rendering and updated props

## Testing
- pnpm test --run app/components/shared/slides/The-slide.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ee22ec4de08333885e86338c60550c