### PR TITLE
Fix swagger schema arrays for ProductFieldOptionsResponse

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductFieldOptionsResponse.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductFieldOptionsResponse.java
@@ -8,11 +8,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Response payload grouping product field options by their scope.
  */
 public record ProductFieldOptionsResponse(
-        @Schema(description = "Fields that are always available regardless of the vertical.", implementation = FieldMetadataDto.class)
+        @Schema(description = "Fields that are always available regardless of the vertical.", implementation = FieldMetadataDto[].class)
         List<FieldMetadataDto> global,
-        @Schema(description = "Fields relating to ecological impact scores only.", implementation = FieldMetadataDto.class)
+        @Schema(description = "Fields relating to ecological impact scores only.", implementation = FieldMetadataDto[].class)
         List<FieldMetadataDto> impact,
-        @Schema(description = "Fields exposing technical attributes available for the vertical.", implementation = FieldMetadataDto.class)
+        @Schema(description = "Fields exposing technical attributes available for the vertical.", implementation = FieldMetadataDto[].class)
         List<FieldMetadataDto> technical
 ) {
 }


### PR DESCRIPTION
## Summary
- update the ProductFieldOptionsResponse schema annotations to emit FieldMetadataDto[] for each scope in the OpenAPI spec

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee67ac17488333b0c05e37a403a453