### PR TITLE
Expose related blog posts for vertical category details

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
@@ -12,6 +12,7 @@ import org.open4goods.model.vertical.RecommandationsConfig;
 import org.open4goods.model.vertical.ResourcesAggregationConfig;
 import org.open4goods.model.vertical.ScoringAggregationConfig;
 import org.open4goods.model.vertical.WikiPageConfig;
+import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -49,6 +50,8 @@ public record VerticalConfigFullDto(
         String verticalMetaOpenGraphTitle,
         @Schema(description = "Localised Open Graph description for the vertical landing page.")
         String verticalMetaOpenGraphDescription,
+        @Schema(description = "Most recent blog posts tagged with the vertical identifier.")
+        List<BlogPostDto> relatedPosts,
         @Schema(description = "Localised wiki pages associated with the vertical.")
         List<WikiPageConfig> wikiPages,
         @Schema(description = "Localised AI generation configuration for the vertical.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -20,6 +20,7 @@ import org.open4goods.model.vertical.SiteNaming;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.model.vertical.VerticalSubset;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
 import org.open4goods.nudgerfrontapi.dto.category.AttributeConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.AttributesConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.FeatureGroupDto;
@@ -79,16 +80,17 @@ public class CategoryMappingService {
                 i18n == null ? null : i18n.getVerticalHomeUrl());
     }
 
-
-
-	/**
+    /**
      * Convert a {@link VerticalConfig} into its detailed DTO representation.
      *
      * @param verticalConfig domain object loaded from the configuration service
      * @param domainLanguage language requested by the caller
+     * @param relatedPosts most recent blog posts referencing the vertical identifier
      * @return DTO exposing the full vertical configuration or {@code null} when the source is {@code null}
      */
-    public VerticalConfigFullDto toVerticalConfigFullDto(VerticalConfig verticalConfig, DomainLanguage domainLanguage) {
+    public VerticalConfigFullDto toVerticalConfigFullDto(VerticalConfig verticalConfig,
+                                                        DomainLanguage domainLanguage,
+                                                        List<BlogPostDto> relatedPosts) {
         if (verticalConfig == null) {
             return null;
         }
@@ -111,6 +113,7 @@ public class CategoryMappingService {
                 i18n == null ? null : i18n.getVerticalMetaDescription(),
                 i18n == null ? null : i18n.getVerticalMetaOpenGraphTitle(),
                 i18n == null ? null : i18n.getVerticalMetaOpenGraphDescription(),
+                defaultList(relatedPosts),
                 defaultList(i18n == null ? null : i18n.getWikiPages()),
                 i18n == null ? null : i18n.getAiConfigs(),
                 defaultList(verticalConfig.getEcoFilters()),


### PR DESCRIPTION
## Summary
- fetch the most recent blog posts tagged with the requested vertical when loading category details
- map the posts to `BlogPostDto` and expose them through the `VerticalConfigFullDto` payload

## Testing
- `mvn --offline -pl front-api -am test`


------
https://chatgpt.com/codex/tasks/task_e_68ef431a0d408333807fafa55fcaab59