### PR TITLE
Refine product search validation and aggregation handling

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
@@ -6,9 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Metadata describing a field that can be used in product queries.
  */
 public record FieldMetadataDto(
-        @Schema(description = "Stable identifier of the field as exposed by the API.", example = "price")
-        String id,
-        @Schema(description = "Path of the field in the product document.", example = "price.minPrice.price")
+        @Schema(description = "Path of the field in the product document acting as its identifier.", example = "price.minPrice.price")
         String mapping,
         @Schema(description = "Localised display name for the field when available.", example = "Prix minimum", nullable = true)
         String title,

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterField;
-import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.AggType;
 
 /**
  * DTO representing a comprehensive product view returned by the API.
@@ -82,47 +81,6 @@ public record ProductDto(
                 private static final Map<String, ProductDtoSortableFields> LOOKUP = Arrays.stream(values()).collect(Collectors.toMap(ProductDtoSortableFields::getText, e -> e));
 
                 public static Optional<ProductDtoSortableFields> fromText(String text) {
-                        return Optional.ofNullable(LOOKUP.get(text));
-                }
-
-        }
-
-        /**
-         * Allowed aggregation fields on Products. (must match elastic mapping)
-         */
-        public enum ProductDtoAggregatableFields {
-                price("price.minPrice.price", AggType.range),
-                offersCount("offersCount", AggType.range),
-                condition(FilterField.condition.fieldPath(), AggType.terms),
-                brand(FilterField.brand.fieldPath(), AggType.terms),
-                country(FilterField.country.fieldPath(), AggType.terms),
-                datasource(FilterField.datasource.fieldPath(), AggType.terms);
-
-                private final String text;
-                private final AggType defaultAggregationType;
-
-                ProductDtoAggregatableFields(String text, AggType defaultAggregationType) {
-                        this.text = text;
-                        this.defaultAggregationType = defaultAggregationType;
-                }
-
-                public String getText() {
-                        return text;
-                }
-
-                public AggType defaultAggregationType() {
-                        return defaultAggregationType;
-                }
-
-                @Override
-                public String toString() {
-                        return text;
-                }
-
-                private static final Map<String, ProductDtoAggregatableFields> LOOKUP =
-                        Arrays.stream(values()).collect(Collectors.toMap(ProductDtoAggregatableFields::getText, e -> e));
-
-                public static Optional<ProductDtoAggregatableFields> fromText(String text) {
                         return Optional.ofNullable(LOOKUP.get(text));
                 }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationRequestDto.java
@@ -3,8 +3,6 @@ package org.open4goods.nudgerfrontapi.dto.search;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
-
 /**
  * Request wrapper for search aggregations.
  */
@@ -16,9 +14,8 @@ public record AggregationRequestDto(
     public record Agg(
             @Schema(description = "Aggregation name", example = "aggName")
             String name,
-            @Schema(description = "Field to aggregate",
-                    implementation = ProductDtoAggregatableFields.class)
-            ProductDtoAggregatableFields field,
+            @Schema(description = "Field mapping to aggregate", example = "price.minPrice.price")
+            String field,
             @Schema(description = "Aggregation type", implementation = AggType.class)
             AggType type,
             @Schema(description = "Minimum value for range aggregations")
@@ -26,7 +23,9 @@ public record AggregationRequestDto(
             @Schema(description = "Maximum value for range aggregations")
             Double max,
             @Schema(description = "Maximum number of buckets to return. For range aggregations this represents the desired bucket count.", defaultValue = "10")
-            Integer buckets) {
+            Integer buckets,
+            @Schema(description = "Interval size for range aggregations. When provided it overrides the automatic bucket interval computation.")
+            Double step) {
     }
 
     /** Supported aggregation types. */

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AggregationResponseDto.java
@@ -2,8 +2,6 @@ package org.open4goods.nudgerfrontapi.dto.search;
 
 import java.util.List;
 
-import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -13,7 +11,7 @@ public record AggregationResponseDto(
         @Schema(description = "Aggregation name mirroring the request payload.")
         String name,
         @Schema(description = "Aggregated field")
-        ProductDtoAggregatableFields field,
+        String field,
         @Schema(description = "Aggregation type", implementation = AggregationRequestDto.AggType.class)
         AggregationRequestDto.AggType type,
         @Schema(description = "Buckets yielded by the aggregation")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
@@ -1,6 +1,10 @@
 package org.open4goods.nudgerfrontapi.dto.search;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -20,8 +24,8 @@ public record FilterRequestDto(
      * Describes a single filter clause sent by the client.
      */
     public record Filter(
-            @Schema(description = "Field targeted by the filter.", implementation = FilterField.class)
-            FilterField field,
+            @Schema(description = "Field mapping targeted by the filter.", example = "price.minPrice.price")
+            String field,
             @Schema(description = "Filtering strategy to apply.", implementation = FilterOperator.class)
             FilterOperator operator,
             @Schema(description = "Exact values accepted when the operator is <code>term</code>. Multiple values are combined with OR semantics.",
@@ -58,9 +62,6 @@ public record FilterRequestDto(
             this.valueType = valueType;
         }
 
-        /**
-         * @return Elasticsearch field backing the filter.
-         */
         public String fieldPath() {
             return fieldPath;
         }
@@ -83,6 +84,12 @@ public record FilterRequestDto(
             case keyword -> operator == FilterOperator.term;
             case numeric -> operator == FilterOperator.range || operator == FilterOperator.term;
             };
+        }
+        private static final Map<String, FilterField> LOOKUP = Arrays.stream(values())
+                .collect(Collectors.toMap(FilterField::fieldPath, f -> f));
+
+        public static Optional<FilterField> fromFieldPath(String fieldPath) {
+            return Optional.ofNullable(LOOKUP.get(fieldPath));
         }
     }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SortRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SortRequestDto.java
@@ -1,0 +1,33 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Describes sort instructions accepted by the products endpoint.
+ */
+public record SortRequestDto(
+        @Schema(description = "Sort options applied in order of appearance")
+        List<SortOption> sorts) {
+
+    /**
+     * Single sort option definition.
+     */
+    public record SortOption(
+            @Schema(description = "Field mapping used for sorting", example = "price.minPrice.price")
+            String field,
+            @Schema(description = "Sort order", defaultValue = "asc")
+            SortOrder order) {
+    }
+
+    /**
+     * Allowed sort orders.
+     */
+    public enum SortOrder {
+        @Schema(description = "Ascending order")
+        asc,
+        @Schema(description = "Descending order")
+        desc
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -79,12 +79,12 @@ class SearchServiceTest {
                 List.of(searchHit), aggregations, null, null);
         when(repository.search(any(NativeQuery.class), eq(ProductRepository.MAIN_INDEX_NAME))).thenReturn(searchHits);
 
-        Filter priceFilter = new Filter(FilterField.price, FilterOperator.range, null, 100.0, 400.0);
-        Filter conditionFilter = new Filter(FilterField.condition, FilterOperator.term, List.of("NEW"), null, null);
+        Filter priceFilter = new Filter(FilterField.price.fieldPath(), FilterOperator.range, null, 100.0, 400.0);
+        Filter conditionFilter = new Filter(FilterField.condition.fieldPath(), FilterOperator.term, List.of("NEW"), null, null);
         FilterRequestDto filters = new FilterRequestDto(List.of(priceFilter, conditionFilter));
 
-        Agg aggregation = new Agg("byOffers", org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoAggregatableFields.offersCount,
-                AggType.terms, null, null, 5);
+        Agg aggregation = new Agg("byOffers", FilterField.offersCount.fieldPath(),
+                AggType.terms, null, null, 5, null);
         AggregationRequestDto aggregationRequest = new AggregationRequestDto(List.of(aggregation));
 
         SearchService.SearchResult result = searchService.search(pageable, "electronics", "eco", aggregationRequest, filters);


### PR DESCRIPTION
## Summary
- drop the FieldMetadata identifier and align filter, sort and aggregation parameters on field mappings
- tighten ProductController validation: support JSON sort payloads, require vertical-specific aggregations and sanitise filters
- update SearchService and tests to consume the new DTO contracts, including range steps and dynamic filter resolution

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68ef5fffe2ac83339386d2d04fa4f81b