### PR TITLE
Add value type to field metadata DTO

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
@@ -11,6 +11,8 @@ public record FieldMetadataDto(
         @Schema(description = "Localised display name for the field when available.", example = "Prix minimum", nullable = true)
         String title,
         @Schema(description = "Localised description for the field when available.", example = "Prix minimum observé pour le produit", nullable = true)
-        String description
+        String description,
+        @Schema(description = "Type of values accepted by the field.", example = "numeric", allowableValues = {"text", "numeric"})
+        String valueType
 ) {
 }


### PR DESCRIPTION
## Summary
- add a value type attribute to `FieldMetadataDto` so the OpenAPI contract exposes the expected input kind
- propagate "text" or "numeric" value types for global filters, sortable fields, vertical attributes and impact scores

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68ef8eac58ec8333964a5f44fd565eeb