### PR TITLE
Fix OpenAPI schema for vertical filter metadata response

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductFieldOptionsResponse.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductFieldOptionsResponse.java
@@ -2,17 +2,28 @@ package org.open4goods.nudgerfrontapi.dto.product;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * Response payload grouping product field options by their scope.
  */
+@Schema(name = "ProductFieldOptionsResponse", description = "Product fields available for filtering or sorting, split by scope.")
 public record ProductFieldOptionsResponse(
-        @Schema(description = "Fields that are always available regardless of the vertical.", implementation = FieldMetadataDto[].class)
+        @ArraySchema(
+                arraySchema = @Schema(description = "Fields that are always available regardless of the vertical."),
+                schema = @Schema(implementation = FieldMetadataDto.class)
+        )
         List<FieldMetadataDto> global,
-        @Schema(description = "Fields relating to ecological impact scores only.", implementation = FieldMetadataDto[].class)
+        @ArraySchema(
+                arraySchema = @Schema(description = "Fields relating to ecological impact scores only."),
+                schema = @Schema(implementation = FieldMetadataDto.class)
+        )
         List<FieldMetadataDto> impact,
-        @Schema(description = "Fields exposing technical attributes available for the vertical.", implementation = FieldMetadataDto[].class)
+        @ArraySchema(
+                arraySchema = @Schema(description = "Fields exposing technical attributes available for the vertical."),
+                schema = @Schema(implementation = FieldMetadataDto.class)
+        )
         List<FieldMetadataDto> technical
 ) {
 }


### PR DESCRIPTION
## Summary
- annotate the product field options response so array components reference FieldMetadataDto directly
- give the ProductFieldOptionsResponse schema a named description to ensure OpenAPI clients generate strong typing

## Testing
- mvn -pl front-api -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ef95876f888333b3e00ade9fc2914a