### PR TITLE
Expose aggregation metadata for vertical filters

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/FieldMetadataDto.java
@@ -13,6 +13,19 @@ public record FieldMetadataDto(
         @Schema(description = "Localised description for the field when available.", example = "Prix minimum observé pour le produit", nullable = true)
         String description,
         @Schema(description = "Type of values accepted by the field.", example = "numeric", allowableValues = {"text", "numeric"})
-        String valueType
+        String valueType,
+        @Schema(description = "Preferred aggregation behaviour when available.", nullable = true)
+        AggregationMetadata aggregationConfiguration
 ) {
+
+    /**
+     * Aggregation hints attached to a field.
+     */
+    public record AggregationMetadata(
+            @Schema(description = "Preferred number of buckets when building histogram aggregations.", example = "10", nullable = true)
+            Integer buckets,
+            @Schema(description = "Preferred interval size for numeric range aggregations.", example = "5.0", nullable = true)
+            Double interval
+    ) {
+    }
 }

--- a/model/src/main/java/org/open4goods/model/vertical/AggregationConfiguration.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AggregationConfiguration.java
@@ -1,0 +1,34 @@
+package org.open4goods.model.vertical;
+
+/**
+ * Configuration describing how an attribute or score should be aggregated.
+ *
+ * <p>
+ * The configuration allows the caller to tailor histogram aggregations by
+ * defining the preferred number of buckets and the interval used for range
+ * aggregations. Both values are optional in the YAML definition in order to
+ * keep backward compatibility with existing configurations.
+ * </p>
+ */
+public class AggregationConfiguration {
+
+    private Integer buckets;
+
+    private Double interval;
+
+    public Integer getBuckets() {
+        return buckets;
+    }
+
+    public void setBuckets(Integer buckets) {
+        this.buckets = buckets;
+    }
+
+    public Double getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Double interval) {
+        this.interval = interval;
+    }
+}

--- a/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
@@ -167,11 +167,17 @@ public class VerticalConfig{
 	@JsonMerge
 	private ResourcesAggregationConfig resourcesConfig = new ResourcesAggregationConfig();
 
-	/**
-	 * Configuration relativ to attributes aggregation
-	 */
-	@JsonMerge
-	private AttributesConfig attributesConfig = new AttributesConfig();
+        /**
+         * Configuration relativ to attributes aggregation
+         */
+        @JsonMerge
+        private AttributesConfig attributesConfig = new AttributesConfig();
+
+        /**
+         * Preferred aggregation parameters for attributes and impact scores.
+         */
+        @JsonMerge
+        private Map<String, AggregationConfiguration> aggregationConfiguration = new HashMap<>();
 
 
 	/**
@@ -607,9 +613,24 @@ public class VerticalConfig{
 	}
 
 
-	public void setAttributesConfig(AttributesConfig attributesConfig) {
-		this.attributesConfig = attributesConfig;
-	}
+        public void setAttributesConfig(AttributesConfig attributesConfig) {
+                this.attributesConfig = attributesConfig;
+        }
+
+        public Map<String, AggregationConfiguration> getAggregationConfiguration() {
+                return aggregationConfiguration;
+        }
+
+        public void setAggregationConfiguration(Map<String, AggregationConfiguration> aggregationConfiguration) {
+                this.aggregationConfiguration = aggregationConfiguration;
+        }
+
+        public AggregationConfiguration getAggregationConfigurationFor(String key) {
+                if (aggregationConfiguration == null) {
+                        return null;
+                }
+                return aggregationConfiguration.get(key);
+        }
 
 //
 //	public RatingsConfig getRatingsConfig() {

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -315,36 +315,51 @@ subsets:
 
 
 aggregationConfiguration:
-  ECOSCORE:
+  "scores.ECOSCORE.value":
     interval: 5
     buckets: 20
-  REPAIRABILITY_INDEX:
+  "scores.REPAIRABILITY_INDEX.value":
     interval: 1
     buckets: 10
-  POWER_CONSUMPTION_TYPICAL:
+  "scores.POWER_CONSUMPTION_TYPICAL.value":
     interval: 25
     buckets: 12
-  POWER_CONSUMPTION_OFF:
+  "scores.POWER_CONSUMPTION_OFF.value":
     interval: 0.1
     buckets: 10
-  WEIGHT:
+  "scores.WEIGHT.value":
     interval: 2
     buckets: 12
-  BRAND_SUSTAINABILITY:
+  "scores.BRAND_SUSTAINABILITY.value":
     interval: 5
     buckets: 20
-  DATA_QUALITY:
+  "scores.DATA_QUALITY.value":
     interval: 5
     buckets: 20
-  ENERGY_CONSUMPTION_1000_HOURS:
+  "attributes.indexed.REPAIRABILITY_INDEX":
+    interval: 1
+    buckets: 10
+  "attributes.indexed.POWER_CONSUMPTION_TYPICAL":
+    interval: 25
+    buckets: 12
+  "attributes.indexed.POWER_CONSUMPTION_OFF":
+    interval: 0.1
+    buckets: 10
+  "attributes.indexed.WEIGHT":
+    interval: 2
+    buckets: 12
+  "attributes.indexed.ENERGY_CONSUMPTION_1000_HOURS":
     interval: 20
     buckets: 12
-  DIAGONALE_POUCES:
+  "attributes.indexed.DIAGONALE_POUCES":
     interval: 5
     buckets: 12
-  HDMI_PORTS_QUANTITY:
+  "attributes.indexed.HDMI_PORTS_QUANTITY":
     interval: 1
     buckets: 6
+  "price.minPrice.price":
+    interval: 100
+    buckets: 20
 
 ecoFilters:
     - "REPAIRABILITY_INDEX" 

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -313,6 +313,39 @@ subsets:
 
 
 
+
+aggregationConfiguration:
+  ECOSCORE:
+    interval: 5
+    buckets: 20
+  REPAIRABILITY_INDEX:
+    interval: 1
+    buckets: 10
+  POWER_CONSUMPTION_TYPICAL:
+    interval: 25
+    buckets: 12
+  POWER_CONSUMPTION_OFF:
+    interval: 0.1
+    buckets: 10
+  WEIGHT:
+    interval: 2
+    buckets: 12
+  BRAND_SUSTAINABILITY:
+    interval: 5
+    buckets: 20
+  DATA_QUALITY:
+    interval: 5
+    buckets: 20
+  ENERGY_CONSUMPTION_1000_HOURS:
+    interval: 20
+    buckets: 12
+  DIAGONALE_POUCES:
+    interval: 5
+    buckets: 12
+  HDMI_PORTS_QUANTITY:
+    interval: 1
+    buckets: 6
+
 ecoFilters:
     - "REPAIRABILITY_INDEX" 
     - "CLASSE_ENERGY"   


### PR DESCRIPTION
## Summary
- add a reusable aggregation configuration model on verticals and wire it to YAML definitions
- surface aggregation hints in field metadata responses so clients can build histograms consistently
- configure the TV vertical with coherent bucket and interval defaults for its filters and scores

## Testing
- mvn --offline -pl model,verticals,front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68ef98dd9a2c8333b2dc1cd09238fdf0