### PR TITLE
feat: expose Google category navigation data

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO aggregating the Google taxonomy information required to reproduce the
+ * legacy navigation layout.
+ */
+public record CategoryNavigationDto(
+        @Schema(description = "Current taxonomy node selected by the caller.")
+        GoogleCategoryDto category,
+
+        @Schema(description = "Breadcrumb entries starting from the catalog root.")
+        List<CategoryBreadcrumbItemDto> breadcrumbs,
+
+        @Schema(description = "Immediate children of the selected node filtered by the presence of verticals downstream.")
+        List<GoogleCategoryDto> childCategories,
+
+        @Schema(description = "Descendant nodes exposing a vertical configuration but not already present in childCategories.")
+        List<GoogleCategoryDto> descendantVerticals
+) {
+}
+

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/GoogleCategoryDto.java
@@ -1,0 +1,42 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing the Google taxonomy navigation nodes required by the frontend
+ * to render the category tree.
+ */
+public record GoogleCategoryDto(
+        @Schema(description = "Google taxonomy identifier of the category.", example = "499972")
+        Integer googleCategoryId,
+
+        @Schema(description = "Localised display label for the category.", example = "Téléviseurs")
+        String title,
+
+        @Schema(description = "Slug corresponding to the current category segment.", example = "televiseurs")
+        String slug,
+
+        @Schema(description = "Hierarchical path made of slug segments separated by '/' starting from the root.",
+                example = "electronique/televiseurs")
+        String path,
+
+        @Schema(description = "Indicates whether the node has no children in the Google taxonomy tree.", example = "false")
+        boolean leaf,
+
+        @Schema(description = "True when a vertical configuration is directly associated with the node.", example = "true")
+        boolean hasVertical,
+
+        @Schema(description = "True when the node or one of its descendants exposes a vertical configuration.",
+                example = "true")
+        boolean hasVerticals,
+
+        @Schema(description = "Summary description of the associated vertical when present.")
+        VerticalConfigDto vertical,
+
+        @Schema(description = "Direct children of the category limited to the requested depth.")
+        List<GoogleCategoryDto> children
+) {
+}
+

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceNavigationTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceNavigationTest.java
@@ -1,0 +1,100 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.vertical.ProductCategory;
+import org.open4goods.model.vertical.ProductI18nElements;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.dto.category.CategoryNavigationDto;
+import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.verticals.GoogleTaxonomyService;
+
+class CategoryMappingServiceNavigationTest {
+
+    private CategoryMappingService service;
+
+    @BeforeEach
+    void setUp() {
+        ApiProperties apiProperties = new ApiProperties();
+        service = new CategoryMappingService(apiProperties, mock(GoogleTaxonomyService.class));
+    }
+
+    @Test
+    void toCategoryNavigationDtoBuildsDeepNavigationStructure() {
+        ProductCategory root = new ProductCategory(0, "Root", "default");
+
+        ProductCategory electronics = new ProductCategory(1, "Électronique", "fr");
+        electronics.setParent(root);
+        root.addChild(electronics);
+
+        ProductCategory tv = new ProductCategory(2, "Téléviseurs", "fr");
+        tv.setParent(electronics);
+        electronics.addChild(tv);
+
+        ProductCategory audio = new ProductCategory(3, "Audio", "fr");
+        audio.setParent(electronics);
+        electronics.addChild(audio);
+
+        ProductCategory headphones = new ProductCategory(4, "Casques", "fr");
+        headphones.setParent(audio);
+        audio.addChild(headphones);
+
+        tv.vertical(createVerticalConfig("tv", 2));
+        headphones.vertical(createVerticalConfig("headphones", 4));
+
+        CategoryNavigationDto navigation = service.toCategoryNavigationDto(electronics, DomainLanguage.fr, true);
+
+        assertThat(navigation).isNotNull();
+        assertThat(navigation.category().googleCategoryId()).isEqualTo(1);
+        assertThat(navigation.category().path()).isEqualTo("electronique");
+
+        assertThat(navigation.breadcrumbs()).hasSize(2);
+        assertThat(navigation.breadcrumbs().get(0).title()).isNull();
+        assertThat(navigation.breadcrumbs().get(0).link()).isEmpty();
+        assertThat(navigation.breadcrumbs().get(1).title()).isEqualTo("Électronique");
+        assertThat(navigation.breadcrumbs().get(1).link()).isEqualTo("electronique");
+
+        List<GoogleCategoryDto> children = navigation.childCategories();
+        assertThat(children).hasSize(2);
+        assertThat(children.get(0).googleCategoryId()).isEqualTo(2);
+        assertThat(children.get(0).vertical()).isNotNull();
+        assertThat(children.get(1).children()).hasSize(1);
+        assertThat(children.get(1).children().get(0).googleCategoryId()).isEqualTo(4);
+
+        assertThat(navigation.descendantVerticals())
+                .hasSize(1)
+                .first()
+                .extracting(GoogleCategoryDto::googleCategoryId)
+                .isEqualTo(4);
+    }
+
+    private VerticalConfig createVerticalConfig(String id, int googleTaxonomyId) {
+        VerticalConfig config = new VerticalConfig();
+        config.setId(id);
+        config.setEnabled(true);
+        config.setGoogleTaxonomyId(googleTaxonomyId);
+        config.setIcecatTaxonomyId(googleTaxonomyId * 10);
+        config.setOrder(1);
+
+        ProductI18nElements elements = new ProductI18nElements();
+        elements.setVerticalHomeTitle(id + " title");
+        elements.setVerticalHomeDescription(id + " description");
+        elements.setVerticalHomeUrl(id + "-url");
+
+        Map<String, ProductI18nElements> i18n = new HashMap<>();
+        i18n.put("fr", elements);
+        config.setI18n(i18n);
+
+        return config;
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose a new /category/navigation endpoint that resolves Google taxonomy nodes by id or path
- add CategoryNavigationDto and GoogleCategoryDto to transport the breadcrumb, children and vertical leaves data
- extend CategoryMappingService with mapping helpers and a dedicated unit test for the navigation structure

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68efa772cd6c8333a5b9abaa78b74e9a