### PR TITLE
Expose WebP metadata for product images

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductImageDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductImageDto.java
@@ -12,10 +12,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * DTO describing a product image resource exposed to the frontend.
  */
 public record ProductImageDto(
-        @Schema(description = "Resource URL", example = "https://cdn.example.org/images/product_abc.jpg")
+        @Schema(description = "Optimised resource URL", example = "https://cdn.example.org/images/product_abc.webp")
         String url,
-        @Schema(description = "Detected MIME type", example = "image/jpeg")
+        @Schema(description = "Optimised MIME type", example = "image/webp")
         String mimeType,
+        @Schema(description = "original resource URL", example = "https://cdn.example.org/images/product_abc.jpg")
+        String originalUrl,
+        @Schema(description = "original MIME type", example = "image/jpeg")
+        String originalMimeType,
         @Schema(description = "Last update timestamp in epoch milliseconds")
         Long timeStamp,
         @Schema(description = "Cache key used by the media pipeline")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -105,11 +105,11 @@ import jakarta.servlet.http.HttpServletRequest;
 public class ProductMappingService {
 
     private static final Logger logger = LoggerFactory.getLogger(ProductMappingService.class);
-    private static final String IMAGE_PREFIX = "/images/verticals/";
     private static final String DEFAULT_LANGUAGE_KEY = "default";
     private static final String IMAGES_PATH = "/images/";
     private static final String PDFS_PATH = "/pdfs/";
     private static final String VIDEOS_PATH = "/videos/";
+	private static final String IMAGE_WEBP_MEDIATYPE = "image/webp";
 
     private final ProductRepository repository;
     private final ApiProperties apiProperties;
@@ -740,7 +740,7 @@ public class ProductMappingService {
         String originalUrl = buildResourceUrl(resource, IMAGES_PATH);
         return new ProductImageDto(
                 toWebpUrl(originalUrl),
-                MediaType.IMAGE_WEBP_VALUE,
+                IMAGE_WEBP_MEDIATYPE,
                 originalUrl,
                 resource.getMimeType(),
                 resource.getTimeStamp(),


### PR DESCRIPTION
## Summary
- add original URL and MIME type fields to `ProductImageDto`
- generate optimised WebP URLs and MIME types when mapping image resources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efaa62cd8c8333a95d406807c032d5