### PR TITLE
feat: build category browsing experience

### DIFF
--- a/frontend/app/components/category/CategoryDocumentationRail.vue
+++ b/frontend/app/components/category/CategoryDocumentationRail.vue
@@ -28,12 +28,12 @@
       <v-list density="comfortable">
         <v-list-item
           v-for="post in relatedPosts"
-          :key="post.slug ?? post.title"
-          :to="resolvePostUrl(post)"
+          :key="post.url ?? post.title"
+          :href="resolvePostUrl(post)"
         >
           <v-list-item-title>{{ post.title }}</v-list-item-title>
-          <v-list-item-subtitle v-if="post.excerpt">
-            {{ post.excerpt }}
+          <v-list-item-subtitle v-if="post.summary">
+            {{ post.summary }}
           </v-list-item-subtitle>
         </v-list-item>
       </v-list>
@@ -66,7 +66,7 @@ const resolveWikiUrl = (page: WikiPageConfig) => {
 }
 
 const resolvePostUrl = (post: BlogPostDto) => {
-  return `/blog/${post.slug ?? ''}`
+  return post.url ?? '#'
 }
 </script>
 

--- a/frontend/app/components/category/CategoryDocumentationRail.vue
+++ b/frontend/app/components/category/CategoryDocumentationRail.vue
@@ -1,0 +1,89 @@
+<template>
+  <aside class="category-doc-rail" data-testid="category-doc-rail">
+    <v-card v-if="wikiPages.length" class="category-doc-rail__card" rounded="xl" elevation="1">
+      <v-card-title class="category-doc-rail__title">
+        <v-icon icon="mdi-book-open-page-variant" size="20" class="me-2" />
+        {{ $t('category.documentation.guidesTitle') }}
+      </v-card-title>
+      <v-divider />
+      <v-list density="comfortable">
+        <v-list-item
+          v-for="page in wikiPages"
+          :key="page.title ?? page.verticalUrl ?? page.wikiUrl"
+          :href="resolveWikiUrl(page)"
+          target="_blank"
+          rel="noopener"
+        >
+          <v-list-item-title>{{ page.title }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-card>
+
+    <v-card v-if="relatedPosts.length" class="category-doc-rail__card" rounded="xl" elevation="1">
+      <v-card-title class="category-doc-rail__title">
+        <v-icon icon="mdi-newspaper-variant-outline" size="20" class="me-2" />
+        {{ $t('category.documentation.postsTitle') }}
+      </v-card-title>
+      <v-divider />
+      <v-list density="comfortable">
+        <v-list-item
+          v-for="post in relatedPosts"
+          :key="post.slug ?? post.title"
+          :to="resolvePostUrl(post)"
+        >
+          <v-list-item-title>{{ post.title }}</v-list-item-title>
+          <v-list-item-subtitle v-if="post.excerpt">
+            {{ post.excerpt }}
+          </v-list-item-subtitle>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import type { BlogPostDto, WikiPageConfig } from '~~/shared/api-client'
+
+const props = defineProps<{
+  wikiPages: WikiPageConfig[]
+  relatedPosts: BlogPostDto[]
+  verticalHomeUrl?: string | null
+}>()
+
+const wikiPages = computed(() => props.wikiPages ?? [])
+const relatedPosts = computed(() => props.relatedPosts ?? [])
+
+const resolveWikiUrl = (page: WikiPageConfig) => {
+  if (page.wikiUrl) {
+    return page.wikiUrl
+  }
+
+  if (props.verticalHomeUrl && page.verticalUrl) {
+    return `${props.verticalHomeUrl.replace(/\/$/, '')}/${page.verticalUrl.replace(/^\//, '')}`
+  }
+
+  return page.verticalUrl ?? '#'
+}
+
+const resolvePostUrl = (post: BlogPostDto) => {
+  return `/blog/${post.slug ?? ''}`
+}
+</script>
+
+<style scoped lang="sass">
+.category-doc-rail
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+  &__card
+    background-color: rgb(var(--v-theme-surface-glass))
+
+  &__title
+    font-weight: 600
+    display: flex
+    align-items: center
+
+  :deep(.v-list-item-title)
+    font-weight: 500
+</style>

--- a/frontend/app/components/category/CategoryFastFilters.vue
+++ b/frontend/app/components/category/CategoryFastFilters.vue
@@ -64,8 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Filter } from '~~/shared/api-client'
-import type { VerticalSubsetDto } from '~~/shared/api-client'
+import type { Filter, VerticalSubsetDto } from '~~/shared/api-client'
 import { useI18n } from 'vue-i18n'
 
 import { convertSubsetCriteriaToFilters } from '~/utils/_subset-to-filters'
@@ -120,7 +119,7 @@ const resolveSubsetLabel = (subset: VerticalSubsetDto): string => {
   return subset.title ?? subset.caption ?? subset.id ?? subset.group ?? 'subset'
 }
 
-const buildClauseLabel = (subsetId: string, filter: Filter, index: number): string => {
+const buildClauseLabel = (subsetId: string, filter: Filter): string => {
   const field = filter.field ?? 'field'
 
   if (filter.operator === 'term') {
@@ -158,7 +157,7 @@ const activeClauses = computed<ClauseSummary[]>(() => {
       subsetId,
       filter,
       index,
-      label: buildClauseLabel(subsetId, filter, index),
+      label: buildClauseLabel(subsetId, filter),
     }))
   })
 })

--- a/frontend/app/components/category/CategoryFastFilters.vue
+++ b/frontend/app/components/category/CategoryFastFilters.vue
@@ -1,0 +1,252 @@
+<template>
+  <section v-if="subsets.length" class="category-fast-filters">
+    <header class="category-fast-filters__header">
+      <h2 class="category-fast-filters__title">
+        {{ t('category.fastFilters.title') }}
+      </h2>
+      <v-btn
+        v-if="activeSubsetIds.length"
+        color="primary"
+        variant="text"
+        class="category-fast-filters__reset"
+        size="small"
+        @click="$emit('reset')"
+      >
+        <v-icon icon="mdi-close-circle" size="18" class="me-1" />
+        {{ t('category.fastFilters.reset') }}
+      </v-btn>
+    </header>
+
+    <v-slide-group
+      class="category-fast-filters__chips"
+      show-arrows
+      multiple
+      :model-value="activeSubsetIds"
+      @update:model-value="onChipToggle"
+    >
+      <v-chip
+        v-for="subset in subsets"
+        :key="subset.id ?? subset.caption ?? subset.title ?? subset.group"
+        :value="subset.id"
+        :color="activeSubsetIds.includes(subset.id ?? '') ? 'primary' : undefined"
+        :variant="activeSubsetIds.includes(subset.id ?? '') ? 'flat' : 'outlined'"
+        rounded="lg"
+        class="me-2 mb-2"
+        :closable="activeSubsetIds.includes(subset.id ?? '')"
+        @click:close="emitToggle(subset, false)"
+      >
+        <span class="category-fast-filters__chip-label">
+          {{ resolveSubsetLabel(subset) }}
+        </span>
+      </v-chip>
+    </v-slide-group>
+
+    <div v-if="activeClauses.length" class="category-fast-filters__clauses">
+      <p class="category-fast-filters__clauses-title">
+        {{ t('category.fastFilters.activeClauses') }}
+      </p>
+      <v-chip-group column>
+        <v-chip
+          v-for="clause in activeClauses"
+          :key="clause.id"
+          closable
+          variant="text"
+          class="category-fast-filters__clause"
+          color="primary"
+          @click:close="$emit('remove-clause', clause)"
+        >
+          <v-icon icon="mdi-filter-variant" size="18" class="me-1" />
+          <span>{{ clause.label }}</span>
+        </v-chip>
+      </v-chip-group>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { Filter } from '~~/shared/api-client'
+import type { VerticalSubsetDto } from '~~/shared/api-client'
+import { useI18n } from 'vue-i18n'
+
+import { convertSubsetCriteriaToFilters } from '~/utils/_subset-to-filters'
+
+interface ClauseSummary {
+  id: string
+  subsetId: string
+  filter: Filter
+  label: string
+  index: number
+}
+
+const props = defineProps<{
+  subsets: VerticalSubsetDto[]
+  activeSubsetIds: string[]
+}>()
+
+const emit = defineEmits<{
+  'toggle-subset': [subsetId: string, active: boolean]
+  'remove-clause': [clause: ClauseSummary]
+  reset: []
+}>()
+
+const loggedSubsets = new Set<string>()
+
+const { t } = useI18n()
+
+const subsets = computed(() => props.subsets ?? [])
+const activeSubsetIds = computed(() => props.activeSubsetIds ?? [])
+
+const subsetMap = computed(() => {
+  return subsets.value.reduce<Record<string, VerticalSubsetDto>>((accumulator, subset) => {
+    if (subset.id) {
+      accumulator[subset.id] = subset
+    }
+    return accumulator
+  }, {})
+})
+
+const resolveSubsetLabel = (subset: VerticalSubsetDto): string => {
+  if (!subset.title && !subset.caption && import.meta.server) {
+    const cacheKey = subset.id ?? subset.group ?? 'unknown'
+    if (!loggedSubsets.has(cacheKey)) {
+      console.error('Category subset is missing a display label.', {
+        subsetId: subset.id,
+        group: subset.group,
+      })
+      loggedSubsets.add(cacheKey)
+    }
+  }
+
+  return subset.title ?? subset.caption ?? subset.id ?? subset.group ?? 'subset'
+}
+
+const buildClauseLabel = (subsetId: string, filter: Filter, index: number): string => {
+  const field = filter.field ?? 'field'
+
+  if (filter.operator === 'term') {
+    const term = filter.terms?.[0] ?? ''
+    return `${field} = ${term}`
+  }
+
+  const bounds: string[] = []
+  if (typeof filter.min === 'number') {
+    bounds.push(t('category.fastFilters.operator.greaterThan', { value: filter.min }))
+  }
+
+  if (typeof filter.max === 'number') {
+    bounds.push(t('category.fastFilters.operator.lowerThan', { value: filter.max }))
+  }
+
+  if (!bounds.length) {
+    return `${field}`
+  }
+
+  return `${field}: ${bounds.join(' · ')}`
+}
+
+const activeClauses = computed<ClauseSummary[]>(() => {
+  return activeSubsetIds.value.flatMap((subsetId) => {
+    const subset = subsetMap.value[subsetId]
+    if (!subset) {
+      return []
+    }
+
+    const filters = convertSubsetCriteriaToFilters(subset)
+
+    return filters.map((filter, index) => ({
+      id: `${subsetId}-${index}`,
+      subsetId,
+      filter,
+      index,
+      label: buildClauseLabel(subsetId, filter, index),
+    }))
+  })
+})
+
+const emitToggle = (subset: VerticalSubsetDto, desired: boolean) => {
+  if (!subset.id) {
+    return
+  }
+
+  emit('toggle-subset', subset.id, desired)
+}
+
+const onChipToggle = (subsetIds: string[]) => {
+  const current = new Set(activeSubsetIds.value)
+  const next = new Set(subsetIds)
+
+  subsets.value.forEach((subset) => {
+    if (!subset.id) {
+      return
+    }
+
+    const currentlyActive = current.has(subset.id)
+    const shouldBeActive = next.has(subset.id)
+
+    if (currentlyActive === shouldBeActive) {
+      return
+    }
+
+    emitToggle(subset, shouldBeActive)
+  })
+}
+
+defineExpose({ activeClauses })
+</script>
+
+<style scoped lang="sass">
+.category-fast-filters
+  background-color: rgb(var(--v-theme-surface-glass))
+  border-radius: 1rem
+  padding: 1.5rem
+  margin-bottom: 2rem
+  box-shadow: 0 24px 48px -32px rgba(var(--v-theme-shadow-primary-600), 0.3)
+
+  &__header
+    display: flex
+    align-items: center
+    justify-content: space-between
+    gap: 1rem
+    margin-bottom: 1rem
+
+  &__title
+    margin: 0
+    font-size: 1.25rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__reset
+    text-transform: none
+
+  &__chips
+    padding-bottom: 0.5rem
+
+  &__chip-label
+    font-weight: 500
+
+  &__clauses
+    margin-top: 1rem
+    padding-top: 0.75rem
+    border-top: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6)
+
+  &__clauses-title
+    margin: 0 0 0.5rem
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__clause
+    margin-bottom: 0.5rem
+    justify-content: flex-start
+
+@media (max-width: 959px)
+  .category-fast-filters
+    padding: 1.25rem
+
+    &__header
+      align-items: flex-start
+      flex-direction: column
+      gap: 0.5rem
+
+    &__reset
+      align-self: flex-end
+</style>

--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="category-filters" data-testid="category-filters">
-    <div class="category-filters__active" v-if="activeFilterChips.length">
+    <div v-if="activeFilterChips.length" class="category-filters__active">
       <v-chip-group column>
         <v-chip
           v-for="chip in activeFilterChips"
@@ -22,7 +22,7 @@
         <template #text>
           <div class="category-filters__section">
             <CategoryFilterList
-              :fields="filterOptions.global ?? []"
+              :fields="filterOptions?.global ?? []"
               :aggregations="aggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"
@@ -39,8 +39,8 @@
       >
         <template #text>
           <div class="category-filters__section">
-            <CategoryFilterList
-              :fields="impactPrimary"
+              <CategoryFilterList
+                :fields="impactPrimary"
               :aggregations="aggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"

--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -1,0 +1,299 @@
+<template>
+  <div class="category-filters" data-testid="category-filters">
+    <div class="category-filters__active" v-if="activeFilterChips.length">
+      <v-chip-group column>
+        <v-chip
+          v-for="chip in activeFilterChips"
+          :key="chip.id"
+          closable
+          color="primary"
+          variant="flat"
+          size="small"
+          @click:close="removeFilter(chip.field, chip.type, chip.term)"
+        >
+          <v-icon icon="mdi-close-circle" size="16" class="me-1" />
+          <span>{{ chip.label }}</span>
+        </v-chip>
+      </v-chip-group>
+    </div>
+
+    <v-expansion-panels multiple class="category-filters__panels">
+      <v-expansion-panel value="global" :title="t('category.filters.globalTitle')" expand-icon="mdi-chevron-down">
+        <template #text>
+          <div class="category-filters__section">
+            <CategoryFilterList
+              :fields="filterOptions.global ?? []"
+              :aggregations="aggregationMap"
+              :active-filters="activeFilters"
+              @update-range="updateRangeFilter"
+              @update-terms="updateTermsFilter"
+            />
+          </div>
+        </template>
+      </v-expansion-panel>
+
+      <v-expansion-panel
+        value="impact"
+        :title="t('category.filters.impactTitle')"
+        expand-icon="mdi-chevron-down"
+      >
+        <template #text>
+          <div class="category-filters__section">
+            <CategoryFilterList
+              :fields="impactPrimary"
+              :aggregations="aggregationMap"
+              :active-filters="activeFilters"
+              @update-range="updateRangeFilter"
+              @update-terms="updateTermsFilter"
+            />
+
+            <div v-if="impactRemaining.length" class="category-filters__see-more">
+              <v-btn
+                variant="text"
+                density="comfortable"
+                color="primary"
+                @click="toggleImpactExpansion"
+              >
+                {{ impactExpanded ? t('category.filters.hideImpact') : t('category.filters.showMoreImpact') }}
+              </v-btn>
+
+              <CategoryFilterList
+                v-if="impactExpanded"
+                :fields="impactRemaining"
+                :aggregations="aggregationMap"
+                :active-filters="activeFilters"
+                class="mt-3"
+                @update-range="updateRangeFilter"
+                @update-terms="updateTermsFilter"
+              />
+            </div>
+          </div>
+        </template>
+      </v-expansion-panel>
+
+      <v-expansion-panel
+        value="technical"
+        :title="t('category.filters.technicalTitle')"
+        expand-icon="mdi-chevron-down"
+      >
+        <template #text>
+          <div class="category-filters__section">
+            <CategoryFilterList
+              :fields="technicalPrimary"
+              :aggregations="aggregationMap"
+              :active-filters="activeFilters"
+              @update-range="updateRangeFilter"
+              @update-terms="updateTermsFilter"
+            />
+
+            <div v-if="technicalRemaining.length" class="category-filters__see-more">
+              <v-btn
+                variant="text"
+                density="comfortable"
+                color="primary"
+                @click="toggleTechnicalExpansion"
+              >
+                {{ technicalExpanded ? t('category.filters.hideTechnical') : t('category.filters.showMoreTechnical') }}
+              </v-btn>
+
+              <CategoryFilterList
+                v-if="technicalExpanded"
+                :fields="technicalRemaining"
+                :aggregations="aggregationMap"
+                :active-filters="activeFilters"
+                class="mt-3"
+                @update-range="updateRangeFilter"
+                @update-terms="updateTermsFilter"
+              />
+            </div>
+          </div>
+        </template>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {
+  AggregationResponseDto,
+  FieldMetadataDto,
+  Filter,
+  FilterRequestDto,
+  ProductFieldOptionsResponse,
+} from '~~/shared/api-client'
+import { useI18n } from 'vue-i18n'
+
+import CategoryFilterList from './filters/CategoryFilterList.vue'
+
+const props = defineProps<{
+  filterOptions: ProductFieldOptionsResponse | null
+  aggregations: AggregationResponseDto[]
+  filters: FilterRequestDto | null
+  impactExpanded: boolean
+  technicalExpanded: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:filters': [FilterRequestDto]
+  'update:impactExpanded': [boolean]
+  'update:technicalExpanded': [boolean]
+}>()
+
+const activeFilters = computed(() => props.filters?.filters ?? [])
+
+const { t } = useI18n()
+
+const aggregationMap = computed<Record<string, AggregationResponseDto>>(() => {
+  return (props.aggregations ?? []).reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
+    if (aggregation.field) {
+      accumulator[aggregation.field] = aggregation
+    }
+
+    return accumulator
+  }, {})
+})
+
+const impactPrimary = computed<FieldMetadataDto[]>(() => {
+  const entries = props.filterOptions?.impact ?? []
+  const ecoscore = entries.filter((item) => item.mapping === 'scores.ECOSCORE.value')
+  return ecoscore.length ? ecoscore : entries.slice(0, 1)
+})
+
+const impactRemaining = computed<FieldMetadataDto[]>(() => {
+  const entries = props.filterOptions?.impact ?? []
+  const primary = new Set(impactPrimary.value.map((entry) => entry.mapping))
+  return entries.filter((entry) => entry.mapping && !primary.has(entry.mapping))
+})
+
+const technicalPrimary = computed<FieldMetadataDto[]>(() => {
+  const entries = props.filterOptions?.technical ?? []
+  return entries.slice(0, 3)
+})
+
+const technicalRemaining = computed<FieldMetadataDto[]>(() => {
+  const entries = props.filterOptions?.technical ?? []
+  return entries.slice(3)
+})
+
+const activeFilterChips = computed(() => {
+  return activeFilters.value.map((filter) => {
+    if (filter.operator === 'term') {
+      const term = filter.terms?.[0] ?? ''
+      return {
+        id: `${filter.field}-${term}`,
+        field: filter.field ?? '',
+        type: 'term' as const,
+        term,
+        label: `${filter.field}: ${term}`,
+      }
+    }
+
+    return {
+      id: `${filter.field}-range`,
+      field: filter.field ?? '',
+      type: 'range' as const,
+      term: null,
+      label: `${filter.field}: ${filter.min ?? '–'} → ${filter.max ?? '–'}`,
+    }
+  })
+})
+
+const emitFilters = (filters: Filter[]) => {
+  emit('update:filters', filters.length ? { filters } : {})
+}
+
+const updateRangeFilter = (field: string, range: { min?: number; max?: number }) => {
+  const current = activeFilters.value.filter((filter) => filter.field !== field)
+
+  if (range.min == null && range.max == null) {
+    emitFilters(current)
+    return
+  }
+
+  emitFilters([
+    ...current,
+    {
+      field,
+      operator: 'range',
+      min: range.min,
+      max: range.max,
+    },
+  ])
+}
+
+const updateTermsFilter = (field: string, terms: string[]) => {
+  const current = activeFilters.value.filter((filter) => filter.field !== field)
+
+  if (!terms.length) {
+    emitFilters(current)
+    return
+  }
+
+  emitFilters([
+    ...current,
+    {
+      field,
+      operator: 'term',
+      terms,
+    },
+  ])
+}
+
+const removeFilter = (field: string, type: 'term' | 'range', term: string | null) => {
+  const next = activeFilters.value.filter((filter) => {
+    if (filter.field !== field) {
+      return true
+    }
+
+    if (type === 'term') {
+      return !(filter.operator === 'term' && filter.terms?.includes(term ?? ''))
+    }
+
+    return !(filter.operator === 'range')
+  })
+
+  emitFilters(next)
+}
+
+const toggleImpactExpansion = () => {
+  emit('update:impactExpanded', !props.impactExpanded)
+}
+
+const toggleTechnicalExpansion = () => {
+  emit('update:technicalExpanded', !props.technicalExpanded)
+}
+
+defineExpose({ activeFilterChips })
+</script>
+
+<style scoped lang="sass">
+.category-filters
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+  &__active
+    padding: 0.5rem
+    background: rgb(var(--v-theme-surface-glass))
+    border-radius: 0.75rem
+
+  &__panels
+    background: transparent
+    :deep(.v-expansion-panel)
+      background: rgb(var(--v-theme-surface-default))
+      border-radius: 0.75rem
+      margin-bottom: 0.75rem
+
+  &__section
+    padding: 1rem
+
+  &__see-more
+    margin-top: 1rem
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+@media (max-width: 959px)
+  .category-filters__section
+    padding: 0.75rem
+</style>

--- a/frontend/app/components/category/CategoryHero.spec.ts
+++ b/frontend/app/components/category/CategoryHero.spec.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'category.hero.breadcrumbAriaLabel': 'Category navigation breadcrumb',
+        'category.hero.missingBreadcrumbTitle': 'Category',
+      }
+
+      return map[key] ?? key
+    },
+  }),
+}))
+
+describe('CategoryHero', () => {
+  const mountComponent = async (props: Record<string, unknown>) => {
+    const module = await import('./CategoryHero.vue')
+    const CategoryHero = module.default
+
+    return mount(CategoryHero, {
+      props,
+      global: {
+        stubs: {
+          VSheet: { template: '<div class="v-sheet"><slot /></div>' },
+          VImg: {
+            template: '<div class="v-img"><slot /></div>',
+            props: ['src', 'alt', 'cover'],
+          },
+          VBreadcrumbs: { template: '<nav class="v-breadcrumbs"><slot /></nav>' },
+          VBreadcrumbsItem: { template: '<span class="v-breadcrumbs-item"><slot /></span>' },
+          VSkeletonLoader: { template: '<div class="v-skeleton" />' },
+        },
+      },
+    })
+  }
+
+  it('renders hero title, description and breadcrumbs', async () => {
+    const wrapper = await mountComponent({
+      title: 'Energy efficient dishwashers',
+      description: 'Compare eco-designed dishwashers to reduce energy consumption.',
+      image: 'https://cdn.example.com/hero.jpg',
+      breadcrumbs: [
+        { title: 'Home', link: '/' },
+        { title: 'Appliances', link: '/appliances' },
+      ],
+    })
+
+    expect(wrapper.get('h1').text()).toBe('Energy efficient dishwashers')
+    expect(wrapper.text()).toContain('Compare eco-designed dishwashers to reduce energy consumption.')
+
+    const breadcrumbItems = wrapper.findAll('.v-breadcrumbs-item')
+    expect(breadcrumbItems).toHaveLength(2)
+    expect(breadcrumbItems[0].text()).toBe('Home')
+
+    const section = wrapper.get('section')
+    expect(section.attributes('aria-labelledby')).toBeTruthy()
+  })
+})

--- a/frontend/app/components/category/CategoryHero.spec.ts
+++ b/frontend/app/components/category/CategoryHero.spec.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
+import type { CategoryBreadcrumbItemDto } from '~~/shared/api-client'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -14,8 +15,16 @@ vi.mock('vue-i18n', () => ({
   }),
 }))
 
+interface MountProps {
+  title: string
+  description?: string | null
+  image?: string | null
+  breadcrumbs?: CategoryBreadcrumbItemDto[]
+  eyebrow?: string | null
+}
+
 describe('CategoryHero', () => {
-  const mountComponent = async (props: Record<string, unknown>) => {
+  const mountComponent = async (props: MountProps) => {
     const module = await import('./CategoryHero.vue')
     const CategoryHero = module.default
 
@@ -52,7 +61,8 @@ describe('CategoryHero', () => {
 
     const breadcrumbItems = wrapper.findAll('.v-breadcrumbs-item')
     expect(breadcrumbItems).toHaveLength(2)
-    expect(breadcrumbItems[0].text()).toBe('Home')
+    const firstBreadcrumb = breadcrumbItems.at(0)
+    expect(firstBreadcrumb?.text()).toBe('Home')
 
     const section = wrapper.get('section')
     expect(section.attributes('aria-labelledby')).toBeTruthy()

--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -1,0 +1,152 @@
+<template>
+  <section
+    class="category-hero"
+    :aria-labelledby="headingId"
+    data-testid="category-hero"
+  >
+    <v-sheet class="category-hero__wrapper" elevation="0" rounded="xl">
+      <v-img
+        v-if="image"
+        :src="image"
+        :alt="title"
+        class="category-hero__image"
+        cover
+      >
+        <template #placeholder>
+          <v-skeleton-loader type="image" class="h-100" />
+        </template>
+        <template #default>
+          <v-sheet class="category-hero__overlay" color="transparent" />
+        </template>
+      </v-img>
+
+      <div class="category-hero__content">
+        <v-breadcrumbs
+          v-if="breadcrumbs.length"
+          :aria-label="t('category.hero.breadcrumbAriaLabel')"
+          class="category-hero__breadcrumbs"
+        >
+          <v-breadcrumbs-item
+            v-for="(item, index) in breadcrumbs"
+            :key="`${index}-${item.title ?? item.link ?? index}`"
+            :href="item.link || undefined"
+          >
+            {{ item.title ?? item.link ?? t('category.hero.missingBreadcrumbTitle') }}
+          </v-breadcrumbs-item>
+        </v-breadcrumbs>
+
+        <div class="category-hero__copy">
+          <p v-if="eyebrow" class="category-hero__eyebrow">
+            {{ eyebrow }}
+          </p>
+          <h1 :id="headingId" class="category-hero__title">
+            {{ title }}
+          </h1>
+          <p v-if="description" class="category-hero__description">
+            {{ description }}
+          </p>
+        </div>
+      </div>
+    </v-sheet>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { CategoryBreadcrumbItemDto } from '~~/shared/api-client'
+
+const props = defineProps<{
+  title: string
+  description?: string | null
+  image?: string | null
+  breadcrumbs?: CategoryBreadcrumbItemDto[]
+  eyebrow?: string | null
+}>()
+
+const headingId = useId()
+const { t } = useI18n()
+
+const breadcrumbs = computed(() => props.breadcrumbs ?? [])
+const eyebrow = computed(() => props.eyebrow ?? null)
+
+defineExpose({ headingId, t })
+</script>
+
+<style scoped lang="sass">
+.category-hero
+  position: relative
+  display: block
+  margin-bottom: 2.5rem
+
+  &__wrapper
+    position: relative
+    overflow: hidden
+    min-height: 280px
+    background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.9), rgba(var(--v-theme-hero-gradient-end), 0.85))
+    color: rgb(var(--v-theme-hero-overlay-strong))
+
+  &__image
+    position: absolute
+    inset: 0
+    z-index: 1
+    opacity: 0.5
+
+  &__overlay
+    position: absolute
+    inset: 0
+    background: radial-gradient(circle at top right, rgba(var(--v-theme-hero-overlay-soft), 0.25), transparent)
+
+  &__content
+    position: relative
+    z-index: 2
+    display: flex
+    flex-direction: column
+    gap: 1rem
+    padding: clamp(1.75rem, 3vw + 1rem, 3.5rem)
+
+  &__breadcrumbs
+    --v-breadcrumbs-divider-color: rgba(var(--v-theme-hero-overlay-strong), 0.6)
+    color: rgba(var(--v-theme-hero-overlay-strong), 0.9)
+    font-size: 0.875rem
+
+    :deep(.v-breadcrumbs-item)
+      color: inherit
+
+    :deep(.v-breadcrumbs-divider)
+      color: inherit
+
+  &__copy
+    max-width: 60ch
+
+  &__eyebrow
+    display: inline-flex
+    align-items: center
+    gap: 0.5rem
+    padding: 0.25rem 0.75rem
+    border-radius: 999px
+    background: rgba(var(--v-theme-hero-overlay-soft), 0.25)
+    color: rgb(var(--v-theme-hero-pill-on-dark))
+    font-size: 0.75rem
+    letter-spacing: 0.08em
+    text-transform: uppercase
+
+  &__title
+    margin: 0
+    font-weight: 700
+    font-size: clamp(2rem, 2vw + 1.5rem, 3rem)
+    line-height: 1.1
+
+  &__description
+    margin: 0
+    font-size: 1.125rem
+    line-height: 1.6
+    color: rgba(var(--v-theme-hero-overlay-strong), 0.9)
+
+@media (min-width: 1280px)
+  .category-hero__wrapper
+    min-height: 360px
+
+  .category-hero__copy
+    max-width: 48ch
+</style>

--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="category-filter-list">
+    <component
+      v-for="field in fields"
+      :key="field.mapping ?? field.title"
+      :is="resolveComponent(field)"
+      :field="field"
+      :aggregation="aggregations[field.mapping ?? '']"
+      :model-value="findActiveFilter(field.mapping)"
+      class="category-filter-list__item"
+      @update:model-value="onFilterChange(field, $event)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {
+  AggregationResponseDto,
+  FieldMetadataDto,
+  Filter,
+} from '~~/shared/api-client'
+
+import CategoryFilterNumeric from './CategoryFilterNumeric.vue'
+import CategoryFilterTerms from './CategoryFilterTerms.vue'
+
+const props = defineProps<{
+  fields: FieldMetadataDto[]
+  aggregations: Record<string, AggregationResponseDto>
+  activeFilters: Filter[]
+}>()
+
+const emit = defineEmits<{
+  'update-range': [field: string, payload: { min?: number; max?: number }]
+  'update-terms': [field: string, terms: string[]]
+}>()
+
+const resolveComponent = (field: FieldMetadataDto) => {
+  return field.valueType === 'numeric' ? CategoryFilterNumeric : CategoryFilterTerms
+}
+
+const findActiveFilter = (field?: string | null) => {
+  return props.activeFilters.find((filter) => filter.field === field) ?? null
+}
+
+const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
+  const mapping = field.mapping
+  if (!mapping) {
+    return
+  }
+
+  if (!filter) {
+    if (field.valueType === 'numeric') {
+      emit('update-range', mapping, { min: undefined, max: undefined })
+    } else {
+      emit('update-terms', mapping, [])
+    }
+    return
+  }
+
+  if (filter.operator === 'range') {
+    emit('update-range', mapping, { min: filter.min, max: filter.max })
+    return
+  }
+
+  emit('update-terms', mapping, filter.terms ?? [])
+}
+</script>
+
+<style scoped lang="sass">
+.category-filter-list
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+</style>

--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="category-filter-list">
     <component
+      :is="resolveComponent(field)"
       v-for="field in fields"
       :key="field.mapping ?? field.title"
-      :is="resolveComponent(field)"
       :field="field"
       :aggregation="aggregations[field.mapping ?? '']"
       :model-value="findActiveFilter(field.mapping)"

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -1,0 +1,188 @@
+<template>
+  <div class="category-filter-numeric">
+    <div class="category-filter-numeric__header">
+      <p class="category-filter-numeric__title">{{ displayTitle }}</p>
+      <p v-if="rangeLabel" class="category-filter-numeric__range">
+        {{ rangeLabel }}
+      </p>
+    </div>
+
+    <v-range-slider
+      v-model="localValue"
+      :min="bounds.min"
+      :max="bounds.max"
+      :step="sliderStep"
+      :aria-label="ariaLabel"
+      class="category-filter-numeric__slider"
+      thumb-label="always"
+      color="primary"
+      @end="emitRange"
+    />
+
+    <div v-if="aggregation?.buckets?.length" class="category-filter-numeric__buckets">
+      <div
+        v-for="bucket in aggregation.buckets"
+        :key="bucket.key"
+        class="category-filter-numeric__bucket"
+      >
+        <span class="category-filter-numeric__bucket-label">
+          {{ formatBucketLabel(bucket.key, bucket.to) }}
+        </span>
+        <v-progress-linear
+          :model-value="bucket.count ?? 0"
+          :max="maxBucketCount"
+          height="6"
+          color="primary"
+        />
+        <span class="category-filter-numeric__bucket-count">{{ bucket.count ?? 0 }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+
+const props = defineProps<{
+  field: FieldMetadataDto
+  aggregation?: AggregationResponseDto
+  modelValue?: Filter | null
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [Filter | null] }>()
+
+const { t } = useI18n()
+
+const displayTitle = computed(() => props.field.title ?? props.field.mapping ?? '')
+
+const ariaLabel = computed(() => `${displayTitle.value} ${t('category.filters.rangeAriaSuffix')}`)
+
+const bounds = computed(() => {
+  const min = props.aggregation?.min ?? (props.aggregation?.buckets?.[0]?.key ? Number(props.aggregation?.buckets?.[0]?.key) : 0)
+  const max = props.aggregation?.max ?? (props.aggregation?.buckets?.at(-1)?.to ?? min)
+
+  if (props.modelValue?.operator === 'range') {
+    return {
+      min: props.modelValue.min ?? min,
+      max: props.modelValue.max ?? max,
+    }
+  }
+
+  return { min, max }
+})
+
+const sliderStep = computed(() => {
+  const buckets = props.aggregation?.buckets ?? []
+  if (buckets.length > 1) {
+    const first = Number(buckets[0].key ?? 0)
+    const second = Number(buckets[1].key ?? 0)
+    const diff = Math.abs(second - first)
+    return Number.isFinite(diff) && diff > 0 ? diff : undefined
+  }
+
+  return props.field.aggregationConfiguration?.interval
+})
+
+const localValue = ref<[number, number]>([bounds.value.min, bounds.value.max])
+
+watch(
+  () => bounds.value,
+  (next) => {
+    localValue.value = [next.min, next.max]
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.modelValue,
+  (filter) => {
+    if (filter?.operator === 'range') {
+      localValue.value = [filter.min ?? bounds.value.min, filter.max ?? bounds.value.max]
+    }
+  },
+)
+
+const maxBucketCount = computed(() => {
+  return Math.max(...(props.aggregation?.buckets?.map((bucket) => bucket.count ?? 0) ?? [0]), 1)
+})
+
+const rangeLabel = computed(() => {
+  if (!props.modelValue || props.modelValue.operator !== 'range') {
+    return null
+  }
+
+  const { min, max } = props.modelValue
+  if (min == null && max == null) {
+    return null
+  }
+
+  return `${min ?? '–'} → ${max ?? '–'}`
+})
+
+const emitRange = () => {
+  const [min, max] = localValue.value
+
+  emit('update:modelValue', {
+    field: props.field.mapping,
+    operator: 'range',
+    min,
+    max,
+  })
+}
+
+const formatBucketLabel = (from?: string, to?: number) => {
+  if (from == null && to == null) {
+    return ''
+  }
+
+  if (to == null) {
+    return `${from}+`
+  }
+
+  return `${from ?? '–'} → ${to}`
+}
+</script>
+
+<style scoped lang="sass">
+.category-filter-numeric
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+  &__header
+    display: flex
+    justify-content: space-between
+    align-items: baseline
+
+  &__title
+    font-size: 1rem
+    font-weight: 600
+    margin: 0
+
+  &__range
+    margin: 0
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__slider
+    margin-top: 0.25rem
+
+  &__buckets
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+  &__bucket
+    display: grid
+    grid-template-columns: auto 1fr auto
+    gap: 0.75rem
+    align-items: center
+
+  &__bucket-label
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__bucket-count
+    font-size: 0.75rem
+    font-variant-numeric: tabular-nums
+</style>

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -74,8 +74,9 @@ const bounds = computed(() => {
 const sliderStep = computed(() => {
   const buckets = props.aggregation?.buckets ?? []
   if (buckets.length > 1) {
-    const first = Number(buckets[0].key ?? 0)
-    const second = Number(buckets[1].key ?? 0)
+    const [firstBucket, secondBucket] = buckets
+    const first = Number(firstBucket?.key ?? 0)
+    const second = Number(secondBucket?.key ?? 0)
     const diff = Math.abs(second - first)
     return Number.isFinite(diff) && diff > 0 ? diff : undefined
   }

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -75,7 +75,7 @@ const filteredOptions = computed(() => {
   return options.value.filter((option) => option.key?.toLowerCase().includes(query))
 })
 
-const onCheckboxChange = (term: string | undefined, selected: boolean) => {
+const onCheckboxChange = (term: string | undefined, selected: boolean | null) => {
   if (!term) {
     return
   }

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="category-filter-terms">
+    <div class="category-filter-terms__header">
+      <p class="category-filter-terms__title">{{ displayTitle }}</p>
+      <v-text-field
+        v-model="search"
+        :label="$t('category.filters.searchOptions')"
+        density="compact"
+        variant="outlined"
+        prepend-inner-icon="mdi-magnify"
+        clearable
+        hide-details
+        class="category-filter-terms__search"
+      />
+    </div>
+
+    <div class="category-filter-terms__options" role="listbox">
+      <v-checkbox
+        v-for="option in filteredOptions"
+        :key="option.key"
+        :label="formatOptionLabel(option.key)"
+        :model-value="localTerms.includes(option.key ?? '')"
+        density="compact"
+        hide-details
+        color="primary"
+        class="category-filter-terms__checkbox"
+        @update:model-value="onCheckboxChange(option.key, $event)"
+      >
+        <template #append>
+          <span class="category-filter-terms__count">{{ option.count ?? 0 }}</span>
+        </template>
+      </v-checkbox>
+
+      <p v-if="!filteredOptions.length" class="category-filter-terms__empty">
+        {{ $t('category.filters.noMatch') }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+
+const props = defineProps<{
+  field: FieldMetadataDto
+  aggregation?: AggregationResponseDto
+  modelValue?: Filter | null
+}>()
+
+const emit = defineEmits<{ 'update:modelValue': [Filter | null] }>()
+
+const { t } = useI18n()
+
+const displayTitle = computed(() => props.field.title ?? props.field.mapping ?? '')
+
+const search = ref('')
+const localTerms = ref<string[]>(props.modelValue?.terms ?? [])
+
+watch(
+  () => props.modelValue,
+  (next) => {
+    localTerms.value = next?.operator === 'term' ? [...(next.terms ?? [])] : []
+  },
+  { immediate: true },
+)
+
+const options = computed(() => props.aggregation?.buckets ?? [])
+
+const filteredOptions = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  if (!query) {
+    return options.value
+  }
+
+  return options.value.filter((option) => option.key?.toLowerCase().includes(query))
+})
+
+const onCheckboxChange = (term: string | undefined, selected: boolean) => {
+  if (!term) {
+    return
+  }
+
+  const next = new Set(localTerms.value)
+
+  if (!selected) {
+    next.delete(term)
+  } else {
+    next.add(term)
+  }
+
+  localTerms.value = Array.from(next)
+
+  emit(
+    'update:modelValue',
+    localTerms.value.length
+      ? {
+          field: props.field.mapping,
+          operator: 'term',
+          terms: [...localTerms.value],
+        }
+      : null,
+  )
+}
+
+const formatOptionLabel = (key?: string) => key ?? t('category.filters.missingLabel')
+</script>
+
+<style scoped lang="sass">
+.category-filter-terms
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+  &__header
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+  &__title
+    margin: 0
+    font-size: 1rem
+    font-weight: 600
+
+  &__options
+    max-height: 320px
+    overflow-y: auto
+    padding-right: 0.5rem
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
+
+  &__count
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    margin-inline-start: 0.5rem
+
+  &__empty
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    margin: 0.5rem 0
+</style>

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -1,0 +1,142 @@
+<template>
+  <v-row class="category-product-card-grid" dense>
+    <v-col
+      v-for="product in products"
+      :key="product.gtin ?? product.identity?.bestName ?? Math.random()"
+      cols="12"
+      sm="6"
+      lg="4"
+    >
+      <v-card class="category-product-card-grid__card" rounded="xl" elevation="2">
+        <v-img
+          :src="resolveImage(product)"
+          :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
+          height="200"
+          cover
+          class="category-product-card-grid__image"
+        >
+          <template #placeholder>
+            <v-skeleton-loader type="image" class="h-100" />
+          </template>
+        </v-img>
+
+        <v-card-item class="category-product-card-grid__body">
+          <div class="category-product-card-grid__eyebrow">
+            <span>{{ product.identity?.brand ?? $t('category.products.unknownBrand') }}</span>
+            <v-chip
+              v-if="ecoscoreLetter(product)"
+              size="small"
+              color="success"
+              variant="flat"
+              class="ms-auto"
+            >
+              {{ $t('category.products.ecoscoreLabel', { letter: ecoscoreLetter(product) }) }}
+            </v-chip>
+          </div>
+
+          <h3 class="category-product-card-grid__title">
+            {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
+          </h3>
+
+          <div class="category-product-card-grid__meta">
+            <v-chip
+              color="primary"
+              variant="tonal"
+              size="small"
+              class="me-2"
+            >
+              <v-icon icon="mdi-cash" size="18" class="me-1" />
+              {{ bestPriceLabel(product) }}
+            </v-chip>
+            <span class="category-product-card-grid__offers">
+              <v-icon icon="mdi-store" size="18" class="me-1" />
+              {{ offersCountLabel(product) }}
+            </span>
+          </div>
+        </v-card-item>
+      </v-card>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import type { ProductDto } from '~~/shared/api-client'
+
+const props = defineProps<{ products: ProductDto[] }>()
+
+const { t } = useI18n()
+
+const resolveImage = (product: ProductDto) => {
+  return (
+    product.resources?.coverImagePath ??
+    product.resources?.externalCover ??
+    product.resources?.images?.[0]?.url ??
+    undefined
+  )
+}
+
+const ecoscoreLetter = (product: ProductDto) => {
+  return (
+    product.scores?.ecoscore?.letter ??
+    product.scores?.scores?.['scores.ECOSCORE.value']?.letter ??
+    product.scores?.scores?.['ECOSCORE']?.letter ??
+    null
+  )
+}
+
+const bestPriceLabel = (product: ProductDto) => {
+  return (
+    product.offers?.bestPrice?.shortPrice ??
+    (product.offers?.bestPrice?.price != null
+      ? `${product.offers?.bestPrice?.price} ${product.offers?.bestPrice?.currency ?? ''}`
+      : t('category.products.priceUnavailable'))
+  )
+}
+
+const offersCountLabel = (product: ProductDto) => {
+  const count = product.offers?.offersCount ?? 0
+  return t('category.products.offerCount', count, { count })
+}
+</script>
+
+<style scoped lang="sass">
+.category-product-card-grid
+  margin: 0
+
+  &__card
+    height: 100%
+    display: flex
+    flex-direction: column
+
+  &__image
+    border-top-left-radius: inherit
+    border-top-right-radius: inherit
+
+  &__body
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+  &__eyebrow
+    display: flex
+    align-items: center
+    gap: 0.5rem
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__title
+    font-size: 1.125rem
+    margin: 0
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__meta
+    display: flex
+    align-items: center
+    gap: 0.5rem
+    flex-wrap: wrap
+
+  &__offers
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+</style>

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -62,7 +62,7 @@
 <script setup lang="ts">
 import type { ProductDto } from '~~/shared/api-client'
 
-const props = defineProps<{ products: ProductDto[] }>()
+defineProps<{ products: ProductDto[] }>()
 
 const { t } = useI18n()
 
@@ -95,7 +95,7 @@ const bestPriceLabel = (product: ProductDto) => {
 
 const offersCountLabel = (product: ProductDto) => {
   const count = product.offers?.offersCount ?? 0
-  return t('category.products.offerCount', count, { count })
+  return t('category.products.offerCount', { count })
 }
 </script>
 

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -49,7 +49,7 @@
 <script setup lang="ts">
 import type { ProductDto } from '~~/shared/api-client'
 
-const props = defineProps<{ products: ProductDto[] }>()
+defineProps<{ products: ProductDto[] }>()
 
 const { t } = useI18n()
 
@@ -82,7 +82,7 @@ const bestPriceLabel = (product: ProductDto) => {
 
 const offersCountLabel = (product: ProductDto) => {
   const count = product.offers?.offersCount ?? 0
-  return t('category.products.offerCount', count, { count })
+  return t('category.products.offerCount', { count })
 }
 </script>
 

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -1,0 +1,122 @@
+<template>
+  <v-list class="category-product-list" lines="three" density="comfortable">
+    <v-list-item
+      v-for="product in products"
+      :key="product.gtin ?? product.identity?.bestName ?? Math.random()"
+      class="category-product-list__item"
+    >
+      <template #prepend>
+        <v-avatar size="88" rounded="lg">
+          <v-img
+            :src="resolveImage(product)"
+            :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
+            cover
+          >
+            <template #placeholder>
+              <v-skeleton-loader type="image" class="h-100" />
+            </template>
+          </v-img>
+        </v-avatar>
+      </template>
+
+      <div class="category-product-list__content">
+        <div class="category-product-list__header">
+          <span class="category-product-list__brand">
+            {{ product.identity?.brand ?? $t('category.products.unknownBrand') }}
+          </span>
+          <v-chip v-if="ecoscoreLetter(product)" size="small" color="success" variant="flat">
+            {{ $t('category.products.ecoscoreLabel', { letter: ecoscoreLetter(product) }) }}
+          </v-chip>
+        </div>
+        <h3 class="category-product-list__title">
+          {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
+        </h3>
+        <div class="category-product-list__meta">
+          <span>
+            <v-icon icon="mdi-cash" size="18" class="me-1" />
+            {{ bestPriceLabel(product) }}
+          </span>
+          <span>
+            <v-icon icon="mdi-store" size="18" class="me-1" />
+            {{ offersCountLabel(product) }}
+          </span>
+        </div>
+      </div>
+    </v-list-item>
+  </v-list>
+</template>
+
+<script setup lang="ts">
+import type { ProductDto } from '~~/shared/api-client'
+
+const props = defineProps<{ products: ProductDto[] }>()
+
+const { t } = useI18n()
+
+const resolveImage = (product: ProductDto) => {
+  return (
+    product.resources?.coverImagePath ??
+    product.resources?.externalCover ??
+    product.resources?.images?.[0]?.url ??
+    undefined
+  )
+}
+
+const ecoscoreLetter = (product: ProductDto) => {
+  return (
+    product.scores?.ecoscore?.letter ??
+    product.scores?.scores?.['scores.ECOSCORE.value']?.letter ??
+    product.scores?.scores?.['ECOSCORE']?.letter ??
+    null
+  )
+}
+
+const bestPriceLabel = (product: ProductDto) => {
+  return (
+    product.offers?.bestPrice?.shortPrice ??
+    (product.offers?.bestPrice?.price != null
+      ? `${product.offers?.bestPrice?.price} ${product.offers?.bestPrice?.currency ?? ''}`
+      : t('category.products.priceUnavailable'))
+  )
+}
+
+const offersCountLabel = (product: ProductDto) => {
+  const count = product.offers?.offersCount ?? 0
+  return t('category.products.offerCount', count, { count })
+}
+</script>
+
+<style scoped lang="sass">
+.category-product-list
+  background: transparent
+
+  &__item
+    background: rgb(var(--v-theme-surface-default))
+    border-radius: 1rem
+    margin-bottom: 1rem
+    padding-inline: 1rem
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+  &__header
+    display: flex
+    gap: 0.75rem
+    align-items: center
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__title
+    margin: 0
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__meta
+    display: flex
+    gap: 1rem
+    flex-wrap: wrap
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+</style>

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -1,0 +1,171 @@
+<template>
+  <v-data-table
+    :headers="headers"
+    :items="rows"
+    :items-per-page="itemsPerPage"
+    class="category-product-table"
+    density="comfortable"
+    :fixed-header="true"
+    height="600"
+  >
+    <template #item.brand="{ value }">
+      <span class="category-product-table__brand">{{ value ?? $t('category.products.unknownBrand') }}</span>
+    </template>
+
+    <template #item.model="{ value, item }">
+      <div class="category-product-table__model">
+        <div class="category-product-table__model-name">
+          {{ value ?? item.identity?.bestName ?? '#' + (item.gtin ?? '') }}
+        </div>
+        <div class="category-product-table__model-meta">
+          <v-icon icon="mdi-cash" size="16" class="me-1" />
+          {{ bestPriceLabel(item) }}
+        </div>
+      </div>
+    </template>
+
+    <template #item.ecoscore="{ value }">
+      <v-chip v-if="value" size="small" color="success" variant="flat">
+        {{ value }}
+      </v-chip>
+      <span v-else>{{ $t('category.products.notRated') }}</span>
+    </template>
+
+    <template #item.bestPrice="{ value }">
+      {{ value ?? $t('category.products.priceUnavailable') }}
+    </template>
+
+    <template #item.offersCount="{ value }">
+      {{ $t('category.products.offerCount', value ?? 0, { count: value ?? 0 }) }}
+    </template>
+
+  </v-data-table>
+</template>
+
+<script setup lang="ts">
+import type { FieldMetadataDto, ProductDto } from '~~/shared/api-client'
+
+const props = defineProps<{
+  products: ProductDto[]
+  fields: FieldMetadataDto[]
+  itemsPerPage: number
+}>()
+
+const { t } = useI18n()
+
+const baseHeaders = computed(() => [
+  { key: 'brand', title: t('category.products.headers.brand'), sortable: false },
+  { key: 'model', title: t('category.products.headers.model'), sortable: false },
+  { key: 'ecoscore', title: t('category.products.headers.ecoscore'), sortable: false },
+  { key: 'bestPrice', title: t('category.products.headers.bestPrice'), sortable: false },
+  { key: 'offersCount', title: t('category.products.headers.offers'), sortable: false },
+])
+
+const dynamicHeaders = computed(() => {
+  const seen = new Set<string>()
+
+  return props.fields
+    .filter((field) => field.mapping && !seen.has(field.mapping))
+    .map((field) => {
+      seen.add(field.mapping as string)
+      return {
+        key: field.mapping,
+        title: field.title ?? field.mapping,
+        sortable: false,
+      }
+    })
+})
+
+const headers = computed(() => [...baseHeaders.value, ...dynamicHeaders.value])
+
+const getValueByPath = (product: ProductDto, path: string | undefined) => {
+  if (!path) {
+    return undefined
+  }
+
+  return path.split('.').reduce<any>((accumulator, segment) => {
+    if (accumulator == null) {
+      return undefined
+    }
+
+    if (segment in accumulator) {
+      return accumulator[segment as keyof typeof accumulator]
+    }
+
+    return undefined
+  }, product)
+}
+
+const ecoscoreLabel = (product: ProductDto) => {
+  const letter =
+    product.scores?.ecoscore?.letter ??
+    product.scores?.scores?.['scores.ECOSCORE.value']?.letter ??
+    product.scores?.scores?.['ECOSCORE']?.letter
+
+  const value =
+    product.scores?.ecoscore?.percent ??
+    product.scores?.scores?.['scores.ECOSCORE.value']?.percent ??
+    product.scores?.scores?.['ECOSCORE']?.percent
+
+  if (!letter) {
+    return null
+  }
+
+  return value != null ? `${letter} (${Math.round(value)}%)` : letter
+}
+
+const bestPriceLabel = (product: ProductDto) => {
+  return (
+    product.offers?.bestPrice?.shortPrice ??
+    (product.offers?.bestPrice?.price != null
+      ? `${product.offers?.bestPrice?.price} ${product.offers?.bestPrice?.currency ?? ''}`
+      : t('category.products.priceUnavailable'))
+  )
+}
+
+const rows = computed(() => {
+  return props.products.map((product) => {
+    const row: Record<string, unknown> = {
+      ...product,
+      brand: product.identity?.brand,
+      model: product.identity?.model ?? product.identity?.bestName ?? product.identity?.brand,
+      ecoscore: ecoscoreLabel(product),
+      bestPrice: bestPriceLabel(product),
+      offersCount: product.offers?.offersCount ?? 0,
+    }
+
+    dynamicHeaders.value.forEach((header) => {
+      const value = getValueByPath(product, header.key)
+      row[header.key] = typeof value === 'number' ? value : value ?? null
+    })
+
+    return row
+  })
+})
+</script>
+
+<style scoped lang="sass">
+.category-product-table
+  width: 100%
+
+  :deep(.v-data-table__tr)
+    &:nth-child(even)
+      background-color: rgba(var(--v-theme-surface-muted), 0.6)
+
+  &__brand
+    font-weight: 500
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__model
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
+
+  &__model-name
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__model-meta
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+</style>

--- a/frontend/app/constants/category.ts
+++ b/frontend/app/constants/category.ts
@@ -1,0 +1,11 @@
+import type { CategoryViewMode } from '../utils/_category-filter-state'
+
+export const CATEGORY_VIEW_MODES: CategoryViewMode[] = ['cards', 'list', 'table']
+
+export const CATEGORY_PAGE_SIZES: Record<CategoryViewMode, number> = {
+  cards: 30,
+  list: 15,
+  table: 60,
+}
+
+export const CATEGORY_DEFAULT_VIEW_MODE: CategoryViewMode = 'cards'

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -1,99 +1,239 @@
 <template>
-  <v-container class="py-10 category-page">
+  <div class="category-page">
+    <CategoryHero
+      v-if="category"
+      :title="category.verticalHomeTitle ?? siteName"
+      :description="category.verticalHomeDescription"
+      :image="heroImage"
+      :breadcrumbs="category.breadCrumb ?? []"
+      :eyebrow="category.verticalMetaTitle"
+    />
+
+    <v-container v-if="category" fluid class="py-6 category-page__container">
+      <CategoryFastFilters
+        :subsets="category.subsets ?? []"
+        :active-subset-ids="activeSubsetIds"
+        class="mb-6"
+        @toggle-subset="onToggleSubset"
+        @remove-clause="onRemoveSubsetClause"
+        @reset="onResetSubsets"
+      />
+
+      <div class="category-page__toolbar">
+        <div class="category-page__toolbar-left">
+          <v-btn
+            v-if="!isDesktop"
+            color="primary"
+            variant="flat"
+            prepend-icon="mdi-filter-variant"
+            @click="filtersDrawer = true"
+          >
+            {{ $t('category.products.openFilters') }}
+          </v-btn>
+
+          <p class="category-page__results-count" aria-live="polite">
+            {{ resultsCountLabel }}
+          </p>
+        </div>
+
+        <div class="category-page__toolbar-actions">
+          <v-text-field
+            v-model="searchTerm"
+            :label="$t('category.products.searchPlaceholder')"
+            prepend-inner-icon="mdi-magnify"
+            clearable
+            hide-details
+            density="comfortable"
+            class="category-page__search"
+          />
+
+          <div class="category-page__sort">
+            <v-select
+              v-model="sortField"
+              :items="sortItems"
+              :label="$t('category.products.sortLabel')"
+              item-title="title"
+              item-value="value"
+              clearable
+              hide-details
+              density="comfortable"
+              class="me-2"
+            />
+            <v-btn-toggle v-model="sortOrder" class="category-page__sort-order" density="comfortable">
+              <v-btn value="asc" :aria-label="$t('category.products.sortOrderAsc')">
+                <v-icon icon="mdi-sort-ascending" />
+              </v-btn>
+              <v-btn value="desc" :aria-label="$t('category.products.sortOrderDesc')">
+                <v-icon icon="mdi-sort-descending" />
+              </v-btn>
+            </v-btn-toggle>
+          </div>
+
+          <v-btn-toggle v-model="viewMode" mandatory class="category-page__view-toggle">
+            <v-btn value="cards" :aria-label="$t('category.products.viewCards')">
+              <v-icon icon="mdi-view-grid" />
+            </v-btn>
+            <v-btn value="list" :aria-label="$t('category.products.viewList')">
+              <v-icon icon="mdi-view-list" />
+            </v-btn>
+            <v-btn value="table" :aria-label="$t('category.products.viewTable')">
+              <v-icon icon="mdi-table" />
+            </v-btn>
+          </v-btn-toggle>
+        </div>
+      </div>
+
+      <div class="category-page__layout">
+        <v-navigation-drawer
+          v-model="filtersDrawer"
+          :permanent="isDesktop"
+          :width="isDesktop ? 320 : 360"
+          location="start"
+          class="category-page__filters"
+          :temporary="!isDesktop"
+        >
+          <CategoryFiltersPanel
+            :filter-options="filterOptions"
+            :aggregations="currentAggregations"
+            :filters="manualFilters"
+            :impact-expanded="impactExpanded"
+            :technical-expanded="technicalExpanded"
+            @update:filters="onFiltersChange"
+            @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
+            @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
+          />
+
+          <div v-if="!isDesktop" class="category-page__filters-actions">
+            <v-btn block color="primary" class="mb-2" @click="applyMobileFilters">
+              {{ $t('category.filters.mobileApply') }}
+            </v-btn>
+            <v-btn block variant="text" @click="clearAllFilters">
+              {{ $t('category.filters.mobileClear') }}
+            </v-btn>
+          </div>
+        </v-navigation-drawer>
+
+        <section class="category-page__results">
+          <v-alert
+            v-if="productError"
+            type="error"
+            variant="tonal"
+            border="start"
+            class="mb-4"
+          >
+            {{ productError }}
+          </v-alert>
+
+          <template v-if="loadingProducts">
+            <v-skeleton-loader
+              v-if="viewMode === 'cards'"
+              type="image, article"
+              class="mb-4"
+              v-for="index in 3"
+              :key="`card-skeleton-${index}`"
+            />
+            <v-skeleton-loader
+              v-else-if="viewMode === 'list'"
+              type="list-item-two-line"
+              class="mb-2"
+              v-for="index in 5"
+              :key="`list-skeleton-${index}`"
+            />
+            <v-skeleton-loader
+              v-else
+              type="table"
+              class="mb-4"
+            />
+          </template>
+
+          <template v-else>
+            <component
+              :is="viewComponent"
+              :products="currentProducts"
+              :fields="tableFields"
+              :items-per-page="pageSize"
+              class="mb-6"
+            />
+
+            <p v-if="!currentProducts.length" class="category-page__no-results">
+              {{ $t('category.products.noResults') }}
+            </p>
+
+            <v-pagination
+              v-if="pageCount > 1"
+              :length="pageCount"
+              :model-value="pageNumber + 1"
+              class="category-page__pagination"
+              density="comfortable"
+              @update:model-value="onPageChange"
+            />
+          </template>
+        </section>
+
+        <aside class="category-page__documentation">
+          <CategoryDocumentationRail
+            :wiki-pages="category.wikiPages ?? []"
+            :related-posts="category.relatedPosts ?? []"
+            :vertical-home-url="category.verticalHomeUrl"
+          />
+        </aside>
+      </div>
+    </v-container>
+
+    <v-container v-else fluid class="py-10">
+      <v-skeleton-loader type="image, article" />
+    </v-container>
+
     <v-alert
       v-if="errorMessage"
       type="error"
       variant="tonal"
       border="start"
-      class="mb-6"
+      class="mx-auto my-6"
+      max-width="640"
     >
       {{ errorMessage }}
     </v-alert>
-
-    <v-skeleton-loader
-      v-else-if="pageLoading"
-      type="image, article"
-      class="mb-6"
-    />
-
-    <div v-else-if="category" class="category-page__content">
-      <v-row class="align-center mb-8" justify="space-between">
-        <v-col cols="12" md="6">
-          <h1 class="text-h3 text-md-h2 font-weight-bold mb-4">
-            {{ category.verticalHomeTitle }}
-          </h1>
-          <p v-if="category.verticalHomeDescription" class="text-body-1">
-            {{ category.verticalHomeDescription }}
-          </p>
-        </v-col>
-        <v-col v-if="heroImage" cols="12" md="5">
-          <v-img
-            :src="heroImage"
-            :alt="category.verticalHomeTitle ?? siteName"
-            height="320"
-            cover
-            class="rounded-lg"
-          />
-        </v-col>
-      </v-row>
-
-      <v-card
-        v-if="category.verticalMetaDescription"
-        variant="outlined"
-        class="mb-8"
-      >
-        <v-card-title class="text-h5">
-          {{ category.verticalMetaTitle ?? category.verticalHomeTitle }}
-        </v-card-title>
-        <v-card-text>
-          <p class="text-body-1">
-            {{ category.verticalMetaDescription }}
-          </p>
-        </v-card-text>
-      </v-card>
-
-      <v-row v-if="category.subsets?.length" class="category-page__subsets">
-        <v-col
-          v-for="subset in category.subsets"
-          :key="subset.id ?? subset.title ?? subset.caption"
-          cols="12"
-          md="6"
-          lg="4"
-        >
-          <v-card variant="outlined" class="h-100 d-flex flex-column">
-            <v-img
-              v-if="subset.image"
-              :src="subset.image"
-              :alt="subset.title ?? subset.caption ?? ''"
-              height="180"
-              cover
-            />
-            <v-card-title class="text-h6">
-              {{ subset.title ?? subset.caption }}
-            </v-card-title>
-            <v-card-text class="d-flex flex-column gap-3">
-              <p v-if="subset.description" class="text-body-2">
-                {{ subset.description }}
-              </p>
-              <NuxtLink
-                v-if="subset.url && subset.caption"
-                :to="subset.url"
-                class="text-body-2 font-weight-medium"
-              >
-                {{ subset.caption }}
-              </NuxtLink>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
-    </div>
-  </v-container>
+  </div>
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+import { useDisplay } from 'vuetify'
+import type {
+  AggregationRequestDto,
+  AggregationResponseDto,
+  Agg,
+  BlogPostDto,
+  FilterRequestDto,
+  ProductFieldOptionsResponse,
+  ProductSearchResponseDto,
+  SortRequestDto,
+  VerticalConfigFullDto,
+  WikiPageConfig,
+} from '~~/shared/api-client'
+import { AggTypeEnum } from '~~/shared/api-client'
+
+import CategoryDocumentationRail from '~/components/category/CategoryDocumentationRail.vue'
+import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
+import CategoryFiltersPanel from '~/components/category/CategoryFiltersPanel.vue'
+import CategoryHero from '~/components/category/CategoryHero.vue'
+import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
+import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
+import CategoryProductTable from '~/components/category/products/CategoryProductTable.vue'
+import { CATEGORY_DEFAULT_VIEW_MODE, CATEGORY_PAGE_SIZES } from '~/constants/category'
 import { useCategories } from '~/composables/categories/useCategories'
+import {
+  buildCategoryHash,
+  deserializeCategoryHashState,
+  type CategoryHashState,
+  type CategoryViewMode,
+} from '~/utils/_category-filter-state'
+import { buildFilterRequestFromSubsets } from '~/utils/_subset-to-filters'
 
 const route = useRoute()
+const router = useRouter()
 const { locale, t } = useI18n()
 const requestURL = useRequestURL()
 
@@ -123,7 +263,9 @@ const { data: categoryData } = await useAsyncData(
   { server: true, immediate: true },
 )
 
-const category = computed(() => categoryData.value ?? currentCategory.value ?? null)
+const category = computed<VerticalConfigFullDto | null>(
+  () => categoryData.value ?? currentCategory.value ?? null,
+)
 const pageLoading = computed(() => loading.value && !category.value)
 const errorMessage = computed(() => categoriesError.value)
 
@@ -181,25 +323,585 @@ useSeoMeta({
   ogImageAlt: () => category.value?.verticalHomeTitle ?? siteName.value,
 })
 
+const breadcrumbJsonLd = computed(() => {
+  if (!category.value?.breadCrumb?.length) {
+    return null
+  }
+
+  const elements = category.value.breadCrumb.map((item, index) => {
+    const href = item.link
+      ? new URL(item.link, requestURL.origin).toString()
+      : canonicalUrl.value
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.title ?? siteName.value,
+      item: href,
+    }
+  })
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: elements,
+  }
+})
+
 useHead(() => ({
   link: [
     { rel: 'canonical', href: canonicalUrl.value },
   ],
+  script: breadcrumbJsonLd.value
+    ? [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify(breadcrumbJsonLd.value),
+        },
+      ]
+    : [],
 }))
+
+const verticalId = computed(() => category.value?.id ?? null)
+
+const { data: initialProductsData } = await useAsyncData(
+  `category-products-${slug}`,
+  async () => {
+    if (!verticalId.value) {
+      return null
+    }
+
+    return await $fetch<ProductSearchResponseDto>('/api/products/search', {
+      method: 'POST',
+      body: {
+        verticalId: verticalId.value,
+        pageNumber: 0,
+        pageSize: CATEGORY_PAGE_SIZES[CATEGORY_DEFAULT_VIEW_MODE],
+      },
+    })
+  },
+  { server: true, immediate: true },
+)
+
+const productsData = ref<ProductSearchResponseDto | null>(initialProductsData.value ?? null)
+watch(initialProductsData, (value) => {
+  if (value) {
+    productsData.value = value
+  }
+})
+
+const { data: filterOptionsData, execute: loadFilterOptions } = useLazyAsyncData(
+  `category-filter-options-${slug}`,
+  async () => {
+    if (!verticalId.value) {
+      return null
+    }
+
+    return await $fetch<ProductFieldOptionsResponse>(
+      `/api/products/fields/filters/${encodeURIComponent(verticalId.value)}`,
+    )
+  },
+  { server: false, immediate: false },
+)
+
+const { data: sortOptionsData, execute: loadSortOptions } = useLazyAsyncData(
+  `category-sort-options-${slug}`,
+  async () => {
+    if (!verticalId.value) {
+      return null
+    }
+
+    return await $fetch<ProductFieldOptionsResponse>(
+      `/api/products/fields/sortable/${encodeURIComponent(verticalId.value)}`,
+    )
+  },
+  { server: false, immediate: false },
+)
+
+const filterOptions = computed(() => filterOptionsData.value ?? null)
+const sortOptions = computed(() => sortOptionsData.value ?? null)
+
+const display = useDisplay()
+const isDesktop = computed(() => display.lgAndUp.value)
+const filtersDrawer = ref(false)
+
+watch(
+  isDesktop,
+  (value) => {
+    filtersDrawer.value = value
+  },
+  { immediate: true },
+)
+
+const viewMode = ref<CategoryViewMode>(CATEGORY_DEFAULT_VIEW_MODE)
+const pageNumber = ref(0)
+const searchTerm = ref('')
+const sortField = ref<string | null>(null)
+const sortOrder = ref<'asc' | 'desc'>('asc')
+const activeSubsetIds = ref<string[]>([])
+const manualFilters = ref<FilterRequestDto>({})
+const impactExpanded = ref(false)
+const technicalExpanded = ref(false)
+
+const subsetFilters = computed(() =>
+  buildFilterRequestFromSubsets(category.value?.subsets ?? [], activeSubsetIds.value),
+)
+
+const combinedFilters = computed<FilterRequestDto | undefined>(() => {
+  const subsetClauses = subsetFilters.value.filters ?? []
+  const manualClauses = manualFilters.value.filters ?? []
+  const filters = [...subsetClauses, ...manualClauses]
+
+  return filters.length ? { filters } : undefined
+})
+
+const pageSize = computed(() => CATEGORY_PAGE_SIZES[viewMode.value])
+
+const sortItems = computed(() => {
+  const fields = [
+    ...(sortOptions.value?.global ?? []),
+    ...(sortOptions.value?.impact ?? []),
+    ...(sortOptions.value?.technical ?? []),
+  ]
+
+  const seen = new Set<string>()
+
+  return fields
+    .filter((field) => field.mapping && !seen.has(field.mapping))
+    .map((field) => {
+      seen.add(field.mapping as string)
+      return {
+        value: field.mapping as string,
+        title: field.title ?? field.mapping,
+      }
+    })
+})
+
+const sortRequest = computed<SortRequestDto | undefined>(() => {
+  if (!sortField.value) {
+    return undefined
+  }
+
+  return {
+    sorts: [
+      {
+        field: sortField.value,
+        order: sortOrder.value,
+      },
+    ],
+  }
+})
+
+const currentProducts = computed(() => productsData.value?.products?.data ?? [])
+const resultsCount = computed(() => productsData.value?.products?.page?.totalElements ?? 0)
+const resultsCountLabel = computed(() =>
+  t('category.products.resultsCount', resultsCount.value, { count: resultsCount.value }),
+)
+const pageCount = computed(() => productsData.value?.products?.page?.totalPages ?? 1)
+const currentAggregations = computed<AggregationResponseDto[]>(
+  () => productsData.value?.aggregations ?? [],
+)
+
+const tableFields = computed(() => {
+  if (!filterOptions.value) {
+    return []
+  }
+
+  return [
+    ...(filterOptions.value.global ?? []),
+    ...(filterOptions.value.impact ?? []),
+    ...(filterOptions.value.technical ?? []),
+  ]
+})
+
+const viewComponent = computed(() => {
+  if (viewMode.value === 'list') {
+    return CategoryProductListView
+  }
+
+  if (viewMode.value === 'table') {
+    return CategoryProductTable
+  }
+
+  return CategoryProductCardGrid
+})
+
+const loadingProducts = ref(false)
+const productError = ref<string | null>(null)
+const hasHydrated = ref(false)
+
+const buildAggregationRequest = (
+  options: ProductFieldOptionsResponse | null,
+): AggregationRequestDto | undefined => {
+  if (!options) {
+    return undefined
+  }
+
+  const fields = [
+    ...(options.global ?? []),
+    ...(options.impact ?? []),
+    ...(options.technical ?? []),
+  ]
+
+  const seen = new Set<string>()
+  const aggs: Agg[] = []
+
+  fields.forEach((field) => {
+    if (!field.mapping || seen.has(field.mapping)) {
+      return
+    }
+
+    seen.add(field.mapping)
+
+    const agg: Agg = {
+      name: field.mapping,
+      field: field.mapping,
+      type: field.valueType === 'numeric' ? AggTypeEnum.Range : AggTypeEnum.Terms,
+    }
+
+    if (field.aggregationConfiguration?.buckets != null) {
+      agg.buckets = field.aggregationConfiguration.buckets
+    }
+
+    if (field.aggregationConfiguration?.interval != null) {
+      agg.step = field.aggregationConfiguration.interval
+    }
+
+    aggs.push(agg)
+  })
+
+  return aggs.length ? { aggs } : undefined
+}
+
+const fetchProducts = async () => {
+  if (!verticalId.value || !hasHydrated.value) {
+    return
+  }
+
+  loadingProducts.value = true
+  productError.value = null
+
+  try {
+    const response = await $fetch<ProductSearchResponseDto>('/api/products/search', {
+      method: 'POST',
+      body: {
+        verticalId: verticalId.value,
+        pageNumber: pageNumber.value,
+        pageSize: pageSize.value,
+        query: searchTerm.value || undefined,
+        sort: sortRequest.value,
+        filters: combinedFilters.value,
+        aggs: buildAggregationRequest(filterOptions.value),
+      },
+    })
+
+    productsData.value = response
+  } catch (error) {
+    productError.value =
+      error instanceof Error ? error.message : t('category.products.fetchError')
+  } finally {
+    loadingProducts.value = false
+  }
+}
+
+const debouncedFetch = useDebounceFn(() => {
+  if (import.meta.client) {
+    fetchProducts()
+  }
+}, 250)
+
+watch(
+  () => [viewMode.value, sortField.value, sortOrder.value],
+  () => {
+    if (!hasHydrated.value) {
+      return
+    }
+
+    pageNumber.value = 0
+    debouncedFetch()
+  },
+)
+
+watch(
+  () => manualFilters.value,
+  () => {
+    if (!hasHydrated.value) {
+      return
+    }
+
+    pageNumber.value = 0
+    debouncedFetch()
+  },
+  { deep: true },
+)
+
+watch(
+  () => activeSubsetIds.value,
+  () => {
+    if (!hasHydrated.value) {
+      return
+    }
+
+    pageNumber.value = 0
+    debouncedFetch()
+  },
+  { deep: true },
+)
+
+watch(
+  () => searchTerm.value,
+  () => {
+    if (!hasHydrated.value) {
+      return
+    }
+
+    pageNumber.value = 0
+    debouncedFetch()
+  },
+)
+
+watch(
+  () => pageNumber.value,
+  () => {
+    if (!hasHydrated.value) {
+      return
+    }
+
+    debouncedFetch()
+  },
+)
+
+watch(
+  () => filterOptions.value,
+  (value) => {
+    if (value && hasHydrated.value) {
+      fetchProducts()
+    }
+  },
+)
+
+const hashState = computed<CategoryHashState>(() => ({
+  filters: manualFilters.value.filters?.length ? manualFilters.value : {},
+  activeSubsets: activeSubsetIds.value,
+  view: viewMode.value,
+  pageNumber: pageNumber.value,
+  search: searchTerm.value || undefined,
+  sort: sortRequest.value,
+  impactExpanded: impactExpanded.value || undefined,
+  technicalExpanded: technicalExpanded.value || undefined,
+}))
+
+watch(
+  hashState,
+  (state) => {
+    if (!import.meta.client || !hasHydrated.value) {
+      return
+    }
+
+    const hash = buildCategoryHash(state)
+    const currentHash = window.location.hash ?? ''
+
+    if (currentHash !== hash) {
+      router.replace({ hash })
+    }
+  },
+  { deep: true },
+)
+
+onMounted(async () => {
+  const hashPayload = deserializeCategoryHashState(window.location.hash.slice(1))
+
+  if (hashPayload) {
+    if (hashPayload.view) {
+      viewMode.value = hashPayload.view
+    }
+
+    if (hashPayload.pageNumber != null) {
+      pageNumber.value = hashPayload.pageNumber
+    }
+
+    if (hashPayload.search) {
+      searchTerm.value = hashPayload.search
+    }
+
+    if (hashPayload.sort?.sorts?.length) {
+      const sort = hashPayload.sort.sorts[0]
+      sortField.value = sort.field ?? null
+      sortOrder.value = sort.order ?? 'asc'
+    }
+
+    if (hashPayload.filters?.filters?.length) {
+      manualFilters.value = hashPayload.filters
+    }
+
+    if (hashPayload.activeSubsets?.length) {
+      activeSubsetIds.value = [...hashPayload.activeSubsets]
+    }
+
+    if (typeof hashPayload.impactExpanded === 'boolean') {
+      impactExpanded.value = hashPayload.impactExpanded
+    }
+
+    if (typeof hashPayload.technicalExpanded === 'boolean') {
+      technicalExpanded.value = hashPayload.technicalExpanded
+    }
+  }
+
+  hasHydrated.value = true
+
+  if (verticalId.value) {
+    await Promise.all([loadFilterOptions(), loadSortOptions()])
+    await fetchProducts()
+  }
+})
+
+watch(
+  verticalId,
+  (id) => {
+    if (import.meta.client && id) {
+      loadFilterOptions()
+      loadSortOptions()
+    }
+  },
+)
+
+const onToggleSubset = (subsetId: string, active: boolean) => {
+  const next = new Set(activeSubsetIds.value)
+
+  if (active) {
+    next.add(subsetId)
+  } else {
+    next.delete(subsetId)
+  }
+
+  activeSubsetIds.value = Array.from(next)
+}
+
+const onRemoveSubsetClause = (clause: { subsetId: string }) => {
+  activeSubsetIds.value = activeSubsetIds.value.filter((id) => id !== clause.subsetId)
+}
+
+const onResetSubsets = () => {
+  activeSubsetIds.value = []
+}
+
+const onFiltersChange = (filters: FilterRequestDto) => {
+  manualFilters.value = filters
+}
+
+const onPageChange = (page: number) => {
+  pageNumber.value = page - 1
+}
+
+const applyMobileFilters = () => {
+  filtersDrawer.value = false
+}
+
+const clearAllFilters = () => {
+  manualFilters.value = {}
+  activeSubsetIds.value = []
+  searchTerm.value = ''
+  sortField.value = null
+  sortOrder.value = 'asc'
+  impactExpanded.value = false
+  technicalExpanded.value = false
+  pageNumber.value = 0
+}
 </script>
 
 <style scoped lang="sass">
 .category-page
-  min-height: 70vh
+  display: flex
+  flex-direction: column
 
-  &__content
+  &__container
+    max-width: 1400px
+
+  &__toolbar
     display: flex
     flex-direction: column
+    gap: 1rem
+    margin-bottom: 1.5rem
+
+  &__toolbar-left
+    display: flex
+    align-items: center
+    gap: 1rem
+    flex-wrap: wrap
+
+  &__toolbar-actions
+    display: flex
+    align-items: center
+    flex-wrap: wrap
+    gap: 1rem
+
+  &__search
+    min-width: 240px
+
+  &__sort
+    display: flex
+    align-items: center
+    gap: 0.5rem
+
+  &__sort-order
+    border-radius: 999px
+
+  &__view-toggle
+    border-radius: 999px
+
+  &__results-count
+    margin: 0
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__layout
+    display: grid
     gap: 2rem
+    grid-template-columns: minmax(0, 1fr)
 
-  &__subsets
-    gap: 1.5rem
+  &__filters
+    position: sticky
+    top: 96px
+    height: calc(100vh - 120px)
+    overflow-y: auto
+    border-radius: 1rem
 
-  .v-card-text
-    flex-grow: 1
+  &__filters-actions
+    padding: 1rem
+
+  &__results
+    min-height: 420px
+
+  &__no-results
+    font-size: 1rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__pagination
+    justify-content: center
+
+  &__documentation
+    position: sticky
+    top: 96px
+    align-self: start
+
+@media (min-width: 1280px)
+  .category-page__layout
+    grid-template-columns: 320px minmax(0, 1fr) 320px
+
+  .category-page__filters
+    background: transparent
+    box-shadow: none
+
+@media (max-width: 959px)
+  .category-page__toolbar
+    align-items: stretch
+
+  .category-page__toolbar-actions
+    justify-content: space-between
+
+  .category-page__layout
+    grid-template-columns: minmax(0, 1fr)
+
+  .category-page__documentation
+    position: static
 </style>

--- a/frontend/app/utils/_category-filter-state.spec.ts
+++ b/frontend/app/utils/_category-filter-state.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildCategoryHash,
+  deserializeCategoryHashState,
+  serializeCategoryHashState,
+  type CategoryHashState,
+} from './_category-filter-state'
+
+describe('category filter hash serialisation', () => {
+  it('serialises and deserialises state payloads', () => {
+    const state: CategoryHashState = {
+      search: 'smartphone',
+      pageNumber: 2,
+      view: 'cards',
+      activeSubsets: ['eco', 'budget'],
+      impactExpanded: true,
+      filters: {
+        filters: [
+          {
+            field: 'scores.ECOSCORE.value',
+            operator: 'range',
+            min: 80,
+            max: 100,
+          },
+        ],
+      },
+    }
+
+    const serialised = serializeCategoryHashState(state)
+    expect(serialised).toBeTypeOf('string')
+    expect(serialised.length).toBeGreaterThan(0)
+
+    const deserialised = deserializeCategoryHashState(serialised)
+    expect(deserialised).toEqual(state)
+  })
+
+  it('returns null when payload is empty or invalid', () => {
+    expect(deserializeCategoryHashState('')).toBeNull()
+    expect(deserializeCategoryHashState(undefined)).toBeNull()
+
+    const invalidPayload = 'invalid-base64'
+    expect(deserializeCategoryHashState(invalidPayload)).toBeNull()
+  })
+
+  it('buildCategoryHash prefixes with hash character', () => {
+    const payload: CategoryHashState = { view: 'list' }
+    const hash = buildCategoryHash(payload)
+
+    expect(hash.startsWith('#')).toBe(true)
+
+    const restored = deserializeCategoryHashState(hash.slice(1))
+    expect(restored).toEqual(payload)
+  })
+})

--- a/frontend/app/utils/_category-filter-state.ts
+++ b/frontend/app/utils/_category-filter-state.ts
@@ -1,0 +1,68 @@
+import { decompressFromBase64, compressToBase64 } from 'lz-string'
+import type { FilterRequestDto, SortRequestDto } from '~~/shared/api-client'
+
+export type CategoryViewMode = 'cards' | 'list' | 'table'
+
+export interface CategoryHashState {
+  filters?: FilterRequestDto
+  search?: string
+  sort?: SortRequestDto
+  pageNumber?: number
+  view?: CategoryViewMode
+  activeSubsets?: string[]
+  impactExpanded?: boolean
+  technicalExpanded?: boolean
+}
+
+const removeUndefined = <T extends Record<string, unknown>>(value: T): Partial<T> => {
+  return Object.entries(value).reduce<Partial<T>>((accumulator, [key, entryValue]) => {
+    if (entryValue === undefined) {
+      return accumulator
+    }
+
+    if (Array.isArray(entryValue) && entryValue.length === 0) {
+      return accumulator
+    }
+
+    accumulator[key as keyof T] = entryValue as T[keyof T]
+    return accumulator
+  }, {})
+}
+
+export const serializeCategoryHashState = (state: CategoryHashState): string => {
+  const cleaned = removeUndefined(state)
+
+  if (!Object.keys(cleaned).length) {
+    return ''
+  }
+
+  const rawPayload = JSON.stringify(cleaned)
+  return compressToBase64(rawPayload)
+}
+
+export const deserializeCategoryHashState = (payload: string | null | undefined): CategoryHashState | null => {
+  if (!payload || payload.trim().length === 0) {
+    return null
+  }
+
+  try {
+    const json = decompressFromBase64(payload)
+    if (!json) {
+      return null
+    }
+
+    const parsed = JSON.parse(json) as CategoryHashState
+    return parsed ?? null
+  } catch (error) {
+    if (import.meta.server) {
+      console.error('Failed to decode category hash state payload.', error)
+    }
+
+    return null
+  }
+}
+
+export const buildCategoryHash = (state: CategoryHashState): string => {
+  const serialized = serializeCategoryHashState(state)
+  return serialized ? `#${serialized}` : ''
+}

--- a/frontend/app/utils/_category-filter-state.ts
+++ b/frontend/app/utils/_category-filter-state.ts
@@ -14,8 +14,10 @@ export interface CategoryHashState {
   technicalExpanded?: boolean
 }
 
-const removeUndefined = <T extends Record<string, unknown>>(value: T): Partial<T> => {
-  return Object.entries(value).reduce<Partial<T>>((accumulator, [key, entryValue]) => {
+const removeUndefined = <T extends object>(value: T): Partial<T> => {
+  return (Object.keys(value) as Array<keyof T>).reduce<Partial<T>>((accumulator, key) => {
+    const entryValue = value[key]
+
     if (entryValue === undefined) {
       return accumulator
     }
@@ -24,7 +26,16 @@ const removeUndefined = <T extends Record<string, unknown>>(value: T): Partial<T
       return accumulator
     }
 
-    accumulator[key as keyof T] = entryValue as T[keyof T]
+    if (
+      entryValue &&
+      typeof entryValue === 'object' &&
+      !Array.isArray(entryValue) &&
+      Object.keys(entryValue as Record<string, unknown>).length === 0
+    ) {
+      return accumulator
+    }
+
+    ;(accumulator as Record<keyof T, T[keyof T]>)[key] = entryValue
     return accumulator
   }, {})
 }

--- a/frontend/app/utils/_subset-to-filters.ts
+++ b/frontend/app/utils/_subset-to-filters.ts
@@ -1,0 +1,73 @@
+import type { Filter, FilterRequestDto, SubsetCriteria, VerticalSubsetDto } from '~~/shared/api-client'
+
+const parseNumericValue = (value: string | undefined): number | undefined => {
+  if (value == null) {
+    return undefined
+  }
+
+  const parsed = Number.parseFloat(value)
+
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const convertCriteria = (criteria: SubsetCriteria | undefined): Filter | null => {
+  if (!criteria?.field || !criteria.operator) {
+    return null
+  }
+
+  if (criteria.operator === 'EQUALS') {
+    if (!criteria.value) {
+      return null
+    }
+
+    return {
+      field: criteria.field,
+      operator: 'term',
+      terms: [criteria.value],
+    }
+  }
+
+  const numericValue = parseNumericValue(criteria.value)
+
+  if (numericValue == null) {
+    return null
+  }
+
+  if (criteria.operator === 'LOWER_THAN') {
+    return {
+      field: criteria.field,
+      operator: 'range',
+      max: numericValue,
+    }
+  }
+
+  if (criteria.operator === 'GREATER_THAN') {
+    return {
+      field: criteria.field,
+      operator: 'range',
+      min: numericValue,
+    }
+  }
+
+  return null
+}
+
+export const convertSubsetCriteriaToFilters = (subset: VerticalSubsetDto): Filter[] => {
+  const clauses = subset.criterias ?? []
+
+  return clauses
+    .map((criteria) => convertCriteria(criteria))
+    .filter((filter): filter is Filter => Boolean(filter))
+}
+
+export const buildFilterRequestFromSubsets = (
+  subsets: VerticalSubsetDto[],
+  activeSubsetIds: string[],
+): FilterRequestDto => {
+  const filters = activeSubsetIds.flatMap((subsetId) => {
+    const subset = subsets.find((candidate) => candidate.id === subsetId)
+    return subset ? convertSubsetCriteriaToFilters(subset) : []
+  })
+
+  return filters.length ? { filters } : {}
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -70,6 +70,66 @@
     },
     "siteName": "Nudger"
   },
+  "category": {
+    "hero": {
+      "breadcrumbAriaLabel": "Category navigation breadcrumb",
+      "missingBreadcrumbTitle": "Category"
+    },
+    "fastFilters": {
+      "title": "Quick filters",
+      "reset": "Clear fast filters",
+      "activeClauses": "Applied subset filters",
+      "operator": {
+        "greaterThan": "≥ {value}",
+        "lowerThan": "≤ {value}"
+      }
+    },
+    "filters": {
+      "globalTitle": "Global filters",
+      "impactTitle": "Impact filters",
+      "technicalTitle": "Technical filters",
+      "showMoreImpact": "Show more impact filters",
+      "hideImpact": "Hide impact filters",
+      "showMoreTechnical": "Show more technical filters",
+      "hideTechnical": "Hide technical filters",
+      "rangeAriaSuffix": "range selection",
+      "searchOptions": "Search options",
+      "noMatch": "No matching options",
+      "missingLabel": "Unlabelled option",
+      "mobileApply": "Apply filters",
+      "mobileClear": "Clear all filters"
+    },
+    "products": {
+      "untitledProduct": "Unnamed product",
+      "unknownBrand": "Unknown brand",
+      "ecoscoreLabel": "Eco score {letter}",
+      "priceUnavailable": "Price unavailable",
+      "offerCount": "{count, plural, one {# offer} other {# offers}}",
+      "notRated": "Not rated",
+      "fetchError": "Unable to load products. Please try again.",
+      "headers": {
+        "brand": "Brand",
+        "model": "Model",
+        "ecoscore": "Eco score",
+        "bestPrice": "Best price",
+        "offers": "Offers"
+      },
+      "resultsCount": "{count, plural, one {# product} other {# products}}",
+      "searchPlaceholder": "Search products",
+      "sortLabel": "Sort by",
+      "sortOrderAsc": "Ascending order",
+      "sortOrderDesc": "Descending order",
+      "viewCards": "Card view",
+      "viewList": "List view",
+      "viewTable": "Table view",
+      "openFilters": "Filters",
+      "noResults": "No products match the selected filters."
+    },
+    "documentation": {
+      "guidesTitle": "Helpful guides",
+      "postsTitle": "Related articles"
+    }
+  },
   "blog": {
     "seo": {
       "baseTitle": "Nudger Blog – Impact Score insights",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -69,6 +69,66 @@
     },
     "siteName": "Nudger"
   },
+  "category": {
+    "hero": {
+      "breadcrumbAriaLabel": "Fil d'Ariane des catégories",
+      "missingBreadcrumbTitle": "Catégorie"
+    },
+    "fastFilters": {
+      "title": "Filtres rapides",
+      "reset": "Réinitialiser les filtres rapides",
+      "activeClauses": "Filtres de sous-ensemble appliqués",
+      "operator": {
+        "greaterThan": "≥ {value}",
+        "lowerThan": "≤ {value}"
+      }
+    },
+    "filters": {
+      "globalTitle": "Filtres globaux",
+      "impactTitle": "Filtres d'impact",
+      "technicalTitle": "Filtres techniques",
+      "showMoreImpact": "Afficher plus de filtres d'impact",
+      "hideImpact": "Masquer les filtres d'impact",
+      "showMoreTechnical": "Afficher plus de filtres techniques",
+      "hideTechnical": "Masquer les filtres techniques",
+      "rangeAriaSuffix": "sélection d'intervalle",
+      "searchOptions": "Rechercher dans les options",
+      "noMatch": "Aucune option correspondante",
+      "missingLabel": "Option sans libellé",
+      "mobileApply": "Appliquer les filtres",
+      "mobileClear": "Effacer les filtres"
+    },
+    "products": {
+      "untitledProduct": "Produit sans nom",
+      "unknownBrand": "Marque inconnue",
+      "ecoscoreLabel": "Score éco {letter}",
+      "priceUnavailable": "Prix non disponible",
+      "offerCount": "{count, plural, one {# offre} other {# offres}}",
+      "notRated": "Non noté",
+      "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
+      "headers": {
+        "brand": "Marque",
+        "model": "Modèle",
+        "ecoscore": "Score éco",
+        "bestPrice": "Meilleur prix",
+        "offers": "Offres"
+      },
+      "resultsCount": "{count, plural, one {# produit} other {# produits}}",
+      "searchPlaceholder": "Rechercher des produits",
+      "sortLabel": "Trier par",
+      "sortOrderAsc": "Ordre croissant",
+      "sortOrderDesc": "Ordre décroissant",
+      "viewCards": "Vue cartes",
+      "viewList": "Vue liste",
+      "viewTable": "Vue tableau",
+      "openFilters": "Filtres",
+      "noResults": "Aucun produit ne correspond aux filtres sélectionnés."
+    },
+    "documentation": {
+      "guidesTitle": "Guides utiles",
+      "postsTitle": "Articles associés"
+    }
+  },
   "blog": {
     "seo": {
       "baseTitle": "Blog Nudger",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,6 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "sharp": "^0.34.0",
     "@hcaptcha/vue3-hcaptcha": "^1.3.0",
     "@mdi/font": "^7.4.47",
     "@nuxt/fonts": "0.11.4",
@@ -36,19 +35,20 @@
     "@vueuse/core": "^13.9.0",
     "@vueuse/nuxt": "^13.9.0",
     "cookie-es": "^2.0.0",
-    "isomorphic-dompurify": "^2.28.0",
     "i": "^0.3.7",
+    "isomorphic-dompurify": "^2.28.0",
     "jsdom": "^27.0.0",
     "jwt-decode": "^4.0.0",
+    "lz-string": "^1.5.0",
     "npm": "^11.6.0",
     "nuxt": "^4.0.0",
     "nuxt-device": "^2.1.0",
     "nuxt-mcp": "^0.2.4",
     "pinia": "^3.0.3",
+    "sharp": "^0.34.0",
     "unhead": "^2.0.14",
     "vue": "3.5.22",
-    "vuetify-nuxt-module": "^0.18.7",
-    "lz-string": "^1.5.0"
+    "vuetify-nuxt-module": "^0.18.7"
   },
   "devDependencies": {
     "@iconify-json/bxl": "^1.2.2",
@@ -70,6 +70,7 @@
     "@semantic-release/github": "^11.0.5",
     "@semantic-release/npm": "^12.0.2",
     "@types/jsdom": "^27.0.0",
+    "@types/lz-string": "^1.5.0",
     "@typescript-eslint/parser": "^8.43.0",
     "@vite-pwa/nuxt": "^1.0.4",
     "@vue/compiler-dom": "3.5.22",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,8 @@
     "pinia": "^3.0.3",
     "unhead": "^2.0.14",
     "vue": "3.5.22",
-    "vuetify-nuxt-module": "^0.18.7"
+    "vuetify-nuxt-module": "^0.18.7",
+    "lz-string": "^1.5.0"
   },
   "devDependencies": {
     "@iconify-json/bxl": "^1.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
+      lz-string:
+        specifier: ^1.5.0
+        version: 1.5.0
       npm:
         specifier: ^11.6.0
         version: 11.6.2
@@ -6211,6 +6214,10 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-regexp@0.10.0:
     resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
@@ -15987,6 +15994,8 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-regexp@0.10.0:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
+      '@types/lz-string':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@typescript-eslint/parser':
         specifier: ^8.43.0
         version: 8.46.1(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.2)
@@ -3199,6 +3202,10 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lz-string@1.5.0':
+    resolution: {integrity: sha512-s84fKOrzqqNCAPljhVyC5TjAo6BH4jKHw9NRNFNiRUY5QSgZCmVm5XILlWbisiKl+0OcS7eWihmKGS5akc2iQw==}
+    deprecated: This is a stub types definition. lz-string provides its own type definitions, so you do not need this installed.
 
   '@types/node@20.19.21':
     resolution: {integrity: sha512-CsGG2P3I5y48RPMfprQGfy4JPRZ6csfC3ltBZSRItG3ngggmNY/qs2uZKp4p9VbrpqNNSMzUZNFZKzgOGnd/VA==}
@@ -12530,6 +12537,10 @@ snapshots:
       parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lz-string@1.5.0':
+    dependencies:
+      lz-string: 1.5.0
 
   '@types/node@20.19.21':
     dependencies:

--- a/frontend/server/api/products/fields/filters/[verticalId].get.ts
+++ b/frontend/server/api/products/fields/filters/[verticalId].get.ts
@@ -1,0 +1,42 @@
+import type { ProductFieldOptionsResponse } from '~~/shared/api-client'
+import { useProductService } from '~~/shared/api-client/services/products.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../../../../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../../../../utils/cache-headers'
+
+export default defineEventHandler(
+  async (event): Promise<ProductFieldOptionsResponse> => {
+    setDomainLanguageCacheHeaders(event, 'public, max-age=600, s-maxage=600')
+
+    const verticalIdParam = getRouterParam(event, 'verticalId')
+    if (!verticalIdParam) {
+      throw createError({ statusCode: 400, statusMessage: 'verticalId parameter is required.' })
+    }
+
+    const verticalId = decodeURIComponent(verticalIdParam)
+
+    const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+    const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+    const productService = useProductService(domainLanguage)
+
+    try {
+      return await productService.getFilterableFieldsForVertical(verticalId)
+    } catch (error) {
+      const backendError = await extractBackendErrorDetails(error)
+      console.error(
+        'Error fetching filterable fields for vertical:',
+        verticalId,
+        backendError.logMessage,
+        backendError,
+      )
+
+      throw createError({
+        statusCode: backendError.statusCode,
+        statusMessage: backendError.statusMessage,
+        cause: error,
+      })
+    }
+  },
+)

--- a/frontend/server/api/products/fields/filters/[verticalId].get.ts
+++ b/frontend/server/api/products/fields/filters/[verticalId].get.ts
@@ -2,8 +2,8 @@ import type { ProductFieldOptionsResponse } from '~~/shared/api-client'
 import { useProductService } from '~~/shared/api-client/services/products.services'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
-import { extractBackendErrorDetails } from '../../../../../utils/log-backend-error'
-import { setDomainLanguageCacheHeaders } from '../../../../../utils/cache-headers'
+import { extractBackendErrorDetails } from '../../../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../../../utils/cache-headers'
 
 export default defineEventHandler(
   async (event): Promise<ProductFieldOptionsResponse> => {

--- a/frontend/server/api/products/fields/sortable/[verticalId].get.ts
+++ b/frontend/server/api/products/fields/sortable/[verticalId].get.ts
@@ -1,0 +1,42 @@
+import type { ProductFieldOptionsResponse } from '~~/shared/api-client'
+import { useProductService } from '~~/shared/api-client/services/products.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../../../../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../../../../utils/cache-headers'
+
+export default defineEventHandler(
+  async (event): Promise<ProductFieldOptionsResponse> => {
+    setDomainLanguageCacheHeaders(event, 'public, max-age=600, s-maxage=600')
+
+    const verticalIdParam = getRouterParam(event, 'verticalId')
+    if (!verticalIdParam) {
+      throw createError({ statusCode: 400, statusMessage: 'verticalId parameter is required.' })
+    }
+
+    const verticalId = decodeURIComponent(verticalIdParam)
+
+    const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+    const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+    const productService = useProductService(domainLanguage)
+
+    try {
+      return await productService.getSortableFieldsForVertical(verticalId)
+    } catch (error) {
+      const backendError = await extractBackendErrorDetails(error)
+      console.error(
+        'Error fetching sortable fields for vertical:',
+        verticalId,
+        backendError.logMessage,
+        backendError,
+      )
+
+      throw createError({
+        statusCode: backendError.statusCode,
+        statusMessage: backendError.statusMessage,
+        cause: error,
+      })
+    }
+  },
+)

--- a/frontend/server/api/products/fields/sortable/[verticalId].get.ts
+++ b/frontend/server/api/products/fields/sortable/[verticalId].get.ts
@@ -2,8 +2,8 @@ import type { ProductFieldOptionsResponse } from '~~/shared/api-client'
 import { useProductService } from '~~/shared/api-client/services/products.services'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
-import { extractBackendErrorDetails } from '../../../../../utils/log-backend-error'
-import { setDomainLanguageCacheHeaders } from '../../../../../utils/cache-headers'
+import { extractBackendErrorDetails } from '../../../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../../../utils/cache-headers'
 
 export default defineEventHandler(
   async (event): Promise<ProductFieldOptionsResponse> => {

--- a/frontend/server/api/products/search.post.ts
+++ b/frontend/server/api/products/search.post.ts
@@ -1,0 +1,61 @@
+import type {
+  AggregationRequestDto,
+  FilterRequestDto,
+  ProductSearchResponseDto,
+  SortRequestDto,
+} from '~~/shared/api-client'
+import { useProductService } from '~~/shared/api-client/services/products.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
+
+interface ProductsSearchPayload {
+  verticalId?: string
+  pageNumber?: number
+  pageSize?: number
+  sort?: SortRequestDto
+  aggs?: AggregationRequestDto
+  filters?: FilterRequestDto
+  query?: string
+  include?: string[]
+}
+
+export default defineEventHandler(
+  async (event): Promise<ProductSearchResponseDto> => {
+    setDomainLanguageCacheHeaders(event, 'private, no-store')
+
+    const payload = await readBody<ProductsSearchPayload | null>(event)
+
+    if (!payload) {
+      throw createError({ statusCode: 400, statusMessage: 'Request body is required.' })
+    }
+
+    const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+    const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+    const productService = useProductService(domainLanguage)
+
+    try {
+      return await productService.searchProducts({
+        verticalId: payload.verticalId,
+        pageNumber: payload.pageNumber,
+        pageSize: payload.pageSize,
+        sort: payload.sort,
+        aggs: payload.aggs,
+        filters: payload.filters,
+        query: payload.query,
+        include: payload.include,
+      })
+    } catch (error) {
+      const backendError = await extractBackendErrorDetails(error)
+      console.error('Error searching products:', backendError.logMessage, backendError)
+
+      throw createError({
+        statusCode: backendError.statusCode,
+        statusMessage: backendError.statusMessage,
+        cause: error,
+      })
+    }
+  },
+)

--- a/frontend/server/api/products/search.post.ts
+++ b/frontend/server/api/products/search.post.ts
@@ -3,6 +3,7 @@ import type {
   FilterRequestDto,
   ProductSearchResponseDto,
   SortRequestDto,
+  ProductsIncludeEnum,
 } from '~~/shared/api-client'
 import { useProductService } from '~~/shared/api-client/services/products.services'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
@@ -18,7 +19,7 @@ interface ProductsSearchPayload {
   aggs?: AggregationRequestDto
   filters?: FilterRequestDto
   query?: string
-  include?: string[]
+  include?: ProductsIncludeEnum[]
 }
 
 export default defineEventHandler(

--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -1,5 +1,14 @@
 import { ProductApi } from '..'
-import type { ProductDto } from '..'
+import type {
+  ProductDto,
+  ProductFieldOptionsResponse,
+  ProductSearchResponseDto,
+} from '..'
+import type {
+  FilterableFieldsForVerticalRequest,
+  ProductsRequest,
+  SortableFieldsForVerticalRequest,
+} from '../apis/ProductApi'
 import type { DomainLanguage } from '../../utils/domain-language'
 import { createBackendApiConfig } from './createBackendApiConfig'
 
@@ -38,5 +47,66 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
     }
   }
 
-  return { getProductByGtin }
+  const getFilterableFieldsForVertical = async (
+    verticalId: string,
+  ): Promise<ProductFieldOptionsResponse> => {
+    if (!verticalId) {
+      throw new TypeError('verticalId is required to resolve filterable fields.')
+    }
+
+    const request: FilterableFieldsForVerticalRequest = {
+      verticalId,
+      domainLanguage,
+    }
+
+    try {
+      return await resolveApi().filterableFieldsForVertical(request)
+    } catch (error) {
+      console.error('Error fetching filterable fields for vertical:', verticalId, error)
+      throw error
+    }
+  }
+
+  const getSortableFieldsForVertical = async (
+    verticalId: string,
+  ): Promise<ProductFieldOptionsResponse> => {
+    if (!verticalId) {
+      throw new TypeError('verticalId is required to resolve sortable fields.')
+    }
+
+    const request: SortableFieldsForVerticalRequest = {
+      verticalId,
+      domainLanguage,
+    }
+
+    try {
+      return await resolveApi().sortableFieldsForVertical(request)
+    } catch (error) {
+      console.error('Error fetching sortable fields for vertical:', verticalId, error)
+      throw error
+    }
+  }
+
+  const searchProducts = async (
+    parameters: Omit<ProductsRequest, 'domainLanguage'>,
+  ): Promise<ProductSearchResponseDto> => {
+    const request: ProductsRequest = {
+      domainLanguage,
+      ...parameters,
+    }
+
+    try {
+      return await resolveApi().products(request)
+    } catch (error) {
+      console.error('Error searching products with parameters:', request, error)
+      throw error
+    }
+  }
+
+  return {
+    getProductByGtin,
+    getFilterableFieldsForVertical,
+    getSortableFieldsForVertical,
+    searchProducts,
+  }
 }


### PR DESCRIPTION
## Summary
- build the category page layout with hero, responsive filters, product toolbar, and documentation rail wired to SSR data and URL hash state
- add fast filters, filter panel, and product view components plus utilities for subset conversion and state serialization with accompanying unit tests and translations
- extend server product routes and shared API service to fetch category filter/sort metadata and execute product searches via the backend proxy

## Testing
- pnpm test -- --runInBand --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68efa08a18cc83339438a9e887c5e3e9