### PR TITLE
Fix product search aggregations and pluralized labels

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -65,6 +65,7 @@ import type { ProductDto } from '~~/shared/api-client'
 defineProps<{ products: ProductDto[] }>()
 
 const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 
 const resolveImage = (product: ProductDto) => {
   return (
@@ -95,7 +96,7 @@ const bestPriceLabel = (product: ProductDto) => {
 
 const offersCountLabel = (product: ProductDto) => {
   const count = product.offers?.offersCount ?? 0
-  return t('category.products.offerCount', { count })
+  return translatePlural('category.products.offerCount', count)
 }
 </script>
 

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -52,6 +52,7 @@ import type { ProductDto } from '~~/shared/api-client'
 defineProps<{ products: ProductDto[] }>()
 
 const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 
 const resolveImage = (product: ProductDto) => {
   return (
@@ -82,7 +83,7 @@ const bestPriceLabel = (product: ProductDto) => {
 
 const offersCountLabel = (product: ProductDto) => {
   const count = product.offers?.offersCount ?? 0
-  return t('category.products.offerCount', { count })
+  return translatePlural('category.products.offerCount', count)
 }
 </script>
 

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -36,7 +36,7 @@
     </template>
 
     <template #[`item.offersCount`]="{ value }">
-      {{ $t('category.products.offerCount', { count: value ?? 0 }) }}
+      {{ translatePlural('category.products.offerCount', value ?? 0) }}
     </template>
 
   </v-data-table>
@@ -61,6 +61,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 
 const baseHeaders = computed(() => [
   { key: 'brand', title: t('category.products.headers.brand'), sortable: false },

--- a/frontend/app/composables/usePluralizedTranslation.ts
+++ b/frontend/app/composables/usePluralizedTranslation.ts
@@ -1,0 +1,23 @@
+import { computed } from 'vue'
+
+export const usePluralizedTranslation = () => {
+  const { t, te, locale } = useI18n()
+
+  const pluralRules = computed(() => new Intl.PluralRules(locale.value))
+
+  const translatePlural = (
+    baseKey: string,
+    count: number,
+    values: Record<string, unknown> = {},
+  ): string => {
+    const selection = pluralRules.value.select(count)
+    const normalized = selection === 'one' && count === 0 ? 'other' : selection
+    const candidateKey = `${baseKey}.${normalized}`
+    const fallbackKey = `${baseKey}.other`
+    const targetKey = te(candidateKey) ? candidateKey : fallbackKey
+
+    return t(targetKey, { count, ...values })
+  }
+
+  return { translatePlural }
+}

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -233,6 +233,7 @@ import { buildFilterRequestFromSubsets } from '~/utils/_subset-to-filters'
 const route = useRoute()
 const router = useRouter()
 const { locale, t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 const requestURL = useRequestURL()
 
 const rawParam = route.params.categorySlug
@@ -497,7 +498,7 @@ const sortRequest = computed<SortRequestDto | undefined>(() => {
 const currentProducts = computed(() => productsData.value?.products?.data ?? [])
 const resultsCount = computed(() => productsData.value?.products?.page?.totalElements ?? 0)
 const resultsCountLabel = computed(() =>
-  t('category.products.resultsCount', { count: resultsCount.value }),
+  translatePlural('category.products.resultsCount', resultsCount.value),
 )
 const pageCount = computed(() => productsData.value?.products?.page?.totalPages ?? 1)
 const currentAggregations = computed<AggregationResponseDto[]>(

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -104,7 +104,10 @@
       "unknownBrand": "Unknown brand",
       "ecoscoreLabel": "Eco score {letter}",
       "priceUnavailable": "Price unavailable",
-      "offerCount": "{count, plural, one {# offer} other {# offers}}",
+      "offerCount": {
+        "one": "{count} offer",
+        "other": "{count} offers"
+      },
       "notRated": "Not rated",
       "fetchError": "Unable to load products. Please try again.",
       "headers": {
@@ -114,7 +117,10 @@
         "bestPrice": "Best price",
         "offers": "Offers"
       },
-      "resultsCount": "{count, plural, one {# product} other {# products}}",
+      "resultsCount": {
+        "one": "{count} product",
+        "other": "{count} products"
+      },
       "searchPlaceholder": "Search products",
       "sortLabel": "Sort by",
       "sortOrderAsc": "Ascending order",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -103,7 +103,10 @@
       "unknownBrand": "Marque inconnue",
       "ecoscoreLabel": "Score éco {letter}",
       "priceUnavailable": "Prix non disponible",
-      "offerCount": "{count, plural, one {# offre} other {# offres}}",
+      "offerCount": {
+        "one": "{count} offre",
+        "other": "{count} offres"
+      },
       "notRated": "Non noté",
       "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
       "headers": {
@@ -113,7 +116,10 @@
         "bestPrice": "Meilleur prix",
         "offers": "Offres"
       },
-      "resultsCount": "{count, plural, one {# produit} other {# produits}}",
+      "resultsCount": {
+        "one": "{count} produit",
+        "other": "{count} produits"
+      },
       "searchPlaceholder": "Rechercher des produits",
       "sortLabel": "Trier par",
       "sortOrderAsc": "Ordre croissant",

--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -1,8 +1,11 @@
 import { ProductApi } from '..'
 import type {
+  AggregationRequestDto,
+  FilterRequestDto,
   ProductDto,
   ProductFieldOptionsResponse,
   ProductSearchResponseDto,
+  SortRequestDto,
 } from '..'
 import type {
   FilterableFieldsForVerticalRequest,
@@ -88,11 +91,32 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
   }
 
   const searchProducts = async (
-    parameters: Omit<ProductsRequest, 'domainLanguage'>,
+    parameters: Omit<ProductsRequest, 'domainLanguage'> & {
+      aggs?: AggregationRequestDto | string
+      sort?: SortRequestDto | string
+      filters?: FilterRequestDto | string
+    },
   ): Promise<ProductSearchResponseDto> => {
+    const { aggs, sort, filters, ...rest } = parameters
+
     const request: ProductsRequest = {
       domainLanguage,
-      ...parameters,
+      ...rest,
+    }
+
+    if (aggs != null) {
+      const serialized = typeof aggs === 'string' ? aggs : JSON.stringify(aggs)
+      ;(request as ProductsRequest & { aggs?: string }).aggs = serialized
+    }
+
+    if (sort != null) {
+      const serialized = typeof sort === 'string' ? sort : JSON.stringify(sort)
+      ;(request as ProductsRequest & { sort?: string }).sort = serialized
+    }
+
+    if (filters != null) {
+      const serialized = typeof filters === 'string' ? filters : JSON.stringify(filters)
+      ;(request as ProductsRequest & { filters?: string }).filters = serialized
     }
 
     try {


### PR DESCRIPTION
## Summary
- serialize aggregation, sort, and filter payloads before calling the backend search API to avoid `[object Object]` query params
- add a reusable `usePluralizedTranslation` composable and update product views to use it for offer and result counts
- replace ICU-style strings with keyed plural forms in the English and French locale files

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efc8734f948333bb202e60c5ab993e