### PR TITLE
feat(frontend): add categories navigation experience

### DIFF
--- a/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
@@ -1,0 +1,92 @@
+<template>
+  <nav
+    v-if="items.length"
+    class="category-navigation-breadcrumbs"
+    :aria-label="ariaLabel"
+  >
+    <ol class="category-navigation-breadcrumbs__list">
+      <li
+        v-for="(item, index) in items"
+        :key="`${item.title}-${index}`"
+        class="category-navigation-breadcrumbs__item"
+      >
+        <span v-if="!item.link" class="category-navigation-breadcrumbs__current">
+          {{ item.title }}
+        </span>
+        <NuxtLink
+          v-else
+          :to="item.link"
+          class="category-navigation-breadcrumbs__link"
+        >
+          {{ item.title }}
+        </NuxtLink>
+        <span
+          v-if="index < items.length - 1"
+          aria-hidden="true"
+          class="category-navigation-breadcrumbs__separator"
+        >
+          /
+        </span>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script setup lang="ts">
+interface BreadcrumbItem {
+  title: string
+  link?: string
+}
+
+defineProps<{
+  items: BreadcrumbItem[]
+  ariaLabel: string
+}>()
+</script>
+
+<style scoped>
+.category-navigation-breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.category-navigation-breadcrumbs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.category-navigation-breadcrumbs__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.category-navigation-breadcrumbs__link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.category-navigation-breadcrumbs__link:hover,
+.category-navigation-breadcrumbs__link:focus-visible {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: underline;
+}
+
+.category-navigation-breadcrumbs__separator {
+  opacity: 0.6;
+}
+
+.category-navigation-breadcrumbs__current {
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+</style>

--- a/frontend/app/components/category/navigation/CategoryNavigationGrid.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationGrid.vue
@@ -1,0 +1,213 @@
+<template>
+  <section class="category-navigation-grid">
+    <v-container class="py-12 px-4" max-width="xl">
+      <div class="category-navigation-grid__header">
+        <div>
+          <h2 class="text-h4 text-md-h3 font-weight-bold mb-2">
+            {{ t('categories.navigation.grid.title') }}
+          </h2>
+          <p class="text-body-2 text-neutral-secondary mb-0">
+            {{ t('categories.navigation.grid.subtitle') }}
+          </p>
+        </div>
+      </div>
+
+      <div v-if="!categories.length" class="category-navigation-grid__empty">
+        <v-icon icon="mdi-folder-search-outline" size="48" class="mb-4" />
+        <p class="text-h6 text-center mb-2">
+          {{ t('categories.navigation.grid.emptyTitle') }}
+        </p>
+        <p class="text-body-2 text-neutral-secondary text-center mb-0">
+          {{ t('categories.navigation.grid.emptySubtitle') }}
+        </p>
+      </div>
+
+      <v-row v-else :gap="24" align="stretch">
+        <v-col
+          v-for="category in categories"
+          :key="category.path ?? category.slug ?? category.googleCategoryId"
+          cols="12"
+          md="6"
+          lg="4"
+        >
+          <article class="category-navigation-grid__card" :aria-label="ariaLabel(category.title)">
+            <v-card
+              class="h-100 d-flex flex-column"
+              elevation="0"
+              variant="tonal"
+            >
+              <v-img
+                v-if="category.vertical?.imageMedium"
+                :src="category.vertical.imageMedium"
+                :alt="category.vertical?.verticalHomeTitle ?? category.title ?? ''"
+                class="category-navigation-grid__image"
+                cover
+              />
+
+              <div class="category-navigation-grid__card-body">
+                <div class="d-flex align-center justify-space-between mb-2">
+                  <v-chip
+                    v-if="category.hasVertical"
+                    color="accent-supporting"
+                    size="small"
+                    variant="flat"
+                    prepend-icon="mdi-star-outline"
+                  >
+                    {{ t('categories.navigation.grid.verticalLabel') }}
+                  </v-chip>
+                  <v-chip
+                    v-if="category.leaf"
+                    color="surface-primary-120"
+                    size="small"
+                    variant="text"
+                  >
+                    {{ t('categories.navigation.grid.leafLabel') }}
+                  </v-chip>
+                </div>
+
+                <h3 class="text-h5 font-weight-semibold mb-2">
+                  {{ category.title }}
+                </h3>
+
+                <p v-if="category.vertical?.verticalHomeDescription" class="text-body-2 mb-4 text-neutral-secondary">
+                  {{ category.vertical.verticalHomeDescription }}
+                </p>
+
+                <ul
+                  v-else-if="childrenPreview(category).length"
+                  class="category-navigation-grid__children"
+                >
+                  <li
+                    v-for="child in childrenPreview(category)"
+                    :key="child.slug ?? child.googleCategoryId"
+                  >
+                    {{ child.title }}
+                  </li>
+                </ul>
+              </div>
+
+              <div class="category-navigation-grid__actions">
+                <NuxtLink
+                  v-if="category.path"
+                  :to="`/categories/${category.path}`"
+                  class="category-navigation-grid__link"
+                  :aria-label="t('categories.navigation.grid.openSubcategory', { category: category.title })"
+                >
+                  <span>{{ t('categories.navigation.grid.openSubcategoryCta') }}</span>
+                  <v-icon icon="mdi-arrow-right" size="small" />
+                </NuxtLink>
+
+                <NuxtLink
+                  v-if="category.vertical?.verticalHomeUrl"
+                  :to="`/${category.vertical.verticalHomeUrl}`"
+                  class="category-navigation-grid__link"
+                  :aria-label="t('categories.navigation.grid.viewVertical', { category: category.title })"
+                >
+                  <span>{{ t('categories.navigation.grid.viewVerticalCta') }}</span>
+                  <v-icon icon="mdi-open-in-new" size="small" />
+                </NuxtLink>
+              </div>
+            </v-card>
+          </article>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { CategoryNavigationDtoChildCategoriesInner } from '~~/shared/api-client'
+import { useI18n } from 'vue-i18n'
+
+const { categories } = defineProps<{
+  categories: CategoryNavigationDtoChildCategoriesInner[]
+}>()
+
+const { t } = useI18n()
+
+const ariaLabel = (title?: string) =>
+  t('categories.navigation.grid.cardAriaLabel', {
+    category: title ?? '',
+  })
+
+const childrenPreview = (category: CategoryNavigationDtoChildCategoriesInner) =>
+  (category.children as CategoryNavigationDtoChildCategoriesInner[] | undefined)?.slice(0, 4) ?? []
+
+defineExpose({
+  ariaLabel,
+  childrenPreview,
+})
+</script>
+
+<style scoped>
+.category-navigation-grid {
+  background: rgb(var(--v-theme-surface-default));
+}
+
+.category-navigation-grid__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2rem;
+  gap: 1.5rem;
+}
+
+.category-navigation-grid__empty {
+  text-align: center;
+  padding: 4rem 1rem;
+  border-radius: 1.5rem;
+  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+}
+
+.category-navigation-grid__card-body {
+  padding: 1.5rem;
+  flex: 1;
+}
+
+.category-navigation-grid__image {
+  height: 180px;
+}
+
+.category-navigation-grid__children {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  font-size: 0.9rem;
+}
+
+.category-navigation-grid__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.category-navigation-grid__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.category-navigation-grid__link:hover,
+.category-navigation-grid__link:focus-visible {
+  color: rgb(var(--v-theme-accent-supporting));
+}
+
+@media (min-width: 1280px) {
+  .category-navigation-grid__actions {
+    justify-content: flex-start;
+  }
+}
+
+article.category-navigation-grid__card {
+  height: 100%;
+}
+</style>

--- a/frontend/app/components/category/navigation/CategoryNavigationHero.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationHero.vue
@@ -1,0 +1,130 @@
+<template>
+  <section
+    class="category-navigation-hero"
+    :aria-labelledby="titleId"
+  >
+    <v-container class="py-12 px-4" max-width="xl">
+      <div class="category-navigation-hero__content">
+        <div class="category-navigation-hero__copy">
+          <p v-if="eyebrow" class="text-overline mb-2 text-hero-pill-on-dark">
+            {{ eyebrow }}
+          </p>
+          <CategoryNavigationBreadcrumbs
+            v-if="breadcrumbs && breadcrumbs.length"
+            class="mb-4"
+            v-bind="{ items: breadcrumbs, ariaLabel: breadcrumbAriaLabel }"
+          />
+          <h1 :id="titleId" class="text-h3 text-sm-h2 font-weight-bold mb-4">
+            {{ title }}
+          </h1>
+          <p v-if="description" class="text-body-1 text-lg-h6 mb-6">
+            {{ description }}
+          </p>
+          <p
+            v-if="resultSummary"
+            class="text-body-2 text-neutral-soft mb-0"
+            aria-live="polite"
+          >
+            {{ resultSummary }}
+          </p>
+        </div>
+
+        <div class="category-navigation-hero__search">
+          <v-text-field
+            :model-value="modelValue"
+            :label="searchLabel"
+            :placeholder="searchPlaceholder"
+            prepend-inner-icon="mdi-magnify"
+            variant="solo"
+            density="comfortable"
+            color="primary"
+            class="category-navigation-hero__search-field"
+            @update:model-value="onUpdateModelValue"
+          />
+        </div>
+      </div>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useId } from 'vue'
+
+import CategoryNavigationBreadcrumbs from './CategoryNavigationBreadcrumbs.vue'
+
+interface BreadcrumbItem {
+  title: string
+  link?: string
+}
+
+const titleId = useId()
+
+defineProps<{
+  eyebrow?: string
+  title: string
+  description?: string
+  breadcrumbs?: BreadcrumbItem[]
+  modelValue: string
+  searchLabel: string
+  searchPlaceholder: string
+  resultSummary?: string
+  breadcrumbAriaLabel: string
+}>()
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: string): void
+}>()
+
+const onUpdateModelValue = (value: string) => {
+  emit('update:modelValue', value)
+}
+</script>
+
+<style scoped>
+.category-navigation-hero {
+  background: linear-gradient(
+      135deg,
+      rgba(var(--v-theme-hero-gradient-start), 0.95),
+      rgba(var(--v-theme-hero-gradient-end), 0.85)
+    ),
+    url('/images/backgrounds/texture-grid.svg');
+  color: rgb(var(--v-theme-hero-overlay-strong));
+}
+
+.category-navigation-hero__content {
+  display: grid;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+@media (min-width: 960px) {
+  .category-navigation-hero__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3rem;
+  }
+}
+
+.category-navigation-hero__copy {
+  max-width: 640px;
+}
+
+.category-navigation-hero__search {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.category-navigation-hero__search-field {
+  width: 100%;
+  max-width: 420px;
+  --v-field-border-opacity: 0;
+  --v-field-background: rgba(255, 255, 255, 0.14);
+  --v-input-control-height: 64px;
+  backdrop-filter: blur(12px);
+  border-radius: 1rem;
+}
+
+.text-hero-pill-on-dark {
+  color: rgb(var(--v-theme-hero-pill-on-dark));
+  letter-spacing: 0.12em;
+}
+</style>

--- a/frontend/app/components/category/navigation/CategoryNavigationVerticalHighlights.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationVerticalHighlights.vue
@@ -1,0 +1,169 @@
+<template>
+  <section v-if="verticals.length" class="category-navigation-verticals">
+    <v-container class="py-12 px-4" max-width="xl">
+      <header class="category-navigation-verticals__header">
+        <div>
+          <p class="text-overline text-uppercase text-neutral-soft mb-2">
+            {{ t('categories.navigation.verticals.eyebrow') }}
+          </p>
+          <h2 class="text-h4 text-md-h3 font-weight-bold mb-2">
+            {{ t('categories.navigation.verticals.title') }}
+          </h2>
+          <p class="text-body-2 text-neutral-secondary mb-0">
+            {{ t('categories.navigation.verticals.subtitle') }}
+          </p>
+        </div>
+      </header>
+
+      <v-row :gap="24" align="stretch">
+        <v-col
+          v-for="verticalCategory in limitedVerticals"
+          :key="verticalCategory.path ?? verticalCategory.slug ?? verticalCategory.googleCategoryId"
+          cols="12"
+          md="6"
+          lg="4"
+        >
+          <article class="category-navigation-verticals__card">
+            <v-sheet
+              class="category-navigation-verticals__sheet"
+              rounded="xl"
+              elevation="8"
+            >
+              <div class="category-navigation-verticals__media">
+                <v-img
+                  v-if="verticalCategory.vertical?.imageLarge"
+                  :src="verticalCategory.vertical.imageLarge"
+                  :alt="verticalCategory.vertical?.verticalHomeTitle ?? verticalCategory.title ?? ''"
+                  cover
+                />
+                <div v-else class="category-navigation-verticals__media-placeholder">
+                  <v-icon icon="mdi-image-outline" size="36" />
+                </div>
+              </div>
+
+              <div class="category-navigation-verticals__content">
+                <h3 class="text-h5 font-weight-semibold mb-2">
+                  {{ verticalCategory.vertical?.verticalHomeTitle ?? verticalCategory.title }}
+                </h3>
+                <p class="text-body-2 text-neutral-secondary mb-4">
+                  {{ verticalCategory.vertical?.verticalHomeDescription ?? '' }}
+                </p>
+
+                <div class="category-navigation-verticals__actions">
+                  <NuxtLink
+                    v-if="verticalCategory.vertical?.verticalHomeUrl"
+                    :to="`/${verticalCategory.vertical.verticalHomeUrl}`"
+                    class="category-navigation-verticals__cta"
+                    :aria-label="t('categories.navigation.verticals.openVertical', { category: verticalCategory.title })"
+                  >
+                    <span>{{ t('categories.navigation.verticals.openVerticalCta') }}</span>
+                    <v-icon icon="mdi-arrow-right" size="small" />
+                  </NuxtLink>
+                  <NuxtLink
+                    v-if="verticalCategory.path"
+                    :to="`/categories/${verticalCategory.path}`"
+                    class="category-navigation-verticals__secondary"
+                    :aria-label="t('categories.navigation.verticals.viewPath', { category: verticalCategory.title })"
+                  >
+                    {{ t('categories.navigation.verticals.viewPathCta') }}
+                  </NuxtLink>
+                </div>
+              </div>
+            </v-sheet>
+          </article>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { CategoryNavigationDtoChildCategoriesInner } from '~~/shared/api-client'
+import { useI18n } from 'vue-i18n'
+
+const { verticals } = defineProps<{
+  verticals: CategoryNavigationDtoChildCategoriesInner[]
+}>()
+
+const { t } = useI18n()
+
+const limitedVerticals = computed(() => verticals.slice(0, 6))
+</script>
+
+<style scoped>
+.category-navigation-verticals {
+  background: linear-gradient(
+    180deg,
+    rgba(var(--v-theme-surface-ice-050), 0.9),
+    rgba(var(--v-theme-surface-default), 1)
+  );
+}
+
+.category-navigation-verticals__header {
+  max-width: 720px;
+  margin-bottom: 3rem;
+}
+
+.category-navigation-verticals__sheet {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2);
+  overflow: hidden;
+}
+
+.category-navigation-verticals__media {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.category-navigation-verticals__media-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+}
+
+.category-navigation-verticals__content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.category-navigation-verticals__actions {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.category-navigation-verticals__cta,
+.category-navigation-verticals__secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.category-navigation-verticals__cta {
+  color: rgb(var(--v-theme-primary));
+}
+
+.category-navigation-verticals__secondary {
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.category-navigation-verticals__cta:hover,
+.category-navigation-verticals__cta:focus-visible,
+.category-navigation-verticals__secondary:hover,
+.category-navigation-verticals__secondary:focus-visible {
+  color: rgb(var(--v-theme-accent-supporting));
+}
+</style>

--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="categories-page" data-testid="categories-detail-page">
+    <CategoryNavigationHero
+      v-model="searchTerm"
+      :eyebrow="t('categories.navigation.hero.childEyebrow')"
+      :title="heroTitle"
+      :description="heroDescription"
+      :breadcrumbs="breadcrumbs"
+      :result-summary="resultSummary"
+      :search-label="t('categories.navigation.hero.searchLabel')"
+      :search-placeholder="t('categories.navigation.hero.searchPlaceholder')"
+      :breadcrumb-aria-label="t('categories.navigation.hero.breadcrumbAriaLabel')"
+    />
+
+    <v-progress-linear
+      v-if="pending"
+      indeterminate
+      color="primary"
+      class="categories-page__loader"
+      :aria-label="t('categories.navigation.loading')"
+      role="status"
+    />
+
+    <v-container v-if="error" class="py-10 px-4" max-width="xl">
+      <v-alert
+        type="error"
+        variant="tonal"
+        border="start"
+        prominent
+        class="mb-6"
+        role="alert"
+      >
+        {{ t('categories.navigation.error.loadFailed') }}
+      </v-alert>
+      <v-btn color="primary" variant="flat" @click="refresh">
+        {{ t('common.actions.retry') }}
+      </v-btn>
+    </v-container>
+
+    <CategoryNavigationGrid v-if="navigationData" :categories="filteredCategories" />
+
+    <CategoryNavigationVerticalHighlights
+      v-if="navigationData"
+      :verticals="highlightedVerticals"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { CategoryNavigationDto } from '~~/shared/api-client'
+
+import CategoryNavigationGrid from '~/components/category/navigation/CategoryNavigationGrid.vue'
+import CategoryNavigationHero from '~/components/category/navigation/CategoryNavigationHero.vue'
+import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
+
+const { t } = useI18n()
+const route = useRoute()
+const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+
+const searchTerm = ref('')
+
+const slugParam = route.params.slug
+
+const slugSegments = Array.isArray(slugParam)
+  ? slugParam
+  : typeof slugParam === 'string'
+    ? [slugParam]
+    : []
+
+const path = slugSegments.join('/')
+
+const { data, pending, error, refresh } = await useAsyncData<CategoryNavigationDto>(
+  () => `category-navigation-${path}`,
+  async () =>
+    $fetch<CategoryNavigationDto>('/api/categories/navigation', {
+      query: path ? { path } : undefined,
+      headers: requestHeaders,
+    }),
+)
+
+if (error.value && import.meta.server) {
+  throw createError({
+    statusCode: (error.value as { statusCode?: number })?.statusCode ?? 500,
+    statusMessage: (error.value as { statusMessage?: string })?.statusMessage ?? 'Failed to load categories',
+  })
+}
+
+const navigationData = computed(() => data.value ?? null)
+
+const heroTitle = computed(() =>
+  navigationData.value?.category?.title ?? t('categories.navigation.hero.title'),
+)
+
+const heroDescription = computed(() => {
+  if (navigationData.value?.category?.vertical?.verticalHomeDescription) {
+    return navigationData.value.category.vertical.verticalHomeDescription
+  }
+
+  return t('categories.navigation.hero.childDescription', {
+    category: navigationData.value?.category?.title ?? t('categories.navigation.hero.title'),
+  })
+})
+
+const breadcrumbs = computed(() => {
+  const items = navigationData.value?.breadcrumbs ?? []
+  const normalized = items.map((breadcrumb, index) => ({
+    title: breadcrumb.title ?? '',
+    link:
+      index < items.length - 1 && breadcrumb.link
+        ? `/categories/${breadcrumb.link}`
+        : undefined,
+  }))
+
+  const trail: { title: string; link?: string }[] = [
+    {
+      title: t('categories.navigation.hero.rootBreadcrumb'),
+      link: '/categories',
+    },
+    ...normalized,
+  ]
+
+  const lastBreadcrumbTitle = items.at(-1)?.title
+  const currentTitle = navigationData.value?.category?.title
+
+  if (!lastBreadcrumbTitle || lastBreadcrumbTitle !== currentTitle) {
+    trail.push({ title: currentTitle ?? '' })
+  }
+
+  return trail.filter((item, idx, array) => {
+    if (idx === 0) {
+      return true
+    }
+
+    const previous = array[idx - 1]
+    return previous?.title !== item.title
+  })
+})
+
+const filteredCategories = computed(() => {
+  const categories = navigationData.value?.childCategories ?? []
+  if (!searchTerm.value.trim()) {
+    return categories
+  }
+
+  const query = searchTerm.value.trim().toLowerCase()
+  return categories.filter((category) =>
+    category.title?.toLowerCase().includes(query) ?? false,
+  )
+})
+
+const highlightedVerticals = computed(() => navigationData.value?.descendantVerticals ?? [])
+
+const resultSummary = computed(() =>
+  t('categories.navigation.hero.resultsSummary', {
+    count: filteredCategories.value.length,
+  }),
+)
+
+const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+
+useSeoMeta({
+  title: () => String(heroTitle.value),
+  description: () => String(heroDescription.value),
+  ogTitle: () => String(heroTitle.value),
+  ogDescription: () => String(heroDescription.value),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+})
+</script>
+
+<style scoped>
+.categories-page__loader {
+  margin: -0.5rem 0 0;
+}
+</style>

--- a/frontend/app/pages/categories/index.vue
+++ b/frontend/app/pages/categories/index.vue
@@ -1,0 +1,157 @@
+<template>
+  <div class="categories-page" data-testid="categories-index-page">
+    <CategoryNavigationHero
+      v-model="searchTerm"
+      :eyebrow="t('categories.navigation.hero.eyebrow')"
+      :title="heroTitle"
+      :description="heroDescription"
+      :breadcrumbs="breadcrumbs"
+      :result-summary="resultSummary"
+      :search-label="t('categories.navigation.hero.searchLabel')"
+      :search-placeholder="t('categories.navigation.hero.searchPlaceholder')"
+      :breadcrumb-aria-label="t('categories.navigation.hero.breadcrumbAriaLabel')"
+    />
+
+    <v-progress-linear
+      v-if="pending"
+      indeterminate
+      color="primary"
+      class="categories-page__loader"
+      :aria-label="t('categories.navigation.loading')"
+      role="status"
+    />
+
+    <v-container v-if="error" class="py-10 px-4" max-width="xl">
+      <v-alert
+        type="error"
+        variant="tonal"
+        border="start"
+        prominent
+        class="mb-6"
+        role="alert"
+      >
+        {{ t('categories.navigation.error.loadFailed') }}
+      </v-alert>
+      <v-btn color="primary" variant="flat" @click="refresh">
+        {{ t('common.actions.retry') }}
+      </v-btn>
+    </v-container>
+
+    <CategoryNavigationGrid v-if="navigationData" :categories="filteredCategories" />
+
+    <CategoryNavigationVerticalHighlights
+      v-if="navigationData"
+      :verticals="highlightedVerticals"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { CategoryNavigationDto } from '~~/shared/api-client'
+
+import CategoryNavigationGrid from '~/components/category/navigation/CategoryNavigationGrid.vue'
+import CategoryNavigationHero from '~/components/category/navigation/CategoryNavigationHero.vue'
+import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
+
+const { t } = useI18n()
+const route = useRoute()
+const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+
+const searchTerm = ref('')
+
+const { data, pending, error, refresh } = await useAsyncData<CategoryNavigationDto>(
+  'category-navigation-root',
+  async () =>
+    $fetch<CategoryNavigationDto>('/api/categories/navigation', {
+      headers: requestHeaders,
+    }),
+)
+
+if (error.value && import.meta.server) {
+  throw createError({
+    statusCode: (error.value as { statusCode?: number })?.statusCode ?? 500,
+    statusMessage: (error.value as { statusMessage?: string })?.statusMessage ?? 'Failed to load categories',
+  })
+}
+
+const navigationData = computed(() => data.value ?? null)
+
+const heroTitle = computed(() =>
+  navigationData.value?.category?.title ?? t('categories.navigation.hero.title'),
+)
+
+const heroDescription = computed(() =>
+  navigationData.value?.category?.vertical?.verticalHomeDescription ??
+    t('categories.navigation.hero.description'),
+)
+
+const breadcrumbs = computed(() => {
+  const items = navigationData.value?.breadcrumbs ?? []
+  const normalized = items.map((breadcrumb, index) => ({
+    title: breadcrumb.title ?? '',
+    link:
+      index < items.length - 1 && breadcrumb.link
+        ? `/categories/${breadcrumb.link}`
+        : undefined,
+  }))
+
+  const trail = [
+    {
+      title: t('categories.navigation.hero.rootBreadcrumb'),
+      link: '/categories',
+    },
+    ...normalized,
+  ]
+
+  return trail.filter((item, idx, array) => {
+    if (idx === 0) {
+      return true
+    }
+
+    const previous = array[idx - 1]
+    return previous?.title !== item.title
+  })
+})
+
+const filteredCategories = computed(() => {
+  const categories = navigationData.value?.childCategories ?? []
+  if (!searchTerm.value.trim()) {
+    return categories
+  }
+
+  const query = searchTerm.value.trim().toLowerCase()
+  return categories.filter((category) =>
+    category.title?.toLowerCase().includes(query) ?? false,
+  )
+})
+
+const highlightedVerticals = computed(() => navigationData.value?.descendantVerticals ?? [])
+
+const resultSummary = computed(() =>
+  t('categories.navigation.hero.resultsSummary', {
+    count: filteredCategories.value.length,
+  }),
+)
+
+const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+
+useSeoMeta({
+  title: () => String(heroTitle.value),
+  description: () => String(heroDescription.value),
+  ogTitle: () => String(heroTitle.value),
+  ogDescription: () => String(heroDescription.value),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+})
+</script>
+
+<style scoped>
+.categories-page__loader {
+  margin: -0.5rem 0 0;
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -130,6 +130,48 @@
       "postsTitle": "Related articles"
     }
   },
+  "categories": {
+    "navigation": {
+      "loading": "Loading category navigation",
+      "error": {
+        "loadFailed": "We couldn’t load the category navigation. Please try again."
+      },
+      "hero": {
+        "eyebrow": "Browse by topic",
+        "childEyebrow": "Deep dive",
+        "title": "All product categories",
+        "description": "Discover every product family we analyse and jump directly to the most relevant section.",
+        "childDescription": "Explore the subcategories and curated selections inside {category}.",
+        "rootBreadcrumb": "All categories",
+        "searchLabel": "Search categories",
+        "searchPlaceholder": "Search for a category",
+        "breadcrumbAriaLabel": "Category navigation breadcrumb trail",
+        "resultsSummary": "{count, plural, one {# category visible} other {# categories visible}}"
+      },
+      "grid": {
+        "title": "Continue exploring",
+        "subtitle": "Select a family to reveal its subcategories or discover our curated guides.",
+        "emptyTitle": "No matching categories",
+        "emptySubtitle": "Try adjusting your search to find relevant categories.",
+        "verticalLabel": "Curated guide",
+        "leafLabel": "Leaf node",
+        "openSubcategory": "Open {category} subcategories",
+        "openSubcategoryCta": "View subcategories",
+        "viewVertical": "Open the {category} guide",
+        "viewVerticalCta": "View guide",
+        "cardAriaLabel": "Category card for {category}"
+      },
+      "verticals": {
+        "eyebrow": "Highlighted guides",
+        "title": "Featured selections",
+        "subtitle": "Hand-picked guides to jump straight into popular product families.",
+        "openVertical": "Open the {category} guide",
+        "openVerticalCta": "Discover the guide",
+        "viewPath": "Open the {category} taxonomy path",
+        "viewPathCta": "Browse taxonomy"
+      }
+    }
+  },
   "blog": {
     "seo": {
       "baseTitle": "Nudger Blog – Impact Score insights",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -129,6 +129,48 @@
       "postsTitle": "Articles associés"
     }
   },
+  "categories": {
+    "navigation": {
+      "loading": "Chargement de la navigation des catégories",
+      "error": {
+        "loadFailed": "Impossible de charger la navigation des catégories. Veuillez réessayer."
+      },
+      "hero": {
+        "eyebrow": "Parcourir par thème",
+        "childEyebrow": "Approfondir",
+        "title": "Toutes les catégories de produits",
+        "description": "Découvrez toutes les familles de produits analysées et accédez directement à la plus pertinente.",
+        "childDescription": "Explorez les sous-catégories et les sélections associées à {category}.",
+        "rootBreadcrumb": "Toutes les catégories",
+        "searchLabel": "Rechercher une catégorie",
+        "searchPlaceholder": "Tapez le nom d'une catégorie",
+        "breadcrumbAriaLabel": "Fil d'Ariane de la navigation par catégories",
+        "resultsSummary": "{count, plural, one {# catégorie affichée} other {# catégories affichées}}"
+      },
+      "grid": {
+        "title": "Poursuivre l'exploration",
+        "subtitle": "Choisissez une famille pour afficher ses sous-catégories ou découvrir nos guides.",
+        "emptyTitle": "Aucune catégorie trouvée",
+        "emptySubtitle": "Modifiez votre recherche pour afficher des catégories pertinentes.",
+        "verticalLabel": "Guide sélectionné",
+        "leafLabel": "Feuille",
+        "openSubcategory": "Ouvrir les sous-catégories de {category}",
+        "openSubcategoryCta": "Voir les sous-catégories",
+        "viewVertical": "Ouvrir le guide {category}",
+        "viewVerticalCta": "Voir le guide",
+        "cardAriaLabel": "Carte de catégorie {category}"
+      },
+      "verticals": {
+        "eyebrow": "Guides mis en avant",
+        "title": "Sélections à découvrir",
+        "subtitle": "Des guides choisis pour rejoindre rapidement les familles les plus recherchées.",
+        "openVertical": "Ouvrir le guide {category}",
+        "openVerticalCta": "Découvrir le guide",
+        "viewPath": "Ouvrir le chemin taxonomique {category}",
+        "viewPathCta": "Parcourir la taxonomie"
+      }
+    }
+  },
   "blog": {
     "seo": {
       "baseTitle": "Blog Nudger",

--- a/frontend/server/api/categories/navigation.get.ts
+++ b/frontend/server/api/categories/navigation.get.ts
@@ -1,0 +1,49 @@
+import type { CategoryNavigationDto } from '~~/shared/api-client'
+import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
+
+export default defineEventHandler(async (event): Promise<CategoryNavigationDto> => {
+  setDomainLanguageCacheHeaders(event, 'public, max-age=1800, s-maxage=1800')
+
+  const query = getQuery(event)
+
+  const googleCategoryId = (() => {
+    const rawValue = query.googleCategoryId
+    if (typeof rawValue === 'string' && rawValue.length > 0) {
+      const parsed = Number.parseInt(rawValue, 10)
+      if (Number.isFinite(parsed)) {
+        return parsed
+      }
+
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'googleCategoryId must be a valid integer when provided',
+      })
+    }
+
+    return undefined
+  })()
+
+  const path = typeof query.path === 'string' && query.path.length > 0 ? query.path : undefined
+
+  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const categoriesService = useCategoriesService(domainLanguage)
+
+  try {
+    return await categoriesService.getNavigation({ googleCategoryId, path })
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    console.error('Error fetching category navigation:', backendError.logMessage, backendError)
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/shared/api-client/services/categories.services.ts
+++ b/frontend/shared/api-client/services/categories.services.ts
@@ -1,5 +1,9 @@
 import { CategoriesApi } from '..'
-import type { VerticalConfigDto, VerticalConfigFullDto } from '..'
+import type {
+  CategoryNavigationDto,
+  VerticalConfigDto,
+  VerticalConfigFullDto,
+} from '..'
 import type { DomainLanguage } from '../../utils/domain-language'
 import { createBackendApiConfig } from './createBackendApiConfig'
 
@@ -53,5 +57,29 @@ export const useCategoriesService = (domainLanguage: DomainLanguage) => {
     }
   }
 
-  return { getCategories, getCategoryById }
+  /**
+   * Fetch the navigation tree for the provided Google taxonomy node.
+   * @param params - Optional parameters to identify the taxonomy node.
+   * @returns Promise<CategoryNavigationDto>
+   */
+  const getNavigation = async ({
+    googleCategoryId,
+    path,
+  }: {
+    googleCategoryId?: number
+    path?: string
+  } = {}): Promise<CategoryNavigationDto> => {
+    try {
+      return await resolveApi().navigation({
+        domainLanguage,
+        googleCategoryId,
+        path,
+      })
+    } catch (error) {
+      console.error('Error fetching category navigation:', error)
+      throw error
+    }
+  }
+
+  return { getCategories, getCategoryById, getNavigation }
 }


### PR DESCRIPTION
## Summary
- implement SSR-backed /categories index and nested pages that load navigation data, filter results, and publish SEO metadata
- create dedicated hero, grid, and vertical highlight components with accessible UI for browsing category trees
- expose a server route plus service helper for the navigation API and add the corresponding i18n strings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efcb16295483338aa8cf2d391acf37