### PR TITLE
Fix categories page results summary pluralization

### DIFF
--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -56,6 +56,7 @@ import CategoryNavigationHero from '~/components/category/navigation/CategoryNav
 import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
 
 const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 const route = useRoute()
 const requestURL = useRequestURL()
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
@@ -154,9 +155,10 @@ const filteredCategories = computed(() => {
 const highlightedVerticals = computed(() => navigationData.value?.descendantVerticals ?? [])
 
 const resultSummary = computed(() =>
-  t('categories.navigation.hero.resultsSummary', {
-    count: filteredCategories.value.length,
-  }),
+  translatePlural(
+    'categories.navigation.hero.resultsSummary',
+    filteredCategories.value.length,
+  ),
 )
 
 const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())

--- a/frontend/app/pages/categories/index.vue
+++ b/frontend/app/pages/categories/index.vue
@@ -56,6 +56,7 @@ import CategoryNavigationHero from '~/components/category/navigation/CategoryNav
 import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
 
 const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
 const route = useRoute()
 const requestURL = useRequestURL()
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
@@ -131,9 +132,10 @@ const filteredCategories = computed(() => {
 const highlightedVerticals = computed(() => navigationData.value?.descendantVerticals ?? [])
 
 const resultSummary = computed(() =>
-  t('categories.navigation.hero.resultsSummary', {
-    count: filteredCategories.value.length,
-  }),
+  translatePlural(
+    'categories.navigation.hero.resultsSummary',
+    filteredCategories.value.length,
+  ),
 )
 
 const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -152,7 +152,10 @@
         "searchLabel": "Search categories",
         "searchPlaceholder": "Search for a category",
         "breadcrumbAriaLabel": "Category navigation breadcrumb trail",
-        "resultsSummary": "{count, plural, one {# category visible} other {# categories visible}}"
+        "resultsSummary": {
+          "one": "{count} category visible",
+          "other": "{count} categories visible"
+        }
       },
       "grid": {
         "title": "Continue exploring",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -151,7 +151,10 @@
         "searchLabel": "Rechercher une catégorie",
         "searchPlaceholder": "Tapez le nom d'une catégorie",
         "breadcrumbAriaLabel": "Fil d'Ariane de la navigation par catégories",
-        "resultsSummary": "{count, plural, one {# catégorie affichée} other {# catégories affichées}}"
+        "resultsSummary": {
+          "one": "{count} catégorie affichée",
+          "other": "{count} catégories affichées"
+        }
       },
       "grid": {
         "title": "Poursuivre l'exploration",


### PR DESCRIPTION
## Summary
- replace ICU plural message in the categories navigation summary with keyed plural translations in English and French
- use the existing usePluralizedTranslation composable on the categories pages to format the result summary counts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efd9c108e083339887753fd93a9b17