### PR TITLE
Ensure product search POST body reaches backend

### DIFF
--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -92,22 +92,24 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
   }
 
   const searchProducts = async (
-    parameters: Omit<ProductsRequest, 'domainLanguage' | 'body'> & {
+    parameters: Omit<ProductsRequest, 'domainLanguage'> & {
       aggs?: AggregationRequestDto
       sort?: SortRequestDto
       filters?: FilterRequestDto
+      body?: ProductSearchRequestDto
     },
   ): Promise<ProductSearchResponseDto> => {
-    const { aggs, sort, filters, ...rest } = parameters
+    const { aggs, sort, filters, body: explicitBody, ...rest } = parameters
 
     const body: ProductSearchRequestDto | undefined =
-      sort || aggs || filters
+      explicitBody ??
+      (sort || aggs || filters
         ? {
             ...(sort ? { sort } : {}),
             ...(aggs ? { aggs } : {}),
             ...(filters ? { filters } : {}),
           }
-        : undefined
+        : undefined)
 
     const request: ProductsRequest = {
       domainLanguage,


### PR DESCRIPTION
## Summary
- build the Nuxt products search server route payload before delegating to the backend client
- allow the product service helper to accept an explicit ProductSearchRequestDto body while preserving existing fallbacks

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68efdb2374d48333b66819c49da11520