### PR TITLE
Fix product search body forwarding to backend

### DIFF
--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -99,10 +99,18 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
       body?: ProductSearchRequestDto
     },
   ): Promise<ProductSearchResponseDto> => {
-    const { aggs, sort, filters, body: explicitBody, ...rest } = parameters
+    const {
+      aggs,
+      sort,
+      filters,
+      body: explicitBody,
+      productSearchRequestDto: providedBody,
+      ...rest
+    } = parameters
 
     const body: ProductSearchRequestDto | undefined =
       explicitBody ??
+      providedBody ??
       (sort || aggs || filters
         ? {
             ...(sort ? { sort } : {}),
@@ -114,7 +122,7 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
     const request: ProductsRequest = {
       domainLanguage,
       ...rest,
-      ...(body ? { body } : {}),
+      ...(body ? { productSearchRequestDto: body } : {}),
     }
 
     try {


### PR DESCRIPTION
## Summary
- ensure the products service forwards the POST body using the generated client property
- support explicit and computed product search payloads so filters and sorts reach the backend

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f0955df9ec8333b4b677c30067abe5