### PR TITLE
Refine category navigation layout and links

### DIFF
--- a/frontend/app/components/category/navigation/CategoryNavigationHero.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationHero.vue
@@ -3,7 +3,7 @@
     class="category-navigation-hero"
     :aria-labelledby="titleId"
   >
-    <v-container class="py-12 px-4" max-width="xl">
+    <v-container class="category-navigation-hero__container px-4" max-width="xl">
       <div class="category-navigation-hero__content">
         <div class="category-navigation-hero__copy">
           <p v-if="eyebrow" class="text-overline mb-2 text-hero-pill-on-dark">
@@ -14,10 +14,10 @@
             class="mb-4"
             v-bind="{ items: breadcrumbs, ariaLabel: breadcrumbAriaLabel }"
           />
-          <h1 :id="titleId" class="text-h3 text-sm-h2 font-weight-bold mb-4">
+          <h1 :id="titleId" class="text-h3 text-sm-h2 font-weight-bold mb-3">
             {{ title }}
           </h1>
-          <p v-if="description" class="text-body-1 text-lg-h6 mb-6">
+          <p v-if="description" class="text-body-1 text-lg-h6 mb-4">
             {{ description }}
           </p>
           <p
@@ -36,7 +36,7 @@
             :placeholder="searchPlaceholder"
             prepend-inner-icon="mdi-magnify"
             variant="solo"
-            density="comfortable"
+            density="compact"
             color="primary"
             class="category-navigation-hero__search-field"
             @update:model-value="onUpdateModelValue"
@@ -91,26 +91,41 @@ const onUpdateModelValue = (value: string) => {
   color: rgb(var(--v-theme-hero-overlay-strong));
 }
 
+
+.category-navigation-hero__container {
+  padding-block: 2.75rem;
+}
+
 .category-navigation-hero__content {
   display: grid;
-  gap: 2.5rem;
+  gap: 1.75rem;
   align-items: center;
 }
 
 @media (min-width: 960px) {
+  .category-navigation-hero__container {
+    padding-block: 3.5rem;
+  }
+
   .category-navigation-hero__content {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 3rem;
+    gap: 2.5rem;
   }
 }
 
 .category-navigation-hero__copy {
-  max-width: 640px;
+  max-width: min(60ch, 100%);
+}
+
+@media (min-width: 960px) {
+  .category-navigation-hero__copy {
+    max-width: clamp(52ch, 60vw, 72ch);
+  }
 }
 
 .category-navigation-hero__search {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .category-navigation-hero__search-field {
@@ -118,9 +133,15 @@ const onUpdateModelValue = (value: string) => {
   max-width: 420px;
   --v-field-border-opacity: 0;
   --v-field-background: rgba(255, 255, 255, 0.14);
-  --v-input-control-height: 64px;
+  --v-input-control-height: 52px;
   backdrop-filter: blur(12px);
   border-radius: 1rem;
+}
+
+@media (min-width: 960px) {
+  .category-navigation-hero__search {
+    justify-content: flex-end;
+  }
 }
 
 .text-hero-pill-on-dark {

--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -17,6 +17,7 @@ const { t, locale } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
 const blogPath = computed(() => resolveLocalizedRoutePath('blog', currentLocale.value))
 const feedbackPath = computed(() => resolveLocalizedRoutePath('feedback', currentLocale.value))
+const categoriesPath = computed(() => resolveLocalizedRoutePath('categories', currentLocale.value))
 
 const currentYear = computed(() => new Date().getFullYear())
 const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
@@ -25,7 +26,11 @@ const highlightLinks = computed<FooterLink[]>(() => [
   {
     label: t('siteIdentity.footer.highlightLinks.ecoscore'),
     to: resolveLocalizedRoutePath('/impact-score', currentLocale.value),
-  }
+  },
+  {
+    label: t('siteIdentity.footer.highlightLinks.allProducts'),
+    to: categoriesPath.value,
+  },
 ])
 
 const resourceLinks = computed<FooterLink[]>(() => [

--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -76,7 +76,7 @@ interface MenuItem extends MenuItemDefinition {
 
 const baseMenuItems: MenuItemDefinition[] = [
   { labelKey: 'siteIdentity.menu.items.impactScore', routeName: 'impact-score' },
-  { labelKey: 'siteIdentity.menu.items.products', routeName: 'produits' },
+  { labelKey: 'siteIdentity.menu.items.products', routeName: 'categories' },
   { labelKey: 'siteIdentity.menu.items.blog', routeName: 'blog' },
   { labelKey: 'siteIdentity.menu.items.contact', routeName: 'contact' },
 ]

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -120,7 +120,7 @@ const baseMenuItems: MenuItemDefinition[] = [
   },
   {
     titleKey: 'siteIdentity.menu.items.products',
-    routeName: 'produits',
+    routeName: 'categories',
     icon: 'mdi-package-variant',
   },
   {

--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -2,7 +2,6 @@
   <div class="categories-page" data-testid="categories-detail-page">
     <CategoryNavigationHero
       v-model="searchTerm"
-      :eyebrow="t('categories.navigation.hero.childEyebrow')"
       :title="heroTitle"
       :description="heroDescription"
       :breadcrumbs="breadcrumbs"
@@ -91,9 +90,15 @@ if (error.value && import.meta.server) {
 
 const navigationData = computed(() => data.value ?? null)
 
-const heroTitle = computed(() =>
-  navigationData.value?.category?.title ?? t('categories.navigation.hero.title'),
-)
+const heroTitle = computed(() => {
+  const category = navigationData.value?.category
+
+  if (category?.googleCategoryId === 0) {
+    return t('categories.navigation.hero.rootProductsTitle')
+  }
+
+  return category?.title ?? t('categories.navigation.hero.title')
+})
 
 const heroDescription = computed(() => {
   if (navigationData.value?.category?.vertical?.verticalHomeDescription) {

--- a/frontend/app/pages/categories/index.vue
+++ b/frontend/app/pages/categories/index.vue
@@ -80,9 +80,15 @@ if (error.value && import.meta.server) {
 
 const navigationData = computed(() => data.value ?? null)
 
-const heroTitle = computed(() =>
-  navigationData.value?.category?.title ?? t('categories.navigation.hero.title'),
-)
+const heroTitle = computed(() => {
+  const category = navigationData.value?.category
+
+  if (category?.googleCategoryId === 0) {
+    return t('categories.navigation.hero.rootProductsTitle')
+  }
+
+  return category?.title ?? t('categories.navigation.hero.title')
+})
 
 const heroDescription = computed(() =>
   navigationData.value?.category?.vertical?.verticalHomeDescription ??

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -32,6 +32,7 @@
       "blogLink": "Our blog",
       "highlightLinks": {
         "ecoscore": "Environmental assessment",
+        "allProducts": "All products",
         "compensation": "Ecological contribution"
       },
       "comparator": {
@@ -144,8 +145,8 @@
       },
       "hero": {
         "eyebrow": "Browse by topic",
-        "childEyebrow": "Deep dive",
         "title": "All product categories",
+        "rootProductsTitle": "Available products",
         "description": "Discover every product family we analyse and jump directly to the most relevant section.",
         "childDescription": "Explore the subcategories and curated selections inside {category}.",
         "rootBreadcrumb": "All categories",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -31,7 +31,8 @@
       "mission": "nudger.fr est une approche ouverte pour évaluer l'impact écologique et social des biens que nous achetons.",
       "blogLink": "Notre blog",
       "highlightLinks": {
-        "ecoscore": "Évaluation environnementale"
+        "ecoscore": "Évaluation environnementale",
+        "allProducts": "Tous nos produits"
       },
       "comparator": {
         "title": "Ressources",
@@ -143,8 +144,8 @@
       },
       "hero": {
         "eyebrow": "Parcourir par thème",
-        "childEyebrow": "Approfondir",
         "title": "Toutes les catégories de produits",
+        "rootProductsTitle": "Les produits disponibles",
         "description": "Découvrez toutes les familles de produits analysées et accédez directement à la plus pertinente.",
         "childDescription": "Explorez les sous-catégories et les sélections associées à {category}.",
         "rootBreadcrumb": "Toutes les catégories",


### PR DESCRIPTION
## Summary
- streamline the categories hero layout with tighter spacing and responsive copy widths
- localize the root category title and remove the unused child eyebrow label
- retarget product navigation entries and add a translated footer link to all products

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f0aac25cb88333890a0bf5df8a6e47