### PR TITLE
feat: surface top products in category navigation

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
@@ -2,6 +2,8 @@ package org.open4goods.nudgerfrontapi.dto.category;
 
 import java.util.List;
 
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -19,7 +21,13 @@ public record CategoryNavigationDto(
         List<GoogleCategoryDto> childCategories,
 
         @Schema(description = "Descendant nodes exposing a vertical configuration but not already present in childCategories.")
-        List<GoogleCategoryDto> descendantVerticals
+        List<GoogleCategoryDto> descendantVerticals,
+
+        @Schema(description = "Top five new products for the category ordered by descending impact score.")
+        List<ProductDto> topNewProducts,
+
+        @Schema(description = "Top five occasion products for the category ordered by descending impact score.")
+        List<ProductDto> topOccasionProducts
 ) {
 }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
@@ -47,6 +47,8 @@ public record FilterRequestDto(
         offersCount("offersCount", FilterValueType.numeric),
         @Schema(description = "Filter on the condition of the offers (e.g. NEW, USED)", example = "condition")
         condition("price.conditions", FilterValueType.keyword),
+        @Schema(description = "Filter on the Google taxonomy identifier associated with the product", example = "1234")
+        googleTaxonomyId("googleTaxonomyId", FilterValueType.numeric),
         @Schema(description = "Filter on the product brand reported by datasources", example = "brand")
         brand("attributes.referentielAttributes.BRAND", FilterValueType.keyword),
         @Schema(description = "Filter on the country resolved from the GTIN prefix", example = "country")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -36,6 +36,7 @@ import org.open4goods.nudgerfrontapi.dto.category.SiteNamingDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalSubsetDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.verticals.GoogleTaxonomyService;
 import org.springframework.stereotype.Service;
@@ -162,11 +163,15 @@ public class CategoryMappingService {
      * @param domainLanguage requested language
      * @param havingVertical replicate the legacy flag filtering children with
      *                       verticals in their hierarchy
+     * @param topNewProducts     top ranked new products associated with the category
+     * @param topOccasionProducts top ranked occasion products associated with the category
      * @return navigation DTO or {@code null} when the category is {@code null}
      */
     public CategoryNavigationDto toCategoryNavigationDto(ProductCategory category,
                                                          DomainLanguage domainLanguage,
-                                                         boolean havingVertical) {
+                                                         boolean havingVertical,
+                                                         List<ProductDto> topNewProducts,
+                                                         List<ProductDto> topOccasionProducts) {
         if (category == null) {
             return null;
         }
@@ -200,7 +205,9 @@ public class CategoryMappingService {
                 current,
                 mapBreadcrumbs(category, languageKey),
                 childCategories,
-                descendantVerticals);
+                descendantVerticals,
+                defaultList(topNewProducts),
+                defaultList(topOccasionProducts));
     }
 
     /**

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -161,7 +161,7 @@ public class ProductMappingService {
      * @param domainLanguage domain language requested by the caller
      * @return DTO representing the product or {@code null} when no vertical configuration matches
      */
-    private ProductDto mapProduct(Product product, Locale locale, Set<String> includes, DomainLanguage domainLanguage) {
+    public ProductDto mapProduct(Product product, Locale locale, Set<String> includes, DomainLanguage domainLanguage) {
 
         VerticalConfig vConfig = verticalsConfigService.getConfigById(product.getVertical());
         if (vConfig == null) {

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceNavigationTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceNavigationTest.java
@@ -51,7 +51,9 @@ class CategoryMappingServiceNavigationTest {
         tv.vertical(createVerticalConfig("tv", 2));
         headphones.vertical(createVerticalConfig("headphones", 4));
 
-        CategoryNavigationDto navigation = service.toCategoryNavigationDto(electronics, DomainLanguage.fr, true);
+        CategoryNavigationDto navigation = service.toCategoryNavigationDto(electronics, DomainLanguage.fr, true,
+                List.of(),
+                List.of());
 
         assertThat(navigation).isNotNull();
         assertThat(navigation.category().googleCategoryId()).isEqualTo(1);
@@ -75,6 +77,9 @@ class CategoryMappingServiceNavigationTest {
                 .first()
                 .extracting(GoogleCategoryDto::googleCategoryId)
                 .isEqualTo(4);
+
+        assertThat(navigation.topNewProducts()).isEmpty();
+        assertThat(navigation.topOccasionProducts()).isEmpty();
     }
 
     private VerticalConfig createVerticalConfig(String id, int googleTaxonomyId) {


### PR DESCRIPTION
## Summary
- query Elasticsearch via the search service to attach top new and occasion products to category navigation responses
- extend the CategoryNavigationDto and mapping logic to include the curated product lists while keeping existing structure intact
- expose a google taxonomy filter field and reuse product mapping so the controller can build ProductDto entries

## Testing
- mvn --offline test

------
https://chatgpt.com/codex/tasks/task_e_68f0b25dc76c83339cee9a8a0d5b02f0