### PR TITLE
feat(frontend): refresh category page hero and filters layout

### DIFF
--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -18,7 +18,13 @@
     </div>
 
     <v-expansion-panels multiple class="category-filters__panels">
-      <v-expansion-panel value="global" :title="t('category.filters.globalTitle')" expand-icon="mdi-chevron-down">
+      <v-expansion-panel value="global" expand-icon="mdi-chevron-down">
+        <template #title>
+          <div class="category-filters__title">
+            <v-icon icon="mdi-tune-variant" size="20" class="category-filters__title-icon" />
+            <span>{{ t('category.filters.globalTitle') }}</span>
+          </div>
+        </template>
         <template #text>
           <div class="category-filters__section">
             <CategoryFilterList
@@ -32,15 +38,17 @@
         </template>
       </v-expansion-panel>
 
-      <v-expansion-panel
-        value="impact"
-        :title="t('category.filters.impactTitle')"
-        expand-icon="mdi-chevron-down"
-      >
+      <v-expansion-panel value="impact" expand-icon="mdi-chevron-down">
+        <template #title>
+          <div class="category-filters__title">
+            <v-icon icon="mdi-leaf" size="20" class="category-filters__title-icon" />
+            <span>{{ t('category.filters.impactTitle') }}</span>
+          </div>
+        </template>
         <template #text>
           <div class="category-filters__section">
-              <CategoryFilterList
-                :fields="impactPrimary"
+            <CategoryFilterList
+              :fields="impactPrimary"
               :aggregations="aggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"
@@ -71,11 +79,13 @@
         </template>
       </v-expansion-panel>
 
-      <v-expansion-panel
-        value="technical"
-        :title="t('category.filters.technicalTitle')"
-        expand-icon="mdi-chevron-down"
-      >
+      <v-expansion-panel value="technical" expand-icon="mdi-chevron-down">
+        <template #title>
+          <div class="category-filters__title">
+            <v-icon icon="mdi-cog" size="20" class="category-filters__title-icon" />
+            <span>{{ t('category.filters.technicalTitle') }}</span>
+          </div>
+        </template>
         <template #text>
           <div class="category-filters__section">
             <CategoryFilterList
@@ -292,6 +302,16 @@ defineExpose({ activeFilterChips })
     display: flex
     flex-direction: column
     gap: 0.75rem
+
+  &__title
+    display: inline-flex
+    align-items: center
+    gap: 0.5rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__title-icon
+    color: rgba(var(--v-theme-primary), 0.85)
 
 @media (max-width: 959px)
   .category-filters__section

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="category-page__filters-content">
+    <CategoryFiltersPanel
+      :filter-options="props.filterOptions"
+      :aggregations="props.aggregations"
+      :filters="props.filters"
+      :impact-expanded="props.impactExpanded"
+      :technical-expanded="props.technicalExpanded"
+      @update:filters="(value) => emit('update:filters', value)"
+      @update:impact-expanded="(value) => emit('update:impactExpanded', value)"
+      @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
+    />
+
+    <div v-if="showMobileActions" class="category-page__filters-actions">
+      <v-btn block color="primary" class="mb-2" @click="emit('apply-mobile')">
+        {{ t('category.filters.mobileApply') }}
+      </v-btn>
+      <v-btn block variant="text" @click="emit('clear-mobile')">
+        {{ t('category.filters.mobileClear') }}
+      </v-btn>
+    </div>
+
+    <template v-if="hasDocumentation">
+      <v-divider class="my-4" />
+      <CategoryDocumentationRail
+        class="category-page__documentation-block"
+        :wiki-pages="wikiPages"
+        :related-posts="relatedPosts"
+        :vertical-home-url="props.verticalHomeUrl"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  AggregationResponseDto,
+  BlogPostDto,
+  FilterRequestDto,
+  ProductFieldOptionsResponse,
+  WikiPageConfig,
+} from '~~/shared/api-client'
+
+import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
+import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
+
+const props = defineProps<{
+  filterOptions: ProductFieldOptionsResponse | null
+  aggregations: AggregationResponseDto[]
+  filters: FilterRequestDto | null
+  impactExpanded: boolean
+  technicalExpanded: boolean
+  showMobileActions: boolean
+  hasDocumentation: boolean
+  wikiPages: WikiPageConfig[]
+  relatedPosts: BlogPostDto[]
+  verticalHomeUrl?: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:filters': [FilterRequestDto]
+  'update:impactExpanded': [boolean]
+  'update:technicalExpanded': [boolean]
+  'apply-mobile': []
+  'clear-mobile': []
+}>()
+
+const { t } = useI18n()
+
+const wikiPages = computed(() => props.wikiPages ?? [])
+const relatedPosts = computed(() => props.relatedPosts ?? [])
+const hasDocumentation = computed(() => props.hasDocumentation)
+const showMobileActions = computed(() => props.showMobileActions)
+</script>

--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -154,12 +154,11 @@ defineExpose({ headingId, t })
     align-self: center
 
   .category-hero__copy
-    align-items: flex-end
-    text-align: right
-    max-width: clamp(36ch, 56vw, 72ch)
+    align-items: flex-start
+    text-align: left
 
   .category-hero__description
-    text-align: right
+    text-align: left
 
 @media (max-width: 959px)
   .category-hero__media

--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -1,6 +1,14 @@
 <template>
   <section class="category-hero" :aria-labelledby="headingId" data-testid="category-hero">
     <v-sheet class="category-hero__wrapper" elevation="0" rounded="xl">
+      <div v-if="image" class="category-hero__media" aria-hidden="true">
+        <v-img :src="image" alt="" class="category-hero__image" cover>
+          <template #placeholder>
+            <v-skeleton-loader type="image" class="h-100" />
+          </template>
+        </v-img>
+      </div>
+
       <div class="category-hero__content">
         <v-breadcrumbs
           v-if="breadcrumbs.length"
@@ -27,14 +35,6 @@
             {{ description }}
           </p>
         </div>
-      </div>
-
-      <div v-if="image" class="category-hero__media" aria-hidden="true">
-        <v-img :src="image" alt="" class="category-hero__image" cover>
-          <template #placeholder>
-            <v-skeleton-loader type="image" class="h-100" />
-          </template>
-        </v-img>
       </div>
     </v-sheet>
   </section>
@@ -70,8 +70,8 @@ defineExpose({ headingId, t })
 
   &__wrapper
     position: relative
-    display: flex
-    flex-direction: column
+    display: grid
+    grid-template-columns: minmax(0, 1fr)
     gap: 1.5rem
     overflow: hidden
     min-height: 220px
@@ -83,7 +83,8 @@ defineExpose({ headingId, t })
     display: flex
     flex-direction: column
     gap: 1rem
-    max-width: 62ch
+    max-width: none
+    width: 100%
 
   &__breadcrumbs
     --v-breadcrumbs-divider-color: rgba(var(--v-theme-hero-overlay-strong), 0.6)
@@ -114,6 +115,12 @@ defineExpose({ headingId, t })
     font-size: clamp(2rem, 2vw + 1.25rem, 2.75rem)
     line-height: 1.1
 
+  &__copy
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    align-items: flex-start
+
   &__description
     margin: 0
     font-size: 1.05rem
@@ -133,19 +140,26 @@ defineExpose({ headingId, t })
 
 @media (min-width: 960px)
   .category-hero__wrapper
-    flex-direction: row
+    grid-template-columns: clamp(240px, 30vw, 360px) minmax(0, 1fr)
     align-items: stretch
-    gap: clamp(1.5rem, 4vw, 3rem)
-
-  .category-hero__content
-    flex: 0 1 66%
+    gap: clamp(1.5rem, 4vw, 3.5rem)
 
   .category-hero__media
     display: block
-    flex: 0 0 clamp(240px, 30vw, 360px)
+    grid-column: 1
+    align-self: stretch
 
-  .category-hero__image
-    min-height: 100%
+  .category-hero__content
+    grid-column: 2
+    align-self: center
+
+  .category-hero__copy
+    align-items: flex-end
+    text-align: right
+    max-width: clamp(36ch, 56vw, 72ch)
+
+  .category-hero__description
+    text-align: right
 
 @media (max-width: 959px)
   .category-hero__media

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -85,45 +85,54 @@
 
       <div class="category-page__layout">
         <v-navigation-drawer
+          v-if="!isDesktop"
           v-model="filtersDrawer"
-          :permanent="isDesktop"
-          :width="isDesktop ? 320 : 360"
+          :width="360"
           location="start"
-          class="category-page__filters"
-          :temporary="!isDesktop"
+          class="category-page__filters-drawer"
+          temporary
         >
-          <div class="category-page__filters-content">
-            <CategoryFiltersPanel
-              :filter-options="filterOptions"
-              :aggregations="currentAggregations"
-              :filters="manualFilters"
-              :impact-expanded="impactExpanded"
-              :technical-expanded="technicalExpanded"
-              @update:filters="onFiltersChange"
-              @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
-              @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
-            />
-
-            <div v-if="!isDesktop" class="category-page__filters-actions">
-              <v-btn block color="primary" class="mb-2" @click="applyMobileFilters">
-                {{ $t('category.filters.mobileApply') }}
-              </v-btn>
-              <v-btn block variant="text" @click="clearAllFilters">
-                {{ $t('category.filters.mobileClear') }}
-              </v-btn>
-            </div>
-
-            <template v-if="hasDocumentation">
-              <v-divider class="my-4" />
-              <CategoryDocumentationRail
-                class="category-page__documentation-block"
-                :wiki-pages="category.wikiPages ?? []"
-                :related-posts="category.relatedPosts ?? []"
-                :vertical-home-url="category.verticalHomeUrl"
-              />
-            </template>
-          </div>
+          <CategoryFiltersSidebar
+            :filter-options="filterOptions"
+            :aggregations="currentAggregations"
+            :filters="manualFilters"
+            :impact-expanded="impactExpanded"
+            :technical-expanded="technicalExpanded"
+            :show-mobile-actions="true"
+            :has-documentation="hasDocumentation"
+            :wiki-pages="category?.wikiPages ?? []"
+            :related-posts="category?.relatedPosts ?? []"
+            :vertical-home-url="category?.verticalHomeUrl ?? null"
+            @update:filters="onFiltersChange"
+            @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
+            @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
+            @apply-mobile="applyMobileFilters"
+            @clear-mobile="clearAllFilters"
+          />
         </v-navigation-drawer>
+
+        <aside
+          v-else
+          class="category-page__filters-surface"
+          role="complementary"
+          :aria-label="$t('category.products.openFilters')"
+        >
+          <CategoryFiltersSidebar
+            :filter-options="filterOptions"
+            :aggregations="currentAggregations"
+            :filters="manualFilters"
+            :impact-expanded="impactExpanded"
+            :technical-expanded="technicalExpanded"
+            :show-mobile-actions="false"
+            :has-documentation="hasDocumentation"
+            :wiki-pages="category?.wikiPages ?? []"
+            :related-posts="category?.relatedPosts ?? []"
+            :vertical-home-url="category?.verticalHomeUrl ?? null"
+            @update:filters="onFiltersChange"
+            @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
+            @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
+          />
+        </aside>
 
         <section class="category-page__results">
           <v-alert
@@ -218,10 +227,9 @@ import type {
 } from '~~/shared/api-client'
 import { AggTypeEnum } from '~~/shared/api-client'
 
-import CategoryDocumentationRail from '~/components/category/CategoryDocumentationRail.vue'
 import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
-import CategoryFiltersPanel from '~/components/category/CategoryFiltersPanel.vue'
 import CategoryHero from '~/components/category/CategoryHero.vue'
+import CategoryFiltersSidebar from '~/components/category/CategoryFiltersSidebar.vue'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
 import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
 import CategoryProductTable from '~/components/category/products/CategoryProductTable.vue'
@@ -928,26 +936,36 @@ const clearAllFilters = () => {
     display: grid
     gap: 1.75rem
     grid-template-columns: minmax(0, 1fr)
+    align-items: start
 
-  &__filters
+  &__filters-drawer
+    :deep(.v-navigation-drawer__content)
+      padding: 0
+
+  &__filters-surface
     position: sticky
     top: 96px
-    height: calc(100vh - 120px)
+    align-self: start
+    max-height: calc(100vh - 136px)
     border-radius: 1rem
+    background: rgb(var(--v-theme-surface-glass))
+    box-shadow: 0 22px 46px -28px rgba(var(--v-theme-shadow-primary-600), 0.28)
+    overflow: hidden
 
   &__filters-content
     display: flex
     flex-direction: column
     gap: 1.5rem
     height: 100%
-    padding: 1.25rem 1rem 1.5rem
+    padding: 1.5rem 1.25rem 1.75rem
     overflow-y: auto
 
   &__filters-actions
-    padding: 1rem
+    padding: 0.5rem 0.75rem 0
 
   &__results
     min-height: 420px
+    min-width: 0
 
   &__no-results
     font-size: 1rem
@@ -966,9 +984,8 @@ const clearAllFilters = () => {
   .category-page__layout
     grid-template-columns: 320px minmax(0, 1fr)
 
-  .category-page__filters
-    background: transparent
-    box-shadow: none
+  .category-page__filters-surface
+    max-height: calc(100vh - 152px)
 
 @media (max-width: 959px)
   .category-page__toolbar
@@ -980,10 +997,10 @@ const clearAllFilters = () => {
   .category-page__layout
     grid-template-columns: minmax(0, 1fr)
 
-  .category-page__filters
-    position: static
-    height: auto
-
   .category-page__filters-content
+    padding: 1.25rem 1rem 1.5rem
     overflow-y: visible
+
+  .category-page__filters-actions
+    padding: 0.5rem 0
 </style>


### PR DESCRIPTION
## Summary
- align the category hero media to the left and expand the copy width for better hierarchy
- refactor the category filter sidebar to use a shared component for desktop and mobile drawers
- tighten layout spacing so the product grid aligns with the toolbar and add icons to filter panels

## Testing
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f0bdcad5988333af3b8448cfe06a6d