### PR TITLE
Add cover image and ecoscore to product base DTO

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.open4goods.model.RolesConstants;
 import org.open4goods.model.product.Product;
@@ -18,6 +19,7 @@ import org.open4goods.nudgerfrontapi.dto.category.CategoryNavigationDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto.ProductDtoComponent;
 import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.Filter;
 import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterField;
@@ -231,8 +233,9 @@ public class CategoriesController {
         Locale locale = resolveLocale(domainLanguage);
 
         Map<Long, ProductDto> uniqueProducts = new LinkedHashMap<>();
+        Set<String> includes = Set.of(ProductDtoComponent.base.name());
         for (SearchHit<Product> hit : result.hits().getSearchHits()) {
-            ProductDto dto = productMappingService.mapProduct(hit.getContent(), locale, Collections.emptySet(), domainLanguage);
+            ProductDto dto = productMappingService.mapProduct(hit.getContent(), locale, includes, domainLanguage);
             if (dto != null && !uniqueProducts.containsKey(dto.gtin())) {
                 uniqueProducts.put(dto.gtin(), dto);
             }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryNavigationDto.java
@@ -23,10 +23,10 @@ public record CategoryNavigationDto(
         @Schema(description = "Descendant nodes exposing a vertical configuration but not already present in childCategories.")
         List<GoogleCategoryDto> descendantVerticals,
 
-        @Schema(description = "Top five new products for the category ordered by descending impact score.")
+        @Schema(description = "Top five new products for the category ordered by descending impact score. Only the base facet is populated.")
         List<ProductDto> topNewProducts,
 
-        @Schema(description = "Top five occasion products for the category ordered by descending impact score.")
+        @Schema(description = "Top five occasion products for the category ordered by descending impact score. Only the base facet is populated.")
         List<ProductDto> topOccasionProducts
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductBaseDto.java
@@ -26,6 +26,12 @@ public record ProductBaseDto(
         @Schema(description = "Reasons explaining why the product is excluded")
         Set<String> excludedCauses,
         @Schema(description = "Information inferred from the GTIN itself")
-        ProductGtinInfoDto gtinInfo
+        ProductGtinInfoDto gtinInfo,
+        @Schema(description = "Absolute URL of the preferred cover image when available", example = "https://cdn.example.org/covers/123.jpg", nullable = true)
+        String coverImagePath,
+        @Schema(description = "Best human readable name derived from brand/model or offer data", example = "Fairphone 4")
+        String bestName,
+        @Schema(description = "Value of the ECOSCORE when available", example = "15.5", nullable = true)
+        Double ecoscoreValue
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -235,6 +235,7 @@ public class ProductMappingService {
      * Map immutable product fields describing core metadata (creation timestamps, vertical etc.).
      */
     private ProductBaseDto mapBase(Product product, DomainLanguage domainLanguage, Locale locale) {
+        Score ecoscore = product.ecoscore();
         return new ProductBaseDto(
                 product.getId(),
                 product.getCreationDate(),
@@ -244,7 +245,10 @@ public class ProductMappingService {
                 product.getGoogleTaxonomyId(),
                 product.isExcluded(),
                 product.getExcludedCauses() == null ? Collections.emptySet() : new LinkedHashSet<>(product.getExcludedCauses()),
-                mapGtinInfo(product.getGtinInfos(), domainLanguage, locale));
+                mapGtinInfo(product.getGtinInfos(), domainLanguage, locale),
+                resolveCoverImageUrl(product.getCoverImagePath()),
+                product.bestName(),
+                ecoscore == null ? null : ecoscore.getValue());
     }
 
     /**

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -25,6 +26,7 @@ import org.open4goods.model.resource.ImageInfo;
 import org.open4goods.model.resource.PdfInfo;
 import org.open4goods.model.resource.Resource;
 import org.open4goods.model.resource.ResourceType;
+import org.open4goods.model.product.Score;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
@@ -68,6 +70,12 @@ class ProductMappingServiceTest {
         GtinInfo gtinInfo = new GtinInfo();
         gtinInfo.setCountry("FR");
         product.setGtinInfos(gtinInfo);
+        product.setCoverImagePath("/covers/main.jpg");
+        product.setOfferNames(Set.of("Eco Phone"));
+        Score ecoscore = new Score("ECOSCORE", 12.5);
+        HashMap<String, Score> scores = new HashMap<>();
+        scores.put("ECOSCORE", ecoscore);
+        product.setScores(scores);
 
         when(repository.getById(gtin)).thenReturn(product);
 
@@ -79,6 +87,9 @@ class ProductMappingServiceTest {
         assertThat(dto.base().gtinInfo().countryCode()).isEqualTo("FR");
         assertThat(dto.base().gtinInfo().countryName()).isEqualTo("France");
         assertThat(dto.base().gtinInfo().countryFlagUrl()).isEqualTo("/images/flags/fr.webp");
+        assertThat(dto.base().coverImagePath()).isEqualTo("https://static.example/covers/main.jpg");
+        assertThat(dto.base().bestName()).isEqualTo("Eco Phone");
+        assertThat(dto.base().ecoscoreValue()).isEqualTo(12.5);
         assertThat(dto.resources()).isNull();
     }
 


### PR DESCRIPTION
## Summary
- expose cover image, best name, and ecoscore value on ProductBaseDto while keeping specialised facets untouched
- ensure top navigation product lists request only the base facet and document this limitation
- extend ProductMappingService unit test coverage for the enriched base fields

## Testing
- `mvn --offline test`


------
https://chatgpt.com/codex/tasks/task_e_68f0bf1e73ec8333abdc332c77439dd8