### PR TITLE
feat: add reusable ImpactScore component

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -50,6 +50,9 @@ Offline mode is optional troubleshooting; use it only when network access is del
 - Global styles belong in `app/assets`. Avoid inline styles except for trivial tweaks.
 - When integrating CMS/XWiki content, ensure the preprocess step (`pnpm preprocess:css`) stays current.
 
+### Impact score components
+- Every impact score visualisation must render through `~/components/shared/ui/ImpactScore.vue` to keep the UX consistent across the application. If you need additional behaviour, extend the component via props instead of duplicating markup.
+
 ### Design token glossary
 The theme palette exposes the following generic tokens. Use `rgb(var(--v-theme-<token>))` for solid fills and `rgba(var(--v-theme-<token>), <alpha>)` when translucency is needed.
 

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -1,0 +1,161 @@
+<template>
+  <v-tooltip :text="tooltipLabel" location="top">
+    <template #activator="{ props: activatorProps }">
+      <div
+        class="impact-score"
+        :class="`impact-score--${size}`"
+        v-bind="activatorProps"
+        :aria-label="tooltipLabel"
+        tabindex="0"
+        role="img"
+      >
+        <div class="impact-score__stars" :style="starStyle">
+          <div class="impact-score__stars-track" aria-hidden="true">
+            <v-icon
+              v-for="index in length"
+              :key="`track-${index}`"
+              icon="mdi-star"
+            />
+          </div>
+          <div class="impact-score__stars-fill" :style="{ width: fillWidth }" aria-hidden="true">
+            <v-icon
+              v-for="index in length"
+              :key="`fill-${index}`"
+              icon="mdi-star"
+            />
+          </div>
+        </div>
+        <span v-if="showValue" class="impact-score__value">{{ formattedScore }}</span>
+      </div>
+    </template>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  score: {
+    type: Number,
+    required: true,
+  },
+  max: {
+    type: Number,
+    default: 5,
+  },
+  size: {
+    type: String as PropType<'small' | 'medium' | 'large'>,
+    default: 'medium',
+  },
+  showValue: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const { t, n } = useI18n()
+
+const length = computed(() => Math.max(1, Math.round(Number.isFinite(props.max) ? props.max : 5)))
+
+const normalizedScore = computed(() => {
+  const safeScore = Number.isFinite(props.score) ? props.score : 0
+  return Math.min(Math.max(safeScore, 0), length.value)
+})
+
+const formattedScore = computed(() =>
+  `${n(normalizedScore.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 })} / ${length.value}`,
+)
+
+const starSize = computed(() => {
+  switch (props.size) {
+    case 'small':
+      return 18
+    case 'large':
+      return 32
+    default:
+      return 24
+  }
+})
+
+const starGap = computed(() => {
+  switch (props.size) {
+    case 'small':
+      return 4
+    case 'large':
+      return 8
+    default:
+      return 6
+  }
+})
+
+const fillWidth = computed(() => `${(normalizedScore.value / length.value) * 100}%`)
+
+const starStyle = computed(() => ({
+  '--impact-score-star-size': `${starSize.value}px`,
+  '--impact-score-star-gap': `${starGap.value}px`,
+}))
+
+const tooltipLabel = computed(() =>
+  t('components.impactScore.tooltip', {
+    value: n(normalizedScore.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 }),
+    max: length.value,
+  }),
+)
+
+const size = computed(() => props.size)
+const showValue = computed(() => props.showValue)
+</script>
+
+<style scoped>
+.impact-score {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-score__value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.impact-score--small .impact-score__value {
+  font-size: 0.85rem;
+}
+
+.impact-score--large .impact-score__value {
+  font-size: 1.05rem;
+}
+
+.impact-score__stars {
+  position: relative;
+  display: inline-flex;
+}
+
+.impact-score__stars-track,
+.impact-score__stars-fill {
+  display: inline-flex;
+  gap: var(--impact-score-star-gap);
+}
+
+.impact-score__stars-track {
+  color: rgba(var(--v-theme-text-neutral-soft), 0.35);
+}
+
+.impact-score__stars-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: inline-flex;
+  overflow: hidden;
+  color: rgb(var(--v-theme-accent-supporting));
+  gap: var(--impact-score-star-gap);
+}
+
+.impact-score__stars-track :deep(.v-icon),
+.impact-score__stars-fill :deep(.v-icon) {
+  font-size: var(--impact-score-star-size);
+  line-height: 1;
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -4,6 +4,11 @@
     "fr": "French",
     "en": "English"
   },
+  "components": {
+    "impactScore": {
+      "tooltip": "Impact quality rated at {value} out of {max}"
+    }
+  },
   "siteIdentity": {
     "menu": {
       "title": "Menu",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -4,6 +4,11 @@
     "fr": "Français",
     "en": "Anglais"
   },
+  "components": {
+    "impactScore": {
+      "tooltip": "Qualité de l'impact évalué à {value} sur {max}"
+    }
+  },
   "siteIdentity": {
     "menu": {
       "title": "Menu",


### PR DESCRIPTION
## Summary
- add a reusable `ImpactScore` UI component with responsive star sizing, tooltip messaging, and optional value display
- translate the tooltip string for both English and French locales to keep the component internationalised
- document in the frontend agent guide that all impact score visuals must rely on the new component

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f0c0bdbe80833383933a806b8a6658