### PR TITLE
feat: refresh category layout design

### DIFF
--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="category-hero" :aria-labelledby="headingId" data-testid="category-hero">
-    <v-sheet class="category-hero__wrapper" elevation="0" rounded="xl">
+    <v-sheet class="category-hero__wrapper" elevation="0">
       <div class="category-hero__content">
         <v-breadcrumbs
           v-if="breadcrumbs.length"
@@ -72,12 +72,13 @@ defineExpose({ headingId, t })
     position: relative
     display: flex
     flex-direction: column
-    gap: 1.5rem
+    gap: 1.25rem
     overflow: hidden
-    min-height: 220px
+    min-height: 180px
     background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.95), rgba(var(--v-theme-hero-gradient-end), 0.85))
     color: rgb(var(--v-theme-hero-overlay-strong))
-    padding: clamp(1.5rem, 4vw + 1rem, 3rem)
+    padding: clamp(1.25rem, 3vw + 0.75rem, 2.5rem)
+    border-radius: 0
 
   &__content
     display: flex
@@ -123,13 +124,18 @@ defineExpose({ headingId, t })
   &__media
     position: relative
     flex: 0 0 auto
-    border-radius: 1.25rem
+    display: flex
+    align-items: center
+    justify-content: center
     overflow: hidden
     background: rgba(var(--v-theme-hero-overlay-soft), 0.12)
 
   &__image
-    height: 100%
-    min-height: 200px
+    height: auto
+    width: 100%
+    max-width: 60%
+    min-height: 160px
+    margin: 0 auto
 
 @media (min-width: 960px)
   .category-hero__wrapper
@@ -141,11 +147,10 @@ defineExpose({ headingId, t })
     flex: 0 1 66%
 
   .category-hero__media
-    display: block
-    flex: 0 0 clamp(240px, 30vw, 360px)
+    flex: 0 0 clamp(180px, 18vw, 240px)
 
   .category-hero__image
-    min-height: 100%
+    max-height: 100%
 
 @media (max-width: 959px)
   .category-hero__media

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -37,34 +37,54 @@
         </div>
 
         <div class="category-page__toolbar-actions">
-          <v-text-field
-            v-model="searchTerm"
-            :label="$t('category.products.searchPlaceholder')"
-            prepend-inner-icon="mdi-magnify"
-            clearable
-            hide-details
-            density="comfortable"
-            class="category-page__search"
-          />
+          <div class="category-page__search">
+            <v-tooltip location="bottom">
+              <template #activator="{ props }">
+                <v-text-field
+                  v-bind="props"
+                  v-model="searchTerm"
+                  :label="$t('category.products.searchPlaceholder')"
+                  prepend-inner-icon="mdi-magnify"
+                  clearable
+                  hide-details
+                  density="comfortable"
+                  class="category-page__search-input"
+                />
+              </template>
+              <span>{{ $t('category.products.tooltips.search') }}</span>
+            </v-tooltip>
+          </div>
 
           <div class="category-page__sort">
-            <v-select
-              v-model="sortField"
-              :items="sortItems"
-              :label="$t('category.products.sortLabel')"
-              item-title="title"
-              item-value="value"
-              clearable
-              hide-details
-              density="comfortable"
-              class="me-2"
-            />
+            <v-tooltip location="bottom">
+              <template #activator="{ props }">
+                <v-select
+                  v-bind="props"
+                  v-model="sortField"
+                  :items="sortItems"
+                  :label="$t('category.products.sortLabel')"
+                  item-title="title"
+                  item-value="value"
+                  clearable
+                  hide-details
+                  density="comfortable"
+                  class="category-page__sort-select"
+                />
+              </template>
+              <span>{{ $t('category.products.tooltips.sortField') }}</span>
+            </v-tooltip>
             <v-btn-toggle v-model="sortOrder" class="category-page__sort-order" density="comfortable">
               <v-btn value="asc" :aria-label="$t('category.products.sortOrderAsc')">
                 <v-icon icon="mdi-sort-ascending" />
+                <v-tooltip activator="parent" location="bottom">
+                  <span>{{ $t('category.products.tooltips.sortOrderAsc') }}</span>
+                </v-tooltip>
               </v-btn>
               <v-btn value="desc" :aria-label="$t('category.products.sortOrderDesc')">
                 <v-icon icon="mdi-sort-descending" />
+                <v-tooltip activator="parent" location="bottom">
+                  <span>{{ $t('category.products.tooltips.sortOrderDesc') }}</span>
+                </v-tooltip>
               </v-btn>
             </v-btn-toggle>
           </div>
@@ -72,12 +92,21 @@
           <v-btn-toggle v-model="viewMode" mandatory class="category-page__view-toggle">
             <v-btn value="cards" :aria-label="$t('category.products.viewCards')">
               <v-icon icon="mdi-view-grid" />
+              <v-tooltip activator="parent" location="bottom">
+                <span>{{ $t('category.products.tooltips.viewCards') }}</span>
+              </v-tooltip>
             </v-btn>
             <v-btn value="list" :aria-label="$t('category.products.viewList')">
               <v-icon icon="mdi-view-list" />
+              <v-tooltip activator="parent" location="bottom">
+                <span>{{ $t('category.products.tooltips.viewList') }}</span>
+              </v-tooltip>
             </v-btn>
             <v-btn value="table" :aria-label="$t('category.products.viewTable')">
               <v-icon icon="mdi-table" />
+              <v-tooltip activator="parent" location="bottom">
+                <span>{{ $t('category.products.tooltips.viewTable') }}</span>
+              </v-tooltip>
             </v-btn>
           </v-btn-toggle>
         </div>
@@ -87,7 +116,7 @@
         <v-navigation-drawer
           v-model="filtersDrawer"
           :permanent="isDesktop"
-          :width="isDesktop ? 320 : 360"
+          :width="isDesktop ? 280 : 360"
           location="start"
           class="category-page__filters"
           :temporary="!isDesktop"
@@ -885,7 +914,7 @@ const clearAllFilters = () => {
   flex-direction: column
 
   &__container
-    max-width: 1400px
+    max-width: 1480px
 
   &__toolbar
     display: flex
@@ -906,12 +935,20 @@ const clearAllFilters = () => {
     gap: 1rem
 
   &__search
-    min-width: 240px
+    display: flex
+    min-width: clamp(200px, 24vw, 320px)
+    flex: 1 1 280px
+
+  &__search-input
+    width: 100%
 
   &__sort
     display: flex
     align-items: center
     gap: 0.5rem
+
+  &__sort-select
+    min-width: 180px
 
   &__sort-order
     border-radius: 999px
@@ -926,20 +963,23 @@ const clearAllFilters = () => {
 
   &__layout
     display: grid
-    gap: 1.75rem
+    gap: 1.5rem
     grid-template-columns: minmax(0, 1fr)
 
   &__filters
     position: sticky
     top: 96px
-    height: calc(100vh - 120px)
+    height: calc(100vh - 128px)
     border-radius: 1rem
+    display: flex
+    flex-direction: column
+    overflow: hidden
 
   &__filters-content
     display: flex
     flex-direction: column
     gap: 1.5rem
-    height: 100%
+    flex: 1 1 auto
     padding: 1.25rem 1rem 1.5rem
     overflow-y: auto
 
@@ -964,7 +1004,7 @@ const clearAllFilters = () => {
 
 @media (min-width: 1280px)
   .category-page__layout
-    grid-template-columns: 320px minmax(0, 1fr)
+    grid-template-columns: clamp(260px, 20vw, 300px) minmax(0, 1fr)
 
   .category-page__filters
     background: transparent
@@ -983,6 +1023,7 @@ const clearAllFilters = () => {
   .category-page__filters
     position: static
     height: auto
+    display: block
 
   .category-page__filters-content
     overflow-y: visible

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -130,7 +130,16 @@
       "viewList": "List view",
       "viewTable": "Table view",
       "openFilters": "Filters",
-      "noResults": "No products match the selected filters."
+      "noResults": "No products match the selected filters.",
+      "tooltips": {
+        "search": "Search within the current results",
+        "sortField": "Choose the field used to sort products",
+        "sortOrderAsc": "Sort from lowest to highest",
+        "sortOrderDesc": "Sort from highest to lowest",
+        "viewCards": "Show products as cards",
+        "viewList": "Show products in a list",
+        "viewTable": "Show products in a table"
+      }
     },
     "documentation": {
       "guidesTitle": "Helpful guides",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -129,7 +129,16 @@
       "viewList": "Vue liste",
       "viewTable": "Vue tableau",
       "openFilters": "Filtres",
-      "noResults": "Aucun produit ne correspond aux filtres sélectionnés."
+      "noResults": "Aucun produit ne correspond aux filtres sélectionnés.",
+      "tooltips": {
+        "search": "Rechercher dans les résultats",
+        "sortField": "Choisir le champ de tri des produits",
+        "sortOrderAsc": "Tri du plus bas au plus élevé",
+        "sortOrderDesc": "Tri du plus élevé au plus bas",
+        "viewCards": "Afficher les produits en cartes",
+        "viewList": "Afficher les produits en liste",
+        "viewTable": "Afficher les produits en tableau"
+      }
     },
     "documentation": {
       "guidesTitle": "Guides utiles",


### PR DESCRIPTION
## Summary
- streamline the category hero by removing rounded container edges, tightening spacing, and scaling the supporting artwork
- widen the desktop product grid while keeping the filter rail scrollable and add localized hover tooltips across the toolbar controls
- add English and French tooltip copy for the new affordances in the category toolbar

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f0c63527a08333b57af393cb86a637