### PR TITLE
feat(front-api): add admin cache reset endpoint

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AdminController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AdminController.java
@@ -1,0 +1,60 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * Administrative endpoints to manage runtime behaviours of the frontend API.
+ */
+@RestController
+@RequestMapping("/admin")
+@Validated
+@PreAuthorize("hasAuthority('" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Administration", description = "Runtime administrative operations")
+public class AdminController {
+
+    private final CacheManager cacheManager;
+
+    /**
+     * Create an administrative controller backed by the provided cache manager.
+     *
+     * @param cacheManager Spring cache manager used to access configured caches
+     */
+    public AdminController(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    /**
+     * Reset all configured Spring caches in the application context.
+     *
+     * @return {@link ResponseEntity} with no content once caches are cleared
+     */
+    @PostMapping("/cache/reset")
+    @Operation(
+            summary = "Reset every Spring cache",
+            description = "Clear the content of all caches configured for the frontend API.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "Caches cleared"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "401", description = "Unauthenticated")
+            }
+    )
+    public ResponseEntity<Void> resetCache() {
+        cacheManager.getCacheNames().stream()
+                .map(cacheManager::getCache)
+                .filter(cache -> cache != null)
+                .forEach(Cache::clear);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/AdminControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/AdminControllerTest.java
@@ -1,0 +1,48 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Unit tests for {@link AdminController}.
+ */
+class AdminControllerTest {
+
+    private Cache cacheOne;
+    private Cache cacheTwo;
+    private CacheManager cacheManager;
+    private AdminController controller;
+
+    @BeforeEach
+    void setUp() {
+        cacheOne = new ConcurrentMapCache("one");
+        cacheTwo = new ConcurrentMapCache("two");
+        cacheOne.put("key", "value");
+        cacheTwo.put("another", "entry");
+
+        SimpleCacheManager simpleCacheManager = new SimpleCacheManager();
+        simpleCacheManager.setCaches(List.of(cacheOne, cacheTwo));
+        simpleCacheManager.initializeCaches();
+        cacheManager = simpleCacheManager;
+
+        controller = new AdminController(cacheManager);
+    }
+
+    @Test
+    void resetCacheShouldClearEveryCacheEntry() {
+        ResponseEntity<Void> response = controller.resetCache();
+
+        assertThat(cacheOne.get("key")).isNull();
+        assertThat(cacheTwo.get("another")).isNull();
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+    }
+}


### PR DESCRIPTION
## Summary
- add an admin controller restricted to editors with a cache reset endpoint
- cover cache clearing behaviour with a unit test

## Testing
- mvn -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68f10459b4608333a5151acd025c1be8