### PR TITLE
Fix category page theme toggle and structured data cleanup

### DIFF
--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -8,37 +8,29 @@
     rounded="pill"
     :data-testid="testId"
   >
-    <v-tooltip :text="lightTooltip" location="bottom">
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          v-bind="tooltipProps"
-          :value="'light'"
-          :aria-label="lightAriaLabel"
-          :data-testid="`${testId}-light`"
-          :size="size"
-          icon
-          variant="plain"
-        >
-          <v-icon icon="mdi-white-balance-sunny" />
-        </v-btn>
-      </template>
-    </v-tooltip>
+    <v-btn
+      :value="'light'"
+      :aria-label="lightAriaLabel"
+      :data-testid="`${testId}-light`"
+      :size="size"
+      icon
+      variant="plain"
+    >
+      <v-icon icon="mdi-white-balance-sunny" />
+      <v-tooltip activator="parent" :text="lightTooltip" location="bottom" />
+    </v-btn>
 
-    <v-tooltip :text="darkTooltip" location="bottom">
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          v-bind="tooltipProps"
-          :value="'dark'"
-          :aria-label="darkAriaLabel"
-          :data-testid="`${testId}-dark`"
-          :size="size"
-          icon
-          variant="plain"
-        >
-          <v-icon icon="mdi-weather-night" />
-        </v-btn>
-      </template>
-    </v-tooltip>
+    <v-btn
+      :value="'dark'"
+      :aria-label="darkAriaLabel"
+      :data-testid="`${testId}-dark`"
+      :size="size"
+      icon
+      variant="plain"
+    >
+      <v-icon icon="mdi-weather-night" />
+      <v-tooltip activator="parent" :text="darkTooltip" location="bottom" />
+    </v-btn>
   </v-btn-toggle>
 </template>
 

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -456,11 +456,19 @@ const structuredDataScripts = computed(() => {
   return scripts
 })
 
+const structuredDataHeadScripts = computed(() =>
+  structuredDataScripts.value.map((script, index) => ({
+    key: `category-structured-data-${index}`,
+    type: script.type,
+    children: script.children,
+  })),
+)
+
 useHead(() => ({
   link: [
     { rel: 'canonical', href: canonicalUrl.value },
   ],
-  script: structuredDataScripts.value,
+  script: structuredDataHeadScripts.value,
 }))
 
 const verticalId = computed(() => category.value?.id ?? null)
@@ -1071,6 +1079,8 @@ const clearAllFilters = () => {
 .category-page
   display: flex
   flex-direction: column
+  min-height: 100%
+  background-color: rgb(var(--v-theme-surface-default))
 
   &__container
     max-width: 1560px


### PR DESCRIPTION
## Summary
- ensure ThemeToggle buttons keep Vuetify tooltips without breaking toggle behaviour
- stabilise category page structured data head entries and apply themed background surface

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f10aa9a6c08333a128a4b14434c100