### PR TITLE
Fix menu role chip contrast and visual viewport test typing

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -48,9 +48,9 @@
                   <v-chip
                     v-for="role in accountRoles"
                     :key="role"
-                    color="surface-primary-120"
+                    color="surface-primary-100"
                     size="small"
-                    variant="tonal"
+                    variant="flat"
                     class="role-chip"
                   >
                     {{ role }}
@@ -259,6 +259,8 @@ const navigateToPage = (path: string): void => {
   color: rgb(var(--v-theme-text-neutral-strong))
 
 .role-chip
+  background-color: rgb(var(--v-theme-surface-primary-120))
+  border: 1px solid rgb(var(--v-theme-border-primary-strong))
   color: rgb(var(--v-theme-text-neutral-strong))
 
 .text-neutral-soft

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -65,8 +65,8 @@
               v-for="role in accountRoles"
               :key="role"
               size="small"
-              variant="tonal"
-              color="surface-primary-120"
+              variant="flat"
+              color="surface-primary-100"
               class="role-chip"
             >
               {{ role }}
@@ -255,6 +255,8 @@ const menuItems = computed<MenuItem[]>(() =>
   background-color: rgb(var(--v-theme-surface-default))
 
 .role-chip
+  background-color: rgb(var(--v-theme-surface-primary-120))
+  border: 1px solid rgb(var(--v-theme-border-primary-strong))
   color: rgb(var(--v-theme-text-neutral-strong))
 
 .text-neutral-soft

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -154,7 +154,7 @@ describe('Shared menu authentication controls', () => {
 
       if (!('visualViewport' in window)) {
         ;(window as unknown as {
-          visualViewport?: Pick<Window['visualViewport'], 'addEventListener' | 'removeEventListener'>
+          visualViewport?: Pick<NonNullable<Window['visualViewport']>, 'addEventListener' | 'removeEventListener'>
         }).visualViewport = {
           addEventListener: () => undefined,
           removeEventListener: () => undefined,


### PR DESCRIPTION
## Summary
- improve role chip styling in authenticated hero and mobile menus using theme tokens for proper contrast
- adjust the menus auth test to use a NonNullable visualViewport pick to satisfy TypeScript

## Testing
- pnpm test --run app/components/shared/menus/menus-auth.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f10e1a00f4833392ef87ccc5350989