### PR TITLE
Reload page after cache reset completes

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -155,6 +155,14 @@ const handleLogout = async () => {
   }
 }
 
+const isSuccessfulCacheResetResponse = (payload: unknown): payload is { success: true } =>
+  Boolean(
+    payload &&
+      typeof payload === 'object' &&
+      'success' in payload &&
+      (payload as { success?: boolean }).success === true,
+  )
+
 const handleClearCache = async () => {
   if (isClearingCache.value) {
     return
@@ -170,7 +178,13 @@ const handleClearCache = async () => {
       return
     }
 
-    await fetcher('/api/admin/cache/reset', { method: 'POST' })
+    const response = await fetcher('/api/admin/cache/reset', { method: 'POST' })
+
+    if (!isSuccessfulCacheResetResponse(response)) {
+      console.error('Failed to clear caches', new Error('Unexpected response payload'))
+      return
+    }
+
     isAccountMenuOpen.value = false
 
     if (typeof window !== 'undefined') {

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -184,6 +184,14 @@ const handleLogout = async () => {
   }
 }
 
+const isSuccessfulCacheResetResponse = (payload: unknown): payload is { success: true } =>
+  Boolean(
+    payload &&
+      typeof payload === 'object' &&
+      'success' in payload &&
+      (payload as { success?: boolean }).success === true,
+  )
+
 const handleClearCache = async () => {
   if (!isLoggedIn.value || isClearingCache.value) {
     return
@@ -199,7 +207,13 @@ const handleClearCache = async () => {
       return
     }
 
-    await fetcher('/api/admin/cache/reset', { method: 'POST' })
+    const response = await fetcher('/api/admin/cache/reset', { method: 'POST' })
+
+    if (!isSuccessfulCacheResetResponse(response)) {
+      console.error('Failed to clear caches', new Error('Unexpected response payload'))
+      return
+    }
+
     emit('close')
 
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- ensure the desktop account menu validates the cache reset response before closing and reloading the page
- mirror the same success check for the mobile account menu so a reload only happens after the backend finishes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f112db22b88333a9d11c307dfe051d