### PR TITLE
Fix category filter hash updates to retain hash symbol

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -942,7 +942,7 @@ watch(
         query: { ...route.query },
       }
 
-      const targetLocation = hash ? { ...baseLocation, hash: hash.slice(1) } : baseLocation
+      const targetLocation = hash ? { ...baseLocation, hash } : baseLocation
 
       void router.push(targetLocation).catch((error) => {
         if (!isNavigationFailure(error)) {


### PR DESCRIPTION
## Summary
- ensure the category filter watcher passes the full hash string to vue-router so the browser URL keeps the leading #

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f1193e0344833398298229dbe7f83c