### PR TITLE
Fix category breadcrumb links

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryBreadcrumbItemDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/CategoryBreadcrumbItemDto.java
@@ -11,8 +11,8 @@ public record CategoryBreadcrumbItemDto(
                 example = "Électroménager")
         String title,
 
-        @Schema(description = "Localised URL fragment for the taxonomy node, resolved against the domain language.",
-                example = "electromenager")
+        @Schema(description = "Localised URL path for the taxonomy node, resolved against the domain language.",
+                example = "/categories/electromenager")
         String link
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
 public class CategoryMappingService {
 
     private static final String IMAGE_PREFIX = "/images/verticals/";
+    private static final String CATEGORY_PATH_PREFIX = "/categories/";
     private static final String DEFAULT_LANGUAGE_KEY = "default";
 
     private final ApiProperties apiProperties;
@@ -321,11 +322,12 @@ public class CategoryMappingService {
         if (category == null) {
             return null;
         }
-        String languageKey = domainLanguage == null ? null : domainLanguage.name();
+        String languageKey = languageKey(domainLanguage);
         String title = category.getGoogleNames() == null ? null : category.getGoogleNames().i18n(languageKey);
-        String link = category.getUrls() == null ? null : category.getUrls().i18n(languageKey);
+        String path = computeCategoryPath(category, languageKey);
+        String link = StringUtils.hasText(path) ? CATEGORY_PATH_PREFIX + path : null;
 
-        if (title == null && link == null) {
+        if (title == null && !StringUtils.hasText(path)) {
             return null;
         }
         return new CategoryBreadcrumbItemDto(title, link);

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceFullDtoTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceFullDtoTest.java
@@ -1,0 +1,62 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.vertical.ProductCategory;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.dto.category.CategoryBreadcrumbItemDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.verticals.GoogleTaxonomyService;
+
+class CategoryMappingServiceFullDtoTest {
+
+    private CategoryMappingService service;
+    private GoogleTaxonomyService googleTaxonomyService;
+
+    @BeforeEach
+    void setUp() {
+        ApiProperties apiProperties = new ApiProperties();
+        googleTaxonomyService = mock(GoogleTaxonomyService.class);
+        service = new CategoryMappingService(apiProperties, googleTaxonomyService);
+    }
+
+    @Test
+    void toVerticalConfigFullDtoBuildsFullBreadcrumbPaths() {
+        ProductCategory electronics = new ProductCategory(1, "Appareils électroniques", "fr");
+
+        ProductCategory video = new ProductCategory(2, "Vidéo", "fr");
+        video.setParent(electronics);
+        electronics.addChild(video);
+
+        ProductCategory televisions = new ProductCategory(3, "Téléviseurs", "fr");
+        televisions.setParent(video);
+        video.addChild(televisions);
+
+        when(googleTaxonomyService.byId(3)).thenReturn(televisions);
+
+        VerticalConfig config = new VerticalConfig();
+        config.setId("tv");
+        config.setEnabled(true);
+        config.setGoogleTaxonomyId(3);
+
+        VerticalConfigFullDto dto = service.toVerticalConfigFullDto(config, DomainLanguage.fr, List.of());
+
+        assertThat(dto.breadCrumb())
+                .extracting(CategoryBreadcrumbItemDto::title)
+                .containsExactly("Appareils électroniques", "Vidéo", "Téléviseurs");
+        assertThat(dto.breadCrumb())
+                .extracting(CategoryBreadcrumbItemDto::link)
+                .containsExactly(
+                        "/categories/appareils-electroniques",
+                        "/categories/appareils-electroniques/video",
+                        "/categories/appareils-electroniques/video/televiseurs");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure category breadcrumb links are built from the full taxonomy path and prefixed with `/categories/`
- update the breadcrumb DTO schema documentation to reflect the new link format
- add a unit test covering the breadcrumb paths exposed by the category details endpoint

## Testing
- mvn --offline test

------
https://chatgpt.com/codex/tasks/task_e_68f239384a1c833388789693bf3c1b8d