### PR TITLE
feat: replace numeric filters with echarts histogram

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -54,7 +54,7 @@ import { use as useECharts } from 'echarts/core'
 import { BarChart } from 'echarts/charts'
 import { GridComponent, TooltipComponent } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
-import { VChart } from 'vue-echarts'
+import VChart from 'vue-echarts'
 import { useI18n } from 'vue-i18n'
 import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
 
@@ -316,7 +316,12 @@ function getIndicesForFilter(filter?: Filter | null) {
 
   if (Number.isFinite(max)) {
     for (let index = buckets.value.length - 1; index >= 0; index -= 1) {
-      const bucketStart = buckets.value[index].from ?? Number.NEGATIVE_INFINITY
+      const bucket = buckets.value[index]
+      if (!bucket) {
+        continue
+      }
+
+      const bucketStart = bucket.from ?? Number.NEGATIVE_INFINITY
       if (max >= bucketStart - Number.EPSILON) {
         endIndex = index
         break

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -1,47 +1,71 @@
 <template>
   <div class="category-filter-numeric">
     <div class="category-filter-numeric__header">
-      <p class="category-filter-numeric__title">{{ displayTitle }}</p>
-      <p v-if="rangeLabel" class="category-filter-numeric__range">
-        {{ rangeLabel }}
-      </p>
+      <div class="category-filter-numeric__heading">
+        <p class="category-filter-numeric__title">{{ displayTitle }}</p>
+        <p v-if="overallRangeLabel" class="category-filter-numeric__caption">
+          {{ overallRangeLabel }}
+        </p>
+      </div>
+      <div class="category-filter-numeric__actions">
+        <p v-if="rangeLabel" class="category-filter-numeric__range">
+          {{ rangeLabel }}
+        </p>
+        <v-btn
+          variant="text"
+          density="comfortable"
+          class="category-filter-numeric__reset"
+          :disabled="!hasActiveRange"
+          @click="clearSelection"
+        >
+          {{ t('category.filters.rangeClear') }}
+        </v-btn>
+      </div>
     </div>
 
-    <v-range-slider
-      v-model="localValue"
-      :min="bounds.min"
-      :max="bounds.max"
-      :step="sliderStep"
-      :aria-label="ariaLabel"
-      class="category-filter-numeric__slider"
-      thumb-label="always"
-      color="primary"
-      @end="emitRange"
-    />
+    <p v-if="selectionHint" class="category-filter-numeric__hint">
+      {{ selectionHint }}
+    </p>
 
-    <div v-if="aggregation?.buckets?.length" class="category-filter-numeric__buckets">
-      <div
-        v-for="bucket in aggregation.buckets"
-        :key="bucket.key"
-        class="category-filter-numeric__bucket"
-      >
-        <span class="category-filter-numeric__bucket-label">
-          {{ formatBucketLabel(bucket.key, bucket.to) }}
-        </span>
-        <v-progress-linear
-          :model-value="bucket.count ?? 0"
-          :max="maxBucketCount"
-          height="6"
-          color="primary"
+    <div v-if="hasBuckets" class="category-filter-numeric__chart-wrapper">
+      <ClientOnly>
+        <VChart
+          :option="chartOptions"
+          :on-events="chartEvents"
+          :style="{ height: chartHeight }"
+          :aria-label="ariaLabel"
+          role="img"
+          autoresize
+          class="category-filter-numeric__chart"
         />
-        <span class="category-filter-numeric__bucket-count">{{ bucket.count ?? 0 }}</span>
-      </div>
+      </ClientOnly>
+    </div>
+    <div v-else class="category-filter-numeric__empty">
+      {{ t('category.filters.noMatch') }}
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useCssVar } from '@vueuse/core'
+import type { EChartsOption } from 'echarts'
+import { use as useECharts } from 'echarts/core'
+import { BarChart } from 'echarts/charts'
+import { GridComponent, TooltipComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
+import { VChart } from 'vue-echarts'
+import { useI18n } from 'vue-i18n'
 import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+
+useECharts([GridComponent, TooltipComponent, BarChart, CanvasRenderer])
+
+type NormalizedBucket = {
+  from?: number
+  to?: number
+  count: number
+  label: string
+}
 
 const props = defineProps<{
   field: FieldMetadataDto
@@ -53,61 +77,45 @@ const emit = defineEmits<{ 'update:modelValue': [Filter | null] }>()
 
 const { t } = useI18n()
 
+const cssVarTarget = ref<HTMLElement | null>(null)
+if (import.meta.client) {
+  cssVarTarget.value = document.documentElement
+}
+
+const accentPrimary = useCssVar('--v-theme-accent-primary-highlight', cssVarTarget)
+const textNeutralSecondaryVar = useCssVar('--v-theme-text-neutral-secondary', cssVarTarget)
+const borderPrimaryStrongVar = useCssVar('--v-theme-border-primary-strong', cssVarTarget)
+
 const displayTitle = computed(() => props.field.title ?? props.field.mapping ?? '')
 
 const ariaLabel = computed(() => `${displayTitle.value} ${t('category.filters.rangeAriaSuffix')}`)
 
-const bounds = computed(() => {
-  const min = props.aggregation?.min ?? (props.aggregation?.buckets?.[0]?.key ? Number(props.aggregation?.buckets?.[0]?.key) : 0)
-  const max = props.aggregation?.max ?? (props.aggregation?.buckets?.at(-1)?.to ?? min)
-
-  if (props.modelValue?.operator === 'range') {
-    return {
-      min: props.modelValue.min ?? min,
-      max: props.modelValue.max ?? max,
-    }
+const toNumber = (value?: number | string | null) => {
+  if (value == null) {
+    return undefined
   }
 
-  return { min, max }
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+const buckets = computed<NormalizedBucket[]>(() => {
+  return (props.aggregation?.buckets ?? []).map((bucket) => ({
+    from: toNumber(bucket.key as number | string | null),
+    to: toNumber(bucket.to as number | string | null),
+    count: bucket.count ?? 0,
+    label: formatBucketLabel(bucket.key, bucket.to),
+  }))
 })
 
-const sliderStep = computed(() => {
-  const buckets = props.aggregation?.buckets ?? []
-  if (buckets.length > 1) {
-    const [firstBucket, secondBucket] = buckets
-    const first = Number(firstBucket?.key ?? 0)
-    const second = Number(secondBucket?.key ?? 0)
-    const diff = Math.abs(second - first)
-    return Number.isFinite(diff) && diff > 0 ? diff : undefined
-  }
+const hasBuckets = computed(() => buckets.value.length > 0)
 
-  return props.field.aggregationConfiguration?.interval
-})
+const selectionHint = computed(() => (hasBuckets.value ? t('category.filters.rangeSelectionHint') : ''))
 
-const localValue = ref<[number, number]>([bounds.value.min, bounds.value.max])
+const chartHeight = computed(() => `${Math.max(buckets.value.length * 36, 160)}px`)
 
-watch(
-  () => bounds.value,
-  (next) => {
-    localValue.value = [next.min, next.max]
-  },
-  { immediate: true },
-)
-
-watch(
-  () => props.modelValue,
-  (filter) => {
-    if (filter?.operator === 'range') {
-      localValue.value = [filter.min ?? bounds.value.min, filter.max ?? bounds.value.max]
-      return
-    }
-
-    localValue.value = [bounds.value.min, bounds.value.max]
-  },
-)
-
-const maxBucketCount = computed(() => {
-  return Math.max(...(props.aggregation?.buckets?.map((bucket) => bucket.count ?? 0) ?? [0]), 1)
+const hasActiveRange = computed(() => {
+  return props.modelValue?.operator === 'range' && (props.modelValue.min != null || props.modelValue.max != null)
 })
 
 const rangeLabel = computed(() => {
@@ -123,27 +131,243 @@ const rangeLabel = computed(() => {
   return `${min ?? '–'} → ${max ?? '–'}`
 })
 
-const emitRange = () => {
-  const [min, max] = localValue.value
+const overallRangeLabel = computed(() => {
+  const min = props.aggregation?.min
+  const max = props.aggregation?.max
+
+  if (min == null && max == null) {
+    return null
+  }
+
+  return `${min ?? '–'} → ${max ?? '–'}`
+})
+
+const pendingStartIndex = ref<number | null>(null)
+
+watch(
+  () => props.modelValue,
+  () => {
+    pendingStartIndex.value = null
+  },
+)
+
+watch(hasBuckets, (available) => {
+  if (!available) {
+    pendingStartIndex.value = null
+  }
+})
+
+const accentColor = computed(() => {
+  const value = accentPrimary.value?.trim()
+  return value ? `rgb(${value})` : '#2196F3'
+})
+
+const accentMutedColor = computed(() => {
+  const value = accentPrimary.value?.trim()
+  return value ? `rgba(${value}, 0.25)` : 'rgba(33, 150, 243, 0.25)'
+})
+
+const textNeutralSecondaryColor = computed(() => {
+  const value = textNeutralSecondaryVar.value?.trim()
+  return value ? `rgb(${value})` : '#475467'
+})
+
+const gridLineColor = computed(() => {
+  const value = borderPrimaryStrongVar.value?.trim()
+  return value ? `rgba(${value}, 0.45)` : 'rgba(198, 221, 244, 0.45)'
+})
+
+const activeRangeIndices = computed(() => getIndicesForFilter(props.modelValue))
+
+const highlightedIndices = computed(() => {
+  const indices = new Set<number>()
+  const { start, end } = activeRangeIndices.value
+  if (start != null && end != null) {
+    for (let index = start; index <= end; index += 1) {
+      indices.add(index)
+    }
+  }
+
+  if (pendingStartIndex.value != null) {
+    indices.add(pendingStartIndex.value)
+  }
+
+  return indices
+})
+
+const chartData = computed(() => {
+  return buckets.value.map((bucket, index) => ({
+    value: bucket.count,
+    itemStyle: {
+      color: highlightedIndices.value.has(index) ? accentColor.value : accentMutedColor.value,
+      borderRadius: [0, 8, 8, 0],
+    },
+  }))
+})
+
+const chartOptions = computed<EChartsOption>(() => {
+  if (!buckets.value.length) {
+    return {}
+  }
+
+  return {
+    animation: false,
+    grid: { left: 0, right: 16, top: 8, bottom: 8, containLabel: true },
+    tooltip: {
+      trigger: 'item',
+      formatter: (params) => {
+        const index = 'dataIndex' in params ? Number(params.dataIndex) : NaN
+        if (!Number.isFinite(index)) {
+          return ''
+        }
+
+        const bucket = buckets.value[index]
+        const label = bucket?.label ?? ''
+        const count = bucket?.count ?? 0
+        const countLabel = t('category.products.resultsCount.other', { count })
+        return `<strong>${label}</strong><br/>${countLabel}`
+      },
+      extraCssText: 'text-align: left',
+    },
+    xAxis: {
+      type: 'value',
+      axisLabel: {
+        color: textNeutralSecondaryColor.value,
+      },
+      splitLine: {
+        lineStyle: {
+          color: gridLineColor.value,
+        },
+      },
+    },
+    yAxis: {
+      type: 'category',
+      inverse: true,
+      data: buckets.value.map((bucket) => bucket.label),
+      axisLabel: {
+        color: textNeutralSecondaryColor.value,
+        overflow: 'truncate',
+      },
+    },
+    series: [
+      {
+        type: 'bar',
+        barWidth: 18,
+        data: chartData.value,
+        emphasis: {
+          itemStyle: {
+            color: accentColor.value,
+          },
+        },
+      },
+    ],
+  }
+})
+
+const chartEvents = {
+  click: handleChartClick,
+  dblclick: () => {
+    pendingStartIndex.value = null
+    if (hasActiveRange.value) {
+      clearSelection()
+    }
+  },
+}
+
+function handleChartClick(event: { dataIndex?: number }) {
+  if (event?.dataIndex == null) {
+    return
+  }
+
+  const index = Number(event.dataIndex)
+  if (!Number.isFinite(index)) {
+    return
+  }
+
+  if (pendingStartIndex.value == null) {
+    pendingStartIndex.value = index
+    return
+  }
+
+  const start = pendingStartIndex.value
+  const end = index
+  pendingStartIndex.value = null
+  emitSelection(Math.min(start, end), Math.max(start, end))
+}
+
+function getIndicesForFilter(filter?: Filter | null) {
+  if (!filter || filter.operator !== 'range' || !buckets.value.length) {
+    return { start: null, end: null }
+  }
+
+  const min = filter.min ?? Number.NEGATIVE_INFINITY
+  const max = filter.max ?? Number.POSITIVE_INFINITY
+
+  let startIndex = 0
+  let endIndex = buckets.value.length - 1
+
+  if (Number.isFinite(min)) {
+    const found = buckets.value.findIndex((bucket) => {
+      const bucketEnd = bucket.to ?? Number.POSITIVE_INFINITY
+      return min < bucketEnd + Number.EPSILON
+    })
+    startIndex = found === -1 ? buckets.value.length - 1 : found
+  }
+
+  if (Number.isFinite(max)) {
+    for (let index = buckets.value.length - 1; index >= 0; index -= 1) {
+      const bucketStart = buckets.value[index].from ?? Number.NEGATIVE_INFINITY
+      if (max >= bucketStart - Number.EPSILON) {
+        endIndex = index
+        break
+      }
+    }
+  }
+
+  if (startIndex > endIndex) {
+    ;[startIndex, endIndex] = [endIndex, startIndex]
+  }
+
+  return { start: startIndex, end: endIndex }
+}
+
+function emitSelection(startIndex: number, endIndex: number) {
+  const mapping = props.field.mapping
+  if (!mapping) {
+    return
+  }
+
+  const startBucket = buckets.value[startIndex]
+  const endBucket = buckets.value[endIndex]
+
+  if (!startBucket || !endBucket) {
+    return
+  }
 
   emit('update:modelValue', {
-    field: props.field.mapping,
+    field: mapping,
     operator: 'range',
-    min,
-    max,
+    min: startBucket.from ?? props.aggregation?.min ?? undefined,
+    max: endBucket.to ?? props.aggregation?.max ?? undefined,
   })
 }
 
-const formatBucketLabel = (from?: string, to?: number) => {
+function clearSelection() {
+  emit('update:modelValue', null)
+}
+
+function formatBucketLabel(from?: unknown, to?: unknown) {
   if (from == null && to == null) {
     return ''
   }
 
+  const fromLabel = from == null ? '–' : String(from)
+
   if (to == null) {
-    return `${from}+`
+    return `${fromLabel}+`
   }
 
-  return `${from ?? '–'} → ${to}`
+  return `${fromLabel} → ${to}`
 }
 </script>
 
@@ -156,37 +380,60 @@ const formatBucketLabel = (from?: string, to?: number) => {
   &__header
     display: flex
     justify-content: space-between
-    align-items: baseline
+    align-items: flex-start
+    gap: 1rem
+
+  &__heading
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
 
   &__title
     font-size: 1rem
     font-weight: 600
     margin: 0
 
+  &__caption
+    margin: 0
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__actions
+    display: flex
+    align-items: center
+    gap: 0.75rem
+
   &__range
     margin: 0
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__slider
-    margin-top: 0.25rem
-
-  &__buckets
-    display: flex
-    flex-direction: column
-    gap: 0.5rem
-
-  &__bucket
-    display: grid
-    grid-template-columns: auto 1fr auto
-    gap: 0.75rem
-    align-items: center
-
-  &__bucket-label
-    font-size: 0.75rem
-    color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__bucket-count
-    font-size: 0.75rem
     font-variant-numeric: tabular-nums
+
+  &__reset:deep(.v-btn__content)
+    text-transform: none
+
+  &__hint
+    margin: 0
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-soft))
+
+  &__chart-wrapper
+    border-radius: 0.75rem
+    background: rgb(var(--v-theme-surface-glass))
+    padding: 0.75rem
+
+  &__chart
+    width: 100%
+
+  &__empty
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    background: rgb(var(--v-theme-surface-glass))
+    border-radius: 0.75rem
+    padding: 0.75rem
+    text-align: center
+
+@media (max-width: 959px)
+  .category-filter-numeric__chart-wrapper
+    padding: 0.5rem
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -100,6 +100,8 @@
       "showMoreTechnical": "Show more technical filters",
       "hideTechnical": "Hide technical filters",
       "rangeAriaSuffix": "range selection",
+      "rangeClear": "Clear range",
+      "rangeSelectionHint": "Click a bar to set the minimum, then click another to set the maximum.",
       "searchOptions": "Search options",
       "noMatch": "No matching options",
       "missingLabel": "Unlabelled option",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -99,6 +99,8 @@
       "showMoreTechnical": "Plus de filtres",
       "hideTechnical": "Masquer les filtres techniques",
       "rangeAriaSuffix": "sélection d'intervalle",
+      "rangeClear": "Réinitialiser la plage",
+      "rangeSelectionHint": "Cliquez sur une barre pour définir le minimum, puis sur une autre pour définir le maximum.",
       "searchOptions": "Rechercher dans les options",
       "noMatch": "Aucune option correspondante",
       "missingLabel": "Option sans libellé",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,9 @@
     "sharp": "^0.34.0",
     "unhead": "^2.0.14",
     "vue": "3.5.22",
-    "vuetify-nuxt-module": "^0.18.7"
+    "vuetify-nuxt-module": "^0.18.7",
+    "echarts": "^6.0.0",
+    "vue-echarts": "^8.0.1"
   },
   "devDependencies": {
     "@iconify-json/bxl": "^1.2.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       cookie-es:
         specifier: ^2.0.0
         version: 2.0.0
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
       i:
         specifier: ^0.3.7
         version: 0.3.7
@@ -83,6 +86,9 @@ importers:
       vue:
         specifier: 3.5.22
         version: 3.5.22(typescript@5.9.2)
+      vue-echarts:
+        specifier: ^8.0.1
+        version: 8.0.1(echarts@6.0.0)(vue@3.5.22(typescript@5.9.2))
       vuetify-nuxt-module:
         specifier: ^0.18.7
         version: 0.18.8(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.9(@types/node@24.8.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.2))
@@ -4739,6 +4745,9 @@ packages:
   easy-table@1.1.0:
     resolution: {integrity: sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==}
 
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
     engines: {node: '>=14'}
@@ -8332,6 +8341,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8902,6 +8914,12 @@ packages:
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
+  vue-echarts@8.0.1:
+    resolution: {integrity: sha512-23rJTFLu1OUEGRWjJGmdGt8fP+8+ja1gVgzMYPIPaHWpXegcO1viIAaeu2H4QHESlVeHzUAHIxKXGrwjsyXAaA==}
+    peerDependencies:
+      echarts: ^6.0.0
+      vue: 3.5.22
+
   vue-eslint-parser@10.2.0:
     resolution: {integrity: sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -9211,6 +9229,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
 snapshots:
 
@@ -14234,6 +14255,11 @@ snapshots:
     optionalDependencies:
       wcwidth: 1.0.1
 
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   editorconfig@1.0.4:
     dependencies:
       '@one-ini/wasm': 0.1.1
@@ -18609,6 +18635,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -19236,6 +19264,11 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
+  vue-echarts@8.0.1(echarts@6.0.0)(vue@3.5.22(typescript@5.9.2)):
+    dependencies:
+      echarts: 6.0.0
+      vue: 3.5.22(typescript@5.9.2)
+
   vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.3
@@ -19635,3 +19668,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0


### PR DESCRIPTION
## Summary
- replace the numeric filter slider with a client-side ECharts horizontal bar chart that supports range selection
- surface translated helper copy and reset actions for the new chart interface
- add vue-echarts and echarts dependencies to the frontend package

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f23b3ac2b883338a72574a05afdcca