### PR TITLE
feat: improve numeric range filter chart interactions

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -177,10 +177,7 @@ const chartOptions = computed<EChartsOption | null>(() => {
 
   const series = {
     type: 'bar',
-    data: data.map((bucket) => ({
-      ...bucket,
-      name: bucket.rangeLabel,
-    })),
+    datasetIndex: 0,
     encode: { x: 'value', y: 'rangeLabel' },
     barWidth: 24,
     barCategoryGap: '0%',
@@ -216,6 +213,14 @@ const chartOptions = computed<EChartsOption | null>(() => {
   }
 
   const options = {
+    dataset: [
+      {
+        source: data.map((bucket) => ({
+          ...bucket,
+        })),
+        dimensions: ['rangeLabel', 'value', 'count', 'min', 'max', 'selected'],
+      },
+    ],
     grid: {
       top: 8,
       bottom: 8,

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -173,8 +173,6 @@ const chartOptions = computed<EChartsOption | null>(() => {
     return `<strong>${bucket.rangeLabel}</strong><br />${countLabel}`
   }
 
-  const categories = data.map((bucket) => bucket.rangeLabel)
-
   const series = {
     type: 'bar',
     datasetIndex: 0,
@@ -246,7 +244,6 @@ const chartOptions = computed<EChartsOption | null>(() => {
     },
     yAxis: {
       type: 'category',
-      data: categories,
       axisLine: { show: false },
       axisTick: { show: false },
       axisLabel: {

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -173,9 +173,15 @@ const chartOptions = computed<EChartsOption | null>(() => {
     return `<strong>${bucket.rangeLabel}</strong><br />${countLabel}`
   }
 
+  const categories = data.map((bucket) => bucket.rangeLabel)
+
   const series = {
     type: 'bar',
-    data,
+    data: data.map((bucket) => ({
+      ...bucket,
+      name: bucket.rangeLabel,
+    })),
+    encode: { x: 'value', y: 'rangeLabel' },
     barWidth: 24,
     barCategoryGap: '0%',
     barGap: '0%',
@@ -235,7 +241,7 @@ const chartOptions = computed<EChartsOption | null>(() => {
     },
     yAxis: {
       type: 'category',
-      data: data.map((bucket) => bucket.rangeLabel),
+      data: categories,
       axisLine: { show: false },
       axisTick: { show: false },
       axisLabel: {


### PR DESCRIPTION
## Summary
- restyle the numeric range aggregation chart as a horizontal bar chart without gaps or grid lines
- surface bucket labels on the axis and allow selecting a range directly by clicking a bar
- keep the slider, chart selection and applied filter in sync as aggregations or bounds change

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f259088c8883339ce201e69a2b1e3d