### PR TITLE
Fix category structured data cleanup on category page

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -436,11 +436,18 @@ const toAbsoluteUrl = (value?: string | null) => {
   }
 }
 
+type StructuredDataScript = {
+  key: string
+  type: string
+  children: string
+}
+
 const structuredDataScripts = computed(() => {
-  const scripts: Array<{ type: string; children: string }> = []
+  const scripts: StructuredDataScript[] = []
 
   if (breadcrumbJsonLd.value) {
     scripts.push({
+      key: 'category-breadcrumb-jsonld',
       type: 'application/ld+json',
       children: JSON.stringify(breadcrumbJsonLd.value),
     })
@@ -448,6 +455,7 @@ const structuredDataScripts = computed(() => {
 
   if (productListJsonLd.value) {
     scripts.push({
+      key: 'category-product-list-jsonld',
       type: 'application/ld+json',
       children: JSON.stringify(productListJsonLd.value),
     })


### PR DESCRIPTION
## Summary
- add explicit type for category structured data scripts
- assign stable keys to breadcrumb and product list JSON-LD head entries to prevent disposal errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f3b26ede508333bc78510cf3cbe7c8