### PR TITLE
Remove eyebrow props from partner specs

### DIFF
--- a/frontend/app/components/domains/partners/PartnersAffiliationSection.spec.ts
+++ b/frontend/app/components/domains/partners/PartnersAffiliationSection.spec.ts
@@ -15,7 +15,6 @@ describe('PartnersAffiliationSection', () => {
   const baseProps = {
     title: 'Nos partenaires',
     subtitle: 'Ils nous font confiance',
-    eyebrow: 'Affiliation',
     searchLabel: 'Rechercher',
     searchPlaceholder: 'Nom du partenaire',
     emptyStateLabel: 'Aucun résultat',

--- a/frontend/app/components/domains/partners/PartnersStaticCarouselSection.spec.ts
+++ b/frontend/app/components/domains/partners/PartnersStaticCarouselSection.spec.ts
@@ -17,7 +17,6 @@ describe('PartnersStaticCarouselSection', () => {
   const baseProps = {
     title: 'Ecosystème',
     subtitle: 'Des partenaires engagés',
-    eyebrow: 'Ecosystème',
     carouselAriaLabel: 'Carrousel',
     emptyStateLabel: 'Bientôt disponible',
     linkLabel: 'Découvrir',


### PR DESCRIPTION
## Summary
- remove the eyebrow prop from the partners static carousel spec base props
- remove the eyebrow prop from the partners affiliation spec base props

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3b70796248333bd0ea605a76d7132