### PR TITLE
Fix structured data head disposal on category page

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -437,9 +437,9 @@ const toAbsoluteUrl = (value?: string | null) => {
 }
 
 type StructuredDataScript = {
-  key: string
-  type: string
-  children: string
+  id: string
+  type: 'application/ld+json'
+  innerHTML: string
 }
 
 const structuredDataScripts = computed(() => {
@@ -447,17 +447,17 @@ const structuredDataScripts = computed(() => {
 
   if (breadcrumbJsonLd.value) {
     scripts.push({
-      key: 'category-breadcrumb-jsonld',
+      id: 'category-breadcrumb-jsonld',
       type: 'application/ld+json',
-      children: JSON.stringify(breadcrumbJsonLd.value),
+      innerHTML: JSON.stringify(breadcrumbJsonLd.value),
     })
   }
 
   if (productListJsonLd.value) {
     scripts.push({
-      key: 'category-product-list-jsonld',
+      id: 'category-product-list-jsonld',
       type: 'application/ld+json',
-      children: JSON.stringify(productListJsonLd.value),
+      innerHTML: JSON.stringify(productListJsonLd.value),
     })
   }
 

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -464,12 +464,16 @@ const structuredDataScripts = computed(() => {
   return scripts
 })
 
-useHead(() => ({
-  link: [
-    { rel: 'canonical', href: canonicalUrl.value },
-  ],
-  script: structuredDataScripts.value,
-}))
+useHead(() => {
+  const scripts = structuredDataScripts.value
+
+  return {
+    link: [
+      { rel: 'canonical', href: canonicalUrl.value },
+    ],
+    script: scripts.length ? scripts : undefined,
+  }
+})
 
 const verticalId = computed(() => category.value?.id ?? null)
 


### PR DESCRIPTION
## Summary
- guard structured data head scripts so they are only registered when content exists
- prevent head cleanup from failing when the category page unmounts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f3b626c1a08333abc25091946cd80a