### PR TITLE
Fix readonly category filter guard in home slide component

### DIFF
--- a/frontend/app/components/domains/home/sections/The-section-items-slide.vue
+++ b/frontend/app/components/domains/home/sections/The-section-items-slide.vue
@@ -27,32 +27,27 @@ const { pending } = await useAsyncData(
 );
 
 // Transform categories to image URLs for The-slide component
+type CategoryWithHomeAssets = Readonly<VerticalConfigDto> & {
+  imageSmall: string;
+  verticalHomeTitle: string;
+  verticalHomeUrl: string;
+};
+
 const categoryImages = computed(() => {
   return categories.value
-    .filter((category: VerticalConfigDto): category is VerticalConfigDto & {
-      imageSmall: string;
-      verticalHomeTitle: string;
-      verticalHomeUrl: string;
-    } =>
+    .filter((category): category is CategoryWithHomeAssets =>
       Boolean(category.imageSmall) &&
       Boolean(category.verticalHomeTitle) &&
-      Boolean(category.verticalHomeUrl))
-    .map(
-      (
-        category: VerticalConfigDto & {
-          imageSmall: string;
-          verticalHomeTitle: string;
-          verticalHomeUrl: string;
-        }
-      ) => {
-        const sanitizedSlug = category.verticalHomeUrl.replace(/^\/+/, "");
+      Boolean(category.verticalHomeUrl)
+    )
+    .map((category) => {
+      const sanitizedSlug = category.verticalHomeUrl.replace(/^\/+/, "");
 
-        return {
-          imageSmall: category.imageSmall,
-          verticalHomeTitle: category.verticalHomeTitle,
-          href: `/${sanitizedSlug}`
-        };
-      }
-    );
+      return {
+        imageSmall: category.imageSmall,
+        verticalHomeTitle: category.verticalHomeTitle,
+        href: `/${sanitizedSlug}`
+      };
+    });
 });
 </script>


### PR DESCRIPTION
## Summary
- update the home slide category filter to work with the readonly state returned by `useCategories`
- reuse the refined type when mapping slide items to avoid redundant annotations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f3bebb57608333a2fd3580a9fefc9f