### PR TITLE
Fix Vuetify placeholder slot warnings on category product image placeholders

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -21,8 +21,10 @@
           contain
           class="category-product-card-grid__image"
         >
-          <template #placeholder>
-            <v-skeleton-loader type="image" class="h-100" />
+          <template #placeholder="{ isActive }">
+            <div v-if="isActive" class="category-product-card-grid__placeholder">
+              <v-skeleton-loader type="image" class="category-product-card-grid__placeholder-loader" />
+            </div>
           </template>
         </v-img>
 
@@ -176,6 +178,17 @@ const impactScoreValue = (product: ProductDto) => {
       object-fit: contain
       mix-blend-mode: multiply
       background: #fff
+
+  &__placeholder
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 100%
+    height: 100%
+
+  &__placeholder-loader
+    width: 100%
+    height: 100%
 
   &__body
     display: flex

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -12,8 +12,10 @@
             :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
             cover
           >
-            <template #placeholder>
-              <v-skeleton-loader type="image" class="h-100" />
+            <template #placeholder="{ isActive }">
+              <div v-if="isActive" class="category-product-list__placeholder">
+                <v-skeleton-loader type="image" class="category-product-list__placeholder-loader" />
+              </div>
             </template>
           </v-img>
         </v-avatar>
@@ -120,4 +122,15 @@ const offersCountLabel = (product: ProductDto) => {
     flex-wrap: wrap
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__placeholder
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 100%
+    height: 100%
+
+  &__placeholder-loader
+    width: 100%
+    height: 100%
 </style>


### PR DESCRIPTION
## Summary
- scope the `<v-img>` placeholder slot to its `isActive` state in the card and list product views to avoid Vue transition warnings
- add helper styles so the skeleton loaders remain centered and fill the image container while active

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f4995eeec08333bc81ca097cbf2741