### PR TITLE
Disable v-img transitions to prevent placeholder slot warnings

### DIFF
--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -2,7 +2,7 @@
   <section class="category-hero" :aria-labelledby="headingId" data-testid="category-hero">
     <v-sheet class="category-hero__wrapper" elevation="0">
       <div v-if="image" class="category-hero__media" aria-hidden="true">
-        <v-img :src="image" alt="" class="category-hero__image" cover>
+        <v-img :src="image" alt="" class="category-hero__image" cover :transition="false">
           <template #placeholder>
             <v-skeleton-loader type="image" class="h-100" />
           </template>

--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -2,11 +2,7 @@
   <section class="category-hero" :aria-labelledby="headingId" data-testid="category-hero">
     <v-sheet class="category-hero__wrapper" elevation="0">
       <div v-if="image" class="category-hero__media" aria-hidden="true">
-        <v-img :src="image" alt="" class="category-hero__image" cover :transition="false">
-          <template #placeholder>
-            <v-skeleton-loader type="image" class="h-100" />
-          </template>
-        </v-img>
+        <v-img :src="image" alt="" class="category-hero__image" cover :transition="false" />
       </div>
 
       <div class="category-hero__content">
@@ -155,6 +151,21 @@ defineExpose({ headingId, t })
     height: 100%
     min-height: 180px
     width: 100%
+    &.v-img--booting
+      background: linear-gradient(
+        90deg,
+        rgba(var(--v-theme-surface-glass), 0.4),
+        rgba(var(--v-theme-surface-glass), 0.8),
+        rgba(var(--v-theme-surface-glass), 0.4)
+      )
+      background-size: 200% 100%
+      animation: category-hero-image-skeleton 1.2s ease-in-out infinite
+
+@keyframes category-hero-image-skeleton
+  0%
+    background-position: 200% 0
+  100%
+    background-position: -200% 0
 
 @media (min-width: 960px)
   .category-hero__wrapper

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -18,6 +18,7 @@
           :src="resolveImage(product)"
           :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
           :aspect-ratio="4 / 3"
+          :transition="false"
           contain
           class="category-product-card-grid__image"
         >

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -21,11 +21,7 @@
           :transition="false"
           contain
           class="category-product-card-grid__image"
-        >
-          <template #placeholder>
-            <v-skeleton-loader type="image" class="h-100" />
-          </template>
-        </v-img>
+        />
 
         <v-card-item class="category-product-card-grid__body">
           <h3 class="category-product-card-grid__title">
@@ -172,6 +168,18 @@ const impactScoreValue = (product: ProductDto) => {
     display: flex
     align-items: center
     justify-content: center
+    position: relative
+    overflow: hidden
+
+    &.v-img--booting
+      background: linear-gradient(
+        90deg,
+        rgba(var(--v-theme-surface-glass), 0.35),
+        rgba(var(--v-theme-surface-glass), 0.75),
+        rgba(var(--v-theme-surface-glass), 0.35)
+      )
+      background-size: 200% 100%
+      animation: category-product-card-grid-image-skeleton 1.2s ease-in-out infinite
 
     :deep(img)
       object-fit: contain
@@ -223,4 +231,10 @@ const impactScoreValue = (product: ProductDto) => {
   &__score-fallback
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
+
+@keyframes category-product-card-grid-image-skeleton
+  0%
+    background-position: 200% 0
+  100%
+    background-position: -200% 0
 </style>

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -10,6 +10,7 @@
           <v-img
             :src="resolveImage(product)"
             :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
+            :transition="false"
             cover
           >
             <template #placeholder>

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -12,11 +12,7 @@
             :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
             :transition="false"
             cover
-          >
-            <template #placeholder>
-              <v-skeleton-loader type="image" class="h-100" />
-            </template>
-          </v-img>
+          />
         </v-avatar>
       </template>
 
@@ -121,4 +117,20 @@ const offersCountLabel = (product: ProductDto) => {
     flex-wrap: wrap
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
+
+  :deep(.v-avatar .v-img--booting)
+    background: linear-gradient(
+      90deg,
+      rgba(var(--v-theme-surface-glass), 0.35),
+      rgba(var(--v-theme-surface-glass), 0.75),
+      rgba(var(--v-theme-surface-glass), 0.35)
+    )
+    background-size: 200% 100%
+    animation: category-product-list-image-skeleton 1.2s ease-in-out infinite
+
+@keyframes category-product-list-image-skeleton
+  0%
+    background-position: 200% 0
+  100%
+    background-position: -200% 0
 </style>


### PR DESCRIPTION
## Summary
- disable Vuetify v-img transitions on category hero and product imagery to avoid Vue slot warnings during hydration

## Testing
- pnpm generate
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4a60b8d908333972a7616d51024cf