### PR TITLE
feat: refine category fast filters UX

### DIFF
--- a/frontend/app/components/category/CategoryFastFilters.spec.ts
+++ b/frontend/app/components/category/CategoryFastFilters.spec.ts
@@ -17,7 +17,6 @@ vi.mock('vue-i18n', () => ({
       const translations: Record<string, string> = {
         'category.fastFilters.title': 'Quick filters',
         'category.fastFilters.reset': 'Clear fast filters',
-        'category.fastFilters.activeClauses': 'Applied subset filters',
         'category.fastFilters.groupDefault': 'Other quick filters',
         'category.fastFilters.groups.price': 'Price',
         'category.fastFilters.groups.screen_size': 'Screen size',
@@ -304,15 +303,11 @@ describe('CategoryFastFilters', () => {
     expect(finalEvents).toContainEqual(['price_greater_1000', false])
   })
 
-  it('emits a removal event when closing an active quick filter chip', async () => {
+  it('keeps active quick filter chips visible without a close affordance', async () => {
     const wrapper = await mountComponent({ activeSubsetIds: ['small_screens'] })
 
-    const closeButton = wrapper.find('.v-chip-stub[data-value="small_screens"] .v-chip-stub__close')
-    expect(closeButton.exists()).toBe(true)
-
-    await closeButton.trigger('click')
-
-    const events = wrapper.emitted('toggle-subset') ?? []
-    expect(events).toContainEqual(['small_screens', false])
+    const chip = wrapper.find('.v-chip-stub[data-value="small_screens"]')
+    expect(chip.exists()).toBe(true)
+    expect(chip.attributes('data-closable')).toBe('false')
   })
 })

--- a/frontend/app/components/category/CategoryFastFilters.vue
+++ b/frontend/app/components/category/CategoryFastFilters.vue
@@ -37,8 +37,6 @@
                   :variant="isSubsetActive(subset) ? 'flat' : 'outlined'"
                   rounded="lg"
                   class="me-2 mb-2"
-                  :closable="isSubsetActive(subset)"
-                  @click:close="emitToggle(subset, false)"
                 >
                   <span class="category-fast-filters__chip-label">
                     {{ resolveSubsetLabel(subset) }}
@@ -54,8 +52,6 @@
               :variant="isSubsetActive(subset) ? 'flat' : 'outlined'"
               rounded="lg"
               class="me-2 mb-2"
-              :closable="isSubsetActive(subset)"
-              @click:close="emitToggle(subset, false)"
             >
               <span class="category-fast-filters__chip-label">
                 {{ resolveSubsetLabel(subset) }}
@@ -65,42 +61,12 @@
         </v-chip-group>
       </article>
     </div>
-
-    <div v-if="activeClauses.length" class="category-fast-filters__clauses">
-      <p class="category-fast-filters__clauses-title">
-        {{ t('category.fastFilters.activeClauses') }}
-      </p>
-      <v-chip-group column>
-        <v-chip
-          v-for="clause in activeClauses"
-          :key="clause.id"
-          closable
-          variant="text"
-          class="category-fast-filters__clause"
-          color="primary"
-          @click:close="$emit('remove-clause', clause)"
-        >
-          <v-icon icon="mdi-filter-variant" size="18" class="me-1" />
-          <span>{{ clause.label }}</span>
-        </v-chip>
-      </v-chip-group>
-    </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import type { Filter, VerticalSubsetDto } from '~~/shared/api-client'
+import type { VerticalSubsetDto } from '~~/shared/api-client'
 import { useI18n } from 'vue-i18n'
-
-import { convertSubsetCriteriaToFilters } from '~/utils/_subset-to-filters'
-
-interface ClauseSummary {
-  id: string
-  subsetId: string
-  filter: Filter
-  label: string
-  index: number
-}
 
 const props = defineProps<{
   subsets: VerticalSubsetDto[]
@@ -109,7 +75,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'toggle-subset': [subsetId: string, active: boolean]
-  'remove-clause': [clause: ClauseSummary]
   reset: []
 }>()
 
@@ -222,49 +187,6 @@ const resolveSubsetLabel = (subset: VerticalSubsetDto): string => {
   return subset.title ?? subset.caption ?? subset.id ?? subset.group ?? 'subset'
 }
 
-const buildClauseLabel = (subsetId: string, filter: Filter): string => {
-  const field = filter.field ?? 'field'
-
-  if (filter.operator === 'term') {
-    const term = filter.terms?.[0] ?? ''
-    return `${field} = ${term}`
-  }
-
-  const bounds: string[] = []
-  if (typeof filter.min === 'number') {
-    bounds.push(t('category.fastFilters.operator.greaterThan', { value: filter.min }))
-  }
-
-  if (typeof filter.max === 'number') {
-    bounds.push(t('category.fastFilters.operator.lowerThan', { value: filter.max }))
-  }
-
-  if (!bounds.length) {
-    return `${field}`
-  }
-
-  return `${field}: ${bounds.join(' · ')}`
-}
-
-const activeClauses = computed<ClauseSummary[]>(() => {
-  return activeSubsetIds.value.flatMap((subsetId) => {
-    const subset = subsetMap.value[subsetId]
-    if (!subset) {
-      return []
-    }
-
-    const filters = convertSubsetCriteriaToFilters(subset)
-
-    return filters.map((filter, index) => ({
-      id: `${subsetId}-${index}`,
-      subsetId,
-      filter,
-      index,
-      label: buildClauseLabel(subsetId, filter),
-    }))
-  })
-})
-
 const emitToggle = (subset: VerticalSubsetDto, desired: boolean) => {
   if (!subset.id) {
     return
@@ -301,7 +223,6 @@ const onGroupSelectionChange = (groupKey: string, value: unknown) => {
   }
 }
 
-defineExpose({ activeClauses })
 </script>
 
 <style scoped lang="sass">
@@ -368,20 +289,6 @@ defineExpose({ activeClauses })
     box-shadow: 0 12px 20px -14px rgba(var(--v-theme-shadow-primary-600), 0.45)
     font-weight: 600
     color: rgb(var(--v-theme-on-primary))
-
-  &__clauses
-    margin-top: 1rem
-    padding-top: 0.75rem
-    border-top: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6)
-
-  &__clauses-title
-    margin: 0 0 0.5rem
-    font-size: 0.875rem
-    color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__clause
-    margin-bottom: 0.5rem
-    justify-content: flex-start
 
 @media (max-width: 959px)
   .category-fast-filters

--- a/frontend/app/components/category/CategoryFiltersPanel.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersPanel.spec.ts
@@ -1,0 +1,173 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import type { FilterRequestDto } from '~~/shared/api-client'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
+import type { CategorySubsetClause } from '~/types/category-subset'
+
+const resolveClassList = (value: unknown): string => {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => resolveClassList(entry)).filter(Boolean).join(' ')
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, active]) => Boolean(active))
+      .map(([name]) => name)
+      .join(' ')
+  }
+
+  return String(value)
+}
+
+const VChipGroupStub = defineComponent({
+  name: 'VChipGroup',
+  setup(_, { slots, attrs }) {
+    const className = ['v-chip-group-stub', resolveClassList((attrs as Record<string, unknown>).class)]
+      .filter(Boolean)
+      .join(' ')
+
+    return () => h('div', { ...attrs, class: className }, slots.default?.())
+  },
+})
+
+const VChipStub = defineComponent({
+  name: 'VChip',
+  props: {
+    closable: { type: Boolean, default: false },
+    variant: { type: String, default: 'flat' },
+  },
+  emits: ['click:close'],
+  setup(props, { slots, emit, attrs }) {
+    const className = ['v-chip-stub', resolveClassList((attrs as Record<string, unknown>).class)]
+      .filter(Boolean)
+      .join(' ')
+
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: className,
+          type: 'button',
+          'data-closable': props.closable ? 'true' : 'false',
+          onClick: () => emit('click:close'),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: { icon: { type: String, default: '' } },
+  setup(props) {
+    return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VExpansionPanelsStub = defineComponent({
+  name: 'VExpansionPanels',
+  setup(_, { slots, attrs }) {
+    return () => h('div', { class: 'v-expansion-panels-stub', ...attrs }, slots.default?.())
+  },
+})
+
+const VExpansionPanelStub = defineComponent({
+  name: 'VExpansionPanel',
+  props: { value: { type: String, default: '' } },
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-expansion-panel-stub' }, [slots.title?.(), slots.text?.()])
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  props: { type: { type: String, default: 'button' } },
+  emits: ['click'],
+  setup(props, { slots, emit, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['v-btn-stub', resolveClassList((attrs as Record<string, unknown>).class)].join(' '),
+          type: props.type,
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const CategoryFilterListStub = defineComponent({
+  name: 'CategoryFilterList',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'category-filter-list-stub' }, slots.default?.())
+  },
+})
+
+describe('CategoryFiltersPanel', () => {
+  const subsetClause: CategorySubsetClause = {
+    id: 'subset-0',
+    subsetId: 'subset',
+    index: 0,
+    label: 'Price ≤ 500',
+    filter: { field: 'price.min', operator: 'range', max: 500 },
+  }
+
+  const manualFilters: FilterRequestDto = {
+    filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
+  }
+
+  it('renders subset and manual filter chips together and emits removal events', () => {
+    const wrapper = mount(CategoryFiltersPanel, {
+      props: {
+        filterOptions: null,
+        aggregations: [],
+        filters: manualFilters,
+        impactExpanded: false,
+        technicalExpanded: false,
+        subsetClauses: [subsetClause],
+      },
+      global: {
+        stubs: {
+          VChipGroup: VChipGroupStub,
+          VChip: VChipStub,
+          VIcon: VIconStub,
+          VExpansionPanels: VExpansionPanelsStub,
+          VExpansionPanel: VExpansionPanelStub,
+          VBtn: VBtnStub,
+          CategoryFilterList: CategoryFilterListStub,
+        },
+      },
+    })
+
+    const chips = wrapper.findAll('.v-chip-stub')
+    expect(chips).toHaveLength(2)
+
+    expect(chips[0]?.text()).toContain('Price ≤ 500')
+    expect(chips[1]?.text()).toContain('brand: Acme')
+
+    chips[0]?.trigger('click')
+
+    const removalEvents = wrapper.emitted('remove-subset-clause') ?? []
+    expect(removalEvents).toHaveLength(1)
+    expect(removalEvents[0]?.[0]).toEqual(subsetClause)
+  })
+})

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -6,9 +6,11 @@
       :filters="props.filters"
       :impact-expanded="props.impactExpanded"
       :technical-expanded="props.technicalExpanded"
+      :subset-clauses="props.subsetClauses"
       @update:filters="(value) => emit('update:filters', value)"
       @update:impact-expanded="(value) => emit('update:impactExpanded', value)"
       @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
+      @remove-subset-clause="(clause) => emit('remove-subset-clause', clause)"
     />
 
     <div v-if="showMobileActions" class="category-page__filters-actions">
@@ -45,6 +47,7 @@ import type {
 
 import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
+import type { CategorySubsetClause } from '~/types/category-subset'
 
 const props = defineProps<{
   filterOptions: ProductFieldOptionsResponse | null
@@ -57,6 +60,7 @@ const props = defineProps<{
   wikiPages: WikiPageConfig[]
   relatedPosts: BlogPostDto[]
   verticalHomeUrl?: string | null
+  subsetClauses: CategorySubsetClause[]
 }>()
 
 const emit = defineEmits<{
@@ -65,6 +69,7 @@ const emit = defineEmits<{
   'update:technicalExpanded': [boolean]
   'apply-mobile': []
   'clear-mobile': []
+  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const { t } = useI18n()

--- a/frontend/app/types/category-subset.ts
+++ b/frontend/app/types/category-subset.ts
@@ -1,0 +1,9 @@
+import type { Filter } from '~~/shared/api-client'
+
+export interface CategorySubsetClause {
+  id: string
+  subsetId: string
+  filter: Filter
+  index: number
+  label: string
+}

--- a/frontend/app/utils/_subset-to-filters.spec.ts
+++ b/frontend/app/utils/_subset-to-filters.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Filter, VerticalSubsetDto } from '~~/shared/api-client'
+
+import {
+  convertSubsetCriteriaToFilters,
+  getRemainingSubsetFilters,
+  mergeFiltersWithoutDuplicates,
+} from './_subset-to-filters'
+
+describe('_subset-to-filters helpers', () => {
+  const sampleSubset: VerticalSubsetDto = {
+    id: 'sample',
+    title: 'Sample subset',
+    criterias: [
+      { field: 'price.min', operator: 'LOWER_THAN', value: '500' },
+      { field: 'price.min', operator: 'GREATER_THAN', value: '0' },
+    ],
+  }
+
+  it('returns remaining subset filters when removing a specific clause', () => {
+    const remaining = getRemainingSubsetFilters(sampleSubset, 0)
+    expect(remaining).toHaveLength(1)
+
+    const remainingFilter = remaining[0]
+    expect(remainingFilter).toMatchObject({
+      field: 'price.min',
+      operator: 'range',
+      min: 0,
+    })
+  })
+
+  it('deduplicates filters when merging manual and subset clauses', () => {
+    const existing: Filter[] = [
+      { field: 'price.min', operator: 'range', max: 500 },
+    ]
+    const additions = convertSubsetCriteriaToFilters(sampleSubset)
+
+    const merged = mergeFiltersWithoutDuplicates(existing, additions)
+    expect(merged).toHaveLength(2)
+    expect(merged).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'price.min', operator: 'range', max: 500 }),
+        expect.objectContaining({ field: 'price.min', operator: 'range', min: 0 }),
+      ]),
+    )
+  })
+})

--- a/frontend/app/utils/_subset-to-filters.ts
+++ b/frontend/app/utils/_subset-to-filters.ts
@@ -60,6 +60,71 @@ export const convertSubsetCriteriaToFilters = (subset: VerticalSubsetDto): Filte
     .filter((filter): filter is Filter => Boolean(filter))
 }
 
+const normalizeTerms = (terms: string[] | undefined): string[] => {
+  return (terms ?? []).map((term) => `${term}`)
+}
+
+const areTermFiltersEqual = (left: Filter, right: Filter): boolean => {
+  const leftTerms = normalizeTerms(left.terms)
+  const rightTerms = normalizeTerms(right.terms)
+
+  if (leftTerms.length !== rightTerms.length) {
+    return false
+  }
+
+  const sortedLeft = [...leftTerms].sort()
+  const sortedRight = [...rightTerms].sort()
+
+  return sortedLeft.every((value, index) => value === sortedRight[index])
+}
+
+const areRangeFiltersEqual = (left: Filter, right: Filter): boolean => {
+  return (left.min ?? null) === (right.min ?? null) && (left.max ?? null) === (right.max ?? null)
+}
+
+export const areFiltersEquivalent = (left: Filter, right: Filter): boolean => {
+  if (left.field !== right.field || left.operator !== right.operator) {
+    return false
+  }
+
+  if (left.operator === 'term' && right.operator === 'term') {
+    return areTermFiltersEqual(left, right)
+  }
+
+  if (left.operator === 'range' && right.operator === 'range') {
+    return areRangeFiltersEqual(left, right)
+  }
+
+  return false
+}
+
+export const mergeFiltersWithoutDuplicates = (existing: Filter[], additions: Filter[]): Filter[] => {
+  if (!additions.length) {
+    return [...existing]
+  }
+
+  const merged = [...existing]
+
+  additions.forEach((candidate) => {
+    if (!merged.some((entry) => areFiltersEquivalent(entry, candidate))) {
+      merged.push(candidate)
+    }
+  })
+
+  return merged
+}
+
+export const getRemainingSubsetFilters = (
+  subset: VerticalSubsetDto | undefined,
+  removedIndex: number,
+): Filter[] => {
+  if (!subset) {
+    return []
+  }
+
+  return convertSubsetCriteriaToFilters(subset).filter((_, index) => index !== removedIndex)
+}
+
 export const buildFilterRequestFromSubsets = (
   subsets: VerticalSubsetDto[],
   activeSubsetIds: string[],


### PR DESCRIPTION
## Summary
- keep fast-filter chips visible by removing the close affordance from `CategoryFastFilters`
- surface subset clause chips in the shared active filter area and emit removal events through the sidebar
- rebuild subset clause handling so removing one clause keeps the others active via manual filters, with new helpers and tests

## Testing
- pnpm vitest run category/CategoryFiltersPanel.spec.ts
- pnpm vitest run components/category/CategoryFastFilters.spec.ts utils/_subset-to-filters.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f4adea9638833380674686076d2a44