### PR TITLE
Fix import order in CategoryFiltersPanel spec

### DIFF
--- a/frontend/app/components/category/CategoryFiltersPanel.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersPanel.spec.ts
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
+import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
+import type { CategorySubsetClause } from '~/types/category-subset'
 import type { FilterRequestDto } from '~~/shared/api-client'
 
 vi.mock('vue-i18n', () => ({
@@ -8,9 +10,6 @@ vi.mock('vue-i18n', () => ({
     t: (key: string) => key,
   }),
 }))
-
-import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
 
 const resolveClassList = (value: unknown): string => {
   if (!value) {


### PR DESCRIPTION
## Summary
- move the CategoryFiltersPanel component and related type imports to the top of the spec file so eslint's import-order rule passes

## Testing
- not run (lint-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f4b3be208c8333bfdfacf1df08f178