### PR TITLE
Tighten category fast filters layout and sticky toolbar

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -1283,6 +1283,12 @@ const clearAllFilters = () => {
     gap: 1rem
     margin-bottom: 1.5rem
     width: 100%
+    position: sticky
+    top: 0
+    z-index: 5
+    background: rgb(var(--v-theme-surface-default))
+    padding: 0.75rem 0
+    box-shadow: 0 18px 36px -28px rgba(var(--v-theme-shadow-primary-600), 0.38)
 
   &__toolbar-left
     display: flex
@@ -1338,9 +1344,9 @@ const clearAllFilters = () => {
 
   &__filters-surface
     position: sticky
-    top: 96px
+    top: 0
     align-self: start
-    max-height: calc(100vh - 136px)
+    max-height: calc(100vh - 2rem)
     display: flex
     flex-direction: column
     border-radius: 1rem
@@ -1397,7 +1403,7 @@ const clearAllFilters = () => {
     grid-template-columns: minmax(260px, 300px) minmax(0, 1fr)
 
   .category-page__filters-surface
-    max-height: calc(100vh - 152px)
+    max-height: calc(100vh - 2.5rem)
 
 @media (max-width: 959px)
   .category-page__toolbar

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -86,6 +86,8 @@
       "reset": "Clear fast filters",
       "activeClauses": "Applied subset filters",
       "groupDefault": "Other quick filters",
+      "scrollPrevious": "Scroll fast filters to the left",
+      "scrollNext": "Scroll fast filters to the right",
       "groups": {
         "price": "Price",
         "screen_size": "Screen size",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -85,6 +85,8 @@
       "reset": "Réinitialiser les filtres rapides",
       "activeClauses": "Filtres de sous-ensemble appliqués",
       "groupDefault": "Autres filtres rapides",
+      "scrollPrevious": "Faire défiler les filtres rapides vers la gauche",
+      "scrollNext": "Faire défiler les filtres rapides vers la droite",
       "groups": {
         "price": "Prix",
         "screen_size": "Taille d'écran",


### PR DESCRIPTION
## Summary
- redesign the category fast filters component so groups render inline with horizontal scrolling and navigation arrows
- keep the desktop filters surface and products toolbar sticky at the top of the viewport across layouts
- add i18n strings for the fast filter navigation controls

## Testing
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f4e45ebc608333abb9f06f9a279ee1