### PR TITLE
Fix head entry disposal on category page

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -262,6 +262,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, toRaw, watch } from 'vue'
+import type { ActiveHeadEntry } from '@unhead/vue'
 import { useDebounceFn } from '@vueuse/core'
 import { useDisplay } from 'vuetify'
 import { isNavigationFailure } from 'vue-router'
@@ -479,8 +480,26 @@ useHead(() => ({
   link: [
     { rel: 'canonical', href: canonicalUrl.value },
   ],
-  script: structuredDataScripts.value,
 }))
+
+let structuredDataHeadEntry: ActiveHeadEntry | null = null
+
+watch(
+  structuredDataScripts,
+  (scripts) => {
+    structuredDataHeadEntry?.dispose?.()
+
+    if (!scripts.length) {
+      structuredDataHeadEntry = null
+      return
+    }
+
+    structuredDataHeadEntry = useHead({
+      script: scripts,
+    })
+  },
+  { immediate: true },
+)
 
 const verticalId = computed(() => category.value?.id ?? null)
 
@@ -1168,6 +1187,9 @@ onBeforeUnmount(() => {
   if (import.meta.client) {
     window.removeEventListener('hashchange', handleHashChange)
   }
+
+  structuredDataHeadEntry?.dispose?.()
+  structuredDataHeadEntry = null
 })
 
 watch(

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -454,52 +454,11 @@ type StructuredDataScript = {
   children: string
 }
 
-const structuredDataScripts = computed(() => {
-  const scripts: StructuredDataScript[] = []
-
-  if (breadcrumbJsonLd.value) {
-    scripts.push({
-      key: 'category-breadcrumb-jsonld',
-      type: 'application/ld+json',
-      children: JSON.stringify(breadcrumbJsonLd.value),
-    })
-  }
-
-  if (productListJsonLd.value) {
-    scripts.push({
-      key: 'category-product-list-jsonld',
-      type: 'application/ld+json',
-      children: JSON.stringify(productListJsonLd.value),
-    })
-  }
-
-  return scripts
-})
-
 useHead(() => ({
   link: [
     { rel: 'canonical', href: canonicalUrl.value },
   ],
 }))
-
-let structuredDataHeadEntry: ActiveHeadEntry<UseHeadInput> | null = null
-
-watch(
-  structuredDataScripts,
-  (scripts) => {
-    structuredDataHeadEntry?.dispose?.()
-
-    if (!scripts.length) {
-      structuredDataHeadEntry = null
-      return
-    }
-
-    structuredDataHeadEntry = useHead({
-      script: scripts,
-    })
-  },
-  { immediate: true },
-)
 
 const verticalId = computed(() => category.value?.id ?? null)
 
@@ -929,6 +888,47 @@ const productListJsonLd = computed(() => {
     itemListElement: filteredItems,
   }
 })
+
+const structuredDataScripts = computed(() => {
+  const scripts: StructuredDataScript[] = []
+
+  if (breadcrumbJsonLd.value) {
+    scripts.push({
+      key: 'category-breadcrumb-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(breadcrumbJsonLd.value),
+    })
+  }
+
+  if (productListJsonLd.value) {
+    scripts.push({
+      key: 'category-product-list-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(productListJsonLd.value),
+    })
+  }
+
+  return scripts
+})
+
+let structuredDataHeadEntry: ActiveHeadEntry<UseHeadInput> | null = null
+
+watch(
+  structuredDataScripts,
+  (scripts) => {
+    structuredDataHeadEntry?.dispose?.()
+
+    if (!scripts.length) {
+      structuredDataHeadEntry = null
+      return
+    }
+
+    structuredDataHeadEntry = useHead({
+      script: scripts,
+    })
+  },
+  { immediate: true },
+)
 
 const resultsCountLabel = computed(() =>
   translatePlural('category.products.resultsCount', resultsCount.value),

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -262,7 +262,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, toRaw, watch } from 'vue'
-import type { ActiveHeadEntry } from '@unhead/vue'
+import type { ActiveHeadEntry, UseHeadInput } from '@unhead/vue'
 import { useDebounceFn } from '@vueuse/core'
 import { useDisplay } from 'vuetify'
 import { isNavigationFailure } from 'vue-router'
@@ -482,7 +482,7 @@ useHead(() => ({
   ],
 }))
 
-let structuredDataHeadEntry: ActiveHeadEntry | null = null
+let structuredDataHeadEntry: ActiveHeadEntry<UseHeadInput> | null = null
 
 watch(
   structuredDataScripts,


### PR DESCRIPTION
## Summary
- avoid registering structured data head entries when no schema scripts are available on the category page
- track and dispose the structured data head entry when the component unmounts to prevent undefined dispose errors

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f5b7f11ddc83339ca4ac6e966174cf