### PR TITLE
feat: expose detailed price trends in front-api

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -732,11 +732,12 @@ public class ProductController {
                     @Parameter(name = "gtin",
                             description = "Global Trade Item Number (8–14 digit numeric code)",
                             example = "8806095491998",
-                            required = true),
+                            required = true,
+                            schema = @Schema(type = "integer", format = "int64", minimum = "0")),
                     @Parameter(
                             name        = "include",
                             in          = ParameterIn.QUERY,
-                            description = "Champs à inclure (peut se répéter)",
+                            description = "Components to include in the response (repeatable parameter)",
                             array       = @ArraySchema(
                                 schema = @Schema(implementation = ProductDtoComponent.class)
                             )

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/PriceTrendState.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/PriceTrendState.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Enumeration describing the direction of a price evolution compared to the
+ * previously recorded value.
+ */
+@Schema(description = "Direction of the price change compared to the previous recorded value.")
+public enum PriceTrendState {
+
+    /** Price decreased between the last two measurements. */
+    PRICE_DECREASE,
+
+    /** Price remained stable between the last two measurements. */
+    PRICE_STABLE,
+
+    /** Price increased between the last two measurements. */
+    PRICE_INCREASE
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductOffersDto.java
@@ -2,6 +2,7 @@ package org.open4goods.nudgerfrontapi.dto.product;
 
 import java.util.List;
 import java.util.Map;
+
 import org.open4goods.model.product.ProductCondition;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,8 +27,10 @@ public record ProductOffersDto(
         ProductPriceHistoryDto newHistory,
         @Schema(description = "Price history for second hand products", nullable = true)
         ProductPriceHistoryDto occasionHistory,
-        @Schema(description = "Price evolution trends per condition", nullable = true)
-        Map<ProductCondition, Integer> trends,
+        @Schema(description = "Trend computed from brand new offers", nullable = true)
+        ProductPriceTrendDto newTrend,
+        @Schema(description = "Trend computed from occasion offers", nullable = true)
+        ProductPriceTrendDto occasionTrend,
         @Schema(description = "Gap between current best price and historical lowest price", nullable = true)
         Double historyPriceGap
 ) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceTrendDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductPriceTrendDto.java
@@ -1,0 +1,25 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * API representation of a product price trend, exposing the direction of the
+ * change and additional pricing metrics extracted from the history.
+ */
+public record ProductPriceTrendDto(
+        @Schema(description = "Direction of the price evolution compared to the previous entry", implementation = PriceTrendState.class, nullable = true)
+        PriceTrendState trend,
+        @Schema(description = "Elapsed time in milliseconds between the two last price measurements", example = "86400000", nullable = true)
+        Long period,
+        @Schema(description = "Current price used for the trend computation", example = "199.99", nullable = true)
+        Double actualPrice,
+        @Schema(description = "Previous price used as a comparison point", example = "189.99", nullable = true)
+        Double lastPrice,
+        @Schema(description = "Absolute price difference between the current and the previous value", example = "10.0", nullable = true)
+        Double variation,
+        @Schema(description = "Lowest historical price found in the series", example = "149.99", nullable = true)
+        Double historicalLowestPrice,
+        @Schema(description = "Difference between the current price and the historical lowest value", example = "50.0", nullable = true)
+        Double historicalVariation
+) {
+}


### PR DESCRIPTION
## Summary
- compute price trends for new and occasion offers using the domain PriceTrend model
- expose a dedicated ProductPriceTrendDto backed by a PriceTrendState enum and wire it into ProductOffersDto
- polish the ProductController GTIN parameter documentation to match the method signature

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68f5c37ef22c833383f825dfbbbf1e1f