### PR TITLE
Add client-side localisation for global filter fields

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -43,6 +43,7 @@
 
 <script setup lang="ts">
 import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
 import VueECharts from 'vue-echarts'
 import type { EChartsOption } from 'echarts'
 import type { CallbackDataParams } from 'echarts/types/dist/shared'
@@ -65,7 +66,7 @@ const emit = defineEmits<{ 'update:modelValue': [Filter | null] }>()
 const { t } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
 
-const displayTitle = computed(() => props.field.title ?? props.field.mapping ?? '')
+const displayTitle = computed(() => resolveFilterFieldTitle(props.field, t))
 
 const ariaLabel = computed(() => `${displayTitle.value} ${t('category.filters.rangeAriaSuffix')}`)
 

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
 
 const props = defineProps<{
   field: FieldMetadataDto
@@ -51,7 +52,7 @@ const emit = defineEmits<{ 'update:modelValue': [Filter | null] }>()
 
 const { t } = useI18n()
 
-const displayTitle = computed(() => props.field.title ?? props.field.mapping ?? '')
+const displayTitle = computed(() => resolveFilterFieldTitle(props.field, t))
 
 const search = ref('')
 const localTerms = ref<string[]>(props.modelValue?.terms ?? [])

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -44,6 +44,7 @@
 
 <script setup lang="ts">
 import type { FieldMetadataDto, ProductDto } from '~~/shared/api-client'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
 
 interface CategoryProductTableRow extends Record<string, unknown> {
   product: ProductDto
@@ -81,7 +82,7 @@ const dynamicHeaders = computed(() => {
       seen.add(mapping)
       return {
         key: mapping,
-        title: field.title ?? mapping,
+        title: resolveFilterFieldTitle(field, t, mapping),
         sortable: false,
       }
     })

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -301,6 +301,7 @@ import {
   mergeFiltersWithoutDuplicates,
 } from '~/utils/_subset-to-filters'
 import type { CategorySubsetClause } from '~/types/category-subset'
+import { resolveSortFieldTitle } from '~/utils/_field-localization'
 
 const route = useRoute()
 const router = useRouter()
@@ -762,7 +763,7 @@ const sortItems = computed(() => {
       seen.add(field.mapping as string)
       return {
         value: field.mapping as string,
-        title: field.title ?? field.mapping,
+        title: resolveSortFieldTitle(field, t),
       }
     })
 })

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -1,0 +1,70 @@
+import type { FieldMetadataDto } from '~~/shared/api-client'
+
+type TranslateFn = (key: string, ...args: unknown[]) => string
+
+const FILTER_FIELD_TRANSLATION_KEYS: Record<string, string> = {
+  'price.minPrice.price': 'category.filters.fields.price',
+  offersCount: 'category.filters.fields.offersCount',
+  'price.conditions': 'category.filters.fields.condition',
+  googleTaxonomyId: 'category.filters.fields.googleTaxonomyId',
+  'attributes.referentielAttributes.BRAND': 'category.filters.fields.brand',
+  'gtinInfos.country': 'category.filters.fields.country',
+  datasourceCodes: 'category.filters.fields.datasource',
+}
+
+const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {
+  'price.minPrice.price': 'category.products.sort.fields.price',
+  offersCount: 'category.products.sort.fields.offersCount',
+}
+
+const resolveTranslation = (mapping: string, t: TranslateFn, keys: Record<string, string>): string | null => {
+  const translationKey = keys[mapping]
+  if (!translationKey) {
+    return null
+  }
+
+  const translated = t(translationKey)
+  return translated && translated !== translationKey ? translated : null
+}
+
+const normalizeTitle = (title?: string | null) => title?.trim() ?? ''
+
+export const resolveFilterFieldTitle = (
+  field: FieldMetadataDto | undefined,
+  t: TranslateFn,
+  fallbackMapping?: string | null,
+): string => {
+  const providedTitle = normalizeTitle(field?.title)
+  if (providedTitle) {
+    return providedTitle
+  }
+
+  const mapping = field?.mapping ?? fallbackMapping ?? ''
+  if (!mapping) {
+    return ''
+  }
+
+  const translated =
+    resolveTranslation(mapping, t, FILTER_FIELD_TRANSLATION_KEYS) ??
+    resolveTranslation(mapping, t, SORT_FIELD_TRANSLATION_KEYS)
+
+  return translated ?? mapping
+}
+
+export const resolveSortFieldTitle = (field: FieldMetadataDto, t: TranslateFn): string => {
+  const providedTitle = normalizeTitle(field.title)
+  if (providedTitle) {
+    return providedTitle
+  }
+
+  const mapping = field.mapping ?? ''
+  if (!mapping) {
+    return ''
+  }
+
+  const translated =
+    resolveTranslation(mapping, t, SORT_FIELD_TRANSLATION_KEYS) ??
+    resolveTranslation(mapping, t, FILTER_FIELD_TRANSLATION_KEYS)
+
+  return translated ?? mapping
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -109,7 +109,16 @@
       "noMatch": "No matching options",
       "missingLabel": "Unlabelled option",
       "mobileApply": "Apply filters",
-      "mobileClear": "Clear all filters"
+      "mobileClear": "Clear all filters",
+      "fields": {
+        "price": "Price range",
+        "offersCount": "Number of offers",
+        "condition": "Offer condition",
+        "googleTaxonomyId": "Google product category",
+        "brand": "Brand",
+        "country": "GTIN country code",
+        "datasource": "Data sources"
+      }
     },
     "products": {
       "untitledProduct": "Unnamed product",
@@ -150,7 +159,13 @@
       "viewList": "List view",
       "viewTable": "Table view",
       "openFilters": "Filters",
-      "noResults": "No products match the selected filters."
+      "noResults": "No products match the selected filters.",
+      "sort": {
+        "fields": {
+          "price": "Lowest price",
+          "offersCount": "Number of offers"
+        }
+      }
     },
     "documentation": {
       "guidesTitle": "Helpful guides",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -108,7 +108,16 @@
       "noMatch": "Aucune option correspondante",
       "missingLabel": "Option sans libellé",
       "mobileApply": "Appliquer les filtres",
-      "mobileClear": "Effacer les filtres"
+      "mobileClear": "Effacer les filtres",
+      "fields": {
+        "price": "Fourchette de prix",
+        "offersCount": "Nombre d'offres",
+        "condition": "État des offres",
+        "googleTaxonomyId": "Catégorie produit Google",
+        "brand": "Marque",
+        "country": "Code pays du GTIN",
+        "datasource": "Sources de données"
+      }
     },
     "products": {
       "untitledProduct": "Produit sans nom",
@@ -149,7 +158,13 @@
       "viewList": "Vue liste",
       "viewTable": "Vue tableau",
       "openFilters": "Filtres",
-      "noResults": "Aucun produit ne correspond aux filtres sélectionnés."
+      "noResults": "Aucun produit ne correspond aux filtres sélectionnés.",
+      "sort": {
+        "fields": {
+          "price": "Prix le plus bas",
+          "offersCount": "Nombre d'offres"
+        }
+      }
     },
     "documentation": {
       "guidesTitle": "Guides utiles",


### PR DESCRIPTION
## Summary
- add a utility to translate globally-defined filter and sort fields when the API does not provide titles
- update category filter components, product tables, and sort selectors to use the translated labels
- supply default English and French strings for the affected filter and sort fields

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f5c927ac508333aff538c8aa99a9dd