### PR TITLE
feat: arrange category filter charts in responsive grid

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -68,7 +68,12 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
 
 <style scoped lang="sass">
 .category-filter-list
-  display: flex
-  flex-direction: column
+  display: grid
   gap: 1.5rem
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))
+  align-items: stretch
+
+  &__item
+    display: flex
+    flex-direction: column
 </style>

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -304,6 +304,7 @@ const formatBucketLabel = (from?: string, to?: number) => {
   display: flex
   flex-direction: column
   gap: 0.75rem
+  height: 100%
 
   &__header
     display: flex

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -111,6 +111,7 @@ const formatOptionLabel = (key?: string) => key ?? t('category.filters.missingLa
   display: flex
   flex-direction: column
   gap: 0.75rem
+  height: 100%
 
   &__header
     display: flex


### PR DESCRIPTION
## Summary
- arrange category filter panels in a responsive grid so aggregation charts flow horizontally within the available width
- let numeric and terms filter cards stretch to fill their grid cells for consistent sizing

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f6038809648333a323ddf1be7c11a5