### PR TITLE
Normalize wiki page path lookups

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -249,7 +249,9 @@ export default defineNuxtConfig({
         gtinRedirectPage.path = '/:gtin(\\d{6,})'
       }
 
-      const wikiSourcePage = pages.find(page => page.file?.includes('/app/pages/xwiki-fullpage.vue'))
+      const wikiSourcePage = pages.find((page) =>
+        normalizePath(page.file)?.includes('/app/pages/xwiki-fullpage.vue')
+      )
 
       if (!wikiSourcePage) {
         return


### PR DESCRIPTION
## Summary
- ensure the wiki page lookup in nuxt.config.ts normalizes file paths like the GTIN lookup

## Testing
- pnpm dev *(terminated manually after confirming startup)*

------
https://chatgpt.com/codex/tasks/task_e_68f62cecb86083338b93dbdf2ba3e489