### PR TITLE
Fix sidebar filter widgets width responsiveness

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -67,13 +67,15 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
 </script>
 
 <style scoped lang="sass">
+
 .category-filter-list
   display: grid
   gap: 1.5rem
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr))
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr))
   align-items: stretch
 
   &__item
     display: flex
     flex-direction: column
+    min-width: 0
 </style>

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.vue
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.vue
@@ -323,6 +323,8 @@ const formatBucketLabel = (from?: string, to?: number) => {
 
   &__slider
     margin-top: 0.25rem
+    width: 100%
+    min-width: 0
 
   &__chart
     width: 100%

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -118,6 +118,10 @@ const formatOptionLabel = (key?: string) => key ?? t('category.filters.missingLa
     flex-direction: column
     gap: 0.5rem
 
+  &__search
+    width: 100%
+    min-width: 0
+
   &__title
     margin: 0
     font-size: 1rem


### PR DESCRIPTION
## Summary
- allow category filter grid items to shrink below 280px so the panel adapts when the sidebar is resized
- ensure numeric sliders and terms search inputs stretch to the available width inside the resizable sidebar

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f63df0c7388333841e7c35b7a8738b