### PR TITLE
Add cached product references to score and ranking DTOs

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductRankingDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductRankingDto.java
@@ -10,10 +10,10 @@ public record ProductRankingDto(
         Long globalPosition,
         @Schema(description = "Number of items considered in the global ranking", example = "5000")
         Long globalCount,
-        @Schema(description = "GTIN of the best ranked product in the global ranking", nullable = true)
-        Long globalBest,
-        @Schema(description = "GTIN of the product ranked immediately above", nullable = true)
-        Long globalBetter,
+        @Schema(description = "Details about the best ranked product", implementation = ProductReferenceDto.class, nullable = true)
+        ProductReferenceDto globalBest,
+        @Schema(description = "Details about the product ranked immediately above", implementation = ProductReferenceDto.class, nullable = true)
+        ProductReferenceDto globalBetter,
         @Schema(description = "Specialised ranking position", example = "12")
         Long specializedPosition,
         @Schema(description = "Number of items considered in the specialised ranking", example = "120")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductReferenceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductReferenceDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Lightweight representation of a related product used in ranking sections.
+ */
+public record ProductReferenceDto(
+        @Schema(description = "GTIN identifier of the referenced product", example = "7612345678901")
+        Long id,
+        @Schema(description = "Fully qualified slug pointing to the product page", example = "/telephones-reconditionnes/fairphone-4", nullable = true)
+        String fullSlug,
+        @Schema(description = "Best resolved product name", example = "Fairphone 4", nullable = true)
+        String bestName,
+        @Schema(description = "Brand associated with the product", example = "Fairphone", nullable = true)
+        String brand,
+        @Schema(description = "Model identifier exposed by the datasource", example = "FP4", nullable = true)
+        String model
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
@@ -26,10 +26,10 @@ public record ProductScoreDto(
         Map<String, String> metadatas,
         @Schema(description = "Ranking of the product for this score", nullable = true)
         Integer ranking,
-        @Schema(description = "GTIN of the product with the lowest score", nullable = true)
-        Long lowestScoreId,
-        @Schema(description = "GTIN of the product with the highest score", nullable = true)
-        Long highestScoreId,
+        @Schema(description = "Details for the product with the lowest score", implementation = ProductReferenceDto.class, nullable = true)
+        ProductReferenceDto lowestScore,
+        @Schema(description = "Details for the product with the highest score", implementation = ProductReferenceDto.class, nullable = true)
+        ProductReferenceDto highestScore,
         @Schema(description = "Percentage representation of the score on a 0-100 scale", nullable = true)
         Long percent,
         @Schema(description = "Score scaled on 0-20", nullable = true)


### PR DESCRIPTION
## Summary
- expose a new ProductReferenceDto and replace GTIN-only fields in ProductScoreDto and ProductRankingDto
- resolve score and ranking references via ProductRepository#multiGetById with a one-hour cache in ProductMappingService
- cover the new behaviour in ProductMappingServiceTest by wiring a cache manager mock and verifying slug resolution

## Testing
- mvn -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68f63b83a340833382a226b30f0dff41