### PR TITLE
Add favicons to product offers and AI sources

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CommercialEventsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CommercialEventsController.java
@@ -3,10 +3,12 @@ package org.open4goods.nudgerfrontapi.controller.api;
 import java.util.List;
 
 import org.open4goods.model.RolesConstants;
+import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
 import org.open4goods.nudgerfrontapi.dto.event.CommercialEventDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.nudgerfrontapi.service.CommercialEventService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -46,7 +48,8 @@ public class CommercialEventsController {
      * List commercial events configured in the application properties.
      *
      * @param domainLanguage mandatory domain language hint driving localisation
-     * @return commercial events ready to be consumed by the frontend
+     * @return commercial events ready to be consumed by the frontend. Results are cached for one hour using the
+     *         {@link CacheConstants#ONE_HOUR_LOCAL_CACHE_NAME} cache to avoid recomputing static configuration.
      */
     @GetMapping
     @Operation(
@@ -67,6 +70,7 @@ public class CommercialEventsController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<List<CommercialEventDto>> commercialEvents(
             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
         List<CommercialEventDto> events = commercialEventService.commercialEvents(domainLanguage);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -727,7 +727,8 @@ public class ProductController {
     @GetMapping("/{gtin}")
     @Operation(
             summary = "Get product view",
-            description = "Return high‑level product information, aggregated scores and optional AI review content.",
+            description = "Return high‑level product information, aggregated scores and optional AI review content, "
+                    + "including datasource favicons for offers and AI source references.",
             security = @SecurityRequirement(name = "bearer-jwt"),
             parameters = {
                     @Parameter(name = "gtin",

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/AiReviewSourceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/AiReviewSourceDto.java
@@ -16,6 +16,10 @@ public record AiReviewSourceDto(
         String description,
 
         @Schema(description = "Public URL to access the source", format = "uri", example = "https://example.org/datasheet.pdf")
-        String url
+        String url,
+
+        @Schema(description = "URL pointing to the favicon associated with the source domain", format = "uri",
+                example = "https://static.open4goods.org/favicon?url=https://example.org")
+        String favicon
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAggregatedPriceDto.java
@@ -11,6 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ProductAggregatedPriceDto(
         @Schema(description = "Datasource providing the offer", example = "amazon.fr")
         String datasourceName,
+        @Schema(description = "URL pointing to the datasource favicon", format = "uri",
+                example = "https://static.open4goods.org/icon/amazon.fr")
+        String favicon,
         @Schema(description = "Displayed offer title")
         String offerName,
         @Schema(description = "Target URL of the offer", example = "https://example.org/product/123")


### PR DESCRIPTION
## Summary
- add favicon metadata to product aggregated price and AI review source DTOs
- compute favicon URLs in the product mapping service using the configured resource root
- document favicon availability in the product endpoint and cache commercial events responses for one hour

## Testing
- mvn -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68f734eba42483338ce1772e424c57b9