### PR TITLE
Align category hero breadcrumb styling

### DIFF
--- a/frontend/app/components/category/CategoryHero.spec.ts
+++ b/frontend/app/components/category/CategoryHero.spec.ts
@@ -37,9 +37,8 @@ describe('CategoryHero', () => {
             template: '<div class="v-img"><slot /></div>',
             props: ['src', 'alt', 'cover'],
           },
-          VBreadcrumbs: { template: '<nav class="v-breadcrumbs"><slot /></nav>' },
-          VBreadcrumbsItem: { template: '<span class="v-breadcrumbs-item"><slot /></span>' },
           VSkeletonLoader: { template: '<div class="v-skeleton" />' },
+          NuxtLink: { template: '<a><slot /></a>' },
         },
       },
     })
@@ -59,10 +58,16 @@ describe('CategoryHero', () => {
     expect(wrapper.get('h1').text()).toBe('Energy efficient dishwashers')
     expect(wrapper.text()).toContain('Compare eco-designed dishwashers to reduce energy consumption.')
 
-    const breadcrumbItems = wrapper.findAll('.v-breadcrumbs-item')
+    const breadcrumbItems = wrapper.findAll(
+      '.category-navigation-breadcrumbs__item',
+    )
     expect(breadcrumbItems).toHaveLength(2)
-    const firstBreadcrumb = breadcrumbItems.at(0)
-    expect(firstBreadcrumb?.text()).toBe('Home')
+    const firstBreadcrumbLink = breadcrumbItems.at(0)?.find('a')
+    expect(firstBreadcrumbLink?.text()).toBe('Home')
+
+    const lastBreadcrumb = breadcrumbItems.at(1)
+    expect(lastBreadcrumb?.find('a').exists()).toBe(false)
+    expect(lastBreadcrumb?.text()).toContain('Appliances')
 
     const section = wrapper.get('section')
     expect(section.attributes('aria-labelledby')).toBeTruthy()

--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -10,24 +10,11 @@
       </div>
 
       <div class="category-hero__content">
-        <v-breadcrumbs
-          v-if="breadcrumbs.length"
-          :aria-label="t('category.hero.breadcrumbAriaLabel')"
+        <CategoryNavigationBreadcrumbs
+          v-if="heroBreadcrumbs.length"
+          v-bind="heroBreadcrumbProps"
           class="category-hero__breadcrumbs"
-        >
-          <template #divider>
-            <span class="category-hero__breadcrumb-divider" aria-hidden="true">
-              {{ t('category.hero.breadcrumbDivider') }}
-            </span>
-          </template>
-          <v-breadcrumbs-item
-            v-for="(item, index) in breadcrumbs"
-            :key="`${index}-${item.title ?? item.link ?? index}`"
-            :href="item.link || undefined"
-          >
-            {{ item.title ?? item.link ?? t('category.hero.missingBreadcrumbTitle') }}
-          </v-breadcrumbs-item>
-        </v-breadcrumbs>
+        />
 
         <div class="category-hero__copy">
           <p v-if="eyebrow" class="category-hero__eyebrow">
@@ -50,6 +37,13 @@ import { useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { CategoryBreadcrumbItemDto } from '~~/shared/api-client'
 
+import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
+
+type HeroBreadcrumbItem = {
+  title: string
+  link?: string
+}
+
 const props = defineProps<{
   title: string
   description?: string | null
@@ -63,6 +57,34 @@ const { t } = useI18n()
 
 const breadcrumbs = computed(() => props.breadcrumbs ?? [])
 const eyebrow = computed(() => props.eyebrow ?? null)
+
+const heroBreadcrumbs = computed<HeroBreadcrumbItem[]>(() => {
+  const items = breadcrumbs.value
+    .map((item) => ({
+      title:
+        item.title?.trim().length
+          ? item.title
+          : item.link?.trim().length
+            ? item.link
+            : t('category.hero.missingBreadcrumbTitle'),
+      link: item.link?.trim().length ? item.link : undefined,
+    }))
+    .filter((item) => item.title.trim().length)
+
+  if (!items.length) {
+    return []
+  }
+
+  return items.map((item, index) => ({
+    ...item,
+    link: index === items.length - 1 ? undefined : item.link,
+  }))
+})
+
+const heroBreadcrumbProps = computed(() => ({
+  items: heroBreadcrumbs.value,
+  ariaLabel: t('category.hero.breadcrumbAriaLabel'),
+}))
 
 defineExpose({ headingId, t })
 </script>
@@ -93,22 +115,25 @@ defineExpose({ headingId, t })
     width: 100%
 
   &__breadcrumbs
-    --v-breadcrumbs-divider-color: rgba(var(--v-theme-hero-overlay-strong), 0.6)
-    color: rgba(var(--v-theme-hero-overlay-strong), 0.9)
-    font-size: 0.875rem
-
-    :deep(.v-breadcrumbs-item)
-      color: inherit
-
-    :deep(.v-breadcrumbs-divider)
-      color: inherit
-
-  &__breadcrumb-divider
     display: inline-flex
-    align-items: center
-    padding: 0 0.5rem
-    color: inherit
-    font-size: inherit
+    color: rgba(var(--v-theme-hero-overlay-strong), 0.9)
+
+    :deep(.category-navigation-breadcrumbs)
+      color: inherit
+
+    :deep(.category-navigation-breadcrumbs__separator)
+      color: rgba(var(--v-theme-hero-overlay-strong), 0.6)
+
+    :deep(.category-navigation-breadcrumbs__current)
+      color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
+
+    :deep(.category-navigation-breadcrumbs__link)
+      color: inherit
+
+    :deep(.category-navigation-breadcrumbs__link:hover),
+    :deep(.category-navigation-breadcrumbs__link:focus-visible)
+      color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
+      text-decoration: underline
 
   &__eyebrow
     display: inline-flex


### PR DESCRIPTION
## Summary
- reuse the CategoryNavigationBreadcrumbs component in the category hero to match the categories navigation breadcrumb styling and keep the last crumb non-clickable
- normalize category hero breadcrumb data and styling to follow the shared overlay look and ensure fallbacks for missing labels
- update the CategoryHero unit test to cover the new breadcrumb markup and behaviour

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f733ec7ac883339587cb70ce8b5c23