### PR TITLE
feat: add non-linear price slider scale

### DIFF
--- a/frontend/app/components/category/filters/price-scale.spec.ts
+++ b/frontend/app/components/category/filters/price-scale.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { priceToSliderValue, sliderValueToPrice } from './price-scale'
+
+describe('price-scale conversions', () => {
+  it('maps price bounds to slider positions and back', () => {
+    const cases: Array<{ price: number; slider: number }> = [
+      { price: 0, slider: 0 },
+      { price: 500, slider: 100 },
+      { price: 1000, slider: 200 },
+      { price: 7500, slider: 290 },
+    ]
+
+    cases.forEach(({ price, slider }) => {
+      expect(priceToSliderValue(price)).toBe(slider)
+      expect(sliderValueToPrice(slider)).toBe(price)
+    })
+  })
+})

--- a/frontend/app/components/category/filters/price-scale.ts
+++ b/frontend/app/components/category/filters/price-scale.ts
@@ -1,0 +1,87 @@
+export type PriceScaleSegment = {
+  limit: number
+  step: number
+}
+
+const PRICE_SCALE_SEGMENTS: PriceScaleSegment[] = [
+  { limit: 1000, step: 5 },
+  { limit: 5000, step: 50 },
+  { limit: 20000, step: 250 },
+]
+
+const DEFAULT_STEP = 1000
+
+const clampNumericValue = (value: number | null | undefined, fallback = 0): number => {
+  if (value == null || Number.isNaN(value)) {
+    return fallback
+  }
+
+  return Math.max(0, Number(value))
+}
+
+const resolveSegmentSteps = (lowerBound: number, segment: PriceScaleSegment): number => {
+  return Math.round((segment.limit - lowerBound) / segment.step)
+}
+
+export const priceToSliderValue = (price: number | null | undefined): number => {
+  const safePrice = clampNumericValue(price)
+  let position = 0
+  let lowerBound = 0
+
+  for (const segment of PRICE_SCALE_SEGMENTS) {
+    if (safePrice <= lowerBound) {
+      return position
+    }
+
+    const segmentSteps = resolveSegmentSteps(lowerBound, segment)
+    if (safePrice >= segment.limit) {
+      position += segmentSteps
+      lowerBound = segment.limit
+      continue
+    }
+
+    const relativeValue = Math.round((safePrice - lowerBound) / segment.step)
+    return position + relativeValue
+  }
+
+  const lastLimit = PRICE_SCALE_SEGMENTS.at(-1)?.limit ?? 0
+  const lastStep = PRICE_SCALE_SEGMENTS.at(-1)?.step ?? DEFAULT_STEP
+  const extraSteps = Math.round((safePrice - lastLimit) / lastStep)
+
+  return position + extraSteps
+}
+
+export const sliderValueToPrice = (sliderValue: number | null | undefined): number => {
+  const safeValue = clampNumericValue(sliderValue)
+  let remaining = Math.round(safeValue)
+  let lowerBound = 0
+
+  for (const segment of PRICE_SCALE_SEGMENTS) {
+    const segmentSteps = resolveSegmentSteps(lowerBound, segment)
+    if (remaining <= segmentSteps) {
+      return lowerBound + remaining * segment.step
+    }
+
+    remaining -= segmentSteps
+    lowerBound = segment.limit
+  }
+
+  const lastStep = PRICE_SCALE_SEGMENTS.at(-1)?.step ?? DEFAULT_STEP
+  return lowerBound + remaining * lastStep
+}
+
+export const isPriceField = (mapping: string | null | undefined): boolean => {
+  if (!mapping) {
+    return false
+  }
+
+  return mapping.toLowerCase().includes('price')
+}
+
+export const clampSliderRange = ([min, max]: [number, number]): [number, number] => {
+  if (Number.isNaN(min) || Number.isNaN(max)) {
+    return [0, 0]
+  }
+
+  return min <= max ? [min, max] : [max, min]
+}


### PR DESCRIPTION
## Summary
- detect price-based numeric filters and convert slider values through a dedicated non-linear scale
- keep histogram selections and slider positions in sync while emitting numeric ranges
- add unit coverage for the price scale helper at representative points

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate *(fails: TypeScript reports an excessive stack depth while analysing `app/pages/feedback/index.vue`)*

------
https://chatgpt.com/codex/tasks/task_e_68f8850c5b408333bac6b932b9ba97b0