### PR TITLE
fix: align pdf viewer async component typing

### DIFF
--- a/frontend/app/components/product/ProductDocumentationSection.vue
+++ b/frontend/app/components/product/ProductDocumentationSection.vue
@@ -30,16 +30,16 @@
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent, type DefineComponent, type PropType } from 'vue'
+import { defineAsyncComponent, type PropType } from 'vue'
 import '@vue-pdf-viewer/viewer/dist/style.css'
 import { useI18n } from 'vue-i18n'
 import type { ProductPdfDto } from '~~/shared/api-client'
 
-type PdfViewerComponent = DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>
+type PdfViewerComponent = (typeof import('@vue-pdf-viewer/viewer'))['VPdfViewer']
 
 const PdfViewer = defineAsyncComponent<PdfViewerComponent>(async () => {
   const module = await import('@vue-pdf-viewer/viewer')
-  return module.VPdfViewer as PdfViewerComponent
+  return module.VPdfViewer
 })
 
 defineProps({


### PR DESCRIPTION
## Summary
- derive the PDF viewer component type directly from the module export
- remove the redundant DefineComponent import and unsafe cast in the async component loader

## Testing
- pnpm lint
- pnpm test *(fails: existing suite cannot resolve optional front-end dependencies such as `date-fns`)*
- pnpm generate *(fails: TypeScript compile step reports missing dependencies including `@vue-pdf-viewer/viewer` in type resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68f8d15ed65083339fabf93b47792e89