### PR TITLE
Fix sanitizeHtml initialization order in ProductAiReviewSection

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -268,6 +268,16 @@ const statusMessage = computed(() => {
   })
 })
 
+function sanitizeHtml(content: string | null): string | null {
+  if (!content) {
+    return null
+  }
+
+  return DOMPurify.sanitize(content, {
+    ADD_ATTR: ['target', 'rel', 'class'],
+  })
+}
+
 function normalizeReview(reviewData: AiReviewDto | null): ReviewContent | null {
   if (!reviewData) {
     return null
@@ -316,16 +326,6 @@ function normalizeReview(reviewData: AiReviewDto | null): ReviewContent | null {
     attributes,
     dataQuality: reviewData.dataQuality ?? null,
   }
-}
-
-const sanitizeHtml = (content: string | null): string | null => {
-  if (!content) {
-    return null
-  }
-
-  return DOMPurify.sanitize(content, {
-    ADD_ATTR: ['target', 'rel', 'class'],
-  })
 }
 
 const startRequest = () => {


### PR DESCRIPTION
## Summary
- define the sanitizeHtml helper as a function and place it before normalizeReview so initial review hydration can run without hitting the temporal dead zone
- keep the component logic otherwise unchanged so SSR watchers and existing rendering continue to behave the same way

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68f8d941fff88333a78d5e08538971a9