### PR TITLE
Preserve baseline filter options on category page

### DIFF
--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -29,6 +29,7 @@
             <CategoryFilterList
               :fields="filterOptions?.global ?? []"
               :aggregations="aggregationMap"
+              :baseline-aggregations="baselineAggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"
               @update-terms="updateTermsFilter"
@@ -49,6 +50,7 @@
             <CategoryFilterList
               :fields="impactPrimary"
               :aggregations="aggregationMap"
+              :baseline-aggregations="baselineAggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"
               @update-terms="updateTermsFilter"
@@ -68,6 +70,7 @@
                 v-if="impactExpanded"
                 :fields="impactRemaining"
                 :aggregations="aggregationMap"
+                :baseline-aggregations="baselineAggregationMap"
                 :active-filters="activeFilters"
                 class="mt-3"
                 @update-range="updateRangeFilter"
@@ -90,6 +93,7 @@
             <CategoryFilterList
               :fields="technicalPrimary"
               :aggregations="aggregationMap"
+              :baseline-aggregations="baselineAggregationMap"
               :active-filters="activeFilters"
               @update-range="updateRangeFilter"
               @update-terms="updateTermsFilter"
@@ -109,6 +113,7 @@
                 v-if="technicalExpanded"
                 :fields="technicalRemaining"
                 :aggregations="aggregationMap"
+                :baseline-aggregations="baselineAggregationMap"
                 :active-filters="activeFilters"
                 class="mt-3"
                 @update-range="updateRangeFilter"
@@ -154,14 +159,20 @@ type SubsetFilterChip = {
 
 type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
 
-const props = defineProps<{
-  filterOptions: ProductFieldOptionsResponse | null
-  aggregations: AggregationResponseDto[]
-  filters: FilterRequestDto | null
-  impactExpanded: boolean
-  technicalExpanded: boolean
-  subsetClauses: CategorySubsetClause[]
-}>()
+const props = withDefaults(
+  defineProps<{
+    filterOptions: ProductFieldOptionsResponse | null
+    aggregations: AggregationResponseDto[]
+    baselineAggregations?: AggregationResponseDto[]
+    filters: FilterRequestDto | null
+    impactExpanded: boolean
+    technicalExpanded: boolean
+    subsetClauses: CategorySubsetClause[]
+  }>(),
+  {
+    baselineAggregations: () => [],
+  },
+)
 
 const emit = defineEmits<{
   'update:filters': [FilterRequestDto]
@@ -178,6 +189,16 @@ const { t } = useI18n()
 const aggregationMap = computed<Record<string, AggregationResponseDto>>(() => {
   return (props.aggregations ?? []).reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
     if (aggregation.field) {
+      accumulator[aggregation.field] = aggregation
+    }
+
+    return accumulator
+  }, {})
+})
+
+const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(() => {
+  return (props.baselineAggregations ?? []).reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
+    if (aggregation.field && !(aggregation.field in accumulator)) {
       accumulator[aggregation.field] = aggregation
     }
 

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -3,6 +3,7 @@
     <CategoryFiltersPanel
       :filter-options="props.filterOptions"
       :aggregations="props.aggregations"
+      :baseline-aggregations="props.baselineAggregations"
       :filters="props.filters"
       :impact-expanded="props.impactExpanded"
       :technical-expanded="props.technicalExpanded"
@@ -49,19 +50,26 @@ import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
 import type { CategorySubsetClause } from '~/types/category-subset'
 
-const props = defineProps<{
-  filterOptions: ProductFieldOptionsResponse | null
-  aggregations: AggregationResponseDto[]
-  filters: FilterRequestDto | null
-  impactExpanded: boolean
-  technicalExpanded: boolean
-  showMobileActions: boolean
-  hasDocumentation: boolean
-  wikiPages: WikiPageConfig[]
-  relatedPosts: BlogPostDto[]
-  verticalHomeUrl?: string | null
-  subsetClauses: CategorySubsetClause[]
-}>()
+const props = withDefaults(
+  defineProps<{
+    filterOptions: ProductFieldOptionsResponse | null
+    aggregations: AggregationResponseDto[]
+    baselineAggregations?: AggregationResponseDto[]
+    filters: FilterRequestDto | null
+    impactExpanded: boolean
+    technicalExpanded: boolean
+    showMobileActions: boolean
+    hasDocumentation: boolean
+    wikiPages: WikiPageConfig[]
+    relatedPosts: BlogPostDto[]
+    verticalHomeUrl?: string | null
+    subsetClauses: CategorySubsetClause[]
+  }>(),
+  {
+    baselineAggregations: () => [],
+    verticalHomeUrl: null,
+  },
+)
 
 const emit = defineEmits<{
   'update:filters': [FilterRequestDto]

--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -6,6 +6,7 @@
       :key="field.mapping ?? field.title"
       :field="field"
       :aggregation="aggregations[field.mapping ?? '']"
+      :baseline-aggregation="baselineAggregations[field.mapping ?? '']"
       :model-value="findActiveFilter(field.mapping)"
       class="category-filter-list__item"
       @update:model-value="onFilterChange(field, $event)"
@@ -23,11 +24,17 @@ import type {
 import CategoryFilterNumeric from './CategoryFilterNumeric.vue'
 import CategoryFilterTerms from './CategoryFilterTerms.vue'
 
-const props = defineProps<{
-  fields: FieldMetadataDto[]
-  aggregations: Record<string, AggregationResponseDto>
-  activeFilters: Filter[]
-}>()
+const props = withDefaults(
+  defineProps<{
+    fields: FieldMetadataDto[]
+    aggregations: Record<string, AggregationResponseDto>
+    baselineAggregations?: Record<string, AggregationResponseDto>
+    activeFilters: Filter[]
+  }>(),
+  {
+    baselineAggregations: () => ({} as Record<string, AggregationResponseDto>),
+  },
+)
 
 const emit = defineEmits<{
   'update-range': [field: string, payload: { min?: number; max?: number }]


### PR DESCRIPTION
## Summary
- capture and preserve the initial aggregation payload on the category page so range filters keep their original bounds
- pass the preserved aggregation data through the category filter components and merge it with live buckets so term options remain visible with zero counts
- visually soften zero-count term checkboxes without disabling them so users can re-enable filters if desired

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fa4255fd588333a8a5e34918d8f696