### PR TITLE
Add layout-aware Nuxt error experience

### DIFF
--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -50,16 +50,6 @@
                 {{ actionLabels.goHome }}
               </v-btn>
               <v-btn
-                variant="tonal"
-                color="primary"
-                class="error-page__action"
-                size="large"
-                prepend-icon="mdi-compass-outline"
-                @click="handleBrowseCategories"
-              >
-                {{ actionLabels.browseCategories }}
-              </v-btn>
-              <v-btn
                 variant="text"
                 color="primary"
                 class="error-page__action"
@@ -87,31 +77,6 @@
                 {{ pageStrings.statusMessage }}
               </p>
 
-              <div class="error-page__divider" role="presentation" />
-
-              <p class="error-page__aside-title">
-                {{ asideTitle }}
-              </p>
-              <p class="error-page__aside-description">
-                {{ asideDescription }}
-              </p>
-
-              <ul class="error-page__highlight-list">
-                <li
-                  v-for="highlight in asideHighlights"
-                  :key="highlight"
-                  class="error-page__highlight-item"
-                >
-                  <v-icon
-                    icon="mdi-check-circle-outline"
-                    size="small"
-                    class="error-page__highlight-icon"
-                  />
-                  <span class="error-page__highlight-text">
-                    {{ highlight }}
-                  </span>
-                </li>
-              </ul>
             </div>
           </aside>
         </v-container>
@@ -183,17 +148,8 @@ const actionsAriaLabel = computed(() => String(t('error.page.actions.ariaLabel')
 
 const actionLabels = computed(() => ({
   goHome: String(t('error.page.actions.goHome')),
-  browseCategories: String(t('error.page.actions.browseCategories')),
   contactSupport: String(t('error.page.actions.contactSupport')),
 }))
-
-const asideTitle = computed(() => String(t('error.page.aside.title')))
-const asideDescription = computed(() => String(t('error.page.aside.description')))
-const asideHighlights = computed(() => [
-  String(t('error.page.aside.highlights.catalog')),
-  String(t('error.page.aside.highlights.impact')),
-  String(t('error.page.aside.highlights.community')),
-])
 
 useSeoMeta({
   title: () => pageStrings.value.title,
@@ -210,11 +166,6 @@ const toggleDrawer = () => {
 const handleGoHome = () => {
   clearError({ redirect: localePath('index') })
 }
-
-const handleBrowseCategories = () => {
-  clearError({ redirect: localePath('categories') })
-}
-
 const handleContactSupport = () => {
   clearError({ redirect: localePath('contact') })
 }
@@ -322,42 +273,6 @@ const handleContactSupport = () => {
 .error-page__status-message
   font-size: 1rem
   color: rgba(var(--v-theme-text-neutral-soft), 0.95)
-
-.error-page__divider
-  height: 1px
-  background: linear-gradient(90deg, rgba(var(--v-theme-border-primary-strong), 0), rgba(var(--v-theme-border-primary-strong), 0.65), rgba(var(--v-theme-border-primary-strong), 0))
-  margin-block: 0.5rem
-
-.error-page__aside-title
-  font-size: 1.125rem
-  font-weight: 600
-  color: rgb(var(--v-theme-text-neutral-strong))
-
-.error-page__aside-description
-  font-size: 1rem
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
-
-.error-page__highlight-list
-  list-style: none
-  padding: 0
-  margin: 0
-  display: grid
-  gap: 0.75rem
-
-.error-page__highlight-item
-  display: flex
-  align-items: center
-  gap: 0.5rem
-  padding: 0.75rem 1rem
-  border-radius: 16px
-  background: rgba(var(--v-theme-surface-primary-080), 0.9)
-
-.error-page__highlight-icon
-  color: rgb(var(--v-theme-accent-supporting))
-
-.error-page__highlight-text
-  font-size: 0.95rem
-  color: rgb(var(--v-theme-text-neutral-strong))
 
 @media (max-width: 959px)
   .error-page__content, .error-page__status-card

--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -1,0 +1,372 @@
+<template>
+  <v-app class="error-app">
+    <The-main-menu-container @toggle-drawer="toggleDrawer" />
+
+    <ClientOnly>
+      <v-navigation-drawer
+        v-model="drawer"
+        location="start"
+        temporary
+        width="300"
+        class="mobile-menu-drawer"
+      >
+        <the-mobile-menu @close="drawer = false" />
+      </v-navigation-drawer>
+    </ClientOnly>
+
+    <ClientOnly>
+      <template #fallback>
+        <div class="pre-hydration-app-bar-spacer" aria-hidden="true" />
+      </template>
+    </ClientOnly>
+
+    <v-main>
+      <section class="error-page" aria-labelledby="error-page-title">
+        <v-container fluid class="error-page__container" tag="div">
+          <div class="error-page__content">
+            <p class="error-page__eyebrow">{{ eyebrow }}</p>
+            <h1 id="error-page-title" class="error-page__title">
+              {{ pageStrings.title }}
+            </h1>
+            <p class="error-page__description">
+              {{ pageStrings.description }}
+            </p>
+            <p class="error-page__helper">
+              {{ pageStrings.helper }}
+            </p>
+
+            <div
+              class="error-page__actions"
+              role="group"
+              :aria-label="actionsAriaLabel"
+            >
+              <v-btn
+                color="primary"
+                class="error-page__action"
+                size="large"
+                prepend-icon="mdi-home"
+                @click="handleGoHome"
+              >
+                {{ actionLabels.goHome }}
+              </v-btn>
+              <v-btn
+                variant="tonal"
+                color="primary"
+                class="error-page__action"
+                size="large"
+                prepend-icon="mdi-compass-outline"
+                @click="handleBrowseCategories"
+              >
+                {{ actionLabels.browseCategories }}
+              </v-btn>
+              <v-btn
+                variant="text"
+                color="primary"
+                class="error-page__action"
+                size="large"
+                prepend-icon="mdi-lifebuoy"
+                @click="handleContactSupport"
+              >
+                {{ actionLabels.contactSupport }}
+              </v-btn>
+            </div>
+          </div>
+
+          <aside class="error-page__aside" aria-labelledby="error-status-heading">
+            <div class="error-page__status-card">
+              <p id="error-status-heading" class="error-page__status-eyebrow">
+                {{ pageStrings.badge }}
+              </p>
+              <p class="error-page__status-code" aria-hidden="true">
+                {{ paddedStatusCode }}
+              </p>
+              <p class="error-page__status-label">
+                {{ statusLabel }}
+              </p>
+              <p class="error-page__status-message">
+                {{ pageStrings.statusMessage }}
+              </p>
+
+              <div class="error-page__divider" role="presentation" />
+
+              <p class="error-page__aside-title">
+                {{ asideTitle }}
+              </p>
+              <p class="error-page__aside-description">
+                {{ asideDescription }}
+              </p>
+
+              <ul class="error-page__highlight-list">
+                <li
+                  v-for="highlight in asideHighlights"
+                  :key="highlight"
+                  class="error-page__highlight-item"
+                >
+                  <v-icon
+                    icon="mdi-check-circle-outline"
+                    size="small"
+                    class="error-page__highlight-icon"
+                  />
+                  <span class="error-page__highlight-text">
+                    {{ highlight }}
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </aside>
+        </v-container>
+      </section>
+    </v-main>
+
+    <TheMainFooter>
+      <template #footer>
+        <TheMainFooterContent />
+      </template>
+    </TheMainFooter>
+  </v-app>
+</template>
+
+<script setup lang="ts">
+import type { NuxtError } from '#app'
+
+interface ErrorPageStrings {
+  badge: string
+  title: string
+  description: string
+  helper: string
+  statusMessage: string
+}
+
+const props = defineProps<{
+  error: NuxtError<Record<string, unknown>>
+}>()
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+
+const drawer = useState('mobileDrawer', () => false)
+const drawerStore = useState('mobileDrawer', () => false)
+
+const statusCode = computed(() => props.error?.statusCode ?? 500)
+const paddedStatusCode = computed(() => String(statusCode.value).padStart(3, '0'))
+const is404 = computed(() => statusCode.value === 404)
+
+const pageStrings = computed<ErrorPageStrings>(() => {
+  const fallbackStatusMessage = props.error?.statusMessage
+
+  if (is404.value) {
+    return {
+      badge: String(t('error.page.notFound.badge')),
+      title: String(t('error.page.notFound.title')),
+      description: String(t('error.page.notFound.description')),
+      helper: String(t('error.page.notFound.helper')),
+      statusMessage: String(
+        fallbackStatusMessage ?? t('error.page.notFound.statusMessage'),
+      ),
+    }
+  }
+
+  return {
+    badge: String(t('error.page.generic.badge')),
+    title: String(t('error.page.generic.title')),
+    description: String(t('error.page.generic.description')),
+    helper: String(t('error.page.generic.helper')),
+    statusMessage: String(
+      fallbackStatusMessage ?? t('error.page.generic.statusMessage'),
+    ),
+  }
+})
+
+const eyebrow = computed(() => String(t('error.page.eyebrow')))
+const statusLabel = computed(() => String(t('error.page.statusLabel', { code: paddedStatusCode.value })))
+const actionsAriaLabel = computed(() => String(t('error.page.actions.ariaLabel')))
+
+const actionLabels = computed(() => ({
+  goHome: String(t('error.page.actions.goHome')),
+  browseCategories: String(t('error.page.actions.browseCategories')),
+  contactSupport: String(t('error.page.actions.contactSupport')),
+}))
+
+const asideTitle = computed(() => String(t('error.page.aside.title')))
+const asideDescription = computed(() => String(t('error.page.aside.description')))
+const asideHighlights = computed(() => [
+  String(t('error.page.aside.highlights.catalog')),
+  String(t('error.page.aside.highlights.impact')),
+  String(t('error.page.aside.highlights.community')),
+])
+
+useSeoMeta({
+  title: () => pageStrings.value.title,
+  ogTitle: () => pageStrings.value.title,
+  description: () => pageStrings.value.description,
+  ogDescription: () => pageStrings.value.description,
+  robots: () => (is404.value ? 'noindex, follow' : 'noindex, nofollow'),
+})
+
+const toggleDrawer = () => {
+  drawerStore.value = !drawerStore.value
+}
+
+const handleGoHome = () => {
+  clearError({ redirect: localePath('index') })
+}
+
+const handleBrowseCategories = () => {
+  clearError({ redirect: localePath('categories') })
+}
+
+const handleContactSupport = () => {
+  clearError({ redirect: localePath('contact') })
+}
+</script>
+
+<style scoped lang="sass">
+.error-app
+  background: rgb(var(--v-theme-surface-default))
+
+.pre-hydration-app-bar-spacer
+  height: 64px
+
+  @media (max-width: 959px)
+    height: 56px
+
+.error-page
+  position: relative
+  background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.1), rgba(var(--v-theme-hero-gradient-end), 0.16))
+
+.error-page__container
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(min(340px, 100%), 1fr))
+  gap: clamp(2rem, 4vw, 3.5rem)
+  padding-block: clamp(4rem, 12vh, 8rem)
+  padding-inline: clamp(1.5rem, 6vw, 4rem)
+
+.error-page__content
+  align-self: center
+  background: rgba(var(--v-theme-surface-glass), 0.88)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6)
+  border-radius: 28px
+  box-shadow: 0 32px 80px rgba(var(--v-theme-shadow-primary-600), 0.18)
+  padding: clamp(2rem, 5vw, 3.25rem)
+  backdrop-filter: blur(20px)
+
+.error-page__eyebrow
+  font-size: 0.875rem
+  font-weight: 600
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  margin-bottom: 0.75rem
+
+.error-page__title
+  font-size: clamp(2.25rem, 4vw, 3.25rem)
+  line-height: 1.15
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+  margin-bottom: 1rem
+
+.error-page__description
+  font-size: 1.125rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+  margin-bottom: 1.5rem
+
+.error-page__helper
+  font-size: 1rem
+  color: rgba(var(--v-theme-text-neutral-soft), 0.95)
+  margin-bottom: 2.5rem
+
+.error-page__actions
+  display: flex
+  flex-wrap: wrap
+  gap: 0.75rem
+
+.error-page__action
+  flex: 1 1 220px
+  justify-content: flex-start
+
+.error-page__aside
+  align-self: stretch
+  display: flex
+  justify-content: center
+
+.error-page__status-card
+  background: rgba(var(--v-theme-surface-glass-strong), 0.92)
+  border-radius: 28px
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.55)
+  padding: clamp(2rem, 4.5vw, 3rem)
+  width: min(420px, 100%)
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  box-shadow: 0 26px 60px rgba(var(--v-theme-shadow-primary-600), 0.16)
+  backdrop-filter: blur(16px)
+
+.error-page__status-eyebrow
+  font-size: 0.875rem
+  font-weight: 600
+  letter-spacing: 0.1em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+
+.error-page__status-code
+  font-size: clamp(4.5rem, 8vw, 6rem)
+  font-weight: 700
+  letter-spacing: -0.04em
+  color: rgb(var(--v-theme-accent-primary-highlight))
+  margin: -0.5rem 0 0.25rem
+
+.error-page__status-label
+  font-size: 1rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+
+.error-page__status-message
+  font-size: 1rem
+  color: rgba(var(--v-theme-text-neutral-soft), 0.95)
+
+.error-page__divider
+  height: 1px
+  background: linear-gradient(90deg, rgba(var(--v-theme-border-primary-strong), 0), rgba(var(--v-theme-border-primary-strong), 0.65), rgba(var(--v-theme-border-primary-strong), 0))
+  margin-block: 0.5rem
+
+.error-page__aside-title
+  font-size: 1.125rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.error-page__aside-description
+  font-size: 1rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.error-page__highlight-list
+  list-style: none
+  padding: 0
+  margin: 0
+  display: grid
+  gap: 0.75rem
+
+.error-page__highlight-item
+  display: flex
+  align-items: center
+  gap: 0.5rem
+  padding: 0.75rem 1rem
+  border-radius: 16px
+  background: rgba(var(--v-theme-surface-primary-080), 0.9)
+
+.error-page__highlight-icon
+  color: rgb(var(--v-theme-accent-supporting))
+
+.error-page__highlight-text
+  font-size: 0.95rem
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+@media (max-width: 959px)
+  .error-page__content, .error-page__status-card
+    border-radius: 24px
+    padding: clamp(1.75rem, 6vw, 2.25rem)
+
+  .error-page__actions
+    flex-direction: column
+
+  .error-page__action
+    justify-content: center
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -97,17 +97,7 @@
       "actions": {
         "ariaLabel": "Error recovery quick actions",
         "goHome": "Back to homepage",
-        "browseCategories": "Browse categories",
         "contactSupport": "Contact support"
-      },
-      "aside": {
-        "title": "Here’s what you can do",
-        "description": "Keep exploring our transparent impact resources while we guide you back on track.",
-        "highlights": {
-          "catalog": "Discover curated guides across every product category.",
-          "impact": "Understand how we calculate environmental impact with open data.",
-          "community": "Join the community and share feedback to improve Nudger."
-        }
       }
     }
   },

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -76,6 +76,41 @@
     },
     "siteName": "Nudger"
   },
+  "error": {
+    "page": {
+      "eyebrow": "Unexpected detour",
+      "statusLabel": "Status code {code}",
+      "notFound": {
+        "badge": "Page missing",
+        "title": "We can’t find this page",
+        "description": "The link you followed may be broken or the page may have moved.",
+        "helper": "Use the navigation links below or return to the homepage to continue exploring responsible shopping.",
+        "statusMessage": "Error 404 — the requested resource could not be located."
+      },
+      "generic": {
+        "badge": "We hit a snag",
+        "title": "We're working on a fix",
+        "description": "An unexpected error prevented us from loading this page.",
+        "helper": "Please try another section of Nudger or reach out if the problem persists.",
+        "statusMessage": "Error 500 — something went wrong on our side."
+      },
+      "actions": {
+        "ariaLabel": "Error recovery quick actions",
+        "goHome": "Back to homepage",
+        "browseCategories": "Browse categories",
+        "contactSupport": "Contact support"
+      },
+      "aside": {
+        "title": "Here’s what you can do",
+        "description": "Keep exploring our transparent impact resources while we guide you back on track.",
+        "highlights": {
+          "catalog": "Discover curated guides across every product category.",
+          "impact": "Understand how we calculate environmental impact with open data.",
+          "community": "Join the community and share feedback to improve Nudger."
+        }
+      }
+    }
+  },
   "category": {
     "hero": {
       "breadcrumbAriaLabel": "Category navigation breadcrumb",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -75,6 +75,41 @@
     },
     "siteName": "Nudger"
   },
+  "error": {
+    "page": {
+      "eyebrow": "Changement de cap inattendu",
+      "statusLabel": "Code statut {code}",
+      "notFound": {
+        "badge": "Page introuvable",
+        "title": "Nous ne trouvons pas cette page",
+        "description": "Le lien suivi est peut-être obsolète ou la page a été déplacée.",
+        "helper": "Utilisez les liens ci-dessous ou retournez à l’accueil pour poursuivre votre exploration responsable.",
+        "statusMessage": "Erreur 404 — la ressource demandée est introuvable."
+      },
+      "generic": {
+        "badge": "Un contretemps est survenu",
+        "title": "Nous corrigeons le problème",
+        "description": "Une erreur inattendue nous a empêchés de charger cette page.",
+        "helper": "Essayez une autre section de Nudger ou contactez-nous si le problème persiste.",
+        "statusMessage": "Erreur 500 — quelque chose s’est mal passé de notre côté."
+      },
+      "actions": {
+        "ariaLabel": "Actions rapides pour se remettre sur la bonne voie",
+        "goHome": "Retour à l’accueil",
+        "browseCategories": "Parcourir les catégories",
+        "contactSupport": "Contacter le support"
+      },
+      "aside": {
+        "title": "Ce que vous pouvez faire",
+        "description": "Continuez d’explorer nos ressources transparentes pendant que nous vous remettons sur la bonne voie.",
+        "highlights": {
+          "catalog": "Découvrez nos guides sélectionnés dans chaque catégorie de produits.",
+          "impact": "Comprenez comment nous calculons l’impact environnemental grâce aux données ouvertes.",
+          "community": "Rejoignez la communauté et partagez vos retours pour améliorer Nudger."
+        }
+      }
+    }
+  },
   "category": {
     "hero": {
       "breadcrumbAriaLabel": "Fil d'Ariane des catégories",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -83,7 +83,7 @@
         "badge": "Page introuvable",
         "title": "Nous ne trouvons pas cette page",
         "description": "Le lien suivi est peut-être obsolète ou la page a été déplacée.",
-        "helper": "Utilisez les liens ci-dessous ou retournez à l’accueil pour poursuivre votre exploration responsable.",
+        "helper": "Utilisez les liens ci-dessous ou retournez à l’accueil pour poursuivre votre exploration.",
         "statusMessage": "Erreur 404 — la ressource demandée est introuvable."
       },
       "generic": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -96,17 +96,7 @@
       "actions": {
         "ariaLabel": "Actions rapides pour se remettre sur la bonne voie",
         "goHome": "Retour à l’accueil",
-        "browseCategories": "Parcourir les catégories",
         "contactSupport": "Contacter le support"
-      },
-      "aside": {
-        "title": "Ce que vous pouvez faire",
-        "description": "Continuez d’explorer nos ressources transparentes pendant que nous vous remettons sur la bonne voie.",
-        "highlights": {
-          "catalog": "Découvrez nos guides sélectionnés dans chaque catégorie de produits.",
-          "impact": "Comprenez comment nous calculons l’impact environnemental grâce aux données ouvertes.",
-          "community": "Rejoignez la communauté et partagez vos retours pour améliorer Nudger."
-        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- add a dedicated `app/error.vue` that renders the main menu, mobile drawer, and footer alongside new 404/500 recovery content
- introduce English and French i18n strings for the shared error UI copy and quick actions

## Testing
- pnpm lint
- pnpm test *(fails: existing components/shared/menus/menus-auth.spec.ts mocking issue – `useStorageMock` initialization)*
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fa482b70f883338a7506ff28e7e725