### PR TITLE
Simplify product search validation and enable CLASSE_ENERGY aggregations

### DIFF
--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -45,12 +45,12 @@ excludingTokensFromCategoriesMatching:
 
 # The scores that are available to build the impact score
 availableImpactScoreCriterias:
-#    CLASSE_ENERGY:
-#      key: CLASSE_ENERGY
-#      title:
-#        fr: "Classe énergétique"      
-#      description:
-#        fr: "La classe énergétique"
+    CLASSE_ENERGY:
+      key: CLASSE_ENERGY
+      title:
+        fr: "Classe énergétique"
+      description:
+        fr: "La classe énergétique"
     REPAIRABILITY_INDEX:
       key: REPAIRABILITY_INDEX
       title:


### PR DESCRIPTION
## Summary
- refactored the product search endpoint to centralise filter, sort and aggregation validation with reusable helpers and documentation
- derive aggregation capabilities from vertical configuration to align allowed fields with configured metadata
- enable the CLASSE_ENERGY impact score in the default vertical configuration so related aggregations stay accepted

## Testing
- mvn -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68faeafef0dc83339a443d16dc6a107b