### PR TITLE
Refactor product hero layout and breadcrumbs

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -278,7 +278,9 @@ describe('ProductHero', () => {
 
     const stage = wrapper.get('[data-testid="product-gallery-stage"]')
     expect(stage.classes()).not.toContain('product-gallery__stage--video')
-    expect(stage.text()).toContain('Source A')
+    const stageImage = stage.find('img')
+    expect(stageImage.exists()).toBe(true)
+    expect(stageImage.attributes('alt')).toBe('Front view')
 
     const thumbnails = wrapper.findAll('[data-testid="product-gallery-thumbnail"]')
     expect(thumbnails).toHaveLength(2)
@@ -312,8 +314,8 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     const breadcrumbLinks = wrapper.findAll('.breadcrumbs-stub__item')
-    expect(breadcrumbLinks).toHaveLength(3)
-    expect(breadcrumbLinks[2]?.attributes('href')).toBe('/appliances/demo-product')
+    expect(breadcrumbLinks).toHaveLength(2)
+    expect(breadcrumbLinks[1]?.attributes('href')).toBe('/appliances')
 
     const merchantPrefix = wrapper.get('.product-hero__price-merchant-prefix')
     expect(merchantPrefix.text()).toBe('At')

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -7,116 +7,7 @@
     <meta itemprop="sku" :content="String(product.base?.gtin ?? '')" />
     <meta itemprop="brand" :content="product.identity?.brand ?? ''" />
 
-    <div class="product-hero__gallery">
-      <ClientOnly>
-        <template #default>
-          <div v-if="galleryItems.length" class="product-gallery">
-            <button
-              v-if="heroMedia"
-              type="button"
-              class="product-gallery__stage"
-              :class="{ 'product-gallery__stage--video': heroMedia.type === 'video' }"
-            :aria-label="stageAriaLabel"
-            data-testid="product-gallery-stage"
-            @click="openGallery(activeMediaIndex)"
-            @keydown.enter.prevent="openGallery(activeMediaIndex)"
-            @keydown.space.prevent="openGallery(activeMediaIndex)"
-          >
-            <NuxtImg
-              v-if="heroMedia.type === 'image'"
-              :src="heroMedia.previewUrl"
-              :alt="heroMedia.alt"
-              class="product-gallery__stage-media"
-              format="webp"
-              :width="heroMedia.width"
-              :height="heroMedia.height"
-            />
-            <NuxtImg
-              v-else-if="heroMedia.posterUrl"
-              :src="heroMedia.posterUrl"
-              :alt="heroMedia.alt"
-              class="product-gallery__stage-media"
-              format="webp"
-              :width="heroMedia.width"
-              :height="heroMedia.height"
-            />
-            <div v-if="heroMedia.type === 'video'" class="product-gallery__stage-overlay">
-              <v-icon icon="mdi-play-circle-outline" size="56" class="product-gallery__stage-icon" />
-              <span class="product-gallery__sr-only">{{ $t('product.hero.videoBadge') }}</span>
-            </div>
-            <span v-if="heroMedia.caption" class="product-gallery__caption">{{ heroMedia.caption }}</span>
-          </button>
-
-          <ul class="product-gallery__thumbnails" role="list">
-            <li
-              v-for="(item, index) in galleryItems"
-              :key="item.id"
-              class="product-gallery__thumbnail"
-            >
-              <button
-                type="button"
-                class="product-gallery__thumbnail-button"
-                :class="{ 'product-gallery__thumbnail-button--active': index === activeMediaIndex }"
-                data-testid="product-gallery-thumbnail"
-                :aria-label="thumbnailAriaLabel(item, index)"
-                :aria-pressed="index === activeMediaIndex"
-                @click="setActiveMedia(index)"
-                @dblclick="openGallery(index)"
-                @keydown.enter.prevent="openGallery(index)"
-                @keydown.space.prevent="openGallery(index)"
-              >
-                <NuxtImg
-                  :src="item.thumbnailUrl"
-                  :alt="item.alt"
-                  class="product-gallery__thumbnail-image"
-                  format="webp"
-                  :width="item.thumbnailWidth"
-                  :height="item.thumbnailHeight"
-                />
-                <span
-                  v-if="item.type === 'video'"
-                  class="product-gallery__thumbnail-badge"
-                  aria-hidden="true"
-                >
-                  <v-icon icon="mdi-video-outline" size="18" />
-                </span>
-              </button>
-            </li>
-          </ul>
-
-          <div v-if="pictureSwipeComponent" ref="pictureSwipeContainer" class="product-gallery__lightbox">
-            <component
-              :is="pictureSwipeComponent"
-              ref="pictureSwipeRef"
-              :items="pictureSwipeItems"
-              :options="pictureSwipeOptions"
-            />
-          </div>
-          </div>
-          <div v-else-if="heroFallbackImage" class="product-gallery__fallback">
-            <NuxtImg
-              :src="heroFallbackImage"
-              :alt="title"
-              class="product-hero__fallback"
-              format="webp"
-              :width="600"
-              :height="600"
-            />
-          </div>
-        </template>
-        <template #fallback>
-          <NuxtImg
-            v-if="heroFallbackImage"
-            :src="heroFallbackImage"
-            :alt="title"
-            class="product-hero__fallback"
-            format="webp"
-            :width="600"
-            :height="600"
-          />
-        </template>
-      </ClientOnly>
-    </div>
+    <ProductHeroGallery class="product-hero__gallery" :product="product" :title="title" />
 
     <div class="product-hero__details">
       <CategoryNavigationBreadcrumbs
@@ -178,67 +69,24 @@
     </div>
 
     <aside class="product-hero__pricing">
-      <div class="product-hero__pricing-card" itemprop="offers" itemscope itemtype="https://schema.org/AggregateOffer">
-        <meta itemprop="offerCount" :content="String(product.offers?.offersCount ?? 0)" />
-        <meta itemprop="priceCurrency" :content="product.offers?.bestPrice?.currency ?? 'EUR'" />
-        <h2 class="product-hero__pricing-title">
-          {{ $t('product.hero.bestPriceTitle') }}
-        </h2>
-        <div class="product-hero__price">
-          <span class="product-hero__price-value" itemprop="lowPrice">
-            {{ bestPriceLabel }}
-          </span>
-          <span class="product-hero__price-currency">
-            {{ product.offers?.bestPrice?.currency ?? '€' }}
-          </span>
-        </div>
-        <div class="product-hero__price-meta">
-          <div v-if="bestPriceMerchant" class="product-hero__price-merchant">
-            <span class="product-hero__price-merchant-prefix">{{ t('product.hero.priceMerchantPrefix') }}</span>
-            <NuxtLink
-              :to="bestPriceMerchant.url"
-              class="product-hero__price-merchant-link"
-              target="_blank"
-              rel="nofollow noopener"
-            >
-              <NuxtImg
-                v-if="bestPriceMerchant.favicon"
-                :src="bestPriceMerchant.favicon"
-                :alt="bestPriceMerchant.name"
-                width="20"
-                height="20"
-                class="product-hero__price-merchant-favicon"
-              />
-              <span>{{ bestPriceMerchant.name }}</span>
-            </NuxtLink>
-          </div>
-
-          <button
-            v-if="priceTrendLabel"
-            type="button"
-            class="product-hero__price-trend"
-            @click="scrollToSelector('#price-history')"
-          >
-            <v-icon icon="mdi-chart-line" size="18" class="product-hero__price-trend-icon" />
-            <span>{{ priceTrendLabel }}</span>
-          </button>
-        </div>
-        <div class="product-hero__price-actions">
-          <v-btn color="primary" variant="flat" @click="scrollToSelector('#offers-list', 136)">
-            {{ viewOffersLabel }}
-          </v-btn>
-        </div>
-      </div>
+      <ProductHeroPricing :product="product" />
     </aside>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, shallowRef, watch, type Component, type ComponentPublicInstance, type PropType } from 'vue'
+import { computed, type PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import ProductHeroGallery from '~/components/product/ProductHeroGallery.vue'
+import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
 import type { ProductDto } from '~~/shared/api-client'
+
+export interface ProductHeroBreadcrumb {
+  title: string
+  link?: string
+}
 
 const props = defineProps({
   product: {
@@ -246,88 +94,68 @@ const props = defineProps({
     required: true,
   },
   breadcrumbs: {
-    type: Array as PropType<Array<{ title?: string | null; link?: string | null }>>,
+    type: Array as PropType<ProductHeroBreadcrumb[]>,
     default: () => [],
   },
 })
 
-const pictureSwipeComponent = shallowRef<Component | null>(null)
-const pictureSwipeRef = ref<ComponentPublicInstance<{ pswp?: unknown }> | null>(null)
-const pictureSwipeContainer = ref<HTMLElement | null>(null)
-
 const { n, t } = useI18n()
-const nuxtImage = useImage()
 
-type ImageModifiers = Parameters<typeof nuxtImage>[1]
-
-const resolveImageUrl = (src: string | null | undefined, modifiers?: ImageModifiers) => {
-  if (!src) {
-    return ''
-  }
-
-  try {
-    return nuxtImage(src, modifiers)
-  } catch {
-    return src
-  }
-}
-
-const fallbackDimension = (value: number | null | undefined, fallback: number) =>
-  typeof value === 'number' && value > 0 ? value : fallback
-
-const DEFAULT_IMAGE_WIDTH = 1600
-const DEFAULT_IMAGE_HEIGHT = 1200
-const DEFAULT_THUMBNAIL_SIZE = 200
-const DEFAULT_VIDEO_WIDTH = 1280
-const DEFAULT_VIDEO_HEIGHT = 720
-
-const coverImageRaw = computed(
+const title = computed(
   () =>
-    props.product.resources?.coverImagePath ??
-    props.product.resources?.externalCover ??
-    props.product.base?.coverImagePath ??
-    null,
+    props.product.names?.h1Title ??
+    props.product.identity?.bestName ??
+    props.product.base?.bestName ??
+    '',
 )
-
-const title = computed(() => props.product.names?.h1Title ?? props.product.identity?.bestName ?? props.product.base?.bestName ?? '')
-
-const bestPrice = computed(() => props.product.offers?.bestPrice ?? null)
-
-const bestPriceLabel = computed(() => {
-  if (!bestPrice.value?.price) {
-    return '—'
-  }
-
-  return n(bestPrice.value.price, {
-    style: 'currency',
-    currency: bestPrice.value.currency ?? 'EUR',
-    maximumFractionDigits: 0,
-  })
-})
 
 const offersCount = computed(() => props.product.offers?.offersCount ?? 0)
-
 const offersCountLabel = computed(() => n(offersCount.value))
 
-const viewOffersLabel = computed(() =>
-  offersCount.value <= 1
-    ? t('product.hero.viewSingleOffer')
-    : t('product.hero.viewOffersCount', { count: offersCountLabel.value }),
-)
+const heroBreadcrumbs = computed<ProductHeroBreadcrumb[]>(() => {
+  const normalizedProductTitle = title.value.trim().toLowerCase()
+  const normalizedProductSlug = (props.product.fullSlug ?? props.product.slug ?? '').trim().toLowerCase()
 
-const heroBreadcrumbs = computed(() =>
-  props.breadcrumbs
-    .map((item) => ({
-      title:
-        item.title?.toString().trim().length
-          ? item.title?.toString() ?? ''
-          : item.link?.toString().trim().length
-            ? item.link?.toString() ?? ''
-            : t('product.hero.missingBreadcrumbTitle'),
-      link: item.link?.toString().trim().length ? item.link?.toString() : undefined,
-    }))
-    .filter((item) => item.title.trim().length),
-)
+  return props.breadcrumbs.reduce<ProductHeroBreadcrumb[]>((acc, breadcrumb) => {
+    const rawTitle = breadcrumb?.title ?? breadcrumb?.link ?? ''
+    const trimmedTitle = rawTitle.toString().trim()
+    const titleValue = trimmedTitle.length ? trimmedTitle : t('product.hero.missingBreadcrumbTitle')
+
+    if (!titleValue.trim().length) {
+      return acc
+    }
+
+    const normalizedTitle = titleValue.trim().toLowerCase()
+    const normalizedLinkValue = breadcrumb?.link?.toString().trim().toLowerCase() ?? ''
+
+    const matchesProductTitle = normalizedProductTitle.length
+      ? normalizedTitle === normalizedProductTitle
+      : false
+    const matchesProductLink = normalizedProductSlug.length
+      ? normalizedLinkValue.endsWith(normalizedProductSlug)
+      : false
+
+    if (matchesProductTitle || matchesProductLink) {
+      return acc
+    }
+
+    const trimmedLink = breadcrumb?.link?.toString().trim() ?? ''
+    const normalizedLink = trimmedLink
+      ? trimmedLink.startsWith('http')
+        ? trimmedLink
+        : trimmedLink.startsWith('/')
+          ? trimmedLink
+          : `/${trimmedLink}`
+      : undefined
+
+    acc.push({
+      title: titleValue,
+      link: normalizedLink,
+    })
+
+    return acc
+  }, [])
+})
 
 const heroBreadcrumbProps = computed(() => ({
   items: heroBreadcrumbs.value,
@@ -346,62 +174,6 @@ const gtinCountry = computed(() => {
   }
 })
 
-const bestPriceMerchant = computed(() => {
-  const merchant = props.product.offers?.bestPrice
-  if (!merchant?.datasourceName || !merchant?.url) {
-    return null
-  }
-
-  return {
-    name: merchant.datasourceName,
-    url: merchant.url,
-    favicon: merchant.favicon ?? null,
-  }
-})
-
-const priceTrendLabel = computed(() => {
-  const trend = props.product.offers?.newTrend
-  if (!trend) {
-    return null
-  }
-
-  if (trend.trend === 'PRICE_DECREASE') {
-    return t('product.price.trend.decrease', {
-      amount: n(Math.abs(trend.variation ?? 0), {
-        style: 'currency',
-        currency: props.product.offers?.bestPrice?.currency ?? 'EUR',
-        maximumFractionDigits: 2,
-      }),
-    })
-  }
-
-  if (trend.trend === 'PRICE_INCREASE') {
-    return t('product.price.trend.increase', {
-      amount: n(Math.abs(trend.variation ?? 0), {
-        style: 'currency',
-        currency: props.product.offers?.bestPrice?.currency ?? 'EUR',
-        maximumFractionDigits: 2,
-      }),
-    })
-  }
-
-  return t('product.price.trend.stable')
-})
-
-const scrollToSelector = (selector: string, offset = 120) => {
-  if (!import.meta.client) {
-    return
-  }
-
-  const target = document.querySelector<HTMLElement>(selector)
-  if (!target) {
-    return
-  }
-
-  const top = target.getBoundingClientRect().top + (window.scrollY || window.pageYOffset || 0) - offset
-  window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' })
-}
-
 const impactScore = computed(() => {
   const ecoscore = props.product.base?.ecoscoreValue
   if (typeof ecoscore === 'number') {
@@ -410,363 +182,6 @@ const impactScore = computed(() => {
 
   const relative = props.product.scores?.ecoscore?.relativeValue
   return typeof relative === 'number' ? relative : null
-})
-
-interface ProductGalleryItem {
-  id: string
-  type: 'image' | 'video'
-  originalUrl: string
-  previewUrl: string
-  thumbnailUrl: string
-  thumbnailWidth: number
-  thumbnailHeight: number
-  width: number
-  height: number
-  alt: string
-  caption: string
-  videoUrl?: string
-  posterUrl?: string
-}
-
-type LightboxItem = {
-  el?: Element | null
-  html?: string
-  w?: number
-  h?: number
-  [key: string]: unknown
-}
-
-interface LightboxInstance {
-  listen(event: 'gettingData', handler: (index: number, item: LightboxItem) => void): void
-  listen(event: string, handler: (...args: unknown[]) => void): void
-  getCurrentIndex?: () => number
-  container?: HTMLElement
-}
-
-const galleryItems = computed<ProductGalleryItem[]>(() => {
-  const images = props.product.resources?.images ?? []
-  const videos = props.product.resources?.videos ?? []
-
-  const items: ProductGalleryItem[] = []
-  const fallbackPoster =
-    coverImageRaw.value ??
-    images[0]?.url ??
-    images[0]?.originalUrl ??
-    ''
-
-  images.forEach((image) => {
-    const original = image.originalUrl ?? image.url ?? ''
-    if (!original) {
-      return
-    }
-
-    const source = image.url ?? original
-    const caption = image.datasourceName ?? title.value
-    const width = fallbackDimension(image.width, DEFAULT_IMAGE_WIDTH)
-    const height = fallbackDimension(image.height, DEFAULT_IMAGE_HEIGHT)
-    const preview = resolveImageUrl(source, {
-      width: 1200,
-      height: 900,
-      fit: 'cover',
-      format: 'webp',
-    }) || source
-    const thumbnail = resolveImageUrl(source, {
-      width: DEFAULT_THUMBNAIL_SIZE,
-      height: DEFAULT_THUMBNAIL_SIZE,
-      fit: 'cover',
-      format: 'webp',
-    }) || preview
-
-    items.push({
-      id: `image-${image.cacheKey ?? original}`,
-      type: 'image',
-      originalUrl: original,
-      previewUrl: preview,
-      thumbnailUrl: thumbnail,
-      thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
-      thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
-      width,
-      height,
-      alt: image.fileName ?? caption,
-      caption,
-      posterUrl: preview,
-    })
-  })
-
-  videos.forEach((video) => {
-    const url = video.url ?? ''
-    if (!url) {
-      return
-    }
-
-    const caption = video.datasourceName ?? title.value
-    const posterSource = fallbackPoster || coverImageRaw.value || ''
-    const poster = posterSource
-      ? resolveImageUrl(posterSource, {
-          width: DEFAULT_VIDEO_WIDTH,
-          height: DEFAULT_VIDEO_HEIGHT,
-          fit: 'cover',
-          format: 'webp',
-        }) || posterSource
-      : ''
-    const thumbnail = posterSource
-      ? resolveImageUrl(posterSource, {
-          width: DEFAULT_THUMBNAIL_SIZE,
-          height: DEFAULT_THUMBNAIL_SIZE,
-          fit: 'cover',
-          format: 'webp',
-        }) || posterSource
-      : ''
-
-    items.push({
-      id: `video-${video.cacheKey ?? url}`,
-      type: 'video',
-      originalUrl: poster || url,
-      previewUrl: poster || thumbnail || url,
-      thumbnailUrl: thumbnail || poster || url,
-      thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
-      thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
-      width: DEFAULT_VIDEO_WIDTH,
-      height: DEFAULT_VIDEO_HEIGHT,
-      alt: video.fileName ?? caption,
-      caption,
-      videoUrl: url,
-      posterUrl: poster || thumbnail || url,
-    })
-  })
-
-  return items.filter((item) => Boolean(item.originalUrl))
-})
-
-const heroFallbackImage = computed(() => {
-  const fallback = coverImageRaw.value ?? galleryItems.value[0]?.previewUrl ?? null
-  if (!fallback) {
-    return null
-  }
-
-  return resolveImageUrl(fallback, {
-    width: 960,
-    height: 720,
-    fit: 'cover',
-    format: 'webp',
-  }) || fallback
-})
-
-const activeMediaIndex = ref(0)
-
-watch(
-  galleryItems,
-  (items) => {
-    if (!items.length) {
-      activeMediaIndex.value = 0
-      return
-    }
-
-    if (activeMediaIndex.value >= items.length) {
-      activeMediaIndex.value = items.length - 1
-    }
-  },
-  { immediate: true },
-)
-
-const heroMedia = computed(() => galleryItems.value[activeMediaIndex.value] ?? null)
-
-const stageAriaLabel = computed(() => {
-  const media = heroMedia.value
-  if (!media) {
-    return t('product.hero.openGalleryFallback')
-  }
-
-  const label = media.caption || media.alt || title.value
-  return media.type === 'video'
-    ? t('product.hero.openGalleryVideo', { label })
-    : t('product.hero.openGalleryImage', { label })
-})
-
-const thumbnailAriaLabel = (item: ProductGalleryItem, index: number) => {
-  const label = item.caption || item.alt || title.value
-  const typeKey = item.type === 'video' ? 'video' : 'image'
-
-  return t('product.hero.thumbnailLabel', {
-    type: t(`product.hero.mediaType.${typeKey}`),
-    index: index + 1,
-    total: galleryItems.value.length,
-    label,
-  })
-}
-
-const escapeMap: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#39;',
-}
-
-const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => escapeMap[char] ?? char)
-const escapeAttribute = (value: string | null | undefined) => escapeHtml(String(value ?? ''))
-
-const pictureSwipeItems = computed(() =>
-  galleryItems.value.map((item) => {
-    const caption = item.caption || title.value
-    const sanitizedCaption = escapeHtml(caption)
-
-    const datasetAttributes = [
-      `data-type="${item.type}"`,
-      `data-width="${item.width}"`,
-      `data-height="${item.height}"`,
-    ]
-
-    if (item.videoUrl) {
-      datasetAttributes.push(`data-video="${escapeAttribute(item.videoUrl)}"`)
-    }
-
-    if (item.posterUrl) {
-      datasetAttributes.push(`data-poster="${escapeAttribute(item.posterUrl)}"`)
-    }
-
-    const htmlAfterThumbnail = `<span class="product-gallery__lightbox-caption" ${datasetAttributes.join(' ')}>${sanitizedCaption}</span>`
-
-    return {
-      src: item.type === 'video' ? item.posterUrl ?? item.originalUrl : item.originalUrl,
-      thumbnail: item.thumbnailUrl,
-      w: item.width,
-      h: item.height,
-      title: sanitizedCaption,
-      alt: item.alt,
-      type: item.type,
-      htmlAfterThumbnail,
-    }
-  }),
-)
-
-const pictureSwipeOptions = computed<Record<string, unknown>>(() => {
-  const base: Record<string, unknown> = {
-    shareEl: false,
-    fullscreenEl: true,
-    zoomEl: true,
-    counterEl: true,
-    history: false,
-    bgOpacity: 0.95,
-    closeOnScroll: false,
-  }
-
-  if (import.meta.client) {
-    base.getThumbBoundsFn = (index: number) => {
-      const thumbnails = document.querySelectorAll<HTMLElement>('.product-gallery__thumbnail-image')
-      const element = thumbnails[index]
-
-      if (!element) {
-        const scrollY = window.scrollY || document.documentElement.scrollTop
-        return { x: window.innerWidth / 2, y: scrollY + window.innerHeight / 2, w: 0 }
-      }
-
-      const rect = element.getBoundingClientRect()
-      const scrollY = window.scrollY || document.documentElement.scrollTop
-
-      return {
-        x: rect.left,
-        y: rect.top + scrollY,
-        w: rect.width,
-      }
-    }
-  }
-
-  return base
-})
-
-const lightboxBound = ref(false)
-
-const bindLightboxListeners = () => {
-  const instance = (pictureSwipeRef.value as ComponentPublicInstance<{ pswp?: LightboxInstance }> | null)?.pswp
-
-  if (!instance || lightboxBound.value) {
-    return
-  }
-
-  lightboxBound.value = true
-  let activeVideo: HTMLVideoElement | null = null
-
-  const stopVideo = () => {
-    if (activeVideo) {
-      activeVideo.pause()
-      activeVideo.removeAttribute('src')
-      activeVideo.load()
-      activeVideo = null
-    }
-  }
-
-  instance.listen('gettingData', (_index: number, item: LightboxItem) => {
-    const captionElement = item?.el?.querySelector?.('.product-gallery__lightbox-caption') as HTMLElement | undefined
-    const dataset = captionElement?.dataset
-
-    if (dataset?.type === 'video' && dataset.video) {
-      const poster = dataset.poster ? ` poster="${dataset.poster}"` : ''
-      item.html = `<div class="product-gallery__lightbox-video"><video controls playsinline${poster} src="${dataset.video}"></video></div>`
-      item.w = Number(dataset.width) || item.w || DEFAULT_VIDEO_WIDTH
-      item.h = Number(dataset.height) || item.h || DEFAULT_VIDEO_HEIGHT
-    }
-  })
-
-  instance.listen('afterChange', () => {
-    activeMediaIndex.value = instance.getCurrentIndex?.() ?? activeMediaIndex.value
-    stopVideo()
-
-    nextTick(() => {
-      const video = instance.container?.querySelector?.('.product-gallery__lightbox-video video')
-      if (video instanceof HTMLVideoElement) {
-        activeVideo = video
-        video.play().catch(() => {})
-      }
-    })
-  })
-
-  const resetBinding = () => {
-    stopVideo()
-    lightboxBound.value = false
-  }
-
-  instance.listen('beforeChange', stopVideo)
-  instance.listen('close', resetBinding)
-  instance.listen('destroy', resetBinding)
-}
-
-const setActiveMedia = (index: number) => {
-  if (index >= 0 && index < galleryItems.value.length) {
-    activeMediaIndex.value = index
-  }
-}
-
-const openGallery = (index: number) => {
-  if (!import.meta.client || !galleryItems.value.length) {
-    return
-  }
-
-  const safeIndex = Math.min(Math.max(index, 0), galleryItems.value.length - 1)
-  activeMediaIndex.value = safeIndex
-
-  const componentInstance = pictureSwipeRef.value as ComponentPublicInstance & { $el?: HTMLElement }
-  const rootElement = (componentInstance?.$el ?? pictureSwipeContainer.value) as HTMLElement | undefined
-  const anchors = rootElement?.querySelectorAll<HTMLAnchorElement>('figure.gallery-thumbnail a')
-  const target = anchors?.[safeIndex]
-
-  if (target) {
-    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
-    window.setTimeout(bindLightboxListeners, 150)
-  }
-}
-
-onMounted(async () => {
-  if (!import.meta.client) {
-    return
-  }
-
-  try {
-    const [{ default: VuePictureSwipe }] = await Promise.all([import('vue3-picture-swipe')])
-    pictureSwipeComponent.value = VuePictureSwipe
-  } catch (error) {
-    console.error('Failed to load gallery', error)
-  }
 })
 </script>
 
@@ -781,169 +196,6 @@ onMounted(async () => {
   box-shadow: 0 32px 70px rgba(15, 23, 42, 0.08);
 }
 
-.product-hero__gallery {
-  border-radius: 24px;
-  position: relative;
-  min-height: 420px;
-  background: rgba(15, 23, 42, 0.02);
-}
-
-.product-gallery {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  height: 100%;
-}
-
-.product-gallery__stage {
-  position: relative;
-  border: none;
-  padding: 0;
-  border-radius: 20px;
-  overflow: hidden;
-  width: 100%;
-  background: rgba(15, 23, 42, 0.04);
-  cursor: zoom-in;
-  min-height: 360px;
-}
-
-.product-gallery__stage-media,
-.product-hero__fallback {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
-
-.product-gallery__stage-overlay {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(0deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.2));
-  pointer-events: none;
-}
-
-.product-gallery__stage--video .product-gallery__stage-overlay {
-  background: linear-gradient(0deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.25));
-}
-
-.product-gallery__stage-icon {
-  color: rgba(var(--v-theme-hero-overlay-strong), 0.9);
-}
-
-.product-gallery__caption {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 0.75rem 1rem;
-  background: linear-gradient(0deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0));
-  color: #fff;
-  font-weight: 600;
-  font-size: 0.95rem;
-}
-
-.product-gallery__thumbnails {
-  list-style: none;
-  display: flex;
-  gap: 0.75rem;
-  padding: 0;
-  margin: 0;
-  overflow-x: auto;
-  scrollbar-width: thin;
-}
-
-.product-gallery__thumbnail {
-  flex: 0 0 auto;
-}
-
-.product-gallery__thumbnail-button {
-  position: relative;
-  display: inline-flex;
-  border: none;
-  padding: 0;
-  border-radius: 14px;
-  overflow: hidden;
-  cursor: pointer;
-  background: transparent;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.product-gallery__thumbnail-button:hover {
-  transform: translateY(-2px);
-}
-
-.product-gallery__thumbnail-button:focus-visible {
-  outline: 2px solid rgba(var(--v-theme-accent-primary-highlight), 0.6);
-  outline-offset: 2px;
-}
-
-.product-gallery__thumbnail-button--active {
-  box-shadow: 0 0 0 2px rgba(var(--v-theme-accent-primary-highlight), 0.6);
-}
-
-.product-gallery__thumbnail-image {
-  width: 86px;
-  height: 86px;
-  object-fit: cover;
-  display: block;
-}
-
-.product-gallery__thumbnail-badge {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  padding: 0.25rem;
-  background: rgba(15, 23, 42, 0.75);
-  color: #fff;
-}
-
-.product-gallery__lightbox {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.product-gallery__sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-}
-
-.product-gallery__lightbox-video {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #000;
-}
-
-.product-gallery__lightbox-video video {
-  width: 100%;
-  height: 100%;
-  max-height: 100vh;
-  object-fit: contain;
-}
-
-.product-gallery__fallback {
-  border-radius: 20px;
-  overflow: hidden;
-}
 
 .product-hero__details {
   display: flex;
@@ -1044,110 +296,9 @@ onMounted(async () => {
   font-size: 1rem;
 }
 
+
 .product-hero__pricing {
   align-self: stretch;
-}
-
-.product-hero__pricing-card {
-  border-radius: 24px;
-  background: rgba(var(--v-theme-surface-glass-strong), 0.9);
-  padding: 1.75rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.1);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.product-hero__pricing-title {
-  margin: 0;
-  font-size: 1.2rem;
-  font-weight: 700;
-}
-
-.product-hero__price {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-
-.product-hero__price-value {
-  font-size: clamp(2rem, 3.4vw, 2.6rem);
-  font-weight: 700;
-}
-
-.product-hero__price-currency {
-  font-size: 1.1rem;
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.8);
-}
-
-.product-hero__price-meta {
-  margin-top: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  align-items: flex-start;
-}
-
-.product-hero__price-merchant {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.95rem;
-  color: rgb(var(--v-theme-text-neutral-secondary));
-}
-
-.product-hero__price-merchant-prefix {
-  font-weight: 600;
-}
-
-.product-hero__price-merchant-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: 600;
-  color: rgb(var(--v-theme-primary));
-  text-decoration: none;
-}
-
-.product-hero__price-merchant-link:hover,
-.product-hero__price-merchant-link:focus-visible {
-  text-decoration: underline;
-}
-
-.product-hero__price-merchant-favicon {
-  border-radius: 4px;
-  width: 20px;
-  height: 20px;
-  object-fit: cover;
-}
-
-.product-hero__price-trend {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.4rem 0.5rem;
-  border: none;
-  border-radius: 999px;
-  background: rgba(var(--v-theme-surface-primary-080), 0.6);
-  color: rgb(var(--v-theme-text-neutral-secondary));
-  font-weight: 600;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.product-hero__price-trend:hover,
-.product-hero__price-trend:focus-visible {
-  background: rgba(var(--v-theme-surface-primary-100), 0.85);
-  color: rgb(var(--v-theme-text-neutral-strong));
-}
-
-.product-hero__price-trend-icon {
-  color: rgb(var(--v-theme-accent-primary-highlight));
-}
-
-.product-hero__price-actions {
-  margin-top: 0.5rem;
 }
 
 @media (max-width: 1280px) {
@@ -1159,10 +310,6 @@ onMounted(async () => {
   .product-hero__pricing {
     grid-column: 1 / -1;
   }
-
-  .product-gallery__stage {
-    min-height: 320px;
-  }
 }
 
 @media (max-width: 960px) {
@@ -1170,19 +317,6 @@ onMounted(async () => {
     grid-template-columns: 1fr;
     padding: 1.5rem;
     gap: 1.5rem;
-  }
-
-  .product-hero__gallery {
-    min-height: 280px;
-  }
-
-  .product-gallery__stage {
-    min-height: 240px;
-  }
-
-  .product-gallery__thumbnail-image {
-    width: 68px;
-    height: 68px;
   }
 }
 </style>

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -1,0 +1,736 @@
+<template>
+  <div class="product-gallery-wrapper" v-bind="$attrs">
+    <ClientOnly>
+      <template #default>
+        <div v-if="galleryItems.length" class="product-gallery">
+          <button
+            v-if="heroMedia"
+            type="button"
+            class="product-gallery__stage"
+            :class="{ 'product-gallery__stage--video': heroMedia.type === 'video' }"
+            :aria-label="stageAriaLabel"
+            data-testid="product-gallery-stage"
+            @click="openGallery(activeMediaIndex)"
+            @keydown.enter.prevent="openGallery(activeMediaIndex)"
+            @keydown.space.prevent="openGallery(activeMediaIndex)"
+          >
+            <NuxtImg
+              v-if="heroMedia.type === 'image'"
+              :src="heroMedia.previewUrl"
+              :alt="heroMedia.alt"
+              class="product-gallery__stage-media"
+              format="webp"
+              :width="heroMedia.width"
+              :height="heroMedia.height"
+            />
+            <NuxtImg
+              v-else-if="heroMedia.posterUrl"
+              :src="heroMedia.posterUrl"
+              :alt="heroMedia.alt"
+              class="product-gallery__stage-media"
+              format="webp"
+              :width="heroMedia.width"
+              :height="heroMedia.height"
+            />
+            <div v-if="heroMedia.type === 'video'" class="product-gallery__stage-overlay">
+              <v-icon icon="mdi-play-circle-outline" size="56" class="product-gallery__stage-icon" />
+              <span class="product-gallery__sr-only">{{ $t('product.hero.videoBadge') }}</span>
+            </div>
+          </button>
+
+          <ul class="product-gallery__thumbnails" role="list">
+            <li
+              v-for="(item, index) in galleryItems"
+              :key="item.id"
+              class="product-gallery__thumbnail"
+            >
+              <button
+                type="button"
+                class="product-gallery__thumbnail-button"
+                :class="{ 'product-gallery__thumbnail-button--active': index === activeMediaIndex }"
+                data-testid="product-gallery-thumbnail"
+                :aria-label="thumbnailAriaLabel(item, index)"
+                :aria-pressed="index === activeMediaIndex"
+                @click="setActiveMedia(index)"
+                @dblclick="openGallery(index)"
+                @keydown.enter.prevent="openGallery(index)"
+                @keydown.space.prevent="openGallery(index)"
+              >
+                <NuxtImg
+                  :src="item.thumbnailUrl"
+                  :alt="item.alt"
+                  class="product-gallery__thumbnail-image"
+                  format="webp"
+                  :width="item.thumbnailWidth"
+                  :height="item.thumbnailHeight"
+                />
+                <span
+                  v-if="item.type === 'video'"
+                  class="product-gallery__thumbnail-badge"
+                  aria-hidden="true"
+                >
+                  <v-icon icon="mdi-video-outline" size="18" />
+                </span>
+              </button>
+            </li>
+          </ul>
+
+          <div v-if="pictureSwipeComponent" ref="pictureSwipeContainer" class="product-gallery__lightbox">
+            <component
+              :is="pictureSwipeComponent"
+              ref="pictureSwipeRef"
+              :items="pictureSwipeItems"
+              :options="pictureSwipeOptions"
+            />
+          </div>
+        </div>
+        <div v-else-if="heroFallbackImage" class="product-gallery__fallback">
+          <NuxtImg
+            :src="heroFallbackImage"
+            :alt="title"
+            class="product-hero__fallback"
+            format="webp"
+            :width="600"
+            :height="600"
+          />
+        </div>
+      </template>
+      <template #fallback>
+        <NuxtImg
+          v-if="heroFallbackImage"
+          :src="heroFallbackImage"
+          :alt="title"
+          class="product-hero__fallback"
+          format="webp"
+          :width="600"
+          :height="600"
+        />
+      </template>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  computed,
+  nextTick,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+  type ComponentPublicInstance,
+  type DefineComponent,
+  type PropType,
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ProductDto } from '~~/shared/api-client'
+import type { VuePictureSwipeItem, VuePictureSwipeOptions } from 'vue3-picture-swipe'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  product: {
+    type: Object as PropType<ProductDto>,
+    required: true,
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+})
+
+type PictureSwipeComponent = DefineComponent<{ items: VuePictureSwipeItem[]; options?: VuePictureSwipeOptions }>
+
+type PictureSwipeComponentInstance = ComponentPublicInstance<{ pswp?: LightboxInstance }> & {
+  open?: (index: number) => void
+  $el?: HTMLElement
+}
+
+const pictureSwipeComponent = shallowRef<PictureSwipeComponent | null>(null)
+const pictureSwipeRef = ref<PictureSwipeComponentInstance | null>(null)
+const pictureSwipeContainer = ref<HTMLElement | null>(null)
+
+const { t } = useI18n()
+const nuxtImage = useImage()
+
+type ImageModifiers = Parameters<typeof nuxtImage>[1]
+
+const resolveImageUrl = (src: string | null | undefined, modifiers?: ImageModifiers) => {
+  if (!src) {
+    return ''
+  }
+
+  try {
+    return nuxtImage(src, modifiers)
+  } catch {
+    return src
+  }
+}
+
+const fallbackDimension = (value: number | null | undefined, fallback: number) =>
+  typeof value === 'number' && value > 0 ? value : fallback
+
+const DEFAULT_IMAGE_WIDTH = 1600
+const DEFAULT_IMAGE_HEIGHT = 1200
+const DEFAULT_THUMBNAIL_SIZE = 200
+const DEFAULT_VIDEO_WIDTH = 1280
+const DEFAULT_VIDEO_HEIGHT = 720
+
+const coverImageRaw = computed(
+  () =>
+    props.product.resources?.coverImagePath ??
+    props.product.resources?.externalCover ??
+    props.product.base?.coverImagePath ??
+    null,
+)
+
+interface ProductGalleryItem {
+  id: string
+  type: 'image' | 'video'
+  originalUrl: string
+  previewUrl: string
+  thumbnailUrl: string
+  thumbnailWidth: number
+  thumbnailHeight: number
+  width: number
+  height: number
+  alt: string
+  caption: string
+  videoUrl?: string
+  posterUrl?: string
+}
+
+type LightboxItem = {
+  el?: Element | null
+  html?: string
+  w?: number
+  h?: number
+  [key: string]: unknown
+}
+
+interface LightboxInstance {
+  listen(event: 'gettingData', handler: (index: number, item: LightboxItem) => void): void
+  listen(event: string, handler: (...args: unknown[]) => void): void
+  getCurrentIndex?: () => number
+  container?: HTMLElement
+  init?: () => void
+}
+
+const galleryItems = computed<ProductGalleryItem[]>(() => {
+  const images = props.product.resources?.images ?? []
+  const videos = props.product.resources?.videos ?? []
+
+  const items: ProductGalleryItem[] = []
+  const fallbackPoster =
+    coverImageRaw.value ??
+    images[0]?.url ??
+    images[0]?.originalUrl ??
+    ''
+
+  images.forEach((image) => {
+    const original = image.originalUrl ?? image.url ?? ''
+    if (!original) {
+      return
+    }
+
+    const source = image.url ?? original
+    const caption = image.datasourceName ?? props.title
+    const width = fallbackDimension(image.width, DEFAULT_IMAGE_WIDTH)
+    const height = fallbackDimension(image.height, DEFAULT_IMAGE_HEIGHT)
+    const preview = resolveImageUrl(source, {
+      width: 1200,
+      height: 900,
+      fit: 'cover',
+      format: 'webp',
+    }) || source
+    const thumbnail = resolveImageUrl(source, {
+      width: DEFAULT_THUMBNAIL_SIZE,
+      height: DEFAULT_THUMBNAIL_SIZE,
+      fit: 'cover',
+      format: 'webp',
+    }) || preview
+
+    items.push({
+      id: `image-${image.cacheKey ?? original}`,
+      type: 'image',
+      originalUrl: original,
+      previewUrl: preview,
+      thumbnailUrl: thumbnail,
+      thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
+      thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
+      width,
+      height,
+      alt: image.fileName ?? caption,
+      caption,
+      posterUrl: preview,
+    })
+  })
+
+  videos.forEach((video) => {
+    const url = video.url ?? ''
+    if (!url) {
+      return
+    }
+
+    const caption = video.datasourceName ?? props.title
+    const posterSource = fallbackPoster || coverImageRaw.value || ''
+    const poster = posterSource
+      ? resolveImageUrl(posterSource, {
+          width: DEFAULT_VIDEO_WIDTH,
+          height: DEFAULT_VIDEO_HEIGHT,
+          fit: 'cover',
+          format: 'webp',
+        }) || posterSource
+      : ''
+    const thumbnail = posterSource
+      ? resolveImageUrl(posterSource, {
+          width: DEFAULT_THUMBNAIL_SIZE,
+          height: DEFAULT_THUMBNAIL_SIZE,
+          fit: 'cover',
+          format: 'webp',
+        }) || posterSource
+      : ''
+
+    items.push({
+      id: `video-${video.cacheKey ?? url}`,
+      type: 'video',
+      originalUrl: poster || url,
+      previewUrl: poster || thumbnail || url,
+      thumbnailUrl: thumbnail || poster || url,
+      thumbnailWidth: DEFAULT_THUMBNAIL_SIZE,
+      thumbnailHeight: DEFAULT_THUMBNAIL_SIZE,
+      width: DEFAULT_VIDEO_WIDTH,
+      height: DEFAULT_VIDEO_HEIGHT,
+      alt: video.fileName ?? caption,
+      caption,
+      videoUrl: url,
+      posterUrl: poster || thumbnail || url,
+    })
+  })
+
+  return items.filter((item) => Boolean(item.originalUrl))
+})
+
+const heroFallbackImage = computed(() => {
+  const fallback = coverImageRaw.value ?? galleryItems.value[0]?.previewUrl ?? null
+  if (!fallback) {
+    return null
+  }
+
+  return resolveImageUrl(fallback, {
+    width: 960,
+    height: 720,
+    fit: 'cover',
+    format: 'webp',
+  }) || fallback
+})
+
+const activeMediaIndex = ref(0)
+
+watch(
+  galleryItems,
+  (items) => {
+    if (!items.length) {
+      activeMediaIndex.value = 0
+      return
+    }
+
+    if (activeMediaIndex.value >= items.length) {
+      activeMediaIndex.value = items.length - 1
+    }
+  },
+  { immediate: true },
+)
+
+const heroMedia = computed(() => galleryItems.value[activeMediaIndex.value] ?? null)
+
+const stageAriaLabel = computed(() => {
+  const media = heroMedia.value
+  if (!media) {
+    return t('product.hero.openGalleryFallback')
+  }
+
+  const label = media.caption || media.alt || props.title
+  return media.type === 'video'
+    ? t('product.hero.openGalleryVideo', { label })
+    : t('product.hero.openGalleryImage', { label })
+})
+
+const thumbnailAriaLabel = (item: ProductGalleryItem, index: number) => {
+  const label = item.caption || item.alt || props.title
+  const typeKey = item.type === 'video' ? 'video' : 'image'
+
+  return t('product.hero.thumbnailLabel', {
+    type: t(`product.hero.mediaType.${typeKey}`),
+    index: index + 1,
+    total: galleryItems.value.length,
+    label,
+  })
+}
+
+const escapeMap: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+}
+
+const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => escapeMap[char] ?? char)
+const escapeAttribute = (value: string | null | undefined) => escapeHtml(String(value ?? ''))
+
+const pictureSwipeItems = computed<VuePictureSwipeItem[]>(() =>
+  galleryItems.value.map((item) => {
+    const caption = item.caption || props.title
+    const sanitizedCaption = escapeHtml(caption)
+
+    const datasetAttributes = [
+      `data-type="${item.type}"`,
+      `data-width="${item.width}"`,
+      `data-height="${item.height}"`,
+    ]
+
+    if (item.videoUrl) {
+      datasetAttributes.push(`data-video="${escapeAttribute(item.videoUrl)}"`)
+    }
+
+    if (item.posterUrl) {
+      datasetAttributes.push(`data-poster="${escapeAttribute(item.posterUrl)}"`)
+    }
+
+    const htmlAfterThumbnail = `<span class="product-gallery__lightbox-caption" ${datasetAttributes.join(' ')}>${sanitizedCaption}</span>`
+
+    return {
+      src: item.type === 'video' ? item.posterUrl ?? item.originalUrl : item.originalUrl,
+      thumbnail: item.thumbnailUrl,
+      w: item.width,
+      h: item.height,
+      title: sanitizedCaption,
+      alt: item.alt,
+      type: item.type,
+      htmlAfterThumbnail,
+    }
+  }),
+)
+
+const pictureSwipeOptions = computed<VuePictureSwipeOptions>(() => {
+  const base: VuePictureSwipeOptions = {
+    shareEl: false,
+    fullscreenEl: true,
+    zoomEl: true,
+    counterEl: true,
+    history: false,
+    bgOpacity: 0.95,
+    closeOnScroll: false,
+  }
+
+  if (import.meta.client) {
+    base.getThumbBoundsFn = (index: number) => {
+      const thumbnails = document.querySelectorAll<HTMLElement>('.product-gallery__thumbnail-image')
+      const element = thumbnails[index]
+
+      if (!element) {
+        const scrollY = window.scrollY || document.documentElement.scrollTop
+        return { x: window.innerWidth / 2, y: scrollY + window.innerHeight / 2, w: 0 }
+      }
+
+      const rect = element.getBoundingClientRect()
+      const scrollY = window.scrollY || document.documentElement.scrollTop
+
+      return {
+        x: rect.left,
+        y: rect.top + scrollY,
+        w: rect.width,
+      }
+    }
+  }
+
+  return base
+})
+
+const lightboxBound = ref(false)
+
+const bindLightboxListeners = () => {
+  const instance = (pictureSwipeRef.value as ComponentPublicInstance<{ pswp?: LightboxInstance }> | null)?.pswp
+
+  if (!instance || lightboxBound.value) {
+    return
+  }
+
+  lightboxBound.value = true
+  let activeVideo: HTMLVideoElement | null = null
+
+  const stopVideo = () => {
+    if (activeVideo) {
+      activeVideo.pause()
+      activeVideo.removeAttribute('src')
+      activeVideo.load()
+      activeVideo = null
+    }
+  }
+
+  instance.listen('gettingData', (_index: number, item: LightboxItem) => {
+    const captionElement = item?.el?.querySelector?.('.product-gallery__lightbox-caption') as HTMLElement | undefined
+    const dataset = captionElement?.dataset
+
+    if (dataset?.type === 'video' && dataset.video) {
+      const poster = dataset.poster ? ` poster="${dataset.poster}"` : ''
+      item.html = `<div class="product-gallery__lightbox-video"><video controls playsinline${poster} src="${dataset.video}"></video></div>`
+      item.w = Number(dataset.width) || item.w || DEFAULT_VIDEO_WIDTH
+      item.h = Number(dataset.height) || item.h || DEFAULT_VIDEO_HEIGHT
+    }
+  })
+
+  instance.listen('afterChange', () => {
+    activeMediaIndex.value = instance.getCurrentIndex?.() ?? activeMediaIndex.value
+    stopVideo()
+
+    nextTick(() => {
+      const video = instance.container?.querySelector?.('.product-gallery__lightbox-video video')
+      if (video instanceof HTMLVideoElement) {
+        activeVideo = video
+        video.play().catch(() => {})
+      }
+    })
+  })
+
+  const resetBinding = () => {
+    stopVideo()
+    lightboxBound.value = false
+  }
+
+  instance.listen('beforeChange', stopVideo)
+  instance.listen('close', resetBinding)
+  instance.listen('destroy', resetBinding)
+}
+
+const setActiveMedia = (index: number) => {
+  if (index >= 0 && index < galleryItems.value.length) {
+    activeMediaIndex.value = index
+  }
+}
+
+const ensureLightbox = async () => {
+  if (pictureSwipeComponent.value || !import.meta.client) {
+    return
+  }
+
+  try {
+    const [{ default: VuePictureSwipe }] = await Promise.all([import('vue3-picture-swipe')])
+    pictureSwipeComponent.value = VuePictureSwipe
+  } catch (error) {
+    console.error('Failed to load gallery', error)
+  }
+}
+
+const openGallery = async (index: number) => {
+  if (!galleryItems.value.length) {
+    return
+  }
+
+  await ensureLightbox()
+  await nextTick()
+
+  const safeIndex = Math.min(Math.max(index, 0), galleryItems.value.length - 1)
+  activeMediaIndex.value = safeIndex
+
+  const componentInstance = pictureSwipeRef.value
+
+  if (componentInstance?.open) {
+    componentInstance.open(safeIndex)
+    window.setTimeout(bindLightboxListeners, 150)
+    return
+  }
+
+  const rootElement = (componentInstance?.$el ?? pictureSwipeContainer.value) as HTMLElement | undefined
+  const anchors = rootElement?.querySelectorAll<HTMLAnchorElement>('figure.gallery-thumbnail a')
+  const target = anchors?.[safeIndex]
+
+  if (target) {
+    target.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+    window.setTimeout(bindLightboxListeners, 150)
+  }
+}
+
+onMounted(async () => {
+  await ensureLightbox()
+})
+</script>
+
+<style scoped>
+.product-gallery-wrapper {
+  border-radius: 24px;
+  position: relative;
+  min-height: 420px;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.product-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+}
+
+.product-gallery__stage {
+  position: relative;
+  border: none;
+  padding: 0;
+  border-radius: 20px;
+  overflow: hidden;
+  width: 100%;
+  background: rgba(15, 23, 42, 0.04);
+  cursor: zoom-in;
+  min-height: 360px;
+  aspect-ratio: 4 / 3;
+}
+
+.product-gallery__stage-media,
+.product-hero__fallback {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.product-gallery__stage-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(0deg, rgba(15, 23, 42, 0.65), rgba(15, 23, 42, 0.2));
+  pointer-events: none;
+}
+
+.product-gallery__stage--video .product-gallery__stage-overlay {
+  background: linear-gradient(0deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.25));
+}
+
+.product-gallery__stage-icon {
+  color: rgba(var(--v-theme-hero-overlay-strong), 0.9);
+}
+
+.product-gallery__thumbnails {
+  list-style: none;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.product-gallery__thumbnail {
+  flex: 0 0 auto;
+}
+
+.product-gallery__thumbnail-button {
+  position: relative;
+  display: inline-flex;
+  border: none;
+  padding: 0;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  background: transparent;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.product-gallery__thumbnail-button:hover {
+  transform: translateY(-2px);
+}
+
+.product-gallery__thumbnail-button:focus-visible {
+  outline: 2px solid rgba(var(--v-theme-accent-primary-highlight), 0.6);
+  outline-offset: 2px;
+}
+
+.product-gallery__thumbnail-button--active {
+  box-shadow: 0 0 0 2px rgba(var(--v-theme-accent-primary-highlight), 0.6);
+}
+
+.product-gallery__thumbnail-image {
+  width: 86px;
+  height: 86px;
+  object-fit: cover;
+  display: block;
+}
+
+.product-gallery__thumbnail-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.25rem;
+  background: rgba(15, 23, 42, 0.75);
+  color: #fff;
+}
+
+.product-gallery__lightbox {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.product-gallery__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.product-gallery__lightbox-video {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+}
+
+.product-gallery__lightbox-video video {
+  width: 100%;
+  height: 100%;
+  max-height: 100vh;
+  object-fit: contain;
+}
+
+.product-gallery__fallback {
+  border-radius: 20px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+@media (max-width: 1280px) {
+  .product-gallery__stage {
+    min-height: 320px;
+  }
+}
+
+@media (max-width: 960px) {
+  .product-gallery-wrapper {
+    min-height: 280px;
+  }
+
+  .product-gallery__stage {
+    min-height: 240px;
+  }
+
+  .product-gallery__thumbnail-image {
+    width: 68px;
+    height: 68px;
+  }
+}
+</style>

--- a/frontend/app/components/product/ProductHeroPricing.vue
+++ b/frontend/app/components/product/ProductHeroPricing.vue
@@ -1,0 +1,260 @@
+<template>
+  <div
+    class="product-hero__pricing-card"
+    itemprop="offers"
+    itemscope
+    itemtype="https://schema.org/AggregateOffer"
+    v-bind="$attrs"
+  >
+    <meta itemprop="offerCount" :content="String(product.offers?.offersCount ?? 0)" />
+    <meta itemprop="priceCurrency" :content="product.offers?.bestPrice?.currency ?? 'EUR'" />
+    <h2 class="product-hero__pricing-title">
+      {{ $t('product.hero.bestPriceTitle') }}
+    </h2>
+    <div class="product-hero__price">
+      <span class="product-hero__price-value" itemprop="lowPrice">
+        {{ bestPriceLabel }}
+      </span>
+      <span class="product-hero__price-currency">
+        {{ product.offers?.bestPrice?.currency ?? '€' }}
+      </span>
+    </div>
+    <div class="product-hero__price-meta">
+      <div v-if="bestPriceMerchant" class="product-hero__price-merchant">
+        <span class="product-hero__price-merchant-prefix">{{ t('product.hero.priceMerchantPrefix') }}</span>
+        <NuxtLink
+          :to="bestPriceMerchant.url"
+          class="product-hero__price-merchant-link"
+          target="_blank"
+          rel="nofollow noopener"
+        >
+          <img
+            v-if="bestPriceMerchant.favicon"
+            :src="bestPriceMerchant.favicon"
+            :alt="bestPriceMerchant.name"
+            width="18"
+            height="18"
+            class="product-hero__price-merchant-favicon"
+          />
+          <span>{{ bestPriceMerchant.name }}</span>
+        </NuxtLink>
+      </div>
+
+      <button
+        v-if="priceTrendLabel"
+        type="button"
+        class="product-hero__price-trend"
+        @click="scrollToSelector('#price-history')"
+      >
+        <v-icon icon="mdi-chart-line" size="18" class="product-hero__price-trend-icon" />
+        <span>{{ priceTrendLabel }}</span>
+      </button>
+    </div>
+    <div class="product-hero__price-actions">
+      <v-btn color="primary" variant="flat" @click="scrollToSelector('#offers-list', 136)">
+        {{ viewOffersLabel }}
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, type PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ProductDto } from '~~/shared/api-client'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  product: {
+    type: Object as PropType<ProductDto>,
+    required: true,
+  },
+})
+
+const { n, t } = useI18n()
+
+const bestPrice = computed(() => props.product.offers?.bestPrice ?? null)
+
+const bestPriceLabel = computed(() => {
+  if (!bestPrice.value?.price) {
+    return '—'
+  }
+
+  return n(bestPrice.value.price, {
+    style: 'currency',
+    currency: bestPrice.value.currency ?? 'EUR',
+    maximumFractionDigits: 0,
+  })
+})
+
+const offersCount = computed(() => props.product.offers?.offersCount ?? 0)
+
+const offersCountLabel = computed(() => n(offersCount.value))
+
+const viewOffersLabel = computed(() =>
+  offersCount.value <= 1
+    ? t('product.hero.viewSingleOffer')
+    : t('product.hero.viewOffersCount', { count: offersCountLabel.value }),
+)
+
+const bestPriceMerchant = computed(() => {
+  const merchant = props.product.offers?.bestPrice
+  if (!merchant?.datasourceName || !merchant?.url) {
+    return null
+  }
+
+  return {
+    name: merchant.datasourceName,
+    url: merchant.url,
+    favicon: merchant.favicon ?? null,
+  }
+})
+
+const priceTrendLabel = computed(() => {
+  const trend = props.product.offers?.newTrend
+  if (!trend) {
+    return null
+  }
+
+  if (trend.trend === 'PRICE_DECREASE') {
+    return t('product.price.trend.decrease', {
+      amount: n(Math.abs(trend.variation ?? 0), {
+        style: 'currency',
+        currency: props.product.offers?.bestPrice?.currency ?? 'EUR',
+        maximumFractionDigits: 2,
+      }),
+    })
+  }
+
+  if (trend.trend === 'PRICE_INCREASE') {
+    return t('product.price.trend.increase', {
+      amount: n(Math.abs(trend.variation ?? 0), {
+        style: 'currency',
+        currency: props.product.offers?.bestPrice?.currency ?? 'EUR',
+        maximumFractionDigits: 2,
+      }),
+    })
+  }
+
+  return t('product.price.trend.stable')
+})
+
+const scrollToSelector = (selector: string, offset = 120) => {
+  if (!import.meta.client) {
+    return
+  }
+
+  const target = document.querySelector<HTMLElement>(selector)
+  if (!target) {
+    return
+  }
+
+  const top = target.getBoundingClientRect().top + (window.scrollY || window.pageYOffset || 0) - offset
+  window.scrollTo({ top: Math.max(0, top), behavior: 'smooth' })
+}
+</script>
+
+<style scoped>
+.product-hero__pricing-card {
+  border-radius: 24px;
+  background: rgba(var(--v-theme-surface-glass-strong), 0.9);
+  padding: 1.75rem;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.product-hero__pricing-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.product-hero__price {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.product-hero__price-value {
+  font-size: clamp(2rem, 3.4vw, 2.6rem);
+  font-weight: 700;
+}
+
+.product-hero__price-currency {
+  font-size: 1.1rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.8);
+}
+
+.product-hero__price-meta {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.product-hero__price-merchant {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.product-hero__price-merchant-prefix {
+  font-weight: 600;
+}
+
+.product-hero__price-merchant-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+
+.product-hero__price-merchant-link:hover,
+.product-hero__price-merchant-link:focus-visible {
+  text-decoration: underline;
+}
+
+.product-hero__price-merchant-favicon {
+  border-radius: 4px;
+  width: 18px;
+  height: 18px;
+  object-fit: cover;
+}
+
+.product-hero__price-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.5rem;
+  border: none;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.product-hero__price-trend:hover,
+.product-hero__price-trend:focus-visible {
+  background: rgba(var(--v-theme-surface-primary-100), 0.85);
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-hero__price-trend-icon {
+  color: rgb(var(--v-theme-accent-primary-highlight));
+}
+
+.product-hero__price-actions {
+  margin-top: 0.5rem;
+}
+</style>

--- a/frontend/types/vue3-picture-swipe.d.ts
+++ b/frontend/types/vue3-picture-swipe.d.ts
@@ -1,0 +1,22 @@
+declare module 'vue3-picture-swipe' {
+  import type { DefineComponent } from 'vue'
+
+  export interface VuePictureSwipeItem {
+    src: string
+    thumbnail?: string
+    w: number
+    h: number
+    title?: string
+    alt?: string
+    html?: string
+    htmlAfterThumbnail?: string
+    [key: string]: unknown
+  }
+
+  export interface VuePictureSwipeOptions {
+    [key: string]: unknown
+  }
+
+  const VuePictureSwipe: DefineComponent<{ items: VuePictureSwipeItem[]; options?: VuePictureSwipeOptions }>
+  export default VuePictureSwipe
+}


### PR DESCRIPTION
## Summary
- split ProductHero into dedicated gallery and pricing components with improved lightbox handling
- update product page breadcrumb generation to drop the product leaf and honor category fullSlug values
- add vue3-picture-swipe type declaration and refresh tests to reflect new breadcrumb links

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fb3edd6d6c8333897305a4108e62f0