### PR TITLE
Add route loading overlay plugin and component

### DIFF
--- a/frontend/app/components/shared/ui/PageLoadingOverlay.spec.ts
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.spec.ts
@@ -1,0 +1,99 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref, watchEffect } from 'vue'
+import { createI18n } from 'vue-i18n'
+import PageLoadingOverlay from './PageLoadingOverlay.vue'
+
+const routeLoading = ref(false)
+const overlayStates: boolean[] = []
+
+vi.mock('#imports', () => ({
+  useState: vi.fn(() => routeLoading),
+}))
+
+const stubs = {
+  teleport: true,
+  VOverlay: defineComponent({
+    name: 'VOverlayStub',
+    setup(_, { slots, attrs }) {
+      watchEffect(() => {
+        overlayStates.push(routeLoading.value)
+      })
+
+      return () => (routeLoading.value ? h('div', attrs, slots.default?.()) : null)
+    },
+  }),
+  VProgressCircular: defineComponent({
+    name: 'VProgressCircularStub',
+    props: {
+      ariaLabel: {
+        type: String,
+        default: undefined,
+      },
+    },
+    setup(props, { attrs }) {
+      return () =>
+        h('div', {
+          ...attrs,
+          'data-testid': 'page-loading-spinner',
+          'aria-label': props.ariaLabel,
+        })
+    },
+  }),
+}
+
+const createI18nPlugin = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        components: {
+          pageLoadingOverlay: {
+            label: 'Loading page content',
+          },
+        },
+      },
+    },
+  })
+
+const mountOverlay = () =>
+  mount(PageLoadingOverlay, {
+    global: {
+      stubs,
+      plugins: [createI18nPlugin()],
+    },
+  })
+
+describe('PageLoadingOverlay', () => {
+  beforeEach(() => {
+    routeLoading.value = false
+    overlayStates.length = 0
+  })
+
+  it('renders the spinner when a route is loading', async () => {
+    const wrapper = mountOverlay()
+
+    routeLoading.value = true
+    await nextTick()
+
+    const spinner = wrapper.find('[data-testid="page-loading-spinner"]')
+    expect(spinner.exists()).toBe(true)
+    expect(spinner.attributes('aria-label')).toBe('Loading page content')
+    expect(overlayStates.includes(true)).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('disables the overlay when no route is loading', async () => {
+    const wrapper = mountOverlay()
+
+    await nextTick()
+
+    expect(routeLoading.value).toBe(false)
+    expect(overlayStates.at(-1)).toBe(false)
+    expect(wrapper.find('[data-testid="page-loading-spinner"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/app/components/shared/ui/PageLoadingOverlay.vue
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.vue
@@ -1,0 +1,63 @@
+<template>
+  <v-overlay
+    data-testid="page-loading-overlay"
+    class="page-loading-overlay"
+    :model-value="routeLoading"
+    :scrim="scrimColor"
+    persistent
+  >
+    <div
+      v-if="routeLoading"
+      class="page-loading-overlay__content"
+      role="status"
+      aria-live="polite"
+    >
+      <v-progress-circular
+        data-testid="page-loading-spinner"
+        color="primary"
+        size="64"
+        indeterminate
+        :aria-label="spinnerLabel"
+      />
+      <span class="visually-hidden">{{ spinnerLabel }}</span>
+    </div>
+  </v-overlay>
+</template>
+
+<script setup lang="ts">
+const routeLoading = useState<boolean>('routeLoading', () => false)
+const { t } = useI18n()
+
+const spinnerLabel = computed(() => String(t('components.pageLoadingOverlay.label')))
+const scrimColor = computed(() => 'rgba(var(--v-theme-surface-default), 0.72)')
+</script>
+
+<style scoped lang="sass">
+.page-loading-overlay :deep(.v-overlay__content)
+  width: 100vw
+  height: 100vh
+  display: flex
+  align-items: center
+  justify-content: center
+
+.page-loading-overlay__content
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 0.75rem
+  padding: 1.5rem
+  border-radius: 999px
+  background: rgba(var(--v-theme-surface-glass), 0.85)
+  box-shadow: 0 12px 40px rgba(var(--v-theme-shadow-primary-600), 0.12)
+
+.visually-hidden
+  position: absolute
+  width: 1px
+  height: 1px
+  padding: 0
+  margin: -1px
+  overflow: hidden
+  clip: rect(0, 0, 0, 0)
+  white-space: nowrap
+  border: 0
+</style>

--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app class="error-app">
+    <PageLoadingOverlay />
     <The-main-menu-container @toggle-drawer="toggleDrawer" />
 
     <ClientOnly>

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <v-app>
+    <PageLoadingOverlay />
     <The-main-menu-container @toggle-drawer="toggleDrawer" />
 
     <!-- Mobile menu -->

--- a/frontend/app/plugins/page-loading.client.ts
+++ b/frontend/app/plugins/page-loading.client.ts
@@ -1,0 +1,20 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  if (!import.meta.client) {
+    return
+  }
+
+  const routeLoading = useState('routeLoading', () => false)
+
+  nuxtApp.hooks.hook('page:loading:start', () => {
+    routeLoading.value = true
+  })
+
+  const stopLoading = () => {
+    routeLoading.value = false
+  }
+
+  nuxtApp.hooks.hook('page:loading:end', stopLoading)
+  nuxtApp.hooks.hook('page:error' as Parameters<typeof nuxtApp.hooks.hook>[0], () => {
+    stopLoading()
+  })
+})

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -7,6 +7,9 @@
   "components": {
     "impactScore": {
       "tooltip": "Impact quality rated at {value} out of {max}"
+    },
+    "pageLoadingOverlay": {
+      "label": "Loading page content"
     }
   },
   "siteIdentity": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -7,6 +7,9 @@
   "components": {
     "impactScore": {
       "tooltip": "Qualité de l'impact évalué à {value} sur {max}"
+    },
+    "pageLoadingOverlay": {
+      "label": "Chargement du contenu"
     }
   },
   "siteIdentity": {


### PR DESCRIPTION
## Summary
- add a client-side plugin that toggles a shared routeLoading state from Nuxt page loading hooks
- create a PageLoadingOverlay Vuetify component with localized labels and render it in the default and error layouts
- cover the overlay with a unit test verifying the shared state behaviour

## Testing
- pnpm lint
- CI=1 pnpm test *(fails: vue3-picture-swipe import missing in existing ProductHero.spec.ts)*
- pnpm generate *(fails: vue3-picture-swipe module missing during build)*

------
https://chatgpt.com/codex/tasks/task_e_68fb871f400083339f5dd2bda47db2a1