### PR TITLE
Add Vuetify-aware tests for compare panel

### DIFF
--- a/frontend/app/components/category/products/CategoryComparePanel.spec.ts
+++ b/frontend/app/components/category/products/CategoryComparePanel.spec.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import type { Pinia } from 'pinia'
+import { createI18n } from 'vue-i18n'
+import type { I18n } from 'vue-i18n'
+import { createVuetify } from 'vuetify'
+import { h, defineComponent } from 'vue'
+import type { Component } from 'vue'
+import { useProductCompareStore } from '~/stores/useProductCompareStore'
+import type { ProductDto } from '~~/shared/api-client'
+
+vi.mock('~/composables/usePluralizedTranslation', () => ({
+  usePluralizedTranslation: () => ({
+    translatePlural: (_key: string, count: number) =>
+      count === 1 ? `${count} product selected` : `${count} products selected`,
+  }),
+}))
+
+const ClientOnlyStub = defineComponent({
+  name: 'ClientOnlyStub',
+  setup(_props, { slots }) {
+    return () => slots.default?.()
+  },
+})
+
+const simpleStub = (tag: string): Component => ({
+  inheritAttrs: false,
+  setup(_props, { slots, attrs }) {
+    return () => h(tag, attrs, slots.default?.())
+  },
+})
+
+const ExpandTransitionStub = defineComponent({
+  name: 'ExpandTransitionStub',
+  setup(_props, { slots }) {
+    return () => h('div', slots.default?.())
+  },
+})
+
+const VBtnStub: Component = {
+  inheritAttrs: false,
+  props: {
+    disabled: Boolean,
+  },
+  emits: ['click'],
+  setup(props, { slots, attrs, emit }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          type: 'button',
+          disabled: props.disabled,
+          onClick: (event: MouseEvent) => {
+            if (props.disabled) {
+              event.preventDefault()
+              return
+            }
+            emit('click', event)
+          },
+        },
+        slots.default?.(),
+      )
+  },
+}
+
+type VuetifyInstance = ReturnType<typeof createVuetify>
+
+let sequence = 0
+let pinia: Pinia
+let i18n: I18n
+let vuetify: VuetifyInstance
+
+const createProduct = (overrides: Partial<ProductDto> = {}): ProductDto => ({
+  gtin: overrides.gtin ?? ++sequence,
+  base: {
+    vertical: overrides.base?.vertical ?? 'electronics',
+    bestName: overrides.base?.bestName ?? 'Example product',
+  },
+  identity: {
+    bestName: overrides.identity?.bestName ?? 'Example product',
+  },
+  resources: {
+    coverImagePath: overrides.resources?.coverImagePath ?? 'https://cdn.example.com/image.jpg',
+  },
+  slug: overrides.slug,
+  fullSlug: overrides.fullSlug,
+  offers: overrides.offers,
+  names: overrides.names,
+  scores: overrides.scores,
+  attributes: overrides.attributes,
+  datasources: overrides.datasources,
+  aiReview: overrides.aiReview,
+})
+
+describe('CategoryComparePanel', () => {
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    localStorage.clear()
+    sequence = 0
+    i18n = createI18n({
+      legacy: false,
+      locale: 'en-US',
+      messages: {
+        'en-US': {
+          category: {
+            products: {
+              compare: {
+                title: 'Compare products',
+                expandPanel: 'Show list',
+                collapsePanel: 'Hide list',
+                removeSingle: 'Remove {name}',
+                addMoreHint: 'Select two products.',
+                launchComparison: 'Compare now',
+                regionLabel: 'Products selected for comparison',
+                itemsCount: '{count} products selected',
+                addToList: 'Add to compare',
+                removeFromList: 'Remove from compare',
+                limitReached: 'You can compare up to {count} products.',
+                differentCategory: 'Only compare products from the same category.',
+                missingIdentifier: 'Cannot compare this product.',
+              },
+              untitledProduct: 'Untitled product',
+            },
+          },
+        },
+      },
+    })
+    vuetify = createVuetify()
+  })
+
+  const mountPanel = async () => {
+    const module = await import('./CategoryComparePanel.vue')
+    const CategoryComparePanel = module.default
+
+    return mount(CategoryComparePanel, {
+      global: {
+        plugins: [pinia, i18n, vuetify],
+        stubs: {
+          ClientOnly: ClientOnlyStub,
+          VCard: simpleStub('div'),
+          VBtn: VBtnStub,
+          VAvatar: simpleStub('div'),
+          VImg: simpleStub('div'),
+          VSkeletonLoader: simpleStub('div'),
+          VTooltip: simpleStub('div'),
+          VExpandTransition: ExpandTransitionStub,
+          VIcon: simpleStub('span'),
+        },
+      },
+    })
+  }
+
+  it('remains hidden when no products are selected', async () => {
+    const wrapper = await mountPanel()
+
+    expect(wrapper.find('.category-compare-panel').exists()).toBe(false)
+  })
+
+  it('renders selected items and allows removing them', async () => {
+    const store = useProductCompareStore()
+    store.addProduct(createProduct({ gtin: 101 }))
+    store.addProduct(createProduct({ gtin: 102 }))
+
+    const wrapper = await mountPanel()
+
+    expect(wrapper.text()).toContain('Compare products')
+    const removeButtons = wrapper.findAll('.category-compare-panel__item-remove')
+    expect(removeButtons).toHaveLength(2)
+
+    const firstRemoveButton = removeButtons[0]!
+
+    await firstRemoveButton.trigger('click')
+    expect(store.items).toHaveLength(1)
+  })
+
+  it('emits launch event when comparison is triggered', async () => {
+    const store = useProductCompareStore()
+    const first = createProduct({ gtin: 201 })
+    const second = createProduct({ gtin: 202 })
+
+    store.addProduct(first)
+    store.addProduct(second)
+
+    const wrapper = await mountPanel()
+
+    const launchButton = wrapper.get('.category-compare-panel__cta')
+    expect((launchButton.element as HTMLButtonElement).disabled).toBe(false)
+
+    await launchButton.trigger('click')
+    const emitted = wrapper.emitted('launch-comparison') as unknown[][] | undefined
+    expect(emitted).toBeTruthy()
+    expect(emitted?.[0]?.[0]).toHaveLength(2)
+  })
+})

--- a/frontend/app/components/category/products/CategoryComparePanel.vue
+++ b/frontend/app/components/category/products/CategoryComparePanel.vue
@@ -1,0 +1,235 @@
+<template>
+  <ClientOnly>
+    <VExpandTransition>
+      <aside
+        v-if="hasItems"
+        class="category-compare-panel"
+        role="complementary"
+        :aria-label="t('category.products.compare.regionLabel')"
+      >
+        <v-card class="category-compare-panel__card" elevation="12" rounded="xl">
+          <header class="category-compare-panel__header">
+            <div class="category-compare-panel__title-block">
+              <h2 class="category-compare-panel__title">{{ t('category.products.compare.title') }}</h2>
+              <p class="category-compare-panel__count">{{ itemsCountLabel }}</p>
+            </div>
+
+            <v-btn
+              class="category-compare-panel__toggle"
+              variant="text"
+              color="primary"
+              size="small"
+              @click="toggleCollapse"
+            >
+              {{
+                isCollapsed
+                  ? t('category.products.compare.expandPanel')
+                  : t('category.products.compare.collapsePanel')
+              }}
+            </v-btn>
+          </header>
+
+          <VExpandTransition>
+            <div v-show="!isCollapsed" class="category-compare-panel__body">
+              <ul class="category-compare-panel__items" role="list">
+                <li v-for="item in items" :key="item.id" class="category-compare-panel__item">
+                  <v-avatar class="category-compare-panel__item-avatar" size="52" rounded="lg">
+                    <v-img
+                      v-if="item.image"
+                      :src="item.image"
+                      :alt="item.name"
+                      cover
+                    />
+                    <div v-else class="category-compare-panel__item-placeholder" aria-hidden="true">
+                      {{ itemInitials(item.name) }}
+                    </div>
+                  </v-avatar>
+
+                  <div class="category-compare-panel__item-content">
+                    <span class="category-compare-panel__item-name">{{ item.name }}</span>
+                    <v-btn
+                      class="category-compare-panel__item-remove"
+                      variant="text"
+                      size="small"
+                      color="error"
+                      :aria-label="t('category.products.compare.removeSingle', { name: item.name })"
+                      @click="remove(item.id)"
+                    >
+                      {{ t('category.products.compare.removeFromList') }}
+                    </v-btn>
+                  </div>
+                </li>
+              </ul>
+
+              <p v-if="items.length < 2" class="category-compare-panel__hint">
+                {{ t('category.products.compare.addMoreHint') }}
+              </p>
+
+              <v-btn
+                class="category-compare-panel__cta"
+                color="primary"
+                variant="flat"
+                block
+                :disabled="!canLaunch"
+                @click="launchComparison"
+              >
+                {{ t('category.products.compare.launchComparison') }}
+              </v-btn>
+            </div>
+          </VExpandTransition>
+        </v-card>
+      </aside>
+    </VExpandTransition>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useProductCompareStore, type CompareListItem } from '~/stores/useProductCompareStore'
+
+const emit = defineEmits<{
+  (event: 'launch-comparison', items: CompareListItem[]): void
+}>()
+
+const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
+
+const compareStore = useProductCompareStore()
+const { items, isCollapsed } = storeToRefs(compareStore)
+
+const hasItems = computed(() => items.value.length > 0)
+
+const itemsCountLabel = computed(() =>
+  translatePlural('category.products.compare.itemsCount', items.value.length, { count: items.value.length }),
+)
+
+const canLaunch = computed(() => items.value.length >= 2)
+
+const toggleCollapse = () => {
+  isCollapsed.value = !isCollapsed.value
+}
+
+const remove = (id: string) => {
+  compareStore.removeById(id)
+}
+
+const launchComparison = () => {
+  if (!canLaunch.value) {
+    return
+  }
+
+  emit('launch-comparison', [...items.value])
+}
+
+const itemInitials = (name: string) => {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .slice(0, 2)
+    .join('')
+}
+</script>
+
+<style scoped lang="sass">
+.category-compare-panel
+  position: fixed
+  inset-inline-end: 1.5rem
+  inset-block-end: 1.5rem
+  width: min(420px, calc(100% - 3rem))
+  z-index: 12
+
+  &__card
+    background: rgb(var(--v-theme-surface-glass))
+    box-shadow: 0 24px 40px rgba(15, 35, 65, 0.18)
+    border-radius: 1.25rem
+    padding: 1.25rem
+
+  &__header
+    display: flex
+    align-items: flex-start
+    justify-content: space-between
+    gap: 0.5rem
+
+  &__title
+    margin: 0
+    font-size: 1.1rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__count
+    margin: 0.25rem 0 0
+    font-size: 0.9rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__toggle
+    margin-inline-start: auto
+    text-transform: none
+
+  &__body
+    margin-top: 1rem
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__items
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    margin: 0
+    padding: 0
+    list-style: none
+
+  &__item
+    display: flex
+    align-items: center
+    gap: 0.75rem
+
+  &__item-avatar
+    flex-shrink: 0
+    background: rgb(var(--v-theme-surface-default))
+
+  &__item-placeholder
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 100%
+    height: 100%
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    background: rgba(var(--v-theme-surface-primary-080), 0.6)
+    border-radius: inherit
+
+  &__item-content
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
+    min-width: 0
+
+  &__item-name
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+  &__item-remove
+    align-self: flex-start
+    padding: 0
+    text-transform: none
+
+  &__hint
+    margin: 0
+    font-size: 0.85rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__cta
+    text-transform: none
+    font-weight: 600
+
+@media (max-width: 600px)
+  .category-compare-panel
+    inset-inline: 1rem
+    width: auto
+</style>

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -119,12 +119,11 @@ import {
   shallowRef,
   watch,
   type ComponentPublicInstance,
-  type DefineComponent,
   type PropType,
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ProductDto } from '~~/shared/api-client'
-import type { VuePictureSwipeItem, VuePictureSwipeOptions } from 'vue3-picture-swipe'
+import type { PictureSwipeItem, PictureSwipeOptions } from 'vue3-picture-swipe'
 
 defineOptions({ inheritAttrs: false })
 
@@ -139,7 +138,7 @@ const props = defineProps({
   },
 })
 
-type PictureSwipeComponent = DefineComponent<{ items: VuePictureSwipeItem[]; options?: VuePictureSwipeOptions }>
+type PictureSwipeComponent = typeof import('vue3-picture-swipe')['default']
 
 type PictureSwipeComponentInstance = ComponentPublicInstance<{ pswp?: LightboxInstance }> & {
   open?: (index: number) => void
@@ -379,7 +378,7 @@ const escapeMap: Record<string, string> = {
 const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => escapeMap[char] ?? char)
 const escapeAttribute = (value: string | null | undefined) => escapeHtml(String(value ?? ''))
 
-const pictureSwipeItems = computed<VuePictureSwipeItem[]>(() =>
+const pictureSwipeItems = computed<PictureSwipeItem[]>(() =>
   galleryItems.value.map((item) => {
     const caption = item.caption || props.title
     const sanitizedCaption = escapeHtml(caption)
@@ -413,8 +412,8 @@ const pictureSwipeItems = computed<VuePictureSwipeItem[]>(() =>
   }),
 )
 
-const pictureSwipeOptions = computed<VuePictureSwipeOptions>(() => {
-  const base: VuePictureSwipeOptions = {
+const pictureSwipeOptions = computed<PictureSwipeOptions>(() => {
+  const base: PictureSwipeOptions = {
     shareEl: false,
     fullscreenEl: true,
     zoomEl: true,

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -31,6 +31,8 @@
         <TheMainFooterContent />
       </template>
     </TheMainFooter>
+
+    <CategoryComparePanel />
   </v-app>
 </template>
 

--- a/frontend/app/stores/useProductCompareStore.ts
+++ b/frontend/app/stores/useProductCompareStore.ts
@@ -1,0 +1,211 @@
+import { useLocalStorage } from '@vueuse/core'
+import { computed } from 'vue'
+import { defineStore } from 'pinia'
+import type { ProductDto } from '~~/shared/api-client'
+
+export const MAX_COMPARE_ITEMS = 4
+const STORAGE_KEY = 'open4goods:compare-list'
+const COLLAPSE_STORAGE_KEY = `${STORAGE_KEY}:collapsed`
+
+export type CompareListBlockReason =
+  | 'limit-reached'
+  | 'vertical-mismatch'
+  | 'missing-identifier'
+
+export interface CompareListItem {
+  id: string
+  gtin?: number
+  slug?: string
+  fullSlug?: string
+  verticalId?: string | null
+  name: string
+  image?: string
+}
+
+export interface CompareListActionResult {
+  success: boolean
+  reason?: CompareListBlockReason
+}
+
+const getProductIdentifier = (product: ProductDto): string | null => {
+  if (product.gtin != null) {
+    return String(product.gtin)
+  }
+
+  if (product.slug) {
+    return product.slug
+  }
+
+  if (product.fullSlug) {
+    return product.fullSlug
+  }
+
+  const fallbackParts = [
+    product.identity?.bestName,
+    product.identity?.model,
+    product.identity?.brand,
+    product.base?.bestName,
+  ].filter((part): part is string => Boolean(part))
+
+  if (fallbackParts.length > 0) {
+    return fallbackParts.join('|')
+  }
+
+  return null
+}
+
+const resolveProductName = (product: ProductDto): string => {
+  return (
+    product.identity?.bestName ??
+    product.base?.bestName ??
+    product.identity?.model ??
+    product.identity?.brand ??
+    product.names?.h1Title ??
+    product.names?.longestOfferName ??
+    '#'
+  )
+}
+
+const resolveProductImage = (product: ProductDto): string | undefined => {
+  return (
+    product.resources?.coverImagePath ??
+    product.resources?.externalCover ??
+    product.resources?.images?.[0]?.url ??
+    undefined
+  )
+}
+
+const resolveProductVertical = (product: ProductDto): string | null => {
+  return product.base?.vertical ?? null
+}
+
+export const useProductCompareStore = defineStore('product-compare', () => {
+  const items = useLocalStorage<CompareListItem[]>(STORAGE_KEY, [], {
+    deep: true,
+  })
+  const isCollapsed = useLocalStorage<boolean>(COLLAPSE_STORAGE_KEY, false)
+
+  const referenceVerticalId = computed(() => {
+    return items.value.find((item) => item.verticalId)?.verticalId ?? null
+  })
+
+  const hasReachedLimit = computed(() => items.value.length >= MAX_COMPARE_ITEMS)
+
+  const hasProduct = (product: ProductDto) => {
+    const identifier = getProductIdentifier(product)
+
+    if (!identifier) {
+      return false
+    }
+
+    return items.value.some((item) => item.id === identifier)
+  }
+
+  const removeById = (id: string) => {
+    items.value = items.value.filter((item) => item.id !== id)
+
+    if (items.value.length === 0) {
+      isCollapsed.value = false
+    }
+  }
+
+  const removeProduct = (product: ProductDto) => {
+    const identifier = getProductIdentifier(product)
+
+    if (!identifier) {
+      return
+    }
+
+    removeById(identifier)
+  }
+
+  const canAddProduct = (product: ProductDto): CompareListActionResult => {
+    if (hasProduct(product)) {
+      return { success: true }
+    }
+
+    if (hasReachedLimit.value) {
+      return { success: false, reason: 'limit-reached' }
+    }
+
+    const productIdentifier = getProductIdentifier(product)
+
+    if (!productIdentifier) {
+      return { success: false, reason: 'missing-identifier' }
+    }
+
+    const productVertical = resolveProductVertical(product)
+    const currentVertical = referenceVerticalId.value
+
+    if (currentVertical && productVertical && currentVertical !== productVertical) {
+      return { success: false, reason: 'vertical-mismatch' }
+    }
+
+    if (currentVertical && !productVertical) {
+      return { success: false, reason: 'vertical-mismatch' }
+    }
+
+    return { success: true }
+  }
+
+  const addProduct = (product: ProductDto): CompareListActionResult => {
+    const eligibility = canAddProduct(product)
+
+    if (!eligibility.success) {
+      return eligibility
+    }
+
+    const identifier = getProductIdentifier(product)
+
+    if (!identifier) {
+      return { success: false, reason: 'missing-identifier' }
+    }
+
+    if (hasProduct(product)) {
+      return { success: true }
+    }
+
+    const newItem: CompareListItem = {
+      id: identifier,
+      gtin: product.gtin,
+      slug: product.slug,
+      fullSlug: product.fullSlug,
+      verticalId: resolveProductVertical(product),
+      name: resolveProductName(product),
+      image: resolveProductImage(product),
+    }
+
+    items.value = [...items.value, newItem]
+    isCollapsed.value = false
+
+    return { success: true }
+  }
+
+  const toggleProduct = (product: ProductDto): CompareListActionResult => {
+    if (hasProduct(product)) {
+      removeProduct(product)
+      return { success: true }
+    }
+
+    return addProduct(product)
+  }
+
+  const clear = () => {
+    items.value = []
+    isCollapsed.value = false
+  }
+
+  return {
+    items,
+    isCollapsed,
+    hasReachedLimit,
+    referenceVerticalId,
+    hasProduct,
+    canAddProduct,
+    addProduct,
+    toggleProduct,
+    removeProduct,
+    removeById,
+    clear,
+  }
+})

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -167,6 +167,24 @@
         "other": "{count} offers"
       },
       "notRated": "Not rated",
+      "compare": {
+        "title": "Compare products",
+        "expandPanel": "Show list",
+        "collapsePanel": "Hide list",
+        "removeSingle": "Remove {name}",
+        "addMoreHint": "Select at least two products to start a comparison.",
+        "launchComparison": "Compare now",
+        "regionLabel": "Products selected for comparison",
+        "itemsCount": {
+          "one": "{count} product selected",
+          "other": "{count} products selected"
+        },
+        "addToList": "Add to compare",
+        "removeFromList": "Remove from compare",
+        "limitReached": "You can compare up to {count} products.",
+        "differentCategory": "Only compare products from the same category.",
+        "missingIdentifier": "Cannot compare this product."
+      },
       "fetchError": "Unable to load products. Please try again.",
       "headers": {
         "brand": "Brand",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -166,6 +166,24 @@
         "other": "{count} offres"
       },
       "notRated": "Non noté",
+      "compare": {
+        "title": "Comparer les produits",
+        "expandPanel": "Afficher la liste",
+        "collapsePanel": "Masquer la liste",
+        "removeSingle": "Retirer {name}",
+        "addMoreHint": "Sélectionnez au moins deux produits pour lancer une comparaison.",
+        "launchComparison": "Comparer maintenant",
+        "regionLabel": "Produits sélectionnés pour la comparaison",
+        "itemsCount": {
+          "one": "{count} produit sélectionné",
+          "other": "{count} produits sélectionnés"
+        },
+        "addToList": "Ajouter à la comparaison",
+        "removeFromList": "Retirer de la comparaison",
+        "limitReached": "Vous pouvez comparer jusqu'à {count} produits.",
+        "differentCategory": "Comparez uniquement des produits de la même catégorie.",
+        "missingIdentifier": "Impossible de comparer ce produit."
+      },
       "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
       "headers": {
         "brand": "Marque",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "typeRoots": ["./types", "./node_modules/@types"]
+  }
 }

--- a/frontend/types/vue3-picture-swipe.d.ts
+++ b/frontend/types/vue3-picture-swipe.d.ts
@@ -1,0 +1,37 @@
+declare module 'vue3-picture-swipe' {
+  import type { DefineComponent } from 'vue'
+
+  interface PictureSwipeItem {
+    src: string
+    msrc?: string
+    width?: number
+    height?: number
+    title?: string
+    html?: string
+    el?: HTMLElement
+  }
+
+  interface PictureSwipeOptions {
+    loop?: boolean
+    allowPanToNext?: boolean
+    spacing?: number
+    bgOpacity?: number
+    mouseUsed?: boolean
+    escKey?: boolean
+    arrowKeys?: boolean
+    history?: boolean
+    galleryUID?: string
+    gallerySelector?: string | false
+    getThumbBoundsFn?: (index: number) => { x: number; y: number; w: number }
+  }
+
+  const VuePictureSwipe: DefineComponent<{
+    items: PictureSwipeItem[]
+    options?: PictureSwipeOptions
+    openOn?: number | null
+    isOpen?: boolean
+  }>
+
+  export type { PictureSwipeItem, PictureSwipeOptions }
+  export default VuePictureSwipe
+}

--- a/frontend/types/vue3-picture-swipe.d.ts
+++ b/frontend/types/vue3-picture-swipe.d.ts
@@ -23,6 +23,12 @@ declare module 'vue3-picture-swipe' {
     galleryUID?: string
     gallerySelector?: string | false
     getThumbBoundsFn?: (index: number) => { x: number; y: number; w: number }
+    shareEl?: boolean
+    fullscreenEl?: boolean
+    zoomEl?: boolean
+    counterEl?: boolean
+    closeOnScroll?: boolean
+    [key: string]: unknown
   }
 
   const VuePictureSwipe: DefineComponent<{

--- a/frontend/types/vue3-picture-swipe/index.d.ts
+++ b/frontend/types/vue3-picture-swipe/index.d.ts
@@ -23,6 +23,12 @@ declare module 'vue3-picture-swipe' {
     galleryUID?: string
     gallerySelector?: string | false
     getThumbBoundsFn?: (index: number) => { x: number; y: number; w: number }
+    shareEl?: boolean
+    fullscreenEl?: boolean
+    zoomEl?: boolean
+    counterEl?: boolean
+    closeOnScroll?: boolean
+    [key: string]: unknown
   }
 
   const VuePictureSwipe: DefineComponent<{


### PR DESCRIPTION
## Summary
- add Vuetify/i18n-aware setups to the compare panel and grid specs so they mount with real plugins
- adjust the compare store fallback name resolution and expose the vue3-picture-swipe typings to Nuxt
- extend tsconfig type roots so local declaration files are respected during type checking

## Testing
- pnpm vitest run app/stores/useProductCompareStore.spec.ts app/components/category/products/CategoryProductCardGrid.spec.ts app/components/category/products/CategoryComparePanel.spec.ts
- pnpm lint
- pnpm generate
- pnpm test *(cancelled once the suite had already executed the changed specs because of the full-suite runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68fb887e345083339c5fed4ad9f13486