### PR TITLE
feat(frontend): add global compare panel

### DIFF
--- a/frontend/app/components/category/products/CategoryComparePanel.vue
+++ b/frontend/app/components/category/products/CategoryComparePanel.vue
@@ -1,0 +1,235 @@
+<template>
+  <ClientOnly>
+    <VExpandTransition>
+      <aside
+        v-if="hasItems"
+        class="category-compare-panel"
+        role="complementary"
+        :aria-label="t('category.products.compare.regionLabel')"
+      >
+        <v-card class="category-compare-panel__card" elevation="12" rounded="xl">
+          <header class="category-compare-panel__header">
+            <div class="category-compare-panel__title-block">
+              <h2 class="category-compare-panel__title">{{ t('category.products.compare.title') }}</h2>
+              <p class="category-compare-panel__count">{{ itemsCountLabel }}</p>
+            </div>
+
+            <v-btn
+              class="category-compare-panel__toggle"
+              variant="text"
+              color="primary"
+              size="small"
+              @click="toggleCollapse"
+            >
+              {{
+                isCollapsed
+                  ? t('category.products.compare.expandPanel')
+                  : t('category.products.compare.collapsePanel')
+              }}
+            </v-btn>
+          </header>
+
+          <VExpandTransition>
+            <div v-show="!isCollapsed" class="category-compare-panel__body">
+              <ul class="category-compare-panel__items" role="list">
+                <li v-for="item in items" :key="item.id" class="category-compare-panel__item">
+                  <v-avatar class="category-compare-panel__item-avatar" size="52" rounded="lg">
+                    <v-img
+                      v-if="item.image"
+                      :src="item.image"
+                      :alt="item.name"
+                      cover
+                    />
+                    <div v-else class="category-compare-panel__item-placeholder" aria-hidden="true">
+                      {{ itemInitials(item.name) }}
+                    </div>
+                  </v-avatar>
+
+                  <div class="category-compare-panel__item-content">
+                    <span class="category-compare-panel__item-name">{{ item.name }}</span>
+                    <v-btn
+                      class="category-compare-panel__item-remove"
+                      variant="text"
+                      size="small"
+                      color="error"
+                      :aria-label="t('category.products.compare.removeSingle', { name: item.name })"
+                      @click="remove(item.id)"
+                    >
+                      {{ t('category.products.compare.removeFromList') }}
+                    </v-btn>
+                  </div>
+                </li>
+              </ul>
+
+              <p v-if="items.length < 2" class="category-compare-panel__hint">
+                {{ t('category.products.compare.addMoreHint') }}
+              </p>
+
+              <v-btn
+                class="category-compare-panel__cta"
+                color="primary"
+                variant="flat"
+                block
+                :disabled="!canLaunch"
+                @click="launchComparison"
+              >
+                {{ t('category.products.compare.launchComparison') }}
+              </v-btn>
+            </div>
+          </VExpandTransition>
+        </v-card>
+      </aside>
+    </VExpandTransition>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useProductCompareStore, type CompareListItem } from '~/stores/useProductCompareStore'
+
+const emit = defineEmits<{
+  (event: 'launch-comparison', items: CompareListItem[]): void
+}>()
+
+const { t } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
+
+const compareStore = useProductCompareStore()
+const { items, isCollapsed } = storeToRefs(compareStore)
+
+const hasItems = computed(() => items.value.length > 0)
+
+const itemsCountLabel = computed(() =>
+  translatePlural('category.products.compare.itemsCount', items.value.length, { count: items.value.length }),
+)
+
+const canLaunch = computed(() => items.value.length >= 2)
+
+const toggleCollapse = () => {
+  isCollapsed.value = !isCollapsed.value
+}
+
+const remove = (id: string) => {
+  compareStore.removeById(id)
+}
+
+const launchComparison = () => {
+  if (!canLaunch.value) {
+    return
+  }
+
+  emit('launch-comparison', [...items.value])
+}
+
+const itemInitials = (name: string) => {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .slice(0, 2)
+    .join('')
+}
+</script>
+
+<style scoped lang="sass">
+.category-compare-panel
+  position: fixed
+  inset-inline-end: 1.5rem
+  inset-block-end: 1.5rem
+  width: min(420px, calc(100% - 3rem))
+  z-index: 12
+
+  &__card
+    background: rgb(var(--v-theme-surface-glass))
+    box-shadow: 0 24px 40px rgba(15, 35, 65, 0.18)
+    border-radius: 1.25rem
+    padding: 1.25rem
+
+  &__header
+    display: flex
+    align-items: flex-start
+    justify-content: space-between
+    gap: 0.5rem
+
+  &__title
+    margin: 0
+    font-size: 1.1rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__count
+    margin: 0.25rem 0 0
+    font-size: 0.9rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__toggle
+    margin-inline-start: auto
+    text-transform: none
+
+  &__body
+    margin-top: 1rem
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__items
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    margin: 0
+    padding: 0
+    list-style: none
+
+  &__item
+    display: flex
+    align-items: center
+    gap: 0.75rem
+
+  &__item-avatar
+    flex-shrink: 0
+    background: rgb(var(--v-theme-surface-default))
+
+  &__item-placeholder
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 100%
+    height: 100%
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    background: rgba(var(--v-theme-surface-primary-080), 0.6)
+    border-radius: inherit
+
+  &__item-content
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
+    min-width: 0
+
+  &__item-name
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+  &__item-remove
+    align-self: flex-start
+    padding: 0
+    text-transform: none
+
+  &__hint
+    margin: 0
+    font-size: 0.85rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__cta
+    text-transform: none
+    font-weight: 600
+
+@media (max-width: 600px)
+  .category-compare-panel
+    inset-inline: 1rem
+    width: auto
+</style>

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -119,12 +119,11 @@ import {
   shallowRef,
   watch,
   type ComponentPublicInstance,
-  type DefineComponent,
   type PropType,
 } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ProductDto } from '~~/shared/api-client'
-import type { VuePictureSwipeItem, VuePictureSwipeOptions } from 'vue3-picture-swipe'
+import type { PictureSwipeItem, PictureSwipeOptions } from 'vue3-picture-swipe'
 
 defineOptions({ inheritAttrs: false })
 
@@ -139,7 +138,7 @@ const props = defineProps({
   },
 })
 
-type PictureSwipeComponent = DefineComponent<{ items: VuePictureSwipeItem[]; options?: VuePictureSwipeOptions }>
+type PictureSwipeComponent = typeof import('vue3-picture-swipe')['default']
 
 type PictureSwipeComponentInstance = ComponentPublicInstance<{ pswp?: LightboxInstance }> & {
   open?: (index: number) => void
@@ -379,7 +378,7 @@ const escapeMap: Record<string, string> = {
 const escapeHtml = (value: string) => value.replace(/[&<>"']/g, (char) => escapeMap[char] ?? char)
 const escapeAttribute = (value: string | null | undefined) => escapeHtml(String(value ?? ''))
 
-const pictureSwipeItems = computed<VuePictureSwipeItem[]>(() =>
+const pictureSwipeItems = computed<PictureSwipeItem[]>(() =>
   galleryItems.value.map((item) => {
     const caption = item.caption || props.title
     const sanitizedCaption = escapeHtml(caption)
@@ -413,8 +412,8 @@ const pictureSwipeItems = computed<VuePictureSwipeItem[]>(() =>
   }),
 )
 
-const pictureSwipeOptions = computed<VuePictureSwipeOptions>(() => {
-  const base: VuePictureSwipeOptions = {
+const pictureSwipeOptions = computed<PictureSwipeOptions>(() => {
+  const base: PictureSwipeOptions = {
     shareEl: false,
     fullscreenEl: true,
     zoomEl: true,

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -31,6 +31,8 @@
         <TheMainFooterContent />
       </template>
     </TheMainFooter>
+
+    <CategoryComparePanel />
   </v-app>
 </template>
 

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -167,6 +167,24 @@
         "other": "{count} offers"
       },
       "notRated": "Not rated",
+      "compare": {
+        "title": "Compare products",
+        "expandPanel": "Show list",
+        "collapsePanel": "Hide list",
+        "removeSingle": "Remove {name}",
+        "addMoreHint": "Select at least two products to start a comparison.",
+        "launchComparison": "Compare now",
+        "regionLabel": "Products selected for comparison",
+        "itemsCount": {
+          "one": "{count} product selected",
+          "other": "{count} products selected"
+        },
+        "addToList": "Add to compare",
+        "removeFromList": "Remove from compare",
+        "limitReached": "You can compare up to {count} products.",
+        "differentCategory": "Only compare products from the same category.",
+        "missingIdentifier": "Cannot compare this product."
+      },
       "fetchError": "Unable to load products. Please try again.",
       "headers": {
         "brand": "Brand",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -166,6 +166,24 @@
         "other": "{count} offres"
       },
       "notRated": "Non noté",
+      "compare": {
+        "title": "Comparer les produits",
+        "expandPanel": "Afficher la liste",
+        "collapsePanel": "Masquer la liste",
+        "removeSingle": "Retirer {name}",
+        "addMoreHint": "Sélectionnez au moins deux produits pour lancer une comparaison.",
+        "launchComparison": "Comparer maintenant",
+        "regionLabel": "Produits sélectionnés pour la comparaison",
+        "itemsCount": {
+          "one": "{count} produit sélectionné",
+          "other": "{count} produits sélectionnés"
+        },
+        "addToList": "Ajouter à la comparaison",
+        "removeFromList": "Retirer de la comparaison",
+        "limitReached": "Vous pouvez comparer jusqu'à {count} produits.",
+        "differentCategory": "Comparez uniquement des produits de la même catégorie.",
+        "missingIdentifier": "Impossible de comparer ce produit."
+      },
       "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
       "headers": {
         "brand": "Marque",

--- a/frontend/types/vue3-picture-swipe.d.ts
+++ b/frontend/types/vue3-picture-swipe.d.ts
@@ -23,6 +23,12 @@ declare module 'vue3-picture-swipe' {
     galleryUID?: string
     gallerySelector?: string | false
     getThumbBoundsFn?: (index: number) => { x: number; y: number; w: number }
+    shareEl?: boolean
+    fullscreenEl?: boolean
+    zoomEl?: boolean
+    counterEl?: boolean
+    closeOnScroll?: boolean
+    [key: string]: unknown
   }
 
   const VuePictureSwipe: DefineComponent<{

--- a/frontend/types/vue3-picture-swipe/index.d.ts
+++ b/frontend/types/vue3-picture-swipe/index.d.ts
@@ -23,6 +23,12 @@ declare module 'vue3-picture-swipe' {
     galleryUID?: string
     gallerySelector?: string | false
     getThumbBoundsFn?: (index: number) => { x: number; y: number; w: number }
+    shareEl?: boolean
+    fullscreenEl?: boolean
+    zoomEl?: boolean
+    counterEl?: boolean
+    closeOnScroll?: boolean
+    [key: string]: unknown
   }
 
   const VuePictureSwipe: DefineComponent<{


### PR DESCRIPTION
## Summary
- add a CategoryComparePanel widget rendered from the layout to keep comparison items visible across pages
- expose compare controls on category product cards and translate all compare strings in both locales
- align ProductHeroGallery with local vue3-picture-swipe typings so picture swipe options compile cleanly

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fb9a89daa483338624c77e403347f6