### PR TITLE
Fix product page error handling and stop error overlay spinner

### DIFF
--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -112,6 +112,9 @@ const localePath = useLocalePath()
 
 const drawer = useState('mobileDrawer', () => false)
 const drawerStore = useState('mobileDrawer', () => false)
+const routeLoading = useState('routeLoading', () => false)
+
+routeLoading.value = false
 
 const statusCode = computed(() => props.error?.statusCode ?? 500)
 const paddedStatusCode = computed(() => String(statusCode.value).padStart(3, '0'))

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -142,6 +142,8 @@ if (!productRoute) {
 
 const { categorySlug, gtin } = productRoute
 
+const productLoadError = ref<Error | null>(null)
+
 const {
   data: productData,
   pending,
@@ -149,6 +151,7 @@ const {
 } = await useAsyncData<ProductDto | null>(
   `product-${gtin}`,
   async () => {
+    productLoadError.value = null
     try {
       return await $fetch<ProductDto>(`/api/products/${gtin}`)
     } catch (fetchError) {
@@ -160,7 +163,21 @@ const {
         })
       }
 
-      throw fetchError
+      const fallbackMessage =
+        fetchError instanceof Error && fetchError.message?.trim().length
+          ? fetchError.message
+          : String(t('error.page.generic.statusMessage'))
+
+      productLoadError.value =
+        fetchError instanceof Error ? fetchError : new Error(fallbackMessage)
+
+      if (!productLoadError.value.message?.trim().length) {
+        productLoadError.value.message = fallbackMessage
+      }
+
+      console.error('Failed to load product details', fetchError)
+
+      return null
     }
   },
   { server: true, immediate: true },
@@ -543,15 +560,19 @@ const scrollToSection = (sectionId: string) => {
 }
 
 const errorMessage = computed(() => {
-  if (!error.value) {
-    return null
+  if (error.value) {
+    if (error.value instanceof Error) {
+      return error.value.message
+    }
+
+    return String(error.value)
   }
 
-  if (error.value instanceof Error) {
-    return error.value.message
+  if (productLoadError.value) {
+    return productLoadError.value.message
   }
 
-  return String(error.value)
+  return null
 })
 
 const structuredOffers = computed(() => {


### PR DESCRIPTION
## Summary
- handle product API failures on the product detail page without triggering the Nuxt 500 screen and surface a localized fallback message
- log unexpected fetch failures while still allowing the view to render and show the inline alert for users
- clear the global route loading overlay when rendering the error layout so 40x/50x pages no longer display a stuck spinner

## Testing
- pnpm lint
- pnpm generate
- pnpm test --run *(fails: vitest runner keeps the suite queued in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fba28d427c8333a029a743635c73ca