### PR TITLE
Fix product page slug parsing for client hydration

### DIFF
--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -127,20 +127,20 @@ const { t } = useI18n()
 const { isLoggedIn } = useAuth()
 const display = useDisplay()
 
-const slugParam = route.params.slug
-const segments = Array.isArray(slugParam)
-  ? slugParam.filter((segment): segment is string => typeof segment === 'string')
-  : typeof slugParam === 'string'
-    ? [slugParam]
-    : []
+const pathSegments = computed(() =>
+  route.path
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment): segment is string => Boolean(segment?.length)),
+)
 
-const productRoute = matchProductRouteFromSegments(segments)
+const productRoute = computed(() => matchProductRouteFromSegments(pathSegments.value))
 
-if (!productRoute) {
+if (!productRoute.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 }
 
-const { categorySlug, gtin } = productRoute
+const { categorySlug, gtin } = productRoute.value
 
 const productLoadError = ref<Error | null>(null)
 


### PR DESCRIPTION
## Summary
- ensure the product page derives slug segments from the route path so hydration always resolves the product route

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fbac295fec8333b04e36f40f74fbd1