### PR TITLE
Fix slug parsing on product page

### DIFF
--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -129,9 +129,15 @@ const display = useDisplay()
 
 const slugParam = route.params.slug
 const segments = Array.isArray(slugParam)
-  ? slugParam.filter((segment): segment is string => typeof segment === 'string')
+  ? slugParam
+      .filter((segment): segment is string => typeof segment === 'string')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0)
   : typeof slugParam === 'string'
-    ? [slugParam]
+    ? slugParam
+        .split('/')
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0)
     : []
 
 const productRoute = matchProductRouteFromSegments(segments)


### PR DESCRIPTION
## Summary
- normalize product catch-all slug segments by trimming existing arrays and splitting string values
- ensure route matching receives clean segments to avoid hydration failures when Nuxt provides a single catch-all string

## Testing
- pnpm lint
- pnpm test --run *(fails: Vitest runner stays queued in this environment)*
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_68fbbea924a08333a6a4a5f31f0397b1