### PR TITLE
Add attribute comparison rule to vertical configs

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.open4goods.model.attribute.AttributeType;
+import org.open4goods.model.vertical.AttributeComparisonRule;
 import org.open4goods.model.vertical.AttributeParserConfig;
 import org.open4goods.model.vertical.Order;
 
@@ -29,6 +30,8 @@ public record AttributeConfigDto(
         boolean asScore,
         @Schema(description = "Indicates whether lower values should yield higher scores.")
         boolean reverseScore,
+        @Schema(description = "Comparison rule applied to determine which values are considered better.")
+        AttributeComparisonRule betterIs,
         @Schema(description = "Ordering applied when displaying attribute values.")
         Order attributeValuesOrdering,
         @Schema(description = "When true, the attribute values ordering is reversed.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -398,6 +398,7 @@ public class CategoryMappingService {
                 defaultSet(attributeConfig.getIcecatFeaturesIds()),
                 attributeConfig.isAsScore(),
                 attributeConfig.isReverseScore(),
+                attributeConfig.getBetterIs(),
                 attributeConfig.getAttributeValuesOrdering(),
                 attributeConfig.getAttributeValuesReverseOrder(),
                 defaultMap(attributeConfig.getSynonyms()),

--- a/model/src/main/java/org/open4goods/model/vertical/AttributeComparisonRule.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AttributeComparisonRule.java
@@ -1,0 +1,18 @@
+package org.open4goods.model.vertical;
+
+/**
+ * Comparison rule describing which direction makes an attribute value more
+ * desirable when comparing two products.
+ */
+public enum AttributeComparisonRule {
+
+    /**
+     * Higher values represent a better attribute (e.g. screen size, score).
+     */
+    GREATER,
+
+    /**
+     * Lower values represent a better attribute (e.g. weight, consumption).
+     */
+    LOWER
+}

--- a/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
@@ -71,10 +71,16 @@ public class AttributeConfig {
 	 */
 	private boolean asScore = false;
 
-	/**
-	 * If true, attribute value to score will be reversed (ie : for weight, the better score is the lowest weight)
-	 */
-	private boolean reverseScore = false;
+        /**
+         * If true, attribute value to score will be reversed (ie : for weight, the better score is the lowest weight)
+         */
+        private boolean reverseScore = false;
+
+        /**
+         * Indicates which comparison rule should be applied to determine the most
+         * desirable value when comparing products.
+         */
+        private AttributeComparisonRule betterIs = AttributeComparisonRule.GREATER;
 
 	/**
 	 * The ordering that must be applied to this attributes values after aggregations. (ie rendered in search attributes selection)
@@ -354,13 +360,33 @@ public class AttributeConfig {
 		this.icecatFeaturesIds = icecatFeaturesIds;
 	}
 
-	public boolean isReverseScore() {
-		return reverseScore;
-	}
+        public boolean isReverseScore() {
+                return reverseScore;
+        }
 
-	public void setReverseScore(boolean reverseScore) {
-		this.reverseScore = reverseScore;
-	}
+        public void setReverseScore(boolean reverseScore) {
+                this.reverseScore = reverseScore;
+        }
+
+        /**
+         * Gets the comparison rule describing which values are considered better for
+         * this attribute.
+         *
+         * @return the configured comparison rule, defaults to {@link AttributeComparisonRule#GREATER}.
+         */
+        public AttributeComparisonRule getBetterIs() {
+                return betterIs;
+        }
+
+        /**
+         * Sets the comparison rule describing which values are considered better for
+         * this attribute.
+         *
+         * @param betterIs the comparison rule to apply when comparing values.
+         */
+        public void setBetterIs(AttributeComparisonRule betterIs) {
+                this.betterIs = betterIs == null ? AttributeComparisonRule.GREATER : betterIs;
+        }
 
 	public Localisable<String, String> getUnit() {
 		return unit;

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -378,6 +378,7 @@ attributesConfig:
   ##################################
   
   - key: "CLASSE_ENERGY"
+    betterIs: "GREATER"
     faIcon: "fa-bolt"
     name:
       default: "Energy class"
@@ -440,6 +441,7 @@ attributesConfig:
   ##################################
   
   - key: "REPAIRABILITY_INDEX"
+    betterIs: "GREATER"
     faIcon: "fa-screwdriver-wrench"
     name:
       default: "Repairability index"
@@ -472,6 +474,7 @@ attributesConfig:
   ##################################
   
   - key: "YEAR"
+    betterIs: "GREATER"
     faIcon: "calendar-days"
     name:
       default: "Year"
@@ -504,6 +507,7 @@ attributesConfig:
   ##################################
   
   - key: "HDMI_PORTS_QUANTITY"
+    betterIs: "GREATER"
     faIcon: "fa-sitemap"
     icecatFeaturesIds: 
       - 3566      
@@ -537,6 +541,7 @@ attributesConfig:
   ##################################
   
   - key: "COLOR"
+    betterIs: "GREATER"
     faIcon: "fa-droplet"
     name:
       default: "Color"
@@ -572,6 +577,7 @@ attributesConfig:
   ##################################
   
   - key: "WEIGHT"
+    betterIs: "LOWER"
     icecatFeaturesIds:
       - 94
       - 33015    
@@ -618,6 +624,7 @@ attributesConfig:
 #   
   ##################################
   - key: "POWER_CONSUMPTION_TYPICAL"
+    betterIs: "LOWER"
     filteringType: "NUMERIC"
     asScore: true
     reverseScore: true    
@@ -657,6 +664,7 @@ attributesConfig:
 #   
   ##################################
   - key: "POWER_CONSUMPTION_OFF"
+    betterIs: "LOWER"
     filteringType: "NUMERIC"
     asScore: true
     reverseScore: true    
@@ -697,6 +705,7 @@ attributesConfig:
   ##################################
   
   - key: "FEATURES"
+    betterIs: "GREATER"
     faIcon: "fa-list"
     attributePath: attributes.features
     name:
@@ -704,6 +713,7 @@ attributesConfig:
       fr: "Fonctionnalités"
       
   - key: "BRAND_SUSTAINABILITY"
+    betterIs: "GREATER"
     faIcon: "fa-globe"
 #    attributePath: attributes.features
     name:
@@ -712,6 +722,7 @@ attributesConfig:
       
 
   - key: "DATA_QUALITY"
+    betterIs: "GREATER"
     faIcon: "fa-file-shield"
 #    attributePath: attributes.features
     name:

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -411,6 +411,7 @@ attributesConfig:
      # DIAGONALE
      ##################################
      - key: "DIAGONALE_POUCES"
+       betterIs: "GREATER"
        icecatFeaturesIds:
          - 944       
        faIcon: "fa-arrow-up-right-from-square"
@@ -439,7 +440,8 @@ attributesConfig:
      # TYPE TV
      ##################################
      - key: "DISPLAY_TECHNOLOGY"
-       icecatFeaturesIds: 
+       betterIs: "GREATER"
+       icecatFeaturesIds:
          - 9713          
        faIcon: "fa-tv"
        name:


### PR DESCRIPTION
## Summary
- introduce an `AttributeComparisonRule` enum and extend `AttributeConfig` with a `betterIs` comparison rule
- annotate TV and default vertical attribute definitions with the appropriate `betterIs` indicator
- expose the comparison rule through the front API attribute DTO and mapping service

## Testing
- mvn --offline -pl model,verticals,front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68fc7ac6dca08333a7b55d3bdb3e6e5d