### PR TITLE
Refactor page loading overlay to avoid Vuetify scroll errors

### DIFF
--- a/frontend/app/components/shared/ui/PageLoadingOverlay.spec.ts
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.spec.ts
@@ -1,28 +1,16 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
-import { defineComponent, h, nextTick, ref, watchEffect } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { createI18n } from 'vue-i18n'
 import PageLoadingOverlay from './PageLoadingOverlay.vue'
 
 const routeLoading = ref(false)
-const overlayStates: boolean[] = []
 
 vi.mock('#imports', () => ({
   useState: vi.fn(() => routeLoading),
 }))
 
 const stubs = {
-  teleport: true,
-  VOverlay: defineComponent({
-    name: 'VOverlayStub',
-    setup(_, { slots, attrs }) {
-      watchEffect(() => {
-        overlayStates.push(routeLoading.value)
-      })
-
-      return () => (routeLoading.value ? h('div', attrs, slots.default?.()) : null)
-    },
-  }),
   VProgressCircular: defineComponent({
     name: 'VProgressCircularStub',
     props: {
@@ -63,37 +51,61 @@ const mountOverlay = () =>
       stubs,
       plugins: [createI18nPlugin()],
     },
+    attachTo: document.body,
   })
+
+const findOverlay = () => document.body.querySelector('[data-testid="page-loading-overlay"]')
+const findSpinner = () => document.body.querySelector('[data-testid="page-loading-spinner"]')
+const flushOverlay = () => nextTick()
 
 describe('PageLoadingOverlay', () => {
   beforeEach(() => {
     routeLoading.value = false
-    overlayStates.length = 0
+    document.documentElement.style.overflow = ''
+    findOverlay()?.remove()
+    findSpinner()?.remove()
   })
 
   it('renders the spinner when a route is loading', async () => {
     const wrapper = mountOverlay()
 
     routeLoading.value = true
-    await nextTick()
+    await flushOverlay()
 
-    const spinner = wrapper.find('[data-testid="page-loading-spinner"]')
-    expect(spinner.exists()).toBe(true)
-    expect(spinner.attributes('aria-label')).toBe('Loading page content')
-    expect(overlayStates.includes(true)).toBe(true)
+    const overlay = findOverlay()
+    expect(overlay).not.toBeNull()
+    expect(overlay?.getAttribute('aria-live')).toBe('polite')
+
+    const spinner = findSpinner()
+    expect(spinner).not.toBeNull()
+    expect(spinner?.getAttribute('aria-label')).toBe('Loading page content')
 
     wrapper.unmount()
   })
 
-  it('disables the overlay when no route is loading', async () => {
+  it('removes the overlay after unmounting', async () => {
     const wrapper = mountOverlay()
 
-    await nextTick()
-
-    expect(routeLoading.value).toBe(false)
-    expect(overlayStates.at(-1)).toBe(false)
-    expect(wrapper.find('[data-testid="page-loading-spinner"]').exists()).toBe(false)
+    routeLoading.value = true
+    await flushOverlay()
+    routeLoading.value = false
+    await flushOverlay()
 
     wrapper.unmount()
+    await flushOverlay()
+
+    expect(findOverlay()).toBeNull()
+  })
+
+  it('locks and restores document scrolling around unmount', async () => {
+    const wrapper = mountOverlay()
+
+    routeLoading.value = true
+    await flushOverlay()
+    expect(document.documentElement.style.overflow).toBe('hidden')
+
+    wrapper.unmount()
+    await flushOverlay()
+    expect(document.documentElement.style.overflow).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- replace the Vuetify overlay with a teleport-based loading shell that manually blocks and restores document scrolling
- add targeted unit tests covering the new overlay behaviour and scroll locking lifecycle

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fc79546ae883338e2687228b88e4f4