### PR TITLE
Add deep links and responsive tweaks to category compare panel

### DIFF
--- a/frontend/app/components/category/products/CategoryComparePanel.spec.ts
+++ b/frontend/app/components/category/products/CategoryComparePanel.spec.ts
@@ -131,11 +131,11 @@ describe('CategoryComparePanel', () => {
     vuetify = createVuetify()
   })
 
-  const mountPanel = async () => {
-    const module = await import('./CategoryComparePanel.vue')
-    const CategoryComparePanel = module.default
+const mountPanel = async () => {
+  const module = await import('./CategoryComparePanel.vue')
+  const CategoryComparePanel = module.default
 
-    return mount(CategoryComparePanel, {
+  return mount(CategoryComparePanel, {
       global: {
         plugins: [pinia, i18n, vuetify],
         stubs: {
@@ -148,6 +148,17 @@ describe('CategoryComparePanel', () => {
           VTooltip: simpleStub('div'),
           VExpandTransition: ExpandTransitionStub,
           VIcon: simpleStub('span'),
+          NuxtLink: {
+            props: {
+              to: {
+                type: [String, Object],
+                default: '#',
+              },
+            },
+            setup(props, { slots }) {
+              return () => h('a', { href: typeof props.to === 'string' ? props.to : '#', role: 'link' }, slots.default?.())
+            },
+          },
         },
       },
     })
@@ -193,5 +204,23 @@ describe('CategoryComparePanel', () => {
     const emitted = wrapper.emitted('launch-comparison') as unknown[][] | undefined
     expect(emitted).toBeTruthy()
     expect(emitted?.[0]?.[0]).toHaveLength(2)
+  })
+
+  it('links to the product detail page when a slug is available', async () => {
+    const store = useProductCompareStore()
+    store.addProduct(
+      createProduct({
+        fullSlug: '/products/example-product',
+        base: { bestName: 'Linked product' },
+        identity: { bestName: 'Linked product' },
+      }),
+    )
+
+    const wrapper = await mountPanel()
+    const link = wrapper.get('.category-compare-panel__item-name--link')
+
+    expect(link.element.tagName).toBe('A')
+    expect(link.attributes('href')).toBe('/products/example-product')
+    expect(link.text()).toContain('Linked product')
   })
 })

--- a/frontend/app/components/category/products/CategoryComparePanel.vue
+++ b/frontend/app/components/category/products/CategoryComparePanel.vue
@@ -257,7 +257,7 @@ const itemInitials = (name: string) => {
     width: 100%
 
     &__card
-      border-radius: 0
+      border-radius: 1.25rem 1.25rem 0 0
       box-shadow: 0 -18px 32px rgba(15, 35, 65, 0.16)
       padding: 1rem 1.25rem calc(1rem + env(safe-area-inset-bottom, 0px))
 

--- a/frontend/app/components/category/products/CategoryComparePanel.vue
+++ b/frontend/app/components/category/products/CategoryComparePanel.vue
@@ -46,7 +46,14 @@
                   </v-avatar>
 
                   <div class="category-compare-panel__item-content">
-                    <span class="category-compare-panel__item-name">{{ item.name }}</span>
+                    <NuxtLink
+                      v-if="itemLink(item)"
+                      :to="itemLink(item)"
+                      class="category-compare-panel__item-name category-compare-panel__item-name--link"
+                    >
+                      {{ item.name }}
+                    </NuxtLink>
+                    <span v-else class="category-compare-panel__item-name">{{ item.name }}</span>
                     <v-btn
                       class="category-compare-panel__item-remove"
                       variant="text"
@@ -112,6 +119,10 @@ const toggleCollapse = () => {
 
 const remove = (id: string) => {
   compareStore.removeById(id)
+}
+
+const itemLink = (item: CompareListItem) => {
+  return item.fullSlug ?? item.slug ?? undefined
 }
 
 const launchComparison = () => {
@@ -214,6 +225,17 @@ const itemInitials = (name: string) => {
     overflow: hidden
     text-overflow: ellipsis
 
+    &--link
+      display: inline-block
+      color: rgb(var(--v-theme-primary))
+      text-decoration: none
+      transition: text-decoration-color 0.2s ease
+
+      &:hover,
+      &:focus-visible
+        text-decoration: underline
+        text-decoration-color: currentColor
+
   &__item-remove
     align-self: flex-start
     padding: 0
@@ -230,6 +252,18 @@ const itemInitials = (name: string) => {
 
 @media (max-width: 600px)
   .category-compare-panel
-    inset-inline: 1rem
-    width: auto
+    inset-inline: 0
+    inset-block-end: 0
+    width: 100%
+
+    &__card
+      border-radius: 0
+      box-shadow: 0 -18px 32px rgba(15, 35, 65, 0.16)
+      padding: 1rem 1.25rem calc(1rem + env(safe-area-inset-bottom, 0px))
+
+    &__body
+      gap: 0.75rem
+
+    &__items
+      gap: 0.5rem
 </style>

--- a/frontend/app/stores/useProductCompareStore.ts
+++ b/frontend/app/stores/useProductCompareStore.ts
@@ -169,7 +169,7 @@ export const useProductCompareStore = defineStore('product-compare', () => {
       id: identifier,
       gtin: product.gtin,
       slug: product.slug,
-      fullSlug: product.fullSlug,
+      fullSlug: product.fullSlug ?? product.slug,
       verticalId: resolveProductVertical(product),
       name: resolveProductName(product),
       image: resolveProductImage(product),


### PR DESCRIPTION
## Summary
- add product links to the compare panel using stored slugs so items can be opened directly
- persist the product fullSlug (with slug fallback) in the compare store to support navigation
- refresh the mobile layout to pin the panel to the bottom edge and flatten the card along with a new spec for the link behaviour

## Testing
- pnpm lint
- pnpm vitest run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fc83430ce0833380ec6c17fc64415f