### PR TITLE
Revamp category product views with compare control and attribute helpers

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCompareToggle.vue
+++ b/frontend/app/components/category/products/CategoryProductCompareToggle.vue
@@ -1,0 +1,138 @@
+<template>
+  <v-tooltip :text="tooltip" location="top" open-delay="150">
+    <template #activator="{ props: tooltipProps }">
+      <v-btn
+        v-bind="tooltipProps"
+        class="category-product-compare-toggle"
+        :class="{ 'category-product-compare-toggle--active': isSelected }"
+        variant="text"
+        size="small"
+        color="primary"
+        :icon="isSelected ? activeIcon : icon"
+        :aria-pressed="isSelected"
+        :aria-label="ariaLabel"
+        :title="tooltip"
+        :disabled="isDisabled"
+        density="comfortable"
+        data-test="category-product-compare"
+        @click.stop.prevent="toggle"
+      >
+        <v-icon :icon="isSelected ? activeIcon : icon" size="20" />
+      </v-btn>
+    </template>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ProductDto } from '~~/shared/api-client'
+import {
+  MAX_COMPARE_ITEMS,
+  useProductCompareStore,
+  type CompareListBlockReason,
+} from '~/stores/useProductCompareStore'
+
+const props = withDefaults(
+  defineProps<{
+    product: ProductDto
+    icon?: string
+    activeIcon?: string
+  }>(),
+  {
+    icon: 'mdi-compare',
+    activeIcon: 'mdi-compare',
+  },
+)
+
+defineOptions({ inheritAttrs: false })
+
+const emit = defineEmits<{
+  (event: 'toggled', product: ProductDto, selected: boolean): void
+}>()
+
+const { t, te } = useI18n()
+const compareStore = useProductCompareStore()
+
+const isSelected = computed(() => compareStore.hasProduct(props.product))
+
+const reasonMessage = (reason: CompareListBlockReason | undefined) => {
+  switch (reason) {
+    case 'limit-reached':
+      return t('category.products.compare.limitReached', { count: MAX_COMPARE_ITEMS })
+    case 'vertical-mismatch':
+      return t('category.products.compare.differentCategory')
+    case 'missing-identifier':
+      return t('category.products.compare.missingIdentifier')
+    default:
+      return null
+  }
+}
+
+const productDisplayName = (product: ProductDto) =>
+  product.identity?.bestName ??
+  product.base?.bestName ??
+  product.identity?.model ??
+  product.identity?.brand ??
+  t('category.products.untitledProduct')
+
+const eligibility = computed(() => compareStore.canAddProduct(props.product))
+
+const tooltip = computed(() => {
+  if (isSelected.value) {
+    return t('category.products.compare.removeFromList')
+  }
+
+  if (!eligibility.value.success) {
+    return reasonMessage(eligibility.value.reason) ?? t('category.products.compare.addToList')
+  }
+
+  return t('category.products.compare.addToList')
+})
+
+const ariaLabel = computed(() => {
+  if (isSelected.value) {
+    if (te('category.products.compare.removeSingle')) {
+      return t('category.products.compare.removeSingle', {
+        name: productDisplayName(props.product),
+      })
+    }
+
+    return t('category.products.compare.removeFromList')
+  }
+
+  return reasonMessage(eligibility.value.reason) ?? t('category.products.compare.addToList')
+})
+
+const isDisabled = computed(() => {
+  if (isSelected.value) {
+    return false
+  }
+
+  return !eligibility.value.success
+})
+
+const toggle = () => {
+  if (isDisabled.value && !isSelected.value) {
+    return
+  }
+
+  compareStore.toggleProduct(props.product)
+  emit('toggled', props.product, isSelected.value)
+}
+</script>
+
+<style scoped lang="sass">
+.category-product-compare-toggle
+  border-radius: 50%
+  transition: background-color 0.2s ease, color 0.2s ease
+
+  &--active
+    background-color: rgba(var(--v-theme-primary), 0.12)
+    color: rgb(var(--v-theme-primary))
+
+  :deep(.v-icon)
+    transition: transform 0.2s ease
+
+  &--active :deep(.v-icon)
+    transform: scale(1.05)
+</style>

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -233,10 +233,10 @@
           <template v-else>
             <component
               :is="viewComponent"
-              :products="currentProducts"
-              :fields="tableFields"
-              :items-per-page="pageSize"
+              v-bind="viewComponentProps"
               class="mb-6"
+              @update:sort-field="onTableSortFieldUpdate"
+              @update:sort-order="onTableSortOrderUpdate"
             />
 
             <p v-if="!currentProducts.length" class="category-page__no-results">
@@ -1235,6 +1235,26 @@ const viewComponent = computed(() => {
   return CategoryProductCardGrid
 })
 
+const popularAttributes = computed(() => category.value?.popularAttributes ?? [])
+
+const viewComponentProps = computed(() => {
+  const base = {
+    products: currentProducts.value,
+    popularAttributes: popularAttributes.value,
+  }
+
+  if (viewMode.value === 'table') {
+    return {
+      ...base,
+      itemsPerPage: pageSize.value,
+      sortField: sortField.value,
+      sortOrder: sortOrder.value,
+    }
+  }
+
+  return base
+})
+
 const loadingProducts = ref(false)
 const productError = ref<string | null>(null)
 const hasHydrated = ref(false)
@@ -1399,6 +1419,18 @@ const hashState = computed<CategoryHashState>(() => ({
   impactExpanded: impactExpanded.value || undefined,
   technicalExpanded: technicalExpanded.value || undefined,
 }))
+
+const onTableSortFieldUpdate = (field: string | null) => {
+  if (sortField.value !== field) {
+    sortField.value = field
+  }
+}
+
+const onTableSortOrderUpdate = (order: 'asc' | 'desc') => {
+  if (sortOrder.value !== order) {
+    sortOrder.value = order
+  }
+}
 
 watch(
   hashState,

--- a/frontend/app/utils/_product-attributes.ts
+++ b/frontend/app/utils/_product-attributes.ts
@@ -1,0 +1,240 @@
+import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
+
+type TranslateFn = (key: string, params?: Record<string, unknown>) => string
+type NumberFormatFn = (value: number, options?: Intl.NumberFormatOptions) => string
+
+export interface ResolvedProductAttribute {
+  key: string
+  label: string
+  rawValue: unknown
+  unit?: string | null
+  icon?: string | null
+}
+
+const hasMeaningfulValue = (value: unknown): boolean => {
+  if (value == null) {
+    return false
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasMeaningfulValue(entry))
+  }
+
+  if (typeof value === 'string') {
+    return value.trim().length > 0
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value)
+  }
+
+  return true
+}
+
+const readValueFromIndexedAttribute = (attribute: unknown): unknown => {
+  if (!attribute || typeof attribute !== 'object') {
+    return null
+  }
+
+  const record = attribute as Record<string, unknown>
+
+  if (hasMeaningfulValue(record.value)) {
+    return record.value
+  }
+
+  if (hasMeaningfulValue(record.numericValue)) {
+    return record.numericValue
+  }
+
+  if (record.booleanValue != null) {
+    return record.booleanValue
+  }
+
+  return null
+}
+
+const getValueByPath = (product: ProductDto, path: string | undefined): unknown => {
+  if (!path) {
+    return undefined
+  }
+
+  return path.split('.').reduce<unknown>((accumulator, segment) => {
+    if (accumulator == null || typeof accumulator !== 'object' || Array.isArray(accumulator)) {
+      return undefined
+    }
+
+    const record = accumulator as Record<string, unknown>
+
+    if (!(segment in record)) {
+      return undefined
+    }
+
+    return record[segment]
+  }, product as unknown)
+}
+
+const resolveAttributeRawValue = (product: ProductDto, key: string): unknown => {
+  if (!key) {
+    return null
+  }
+
+  const directValue = getValueByPath(product, key)
+  if (hasMeaningfulValue(directValue)) {
+    return directValue
+  }
+
+  const referential = product.attributes?.referentialAttributes?.[key]
+  if (hasMeaningfulValue(referential)) {
+    return referential
+  }
+
+  const indexed = product.attributes?.indexedAttributes?.[key]
+  const indexedValue = readValueFromIndexedAttribute(indexed)
+  if (hasMeaningfulValue(indexedValue)) {
+    return indexedValue
+  }
+
+  const nestedIndexed = getValueByPath(product, `attributes.indexedAttributes.${key}`)
+  const nestedValue = readValueFromIndexedAttribute(nestedIndexed)
+  if (hasMeaningfulValue(nestedValue)) {
+    return nestedValue
+  }
+
+  const nestedReferential = getValueByPath(product, `attributes.referentialAttributes.${key}`)
+  if (hasMeaningfulValue(nestedReferential)) {
+    return nestedReferential
+  }
+
+  return null
+}
+
+export const resolvePopularAttributes = (
+  product: ProductDto,
+  configs: AttributeConfigDto[] | null | undefined,
+): ResolvedProductAttribute[] => {
+  if (!configs?.length) {
+    return []
+  }
+
+  return configs.reduce<ResolvedProductAttribute[]>((accumulator, config) => {
+    const key = config.key ?? ''
+    if (!key) {
+      return accumulator
+    }
+
+    const rawValue = resolveAttributeRawValue(product, key)
+    if (!hasMeaningfulValue(rawValue)) {
+      return accumulator
+    }
+
+    accumulator.push({
+      key,
+      label: config.name ?? key,
+      rawValue,
+      unit: config.unit,
+      icon: config.icon,
+    })
+
+    return accumulator
+  }, [])
+}
+
+export const resolveRemainingAttributes = (
+  product: ProductDto,
+  popularKeys: string[] = [],
+  limit: number | null = 6,
+): ResolvedProductAttribute[] => {
+  const usedKeys = new Set(popularKeys.filter(Boolean))
+  const results: ResolvedProductAttribute[] = []
+
+  const indexed = product.attributes?.indexedAttributes ?? {}
+  Object.entries(indexed).forEach(([key, attribute]) => {
+    if (usedKeys.has(key)) {
+      return
+    }
+
+    const rawValue = readValueFromIndexedAttribute(attribute)
+    if (!hasMeaningfulValue(rawValue)) {
+      return
+    }
+
+    const label =
+      typeof attribute === 'object' && attribute && 'name' in attribute && typeof attribute.name === 'string'
+        ? attribute.name
+        : key
+
+    results.push({ key, label, rawValue })
+  })
+
+  const referential = product.attributes?.referentialAttributes ?? {}
+  Object.entries(referential).forEach(([key, rawValue]) => {
+    if (usedKeys.has(key)) {
+      return
+    }
+
+    if (!hasMeaningfulValue(rawValue)) {
+      return
+    }
+
+    results.push({ key, label: key, rawValue })
+  })
+
+  return limit != null ? results.slice(0, limit) : results
+}
+
+const formatRawValue = (
+  value: unknown,
+  t: TranslateFn,
+  n: NumberFormatFn,
+): string | null => {
+  if (value == null) {
+    return null
+  }
+
+  if (Array.isArray(value)) {
+    const formatted = value
+      .map((entry) => formatRawValue(entry, t, n))
+      .filter((entry): entry is string => Boolean(entry))
+      .join(', ')
+
+    return formatted || null
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null
+    }
+
+    return n(value)
+  }
+
+  if (typeof value === 'boolean') {
+    return t(`common.boolean.${value ? 'true' : 'false'}`)
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : null
+  }
+
+  return String(value)
+}
+
+export const formatAttributeValue = (
+  attribute: ResolvedProductAttribute,
+  t: TranslateFn,
+  n: NumberFormatFn,
+): string | null => {
+  const base = formatRawValue(attribute.rawValue, t, n)
+
+  if (!base) {
+    return null
+  }
+
+  if (attribute.unit) {
+    return `${base}\u00a0${attribute.unit}`
+  }
+
+  return base
+}
+

--- a/frontend/app/utils/_product-pricing.ts
+++ b/frontend/app/utils/_product-pricing.ts
@@ -1,0 +1,30 @@
+import type { ProductDto } from '~~/shared/api-client'
+
+type NumberFormatFn = (value: number, options?: Intl.NumberFormatOptions) => string
+type TranslateFn = (key: string, params?: Record<string, unknown>) => string
+type PluralizeFn = (key: string, count: number, params?: Record<string, unknown>) => string
+
+export const formatBestPrice = (product: ProductDto, t: TranslateFn, n: NumberFormatFn): string => {
+  const price = product.offers?.bestPrice?.price
+  const currency = product.offers?.bestPrice?.currency
+
+  if (price == null) {
+    return t('category.products.priceUnavailable')
+  }
+
+  if (currency) {
+    try {
+      return n(price, { style: 'currency', currency })
+    } catch {
+      return `${n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`.trim()
+    }
+  }
+
+  return n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+export const formatOffersCount = (product: ProductDto, translatePlural: PluralizeFn): string => {
+  const count = product.offers?.offersCount ?? 0
+  return translatePlural('category.products.offerCount', count, { count })
+}
+

--- a/frontend/app/utils/_product-scores.ts
+++ b/frontend/app/utils/_product-scores.ts
@@ -1,0 +1,50 @@
+import type { ProductDto } from '~~/shared/api-client'
+
+const clampScore = (score: number) => Math.max(0, Math.min(score, 5))
+
+/**
+ * Resolve the primary impact score for a product on a five-point scale.
+ * Falls back to any score whose identifier mentions "impact" when the
+ * ECOSCORE entry is missing.
+ */
+export const resolvePrimaryImpactScore = (product: ProductDto): number | null => {
+  const scores = product.scores?.scores
+
+  if (!scores) {
+    return null
+  }
+
+  const preferredKeys = ['ECOSCORE']
+
+  const impactEntry =
+    preferredKeys.map((key) => scores[key]).find((entry) => entry != null) ??
+    Object.values(scores).find((entry) => entry?.id?.toLowerCase()?.includes('impact')) ??
+    null
+
+  if (!impactEntry) {
+    return null
+  }
+
+  if (impactEntry.on20 != null && Number.isFinite(impactEntry.on20)) {
+    return clampScore((impactEntry.on20 / 20) * 5)
+  }
+
+  if (impactEntry.percent != null && Number.isFinite(impactEntry.percent)) {
+    return clampScore((impactEntry.percent / 100) * 5)
+  }
+
+  if (impactEntry.value != null && impactEntry.absolute?.max) {
+    const max = impactEntry.absolute.max
+
+    if (Number.isFinite(max) && max > 0) {
+      return clampScore((impactEntry.value / max) * 5)
+    }
+  }
+
+  if (impactEntry.value != null && Number.isFinite(impactEntry.value)) {
+    return clampScore(impactEntry.value)
+  }
+
+  return null
+}
+

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -193,11 +193,15 @@
       },
       "fetchError": "Unable to load products. Please try again.",
       "headers": {
+        "compare": "Compare",
         "brand": "Brand",
         "model": "Model",
         "ecoscore": "Eco score",
+        "impactScore": "Impact score",
         "bestPrice": "Best price",
-        "offers": "Offers"
+        "offers": "Offers",
+        "popularAttributes": "Key details",
+        "remainingAttributes": "Other attributes"
       },
       "resultsCount": {
         "one": "{count} product",
@@ -307,6 +311,10 @@
     "actions": {
       "retry": "Retry",
       "goHome": "Back to homepage"
+    },
+    "boolean": {
+      "true": "Yes",
+      "false": "No"
     }
   },
   "contrib": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -192,11 +192,15 @@
       },
       "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
       "headers": {
+        "compare": "Comparer",
         "brand": "Marque",
         "model": "Modèle",
         "ecoscore": "Score éco",
+        "impactScore": "Score d'impact",
         "bestPrice": "Meilleur prix",
-        "offers": "Offres"
+        "offers": "Offres",
+        "popularAttributes": "Atouts clés",
+        "remainingAttributes": "Autres attributs"
       },
       "resultsCount": {
         "one": "{count} produit",
@@ -306,6 +310,10 @@
     "actions": {
       "retry": "Réessayer",
       "goHome": "Retour à l'accueil"
+    },
+    "boolean": {
+      "true": "Oui",
+      "false": "Non"
     }
   },
   "contrib": {


### PR DESCRIPTION
## Summary
- restyle the category card, list, and table product views to surface impact scores, pricing, attributes, and reusable compare toggle actions
- add shared utilities for formatting product attributes, scores, and pricing plus provide popular attributes from the category page
- extend i18n resources and tests to cover the new compare interactions and attribute rendering

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fc935ac1a08333b4e6063560d0b28d