### PR TITLE
Add suffix metadata to vertical attribute configuration

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
@@ -20,6 +20,8 @@ public record AttributeConfigDto(
         String icon,
         @Schema(description = "Localised unit displayed for this attribute.", example = "kg")
         String unit,
+        @Schema(description = "Localised suffix appended to the attribute value for compact rendering.", example = "\"")
+        String suffix,
         @Schema(description = "Localised display name for this attribute.", example = "Poids")
         String name,
         @Schema(description = "Type of filtering applied for this attribute.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -435,6 +435,7 @@ public class CategoryMappingService {
                 attributeConfig.getKey(),
                 attributeConfig.getFaIcon(),
                 localise(attributeConfig.getUnit(), domainLanguage),
+                localise(attributeConfig.getSuffix(), domainLanguage),
                 localise(attributeConfig.getName(), domainLanguage),
                 attributeConfig.getFilteringType(),
                 defaultSet(attributeConfig.getIcecatFeaturesIds()),

--- a/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
@@ -43,10 +43,16 @@ public class AttributeConfig {
 	private String faIcon = "fa-wrench";
 
 	
-	/**
-	 * The localised units
-	 */
-	private Localisable<String,String> unit;
+        /**
+         * The localised units
+         */
+        private Localisable<String,String> unit;
+
+        /**
+         * Localised suffix appended to the raw value when displayed to end-users.
+         * Designed for compact units such as symbols or abbreviations (for example the inch symbol).
+         */
+        private Localisable<String, String> suffix;
 	
 	
 	/**
@@ -388,13 +394,31 @@ public class AttributeConfig {
                 this.betterIs = betterIs == null ? AttributeComparisonRule.GREATER : betterIs;
         }
 
-	public Localisable<String, String> getUnit() {
-		return unit;
-	}
+        public Localisable<String, String> getUnit() {
+                return unit;
+        }
 
-	public void setUnit(Localisable<String, String> unit) {
-		this.unit = unit;
-	}
+        public void setUnit(Localisable<String, String> unit) {
+                this.unit = unit;
+        }
+
+        /**
+         * Gets the suffix appended to the attribute value for display purposes.
+         *
+         * @return the configured suffix or {@code null} when no suffix is required
+         */
+        public Localisable<String, String> getSuffix() {
+                return suffix;
+        }
+
+        /**
+         * Sets the suffix appended to the attribute value for display purposes.
+         *
+         * @param suffix localised suffix to append to rendered values
+         */
+        public void setSuffix(Localisable<String, String> suffix) {
+                this.suffix = suffix;
+        }
 
 
 }

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -580,11 +580,14 @@ attributesConfig:
     betterIs: "LOWER"
     icecatFeaturesIds:
       - 94
-      - 33015    
+      - 33015
     faIcon: "fa-weight"
     name:
       default: "Weight"
       fr: "Poids"
+    suffix:
+      default: "kg"
+      fr: "kg"
     filteringType: "NUMERIC"
     asScore: true
     reverseScore: true

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -418,6 +418,9 @@ attributesConfig:
        name:
          default: "Screen size"
          fr: "Diagonale (en pouces)"
+       suffix:
+         default: "\""
+         fr: "\""
        filteringType: "NUMERIC"
    
        asScore: false


### PR DESCRIPTION
## Summary
- allow vertical attribute configurations to declare a localised suffix for compact rendering
- expose the suffix through the category attribute DTOs returned by the front API
- configure suffixes for TV diagonal and default weight attributes in the YAML definitions

## Testing
- mvn --offline -pl front-api -am test

------
https://chatgpt.com/codex/tasks/task_e_68fcd8bd7cc48333b1846340f2fc0487