### PR TITLE
feat(frontend): enhance category product views

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -21,6 +21,11 @@
           contain
           class="category-product-card-grid__image"
         >
+          <template #default>
+            <div class="category-product-card-grid__compare">
+              <CategoryProductCompareToggle :product="product" />
+            </div>
+          </template>
           <template #placeholder>
             <v-skeleton-loader type="image" class="h-100" />
           </template>
@@ -31,7 +36,6 @@
             <h3 class="category-product-card-grid__title">
               {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
             </h3>
-            <CategoryProductCompareToggle :product="product" />
           </div>
 
           <div class="category-product-card-grid__score" role="presentation">
@@ -39,7 +43,7 @@
               v-if="impactScoreValue(product) != null"
               :score="impactScoreValue(product) ?? 0"
               :max="5"
-              size="small"
+              size="medium"
             />
             <span v-else class="category-product-card-grid__score-fallback">
               {{ $t('category.products.notRated') }}
@@ -55,18 +59,12 @@
             </span>
           </div>
 
-          <ul v-if="popularAttributesByProduct(product).length" class="category-product-card-grid__attributes" role="list">
-            <li
-              v-for="attribute in popularAttributesByProduct(product)"
-              :key="attribute.key"
-              class="category-product-card-grid__attribute"
-              role="listitem"
-            >
-              <v-icon v-if="attribute.icon" :icon="attribute.icon" size="16" class="me-1" />
-              <span class="category-product-card-grid__attribute-label">{{ attribute.label }}</span>
-              <span class="category-product-card-grid__attribute-value">{{ attribute.value }}</span>
-            </li>
-          </ul>
+          <p
+            v-if="popularAttributesHighlightLine(product)"
+            class="category-product-card-grid__attributes"
+          >
+            {{ popularAttributesHighlightLine(product) }}
+          </p>
         </v-card-item>
       </v-card>
     </v-col>
@@ -139,6 +137,20 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
 
   return entries
 }
+
+const popularAttributesHighlights = (product: ProductDto): string[] => {
+  return popularAttributesByProduct(product).map((attribute) => attribute.value)
+}
+
+const popularAttributesHighlightLine = (product: ProductDto): string | null => {
+  const highlights = popularAttributesHighlights(product)
+
+  if (!highlights.length) {
+    return null
+  }
+
+  return highlights.join(' - ')
+}
 </script>
 
 <style scoped lang="sass">
@@ -163,18 +175,27 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
     display: flex
     align-items: center
     justify-content: center
+    position: relative
 
     :deep(img)
       object-fit: contain
       mix-blend-mode: multiply
       background: #fff
 
+  &__compare
+    position: absolute
+    top: 1rem
+    right: 1rem
+    display: flex
+    justify-content: flex-end
+    z-index: 1
+
   &__body
     display: flex
     flex-direction: column
     gap: 1rem
-    align-items: stretch
-    text-align: left
+    align-items: center
+    text-align: center
     padding: 1.25rem
     background: rgb(var(--v-theme-surface-glass))
     border-bottom-left-radius: inherit
@@ -182,22 +203,20 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
 
   &__header
     display: flex
-    align-items: flex-start
-    gap: 0.75rem
+    align-items: center
+    justify-content: center
 
   &__title
     font-size: 1.125rem
     margin: 0
     font-weight: 600
     color: rgb(var(--v-theme-text-neutral-strong))
-    flex: 1 1 auto
-    min-width: 0
-    white-space: normal
+    text-align: center
 
   &__meta
     display: flex
     flex-direction: column
-    align-items: flex-start
+    align-items: center
     gap: 0.25rem
 
   &__offers
@@ -212,6 +231,7 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
   &__score
     display: flex
     align-items: center
+    justify-content: center
     min-height: 1.75rem
 
   &__score-fallback
@@ -219,23 +239,7 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
     color: rgb(var(--v-theme-text-neutral-secondary))
 
   &__attributes
-    display: grid
-    gap: 0.5rem
-    padding: 0
     margin: 0
-    list-style: none
-
-  &__attribute
-    display: flex
-    align-items: center
-    font-size: 0.875rem
+    font-size: 0.95rem
     color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__attribute-label
-    font-weight: 500
-    margin-right: 0.35rem
-    color: rgb(var(--v-theme-text-neutral-strong))
-
-  &__attribute-value
-    color: inherit
 </style>

--- a/frontend/app/components/category/products/CategoryProductCompareToggle.vue
+++ b/frontend/app/components/category/products/CategoryProductCompareToggle.vue
@@ -4,20 +4,22 @@
       <v-btn
         v-bind="tooltipProps"
         class="category-product-compare-toggle"
-        :class="{ 'category-product-compare-toggle--active': isSelected }"
-        variant="text"
-        size="small"
+        :class="{
+          'category-product-compare-toggle--active': isSelected,
+          'category-product-compare-toggle--inactive': !isSelected,
+        }"
+        variant="flat"
+        size="large"
         color="primary"
         :icon="isSelected ? activeIcon : icon"
         :aria-pressed="isSelected"
         :aria-label="ariaLabel"
         :title="tooltip"
         :disabled="isDisabled"
-        density="comfortable"
         data-test="category-product-compare"
         @click.stop.prevent="toggle"
       >
-        <v-icon :icon="isSelected ? activeIcon : icon" size="20" />
+        <v-icon :icon="isSelected ? activeIcon : icon" size="40" />
       </v-btn>
     </template>
   </v-tooltip>
@@ -39,8 +41,8 @@ const props = withDefaults(
     activeIcon?: string
   }>(),
   {
-    icon: 'mdi-compare',
-    activeIcon: 'mdi-compare',
+    icon: 'mdi-compare-horizontal',
+    activeIcon: 'mdi-compare-horizontal',
   },
 )
 
@@ -124,10 +126,23 @@ const toggle = () => {
 <style scoped lang="sass">
 .category-product-compare-toggle
   border-radius: 50%
-  transition: background-color 0.2s ease, color 0.2s ease
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease
+  width: 3.25rem
+  min-width: 3.25rem
+  height: 3.25rem
+  padding: 0
+  background-color: rgba(var(--v-theme-surface-default), 0.92)
+  box-shadow: 0 6px 16px rgba(21, 46, 73, 0.12)
+
+  &:hover
+    opacity: 0.9
+
+  &--inactive
+    opacity: 0.6
 
   &--active
-    background-color: rgba(var(--v-theme-primary), 0.12)
+    opacity: 1
+    background-color: rgba(var(--v-theme-primary), 0.16)
     color: rgb(var(--v-theme-primary))
 
   :deep(.v-icon)

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -22,51 +22,56 @@
         </v-avatar>
       </template>
 
-      <div class="category-product-list__content">
-        <div class="category-product-list__header">
-          <h3 class="category-product-list__title">
-            {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
-          </h3>
+      <div class="category-product-list__layout">
+        <div class="category-product-list__content">
+          <div class="category-product-list__header">
+            <h3 class="category-product-list__title">
+              {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
+            </h3>
+          </div>
+
+          <div class="category-product-list__meta">
+            <span class="category-product-list__price">
+              <span aria-hidden="true" class="category-product-list__price-icon">€</span>
+              {{ listPriceValue(product) }}
+            </span>
+            <span class="category-product-list__offers">
+              <v-icon icon="mdi-store" size="18" class="me-1" />
+              {{ offersCountLabel(product) }}
+            </span>
+          </div>
+
+          <ul v-if="popularAttributesByProduct(product).length" class="category-product-list__attributes" role="list">
+            <li
+              v-for="attribute in popularAttributesByProduct(product)"
+              :key="attribute.key"
+              class="category-product-list__attribute"
+              role="listitem"
+            >
+              <span class="category-product-list__attribute-label">{{ attribute.label }}</span>
+              <span class="category-product-list__attribute-separator" aria-hidden="true">:</span>
+              <span class="category-product-list__attribute-value">{{ attribute.value }}</span>
+            </li>
+          </ul>
+        </div>
+
+        <div class="category-product-list__score">
           <ImpactScore
             v-if="impactScoreValue(product) != null"
             :score="impactScoreValue(product) ?? 0"
             :max="5"
-            size="small"
+            size="large"
+            :show-value="true"
           />
           <span v-else class="category-product-list__score-fallback">
             {{ $t('category.products.notRated') }}
           </span>
         </div>
 
-        <div class="category-product-list__meta">
-          <span class="category-product-list__price">
-            <span aria-hidden="true" class="category-product-list__price-icon">€</span>
-            {{ listPriceValue(product) }}
-          </span>
-          <span class="category-product-list__offers">
-            <v-icon icon="mdi-store" size="18" class="me-1" />
-            {{ offersCountLabel(product) }}
-          </span>
-        </div>
-
-        <ul v-if="popularAttributesByProduct(product).length" class="category-product-list__attributes" role="list">
-          <li
-            v-for="attribute in popularAttributesByProduct(product)"
-            :key="attribute.key"
-            class="category-product-list__attribute"
-            role="listitem"
-          >
-            <span class="category-product-list__attribute-label">{{ attribute.label }}</span>
-            <span class="category-product-list__attribute-value">{{ attribute.value }}</span>
-          </li>
-        </ul>
-      </div>
-
-      <template #append>
-        <div class="category-product-list__aside">
+        <div class="category-product-list__actions">
           <CategoryProductCompareToggle :product="product" />
         </div>
-      </template>
+      </div>
     </v-list-item>
   </v-list>
 </template>
@@ -162,15 +167,17 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
       box-shadow: 0 16px 30px rgba(21, 46, 73, 0.08)
       transform: translateY(-2px)
 
+  &__layout
+    display: flex
+    align-items: stretch
+    gap: 1.5rem
+    flex-wrap: wrap
+
   &__content
     display: flex
     flex-direction: column
-    gap: 0.5rem
-
-  &__aside
-    display: flex
-    align-items: flex-start
-    padding-left: 0.75rem
+    gap: 0.75rem
+    flex: 1 1 auto
 
   &__header
     display: flex
@@ -207,6 +214,19 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
     align-items: center
     gap: 0.35rem
 
+  &__score
+    display: flex
+    align-items: center
+    justify-content: center
+    min-width: 180px
+    flex: 0 0 auto
+
+  &__actions
+    display: flex
+    align-items: center
+    justify-content: flex-end
+    flex: 0 0 auto
+
   &__score-fallback
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
@@ -228,6 +248,10 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
   &__attribute-label
     font-weight: 500
     color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__attribute-separator
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    font-weight: 600
 
   &__attribute-value
     color: rgb(var(--v-theme-text-neutral-secondary))

--- a/frontend/app/components/category/products/CategoryProductTable.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductTable.spec.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createVuetify } from 'vuetify'
+import { defineComponent, h } from 'vue'
+import type { Component } from 'vue'
+import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+vi.mock('~/composables/usePluralizedTranslation', () => ({
+  usePluralizedTranslation: () => ({
+    translatePlural: (_key: string, count: number) => `${count}`,
+  }),
+}))
+
+const VDataTableStub = defineComponent({
+  name: 'VDataTableStub',
+  props: {
+    headers: {
+      type: Array,
+      default: () => [],
+    },
+    items: {
+      type: Array,
+      default: () => [],
+    },
+    sortBy: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ['update:sort-by', 'click:row'],
+  setup(_props, { slots }) {
+    return () => h('div', { 'data-test': 'data-table-stub' }, slots.default?.())
+  },
+})
+
+const CompareToggleStub: Component = {
+  inheritAttrs: false,
+  props: {
+    product: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup() {
+    return () => h('button', { type: 'button', 'data-test': 'category-product-compare' })
+  },
+}
+
+const mountTable = async (props?: Record<string, unknown>) => {
+  const module = await import('./CategoryProductTable.vue')
+  const CategoryProductTable = module.default
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        category: {
+          products: {
+            headers: {
+              compare: 'Compare',
+              brand: 'Brand',
+              model: 'Model',
+              impactScore: 'Impact score',
+              bestPrice: 'Best price',
+              offers: 'Offers',
+              popularAttributes: 'Highlights',
+              remainingAttributes: 'Other attributes',
+            },
+            notRated: 'Not rated',
+            priceUnavailable: 'Price unavailable',
+            notRatedYet: 'Not rated yet',
+          },
+        },
+        common: {
+          boolean: {
+            true: 'Yes',
+            false: 'No',
+          },
+        },
+      },
+    },
+  })
+
+  const vuetify = createVuetify()
+
+  return mount(CategoryProductTable, {
+    props: {
+      products: [],
+      itemsPerPage: 20,
+      popularAttributes: [],
+      sortField: null,
+      sortOrder: 'desc',
+      attributeKeys: [],
+      attributeConfigs: {},
+      fieldMetadata: {},
+      ...props,
+    },
+    global: {
+      plugins: [i18n, vuetify],
+      stubs: {
+        VDataTable: VDataTableStub,
+        ImpactScore: defineComponent({
+          setup(_, { slots }) {
+            return () => h('div', { 'data-test': 'impact-score-stub' }, slots.default?.())
+          },
+        }),
+        CategoryProductCompareToggle: CompareToggleStub,
+      },
+    },
+  })
+}
+
+const buildProduct = (overrides: Partial<ProductDto> = {}): ProductDto => ({
+  gtin: overrides.gtin ?? 1,
+  identity: {
+    bestName: overrides.identity?.bestName ?? 'Example product',
+    model: overrides.identity?.model,
+    brand: overrides.identity?.brand ?? 'Brand',
+  },
+  resources: overrides.resources,
+  offers: overrides.offers ?? {
+    offersCount: 2,
+    bestPrice: {
+      price: 499,
+      currency: 'EUR',
+    },
+  },
+  attributes: overrides.attributes ?? {
+    indexedAttributes: {
+      DIAGONALE_POUCES: {
+        name: 'Diagonale',
+        value: '32',
+        numericValue: 32,
+      },
+    },
+  },
+  scores: overrides.scores,
+  base: overrides.base,
+  slug: overrides.slug,
+  fullSlug: overrides.fullSlug,
+})
+
+describe('CategoryProductTable', () => {
+  let attributeConfigs: Record<string, AttributeConfigDto>
+
+  beforeEach(() => {
+    attributeConfigs = {
+      DIAGONALE_POUCES: {
+        key: 'DIAGONALE_POUCES',
+        name: 'Screen size',
+        suffix: '"',
+        filteringType: 'NUMERIC',
+      } as AttributeConfigDto,
+    }
+  })
+
+  it('renders attribute columns with formatted values', async () => {
+    const product = buildProduct()
+
+    const wrapper = await mountTable({
+      products: [product],
+      attributeKeys: ['DIAGONALE_POUCES'],
+      attributeConfigs,
+      fieldMetadata: {
+        'attributes.indexed.DIAGONALE_POUCES.numericValue': {
+          mapping: 'attributes.indexed.DIAGONALE_POUCES.numericValue',
+          title: 'Screen size',
+        },
+      },
+    })
+
+    const table = wrapper.getComponent(VDataTableStub)
+    const headers = table.props('headers') as Array<{ key: string }>
+    const items = table.props('items') as Array<Record<string, unknown>>
+
+    expect(headers.some((header) => header.key === 'attribute:DIAGONALE_POUCES')).toBe(true)
+    expect(items[0]!['attribute:DIAGONALE_POUCES']).toBe('32 "')
+  })
+
+  it('emits sort updates for attribute columns', async () => {
+    const wrapper = await mountTable({
+      products: [buildProduct()],
+      attributeKeys: ['DIAGONALE_POUCES'],
+      attributeConfigs,
+      fieldMetadata: {
+        'attributes.indexed.DIAGONALE_POUCES.numericValue': {
+          mapping: 'attributes.indexed.DIAGONALE_POUCES.numericValue',
+          title: 'Screen size',
+        },
+      },
+    })
+
+    const table = wrapper.getComponent(VDataTableStub)
+    table.vm.$emit('update:sort-by', [
+      { key: 'attribute:DIAGONALE_POUCES', order: 'asc' },
+    ])
+
+    expect(wrapper.emitted('update:sort-field')?.[0]?.[0]).toBe(
+      'attributes.indexed.DIAGONALE_POUCES.numericValue',
+    )
+    expect(wrapper.emitted('update:sort-order')?.[0]?.[0]).toBe('asc')
+  })
+})

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -41,23 +41,12 @@
       {{ offersCountLabel(item.product) }}
     </template>
 
-    <template #[`item.popularAttributes`]="{ value }">
-      <ul v-if="value.length" class="category-product-table__attributes" role="list">
-        <li v-for="attribute in value" :key="attribute.key" class="category-product-table__attribute" role="listitem">
-          <span class="category-product-table__attribute-label">{{ attribute.label }}</span>
-          <span class="category-product-table__attribute-value">{{ attribute.value }}</span>
-        </li>
-      </ul>
-      <span v-else class="category-product-table__empty">—</span>
-    </template>
-
-    <template #[`item.remainingAttributes`]="{ value }">
-      <ul v-if="value.length" class="category-product-table__attributes" role="list">
-        <li v-for="attribute in value" :key="attribute.key" class="category-product-table__attribute" role="listitem">
-          <span class="category-product-table__attribute-label">{{ attribute.label }}</span>
-          <span class="category-product-table__attribute-value">{{ attribute.value }}</span>
-        </li>
-      </ul>
+    <template
+      v-for="column in attributeColumns"
+      :key="column.headerKey"
+      #[`item.${column.headerKey}`]="{ value }"
+    >
+      <span v-if="value">{{ value }}</span>
       <span v-else class="category-product-table__empty">—</span>
     </template>
   </v-data-table>
@@ -65,24 +54,20 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
+import type { AttributeConfigDto, FieldMetadataDto, ProductDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import CategoryProductCompareToggle from './CategoryProductCompareToggle.vue'
 import {
   formatAttributeValue,
-  resolvePopularAttributes,
-  resolveRemainingAttributes,
+  resolveAttributeRawValueByKey,
 } from '~/utils/_product-attributes'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
 
-interface TableAttribute {
-  key: string
-  label: string
-  value: string
-}
+type AttributeCellValue = string | null
 
-interface CategoryProductTableRow {
+interface CategoryProductTableRowBase {
   product: ProductDto
   compare: null
   brand: string | null | undefined
@@ -90,9 +75,22 @@ interface CategoryProductTableRow {
   impactScore: number | null
   bestPrice: string | null
   offersCount: number
-  popularAttributes: TableAttribute[]
-  remainingAttributes: TableAttribute[]
 }
+
+interface CategoryProductTableRow extends CategoryProductTableRowBase {
+  [key: string]: AttributeCellValue | ProductDto | string | number | null | undefined
+}
+
+interface AttributeColumn {
+  key: string
+  headerKey: string
+  title: string
+  mapping: string
+  config?: AttributeConfigDto
+}
+
+const ATTRIBUTE_COLUMN_PREFIX = 'attribute:'
+const attributeHeaderKey = (key: string) => `${ATTRIBUTE_COLUMN_PREFIX}${key}`
 
 const props = defineProps<{
   products: ProductDto[]
@@ -100,6 +98,9 @@ const props = defineProps<{
   popularAttributes?: AttributeConfigDto[]
   sortField?: string | null
   sortOrder?: 'asc' | 'desc'
+  attributeKeys?: string[]
+  attributeConfigs?: Record<string, AttributeConfigDto>
+  fieldMetadata?: Record<string, FieldMetadataDto>
 }>()
 
 const emit = defineEmits<{
@@ -111,7 +112,86 @@ const router = useRouter()
 const { t, n } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
 
-const popularAttributeConfigs = computed(() => props.popularAttributes ?? [])
+const attributeConfigMap = computed<Record<string, AttributeConfigDto>>(
+  () => props.attributeConfigs ?? {},
+)
+const attributeKeys = computed(() => props.attributeKeys ?? [])
+const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(() => props.fieldMetadata ?? {})
+
+const extractAttributeKeyFromMapping = (mapping: string | undefined): string | null => {
+  if (!mapping) {
+    return null
+  }
+
+  const patterns = [
+    /attributes\.(?:indexed(?:Attributes)?|referential(?:Attributes)?)\.([^.]+)/i,
+    /attributes\.([^.]+)/i,
+  ]
+
+  for (const pattern of patterns) {
+    const match = mapping.match(pattern)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
+const attributeFieldMappingByKey = computed<Record<string, string>>(() => {
+  const entries = Object.entries(fieldMetadataMap.value ?? {})
+  return entries.reduce<Record<string, string>>((accumulator, [mapping]) => {
+    const key = extractAttributeKeyFromMapping(mapping)
+
+    if (key && !(key in accumulator)) {
+      accumulator[key] = mapping
+    }
+
+    return accumulator
+  }, {})
+})
+
+const guessAttributeMapping = (key: string, config: AttributeConfigDto | undefined): string => {
+  const base = `attributes.indexed.${key}`
+
+  switch (config?.filteringType) {
+    case 'NUMERIC':
+      return `${base}.numericValue`
+    case 'BOOLEAN':
+      return `${base}.booleanValue`
+    default:
+      return `${base}.value`
+  }
+}
+
+const attributeColumns = computed<AttributeColumn[]>(() => {
+  const seen = new Set<string>()
+
+  return attributeKeys.value.reduce<AttributeColumn[]>((accumulator, key) => {
+    const normalizedKey = String(key)
+
+    if (!normalizedKey || seen.has(normalizedKey)) {
+      return accumulator
+    }
+
+    seen.add(normalizedKey)
+
+    const config = attributeConfigMap.value?.[normalizedKey]
+    const mapping = attributeFieldMappingByKey.value[normalizedKey] ?? guessAttributeMapping(normalizedKey, config)
+    const field = fieldMetadataMap.value?.[mapping]
+    const title = config?.name ?? resolveFilterFieldTitle(field, t, mapping) ?? normalizedKey
+
+    accumulator.push({
+      key: normalizedKey,
+      headerKey: attributeHeaderKey(normalizedKey),
+      title,
+      mapping,
+      config,
+    })
+
+    return accumulator
+  }, [])
+})
 
 const headers = computed(() => [
   { key: 'compare', title: t('category.products.headers.compare'), sortable: false, width: 48 },
@@ -130,25 +210,40 @@ const headers = computed(() => [
     sortable: true,
     width: 140,
   },
-  { key: 'popularAttributes', title: t('category.products.headers.popularAttributes'), sortable: false, minWidth: 220 },
-  {
-    key: 'remainingAttributes',
-    title: t('category.products.headers.remainingAttributes'),
-    sortable: false,
-    minWidth: 220,
-  },
+  ...attributeColumns.value.map((column) => ({
+    key: column.headerKey,
+    title: column.title,
+    sortable: true,
+    minWidth: 160,
+  })),
 ])
 
-const sortHeaderToFieldMapping: Record<string, string> = {
+const staticSortHeaderToFieldMapping: Record<string, string> = {
   bestPrice: 'price.minPrice.price',
   offersCount: 'offersCount',
 }
 
-const fieldToSortHeader = Object.fromEntries(Object.entries(sortHeaderToFieldMapping).map(([key, value]) => [value, key]))
+const sortHeaderToFieldMapping = computed<Record<string, string>>(() => {
+  const mapping: Record<string, string> = { ...staticSortHeaderToFieldMapping }
+
+  attributeColumns.value.forEach((column) => {
+    if (column.mapping) {
+      mapping[column.headerKey] = column.mapping
+    }
+  })
+
+  return mapping
+})
+
+const fieldToSortHeader = computed<Record<string, string>>(() =>
+  Object.fromEntries(
+    Object.entries(sortHeaderToFieldMapping.value).map(([header, field]) => [field, header]),
+  ),
+)
 
 const internalSortBy = computed(() => {
   const field = props.sortField ?? null
-  const headerKey = field ? (fieldToSortHeader[field] ?? null) : null
+  const headerKey = field ? (fieldToSortHeader.value[field] ?? null) : null
 
   if (!headerKey) {
     return []
@@ -165,53 +260,26 @@ const internalSortBy = computed(() => {
 const bestPriceLabel = (product: ProductDto) => formatBestPrice(product, t, n)
 const offersCountLabel = (product: ProductDto) => formatOffersCount(product, translatePlural)
 
-const formatAttributes = (attributes: ReturnType<typeof resolvePopularAttributes>) => {
-  return attributes
-    .map((attribute) => {
-      const value = formatAttributeValue(attribute, t, n)
+const resolveAttributeCellValue = (product: ProductDto, column: AttributeColumn): string | null => {
+  const rawValue = resolveAttributeRawValueByKey(product, column.key)
 
-      if (!value) {
-        return null
-      }
-
-      return {
-        key: attribute.key,
-        label: attribute.label,
-        value,
-      }
-    })
-    .filter((attribute): attribute is TableAttribute => attribute != null)
-}
-
-const formatRemainingAttributes = (attributes: ReturnType<typeof resolveRemainingAttributes>) => {
-  return attributes
-    .map((attribute) => {
-      const value = formatAttributeValue(attribute, t, n)
-
-      if (!value) {
-        return null
-      }
-
-      return {
-        key: attribute.key,
-        label: attribute.label,
-        value,
-      }
-    })
-    .filter((attribute): attribute is TableAttribute => attribute != null)
+  return formatAttributeValue(
+    {
+      key: column.key,
+      label: column.config?.name ?? column.key,
+      rawValue,
+      unit: column.config?.unit,
+      icon: column.config?.icon,
+      suffix: column.config?.suffix ?? null,
+    },
+    t,
+    n,
+  )
 }
 
 const rows = computed<CategoryProductTableRow[]>(() => {
   return props.products.map((product) => {
-    const popular = formatAttributes(resolvePopularAttributes(product, popularAttributeConfigs.value))
-    const remaining = formatRemainingAttributes(
-      resolveRemainingAttributes(
-        product,
-        popularAttributeConfigs.value.map((attribute) => attribute.key ?? '').filter(Boolean),
-      ),
-    )
-
-    return {
+    const baseRow: CategoryProductTableRow = {
       product,
       compare: null,
       brand: product.identity?.brand,
@@ -219,9 +287,13 @@ const rows = computed<CategoryProductTableRow[]>(() => {
       impactScore: resolvePrimaryImpactScore(product),
       bestPrice: bestPriceLabel(product),
       offersCount: product.offers?.offersCount ?? 0,
-      popularAttributes: popular,
-      remainingAttributes: remaining,
     }
+
+    attributeColumns.value.forEach((column) => {
+      baseRow[column.headerKey] = resolveAttributeCellValue(product, column)
+    })
+
+    return baseRow
   })
 })
 
@@ -234,7 +306,7 @@ const onSortByUpdate = (sortBy: { key: string; order?: 'asc' | 'desc' }[]) => {
     return
   }
 
-  const field = sortHeaderToFieldMapping[entry.key]
+  const field = sortHeaderToFieldMapping.value[entry.key]
 
   if (!field) {
     return
@@ -279,25 +351,6 @@ const onRowClick = (_event: MouseEvent, item: { item: CategoryProductTableRow })
   &__model-name
     font-weight: 600
     color: rgb(var(--v-theme-text-neutral-strong))
-
-  &__attributes
-    display: grid
-    gap: 0.4rem
-    padding: 0
-    margin: 0
-    list-style: none
-
-  &__attribute
-    display: flex
-    gap: 0.4rem
-    align-items: baseline
-
-  &__attribute-label
-    font-weight: 500
-    color: rgb(var(--v-theme-text-neutral-strong))
-
-  &__attribute-value
-    color: rgb(var(--v-theme-text-neutral-secondary))
 
   &__empty
     color: rgb(var(--v-theme-text-neutral-secondary))

--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -284,6 +284,7 @@ import type {
   AggregationRequestDto,
   AggregationResponseDto,
   Agg,
+  AttributeConfigDto,
   FieldMetadataDto,
   Filter,
   FilterRequestDto,
@@ -1237,6 +1238,29 @@ const viewComponent = computed(() => {
 
 const popularAttributes = computed(() => category.value?.popularAttributes ?? [])
 
+const attributeKeys = computed(() => {
+  const technical = category.value?.technicalFilters ?? []
+  const eco = category.value?.ecoFilters ?? []
+
+  return Array.from(
+    new Set(
+      [...technical, ...eco].filter((entry): entry is string => Boolean(entry)),
+    ),
+  )
+})
+
+const attributeConfigMap = computed<Record<string, AttributeConfigDto>>(() => {
+  const configs = category.value?.attributesConfig?.configs ?? []
+
+  return configs.reduce<Record<string, AttributeConfigDto>>((accumulator, config) => {
+    if (config?.key) {
+      accumulator[config.key] = config
+    }
+
+    return accumulator
+  }, {})
+})
+
 const viewComponentProps = computed(() => {
   const base = {
     products: currentProducts.value,
@@ -1249,6 +1273,9 @@ const viewComponentProps = computed(() => {
       itemsPerPage: pageSize.value,
       sortField: sortField.value,
       sortOrder: sortOrder.value,
+      attributeKeys: attributeKeys.value,
+      attributeConfigs: attributeConfigMap.value,
+      fieldMetadata: filterFieldMap.value,
     }
   }
 

--- a/frontend/app/utils/_product-attributes.ts
+++ b/frontend/app/utils/_product-attributes.ts
@@ -9,6 +9,7 @@ export interface ResolvedProductAttribute {
   rawValue: unknown
   unit?: string | null
   icon?: string | null
+  suffix?: string | null
 }
 
 const hasMeaningfulValue = (value: unknown): boolean => {
@@ -108,6 +109,10 @@ const resolveAttributeRawValue = (product: ProductDto, key: string): unknown => 
   return null
 }
 
+export const resolveAttributeRawValueByKey = (product: ProductDto, key: string): unknown => {
+  return resolveAttributeRawValue(product, key)
+}
+
 export const resolvePopularAttributes = (
   product: ProductDto,
   configs: AttributeConfigDto[] | null | undefined,
@@ -133,6 +138,7 @@ export const resolvePopularAttributes = (
       rawValue,
       unit: config.unit,
       icon: config.icon,
+      suffix: config.suffix ?? null,
     })
 
     return accumulator
@@ -231,10 +237,16 @@ export const formatAttributeValue = (
     return null
   }
 
+  let formatted = base
+
   if (attribute.unit) {
-    return `${base}\u00a0${attribute.unit}`
+    formatted = `${formatted}\u00a0${attribute.unit}`
   }
 
-  return base
+  if (attribute.suffix) {
+    formatted = `${formatted} ${attribute.suffix}`
+  }
+
+  return formatted
 }
 


### PR DESCRIPTION
## Summary
- restyle the compare toggle to use the horizontal icon, enlarged sizing, and explicit inactive/active states
- center the category card grid content with an overlay compare action and inline popular attribute highlights that include suffixes
- revamp the list and table views to align scores and actions, surface sortable attribute columns from category filters, and add unit tests for the new table behaviour
- pass attribute filter metadata from the category page and ensure attribute formatting supports localized suffixes

## Testing
- pnpm lint
- pnpm vitest run app/components/category/products/CategoryProductTable.spec.ts app/components/category/products/CategoryProductCardGrid.spec.ts
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_68fcdfd837148333a784e9ebbfb36e9e