### PR TITLE
Revamp category product grid pricing and sorting

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.spec.ts
@@ -64,6 +64,10 @@ const CompareToggleStub: Component = {
       type: Object,
       required: true,
     },
+    size: {
+      type: String,
+      default: 'comfortable',
+    },
   },
   setup(props) {
     const store = useProductCompareStore()
@@ -115,6 +119,7 @@ const mountGrid = async (products: ProductDto[]) => {
         VCardItem: createStub('div'),
         VImg: createStub('div'),
         VSkeletonLoader: createStub('div'),
+        VChip: createStub('div'),
         VTooltip: VTooltipStub,
         VBtn: VBtnStub,
         VIcon: createStub('i'),
@@ -164,6 +169,18 @@ describe('CategoryProductCardGrid', () => {
               untitledProduct: 'Untitled product',
               notRated: 'Not rated yet',
               priceUnavailable: 'Price unavailable',
+              conditions: {
+                new: 'New',
+                occasion: 'Occasion',
+                unknown: 'Unknown',
+                other: 'Other ({condition})',
+              },
+              pricing: {
+                newOfferLabel: 'New',
+                occasionOfferLabel: 'Occasion',
+                bestOfferLabel: 'Best',
+                conditionLabel: 'Condition: {condition}',
+              },
               compare: {
                 addToList: 'Add to compare',
                 removeFromList: 'Remove from compare',

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-row class="category-product-card-grid" dense>
+  <v-row
+    class="category-product-card-grid"
+    :class="[`category-product-card-grid--size-${cardSize}`]"
+    dense
+  >
     <v-col
       v-for="product in products"
       :key="product.gtin ?? product.identity?.bestName ?? Math.random()"
@@ -14,6 +18,10 @@
         hover
         :to="productLink(product)"
       >
+        <div class="category-product-card-grid__compare">
+          <CategoryProductCompareToggle :product="product" size="compact" />
+        </div>
+
         <v-img
           :src="resolveImage(product)"
           :alt="product.identity?.bestName ?? product.identity?.model ?? $t('category.products.untitledProduct')"
@@ -21,11 +29,6 @@
           contain
           class="category-product-card-grid__image"
         >
-          <template #default>
-            <div class="category-product-card-grid__compare">
-              <CategoryProductCompareToggle :product="product" />
-            </div>
-          </template>
           <template #placeholder>
             <v-skeleton-loader type="image" class="h-100" />
           </template>
@@ -36,6 +39,32 @@
             <h3 class="category-product-card-grid__title">
               {{ product.identity?.bestName ?? product.identity?.model ?? product.identity?.brand ?? '#' + product.gtin }}
             </h3>
+          </div>
+
+          <div
+            v-if="popularAttributesByProduct(product).length"
+            class="category-product-card-grid__attributes"
+            role="list"
+          >
+            <v-chip
+              v-for="attribute in popularAttributesByProduct(product)"
+              :key="attribute.key"
+              size="small"
+              class="category-product-card-grid__attribute"
+              variant="flat"
+              color="surface-primary-080"
+              role="listitem"
+            >
+              <v-icon
+                v-if="attribute.icon"
+                :icon="attribute.icon"
+                size="16"
+                class="me-1 category-product-card-grid__attribute-icon"
+              />
+              <span class="category-product-card-grid__attribute-value">
+                {{ attribute.value }}
+              </span>
+            </v-chip>
           </div>
 
           <div class="category-product-card-grid__score" role="presentation">
@@ -50,21 +79,30 @@
             </span>
           </div>
 
+          <div
+            v-if="offerBadges(product).length"
+            class="category-product-card-grid__pricing"
+            role="list"
+          >
+            <div
+              v-for="badge in offerBadges(product)"
+              :key="badge.key"
+              class="category-product-card-grid__price-badge"
+              :class="`category-product-card-grid__price-badge--${badge.appearance}`"
+              role="listitem"
+            >
+              <span class="category-product-card-grid__price-badge-label">{{ badge.label }}</span>
+              <span class="category-product-card-grid__price-badge-amount">{{ badge.price }}</span>
+              <span class="category-product-card-grid__price-badge-condition">{{ badge.conditionText }}</span>
+            </div>
+          </div>
+
           <div class="category-product-card-grid__meta">
-            <span class="category-product-card-grid__price">
-              {{ bestPriceLabel(product) }}
-            </span>
             <span class="category-product-card-grid__offers">
+              <v-icon icon="mdi-store" size="18" class="me-1" />
               {{ offersCountLabel(product) }}
             </span>
           </div>
-
-          <p
-            v-if="popularAttributesHighlightLine(product)"
-            class="category-product-card-grid__attributes"
-          >
-            {{ popularAttributesHighlightLine(product) }}
-          </p>
         </v-card-item>
       </v-card>
     </v-col>
@@ -73,7 +111,11 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
+import type {
+  AttributeConfigDto,
+  ProductAggregatedPriceDto,
+  ProductDto,
+} from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import CategoryProductCompareToggle from './CategoryProductCompareToggle.vue'
 import { formatAttributeValue, resolvePopularAttributes } from '~/utils/_product-attributes'
@@ -83,12 +125,14 @@ import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
 const props = defineProps<{
   products: ProductDto[]
   popularAttributes?: AttributeConfigDto[]
+  size?: 'compact' | 'comfortable'
 }>()
 
 const { t, n } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
 
 const popularAttributeConfigs = computed(() => props.popularAttributes ?? [])
+const cardSize = computed(() => props.size ?? 'comfortable')
 
 const resolveImage = (product: ProductDto) => {
   return (
@@ -138,18 +182,116 @@ const popularAttributesByProduct = (product: ProductDto): DisplayedAttribute[] =
   return entries
 }
 
-const popularAttributesHighlights = (product: ProductDto): string[] => {
-  return popularAttributesByProduct(product).map((attribute) => attribute.value)
+const conditionLabel = (condition?: string | null) => {
+  if (!condition) {
+    return t('category.products.conditions.unknown')
+  }
+
+  const normalized = condition.toUpperCase()
+
+  if (normalized === 'NEW') {
+    return t('category.products.conditions.new')
+  }
+
+  if (normalized === 'OCCASION' || normalized === 'SECOND_HAND') {
+    return t('category.products.conditions.occasion')
+  }
+
+  return t('category.products.conditions.other', { condition })
 }
 
-const popularAttributesHighlightLine = (product: ProductDto): string | null => {
-  const highlights = popularAttributesHighlights(product)
-
-  if (!highlights.length) {
+const formatOfferPrice = (
+  offer: ProductAggregatedPriceDto | undefined,
+  fallback: ProductDto,
+): string | null => {
+  if (!offer) {
     return null
   }
 
-  return highlights.join(' - ')
+  if (offer.shortPrice) {
+    return offer.shortPrice
+  }
+
+  const price = offer.price
+
+  if (price == null) {
+    return null
+  }
+
+  const currency = offer.currency ?? fallback.offers?.bestPrice?.currency
+
+  if (currency) {
+    try {
+      return n(price, { style: 'currency', currency })
+    } catch {
+      return `${n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`.trim()
+    }
+  }
+
+  return n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+type OfferBadge = {
+  key: string
+  label: string
+  price: string
+  conditionText: string
+  appearance: 'new' | 'occasion' | 'default'
+}
+
+const offerBadges = (product: ProductDto): OfferBadge[] => {
+  const entries: OfferBadge[] = []
+  const newOffer = product.offers?.bestNewOffer
+  const occasionOffer = product.offers?.bestOccasionOffer
+
+  if (newOffer) {
+    const formatted = formatOfferPrice(newOffer, product)
+
+    if (formatted) {
+      entries.push({
+        key: 'new',
+        label: t('category.products.pricing.newOfferLabel'),
+        price: formatted,
+        conditionText: t('category.products.pricing.conditionLabel', {
+          condition: conditionLabel(newOffer.condition),
+        }),
+        appearance: 'new',
+      })
+    }
+  }
+
+  if (occasionOffer) {
+    const formatted = formatOfferPrice(occasionOffer, product)
+
+    if (formatted) {
+      entries.push({
+        key: 'occasion',
+        label: t('category.products.pricing.occasionOfferLabel'),
+        price: formatted,
+        conditionText: t('category.products.pricing.conditionLabel', {
+          condition: conditionLabel(occasionOffer.condition),
+        }),
+        appearance: 'occasion',
+      })
+    }
+  }
+
+  if (!entries.length) {
+    const fallbackOffer = product.offers?.bestPrice
+    const formatted = formatOfferPrice(fallbackOffer, product) ?? bestPriceLabel(product)
+
+    entries.push({
+      key: 'best',
+      label: t('category.products.pricing.bestOfferLabel'),
+      price: formatted,
+      conditionText: t('category.products.pricing.conditionLabel', {
+        condition: conditionLabel(fallbackOffer?.condition ?? null),
+      }),
+      appearance: 'default',
+    })
+  }
+
+  return entries
 }
 </script>
 
@@ -163,6 +305,7 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
     flex-direction: column
     text-decoration: none
     transition: transform 0.2s ease, box-shadow 0.2s ease
+    position: relative
 
     &:hover
       transform: translateY(-4px)
@@ -184,11 +327,11 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
 
   &__compare
     position: absolute
-    top: 1rem
-    right: 1rem
+    right: 1.25rem
+    bottom: 1.25rem
     display: flex
     justify-content: flex-end
-    z-index: 1
+    z-index: 2
 
   &__body
     display: flex
@@ -200,6 +343,7 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
     background: rgb(var(--v-theme-surface-glass))
     border-bottom-left-radius: inherit
     border-bottom-right-radius: inherit
+    padding-bottom: 3.5rem
 
   &__header
     display: flex
@@ -213,6 +357,24 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
     color: rgb(var(--v-theme-text-neutral-strong))
     text-align: center
 
+  &__attributes
+    display: flex
+    flex-wrap: wrap
+    justify-content: center
+    gap: 0.5rem
+    margin: 0
+
+  &__attribute
+    background: rgba(var(--v-theme-surface-primary-080), 0.8)
+    color: rgb(var(--v-theme-text-neutral-strong))
+    font-weight: 500
+
+  &__attribute-icon
+    color: rgba(var(--v-theme-text-neutral-strong), 0.75)
+
+  &__attribute-value
+    white-space: nowrap
+
   &__meta
     display: flex
     flex-direction: column
@@ -222,11 +384,6 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
   &__offers
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__price
-    font-size: 1.35rem
-    font-weight: 700
-    color: rgb(var(--v-theme-text-neutral-strong))
 
   &__score
     display: flex
@@ -238,8 +395,64 @@ const popularAttributesHighlightLine = (product: ProductDto): string | null => {
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
 
-  &__attributes
-    margin: 0
-    font-size: 0.95rem
-    color: rgb(var(--v-theme-text-neutral-secondary))
+  &__pricing
+    display: grid
+    gap: 0.75rem
+    width: 100%
+
+  &__price-badge
+    background: rgba(var(--v-theme-surface-primary-080), 0.8)
+    border-radius: 1rem
+    padding: 0.75rem 1rem
+    display: flex
+    flex-direction: column
+    gap: 0.25rem
+    align-items: center
+    text-align: center
+
+    &--new
+      background: rgba(var(--v-theme-primary), 0.12)
+      color: rgb(var(--v-theme-primary))
+
+    &--occasion
+      background: rgba(var(--v-theme-accent-supporting), 0.12)
+      color: rgb(var(--v-theme-accent-supporting))
+
+    &--default
+      color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__price-badge-label
+    font-size: 0.75rem
+    text-transform: uppercase
+    letter-spacing: 0.08em
+    font-weight: 600
+
+  &__price-badge-amount
+    font-size: 1.25rem
+    font-weight: 700
+
+  &__price-badge-condition
+    font-size: 0.875rem
+    color: rgba(var(--v-theme-text-neutral-strong), 0.72)
+
+  &--size-compact
+    .category-product-card-grid__body
+      gap: 0.75rem
+      padding: 1rem
+      padding-bottom: 3rem
+
+    .category-product-card-grid__title
+      font-size: 1rem
+
+    .category-product-card-grid__price-badge
+      padding: 0.6rem 0.85rem
+
+    .category-product-card-grid__price-badge-amount
+      font-size: 1.1rem
+
+    .category-product-card-grid__price-badge-label
+      font-size: 0.7rem
+
+    .category-product-card-grid__price-badge-condition
+      font-size: 0.8rem
 </style>

--- a/frontend/app/components/category/products/CategoryProductCompareToggle.vue
+++ b/frontend/app/components/category/products/CategoryProductCompareToggle.vue
@@ -4,14 +4,15 @@
       <v-btn
         v-bind="tooltipProps"
         class="category-product-compare-toggle"
-        :class="{
-          'category-product-compare-toggle--active': isSelected,
-          'category-product-compare-toggle--inactive': !isSelected,
-        }"
+        :class="[
+          sizeClass,
+          {
+            'category-product-compare-toggle--active': isSelected,
+            'category-product-compare-toggle--inactive': !isSelected,
+          },
+        ]"
         variant="flat"
-        size="large"
         color="primary"
-        :icon="isSelected ? activeIcon : icon"
         :aria-pressed="isSelected"
         :aria-label="ariaLabel"
         :title="tooltip"
@@ -19,7 +20,12 @@
         data-test="category-product-compare"
         @click.stop.prevent="toggle"
       >
-        <v-icon :icon="isSelected ? activeIcon : icon" size="40" />
+        <template v-if="isSelected">
+          <span class="category-product-compare-toggle__minus" aria-hidden="true">&minus;</span>
+        </template>
+        <template v-else>
+          <v-icon :icon="icon" :size="iconSize" />
+        </template>
       </v-btn>
     </template>
   </v-tooltip>
@@ -38,11 +44,11 @@ const props = withDefaults(
   defineProps<{
     product: ProductDto
     icon?: string
-    activeIcon?: string
+    size?: 'compact' | 'comfortable' | 'large'
   }>(),
   {
     icon: 'mdi-compare-horizontal',
-    activeIcon: 'mdi-compare-horizontal',
+    size: 'comfortable',
   },
 )
 
@@ -56,6 +62,21 @@ const { t, te } = useI18n()
 const compareStore = useProductCompareStore()
 
 const isSelected = computed(() => compareStore.hasProduct(props.product))
+
+const sizeClass = computed(() =>
+  `category-product-compare-toggle--size-${props.size ?? 'comfortable'}`,
+)
+
+const iconSize = computed(() => {
+  switch (props.size) {
+    case 'compact':
+      return 26
+    case 'large':
+      return 40
+    default:
+      return 32
+  }
+})
 
 const reasonMessage = (reason: CompareListBlockReason | undefined) => {
   switch (reason) {
@@ -127,12 +148,32 @@ const toggle = () => {
 .category-product-compare-toggle
   border-radius: 50%
   transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease
-  width: 3.25rem
-  min-width: 3.25rem
-  height: 3.25rem
-  padding: 0
   background-color: rgba(var(--v-theme-surface-default), 0.92)
   box-shadow: 0 6px 16px rgba(21, 46, 73, 0.12)
+  display: inline-flex
+  align-items: center
+  justify-content: center
+
+  &--size-compact
+    width: 2.5rem
+    min-width: 2.5rem
+    height: 2.5rem
+
+    :deep(.v-icon)
+      font-size: 1.35rem
+
+  &--size-comfortable
+    width: 3.125rem
+    min-width: 3.125rem
+    height: 3.125rem
+
+  &--size-large
+    width: 3.75rem
+    min-width: 3.75rem
+    height: 3.75rem
+
+    :deep(.v-icon)
+      font-size: 2.25rem
 
   &:hover
     opacity: 0.9
@@ -150,4 +191,16 @@ const toggle = () => {
 
   &--active :deep(.v-icon)
     transform: scale(1.05)
+
+  &__minus
+    font-size: 1.75rem
+    font-weight: 600
+    line-height: 1
+    color: currentColor
+
+  &--size-compact &__minus
+    font-size: 1.4rem
+
+  &--size-large &__minus
+    font-size: 2rem
 </style>

--- a/frontend/app/components/category/products/CategoryProductTable.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductTable.spec.ts
@@ -47,6 +47,10 @@ const CompareToggleStub: Component = {
       type: Object,
       required: true,
     },
+    size: {
+      type: String,
+      default: 'comfortable',
+    },
   },
   setup() {
     return () => h('button', { type: 'button', 'data-test': 'category-product-compare' })
@@ -207,5 +211,25 @@ describe('CategoryProductTable', () => {
       'attributes.indexed.DIAGONALE_POUCES.numericValue',
     )
     expect(wrapper.emitted('update:sort-order')?.[0]?.[0]).toBe('asc')
+  })
+
+  it('emits sort updates for static sortable columns', async () => {
+    const wrapper = await mountTable({
+      products: [buildProduct()],
+    })
+
+    const table = wrapper.getComponent(VDataTableStub)
+
+    table.vm.$emit('update:sort-by', [{ key: 'brand', order: 'asc' }])
+    expect(wrapper.emitted('update:sort-field')?.[0]?.[0]).toBe('identity.brand.keyword')
+    expect(wrapper.emitted('update:sort-order')?.[0]?.[0]).toBe('asc')
+
+    table.vm.$emit('update:sort-by', [{ key: 'model', order: 'desc' }])
+    expect(wrapper.emitted('update:sort-field')?.[1]?.[0]).toBe('identity.model.keyword')
+    expect(wrapper.emitted('update:sort-order')?.[1]?.[0]).toBe('desc')
+
+    table.vm.$emit('update:sort-by', [{ key: 'impactScore' }])
+    expect(wrapper.emitted('update:sort-field')?.[2]?.[0]).toBe('scores.ECOSCORE.value')
+    expect(wrapper.emitted('update:sort-order')?.[2]?.[0]).toBe('asc')
   })
 })

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -13,7 +13,11 @@
     @click:row="onRowClick"
   >
     <template #[`item.compare`]="{ item }">
-      <CategoryProductCompareToggle :product="item.product" class="category-product-table__compare" />
+      <CategoryProductCompareToggle
+        :product="item.product"
+        size="compact"
+        class="category-product-table__compare"
+      />
     </template>
 
     <template #[`item.brand`]="{ value }">
@@ -195,9 +199,9 @@ const attributeColumns = computed<AttributeColumn[]>(() => {
 
 const headers = computed(() => [
   { key: 'compare', title: t('category.products.headers.compare'), sortable: false, width: 48 },
-  { key: 'brand', title: t('category.products.headers.brand'), sortable: false, width: 140 },
-  { key: 'model', title: t('category.products.headers.model'), sortable: false, minWidth: 200 },
-  { key: 'impactScore', title: t('category.products.headers.impactScore'), sortable: false, width: 140 },
+  { key: 'brand', title: t('category.products.headers.brand'), sortable: true, width: 140 },
+  { key: 'model', title: t('category.products.headers.model'), sortable: true, minWidth: 200 },
+  { key: 'impactScore', title: t('category.products.headers.impactScore'), sortable: true, width: 140 },
   {
     key: 'bestPrice',
     title: t('category.products.headers.bestPrice'),
@@ -219,6 +223,9 @@ const headers = computed(() => [
 ])
 
 const staticSortHeaderToFieldMapping: Record<string, string> = {
+  brand: 'identity.brand.keyword',
+  model: 'identity.model.keyword',
+  impactScore: 'scores.ECOSCORE.value',
   bestPrice: 'price.minPrice.price',
   offersCount: 'offersCount',
 }

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -15,6 +15,9 @@ const FILTER_FIELD_TRANSLATION_KEYS: Record<string, string> = {
 const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {
   'price.minPrice.price': 'category.products.sort.fields.price',
   offersCount: 'category.products.sort.fields.offersCount',
+  'identity.brand.keyword': 'category.products.sort.fields.brand',
+  'identity.model.keyword': 'category.products.sort.fields.model',
+  'scores.ECOSCORE.value': 'category.products.sort.fields.impactScore',
 }
 
 const resolveTranslation = (mapping: string, t: TranslateFn, keys: Record<string, string>): string | null => {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -173,6 +173,18 @@
         "other": "{count} offers"
       },
       "notRated": "Not rated",
+      "conditions": {
+        "new": "New",
+        "occasion": "Second-hand",
+        "unknown": "Unspecified",
+        "other": "{condition}"
+      },
+      "pricing": {
+        "newOfferLabel": "New offer",
+        "occasionOfferLabel": "Second-hand offer",
+        "bestOfferLabel": "Best price",
+        "conditionLabel": "Condition: {condition}"
+      },
       "compare": {
         "title": "Compare products",
         "expandPanel": "Show list",
@@ -219,7 +231,10 @@
       "sort": {
         "fields": {
           "price": "Lowest price",
-          "offersCount": "Number of offers"
+          "offersCount": "Number of offers",
+          "brand": "Brand",
+          "model": "Model",
+          "impactScore": "Impact score"
         }
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -172,6 +172,18 @@
         "other": "{count} offres"
       },
       "notRated": "Non noté",
+      "conditions": {
+        "new": "Neuf",
+        "occasion": "Occasion",
+        "unknown": "Non précisée",
+        "other": "Autre ({condition})"
+      },
+      "pricing": {
+        "newOfferLabel": "Offre neuve",
+        "occasionOfferLabel": "Offre d'occasion",
+        "bestOfferLabel": "Meilleur prix",
+        "conditionLabel": "Condition : {condition}"
+      },
       "compare": {
         "title": "Comparer les produits",
         "expandPanel": "Afficher la liste",
@@ -218,7 +230,10 @@
       "sort": {
         "fields": {
           "price": "Prix le plus bas",
-          "offersCount": "Nombre d'offres"
+          "offersCount": "Nombre d'offres",
+          "brand": "Marque",
+          "model": "Modèle",
+          "impactScore": "Score d'impact"
         }
       }
     },


### PR DESCRIPTION
## Summary
- redesign the category product card grid with overlay compare toggles, attribute chips, and distinct badges for new or second-hand offers
- add size support and a minus removal icon to the compare toggle so it can adapt across layouts
- shrink the table compare button, enable sorting by brand/model/impact score, and extend field translations

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68fdef96e8d88333ab3b89c4b6ff7a74