### PR TITLE
Fix sitemap main pages host detection

### DIFF
--- a/frontend/server/plugins/sitemap-main-pages.ts
+++ b/frontend/server/plugins/sitemap-main-pages.ts
@@ -8,7 +8,7 @@ const MAIN_PAGES_SITEMAP_FILENAME = `${APP_ROUTES_SITEMAP_KEY}.xml`
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('sitemap:sources', (ctx) => {
-    if (ctx.sitemapName !== MAIN_PAGES_SITEMAP_FILENAME) {
+    if (ctx.sitemapName !== MAIN_PAGES_SITEMAP_FILENAME && ctx.sitemapName !== APP_ROUTES_SITEMAP_KEY) {
       return
     }
 


### PR DESCRIPTION
## Summary
- ensure the sitemap main pages Nitro plugin accepts both the raw key and the XML filename so static routes are added for every host

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff2198321c833394f54d05bf313217