### PR TITLE
Fix global sort validation with verticals

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -463,7 +463,10 @@ public class ProductController {
         VerticalConfig config = hasVertical ? verticalsConfigService.getConfigById(normalizedVerticalId) : null;
         ProductFieldOptionsResponse fieldOptions = resolveVerticalFields(config, domainLanguage, globalFields);
         Set<String> allowedFilters = collectAllowedFieldMappings(fieldOptions);
-        Set<String> allowedSorts = hasVertical ? allowedFilters : collectGlobalSortMappings();
+        Set<String> allowedSorts = collectGlobalSortMappings();
+        if (hasVertical) {
+            allowedSorts.addAll(allowedFilters);
+        }
         Set<String> allowedAggregations = collectAllowedAggregationMappings(allowedFilters, config);
         return new SearchCapabilities(allowedFilters, allowedSorts, allowedAggregations);
     }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -88,7 +88,7 @@ public class ProductController {
     private static final String VALUE_TYPE_NUMERIC = "numeric";
     private static final String VALUE_TYPE_TEXT = "text";
     private static final String NUMERIC_VALUE_SUFFIX = ".numericValue";
-    private static final String KEYWORD_VALUE_SUFFIX = ".keyword";
+    private static final String KEYWORD_VALUE_SUFFIX = ".value";
     private static final String INDEXED_ATTRIBUTE_PREFIX = "attributes.indexed.";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductController.class);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -61,8 +61,8 @@ public record ProductDto(
         public enum ProductDtoSortableFields {
                 price("price.minPrice.price"),
                 offersCount("offersCount"),
-                brand("attributes.referentielAttributes.BRAND.keyword"),
-                model("attributes.referentielAttributes.MODEL.keyword");
+                brand("attributes.referentielAttributes.BRAND"),
+                model("attributes.referentielAttributes.MODEL");
 
 
                 private final String text;

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -261,6 +261,27 @@ class ProductControllerIT {
     }
 
     @Test
+    void productsEndpointAllowsGlobalSortWhenVerticalSpecified() throws Exception {
+        VerticalConfig config = new VerticalConfig();
+        config.setId("electronics");
+        given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
+
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
+        ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
+        given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
+                .willReturn(responseDto);
+
+        mockMvc.perform(get("/products")
+                        .param("sort", "attributes.referentielAttributes.BRAND.keyword,asc")
+                        .param("verticalId", "electronics")
+                        .param("domainLanguage", "FR")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void productsEndpointAcceptsJsonSortSyntax() throws Exception {
         VerticalConfig config = verticalConfigWithNumericAttribute("battery_life");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -273,7 +273,7 @@ class ProductControllerIT {
                 .willReturn(responseDto);
 
         mockMvc.perform(get("/products")
-                        .param("sort", "attributes.referentielAttributes.BRAND.keyword,asc")
+                        .param("sort", "attributes.referentielAttributes.BRAND,asc")
                         .param("verticalId", "electronics")
                         .param("domainLanguage", "FR")
                         .header("X-Shared-Token", SHARED_TOKEN)

--- a/frontend/app/components/category/products/CategoryProductTable.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductTable.spec.ts
@@ -221,11 +221,11 @@ describe('CategoryProductTable', () => {
     const table = wrapper.getComponent(VDataTableStub)
 
     table.vm.$emit('update:sort-by', [{ key: 'brand', order: 'asc' }])
-    expect(wrapper.emitted('update:sort-field')?.[0]?.[0]).toBe('attributes.referentielAttributes.BRAND.keyword')
+    expect(wrapper.emitted('update:sort-field')?.[0]?.[0]).toBe('attributes.referentielAttributes.BRAND')
     expect(wrapper.emitted('update:sort-order')?.[0]?.[0]).toBe('asc')
 
     table.vm.$emit('update:sort-by', [{ key: 'model', order: 'desc' }])
-    expect(wrapper.emitted('update:sort-field')?.[1]?.[0]).toBe('attributes.referentielAttributes.MODEL.keyword')
+    expect(wrapper.emitted('update:sort-field')?.[1]?.[0]).toBe('attributes.referentielAttributes.MODEL')
     expect(wrapper.emitted('update:sort-order')?.[1]?.[0]).toBe('desc')
 
     table.vm.$emit('update:sort-by', [{ key: 'impactScore' }])

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -223,8 +223,8 @@ const headers = computed(() => [
 ])
 
 const staticSortHeaderToFieldMapping: Record<string, string> = {
-  brand: 'attributes.referentielAttributes.BRAND.keyword',
-  model: 'attributes.referentielAttributes.MODEL.keyword',
+  brand: 'attributes.referentielAttributes.BRAND',
+  model: 'attributes.referentielAttributes.MODEL',
   impactScore: 'scores.ECOSCORE.value',
   bestPrice: 'price.minPrice.price',
   offersCount: 'offersCount',

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -15,8 +15,8 @@ const FILTER_FIELD_TRANSLATION_KEYS: Record<string, string> = {
 const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {
   'price.minPrice.price': 'category.products.sort.fields.price',
   offersCount: 'category.products.sort.fields.offersCount',
-  'attributes.referentielAttributes.BRAND.keyword': 'category.products.sort.fields.brand',
-  'attributes.referentielAttributes.MODEL.keyword': 'category.products.sort.fields.model',
+  'attributes.referentielAttributes.BRAND': 'category.products.sort.fields.brand',
+  'attributes.referentielAttributes.MODEL': 'category.products.sort.fields.model',
   'scores.ECOSCORE.value': 'category.products.sort.fields.impactScore',
 }
 


### PR DESCRIPTION
## Summary
- ensure the global product sort fields remain allowed when a vertical is selected
- cover the behaviour with a ProductController integration test for brand sorting

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_68ff2ade52348333b407514141b45ee0