### PR TITLE
Improve category fast filters layout and filter column toggle

### DIFF
--- a/frontend/app/pages/[categorySlug].vue
+++ b/frontend/app/pages/[categorySlug].vue
@@ -604,7 +604,7 @@ const isDesktop = computed(() => (isHydrated.value ? display.lgAndUp.value : ini
 const filtersDrawer = ref(false)
 const filtersCollapsed = ref(false)
 const filtersToggleIcon = computed(() =>
-  filtersCollapsed.value ? 'mdi-filter-variant' : 'mdi-filter-variant-off',
+  filtersCollapsed.value ? 'mdi-filter-variant-plus' : 'mdi-filter-variant-minus',
 )
 const filtersToggleLabel = computed(() =>
   filtersCollapsed.value

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -125,6 +125,10 @@
         "screen_size": "Screen size",
         "default": "Other quick filters"
       },
+      "navigation": {
+        "previous": "Scroll previous quick filters",
+        "next": "Scroll next quick filters"
+      },
       "operator": {
         "greaterThan": "≥ {value}",
         "lowerThan": "≤ {value}"
@@ -144,6 +148,10 @@
       "missingLabel": "Unlabelled option",
       "mobileApply": "Apply filters",
       "mobileClear": "Clear all filters",
+      "toggle": {
+        "show": "Show filters column",
+        "hide": "Hide filters column"
+      },
       "fields": {
         "price": "Price range",
         "offersCount": "Number of offers",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -124,6 +124,10 @@
         "screen_size": "Taille d'écran",
         "default": "Autres filtres rapides"
       },
+      "navigation": {
+        "previous": "Défiler vers les filtres rapides précédents",
+        "next": "Défiler vers les filtres rapides suivants"
+      },
       "operator": {
         "greaterThan": "≥ {value}",
         "lowerThan": "≤ {value}"
@@ -143,6 +147,10 @@
       "missingLabel": "Option sans libellé",
       "mobileApply": "Appliquer les filtres",
       "mobileClear": "Effacer les filtres",
+      "toggle": {
+        "show": "Afficher la colonne des filtres",
+        "hide": "Masquer la colonne des filtres"
+      },
       "fields": {
         "price": "Fourchette de prix",
         "offersCount": "Nombre d'offres",


### PR DESCRIPTION
## Summary
- compress the CategoryFastFilters layout into a single horizontal row with scroll controls when content overflows
- add a desktop-only toggle to collapse the sidebar filters area and persist responsive layout updates
- localize the new controls and extend unit coverage for the fast filters navigation state

## Testing
- pnpm lint
- pnpm test -- --runInBand components/category/CategoryFastFilters.spec.ts
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_68ff2cc4f0348333b1727f479d4d3927