### PR TITLE
feat: refine product hero interactions

### DIFF
--- a/frontend/app/components/product/ProductHeroPricing.spec.ts
+++ b/frontend/app/components/product/ProductHeroPricing.spec.ts
@@ -1,0 +1,178 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import type { ProductDto } from '~~/shared/api-client'
+import ProductHeroPricing from './ProductHeroPricing.vue'
+
+describe('ProductHeroPricing', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          hero: {
+            bestPriceTitle: 'Best price',
+            viewSingleOffer: 'View the offer',
+            viewOffersCount: 'View the {count} offers',
+            offerConditions: {
+              occasion: 'Second-hand',
+              new: 'New',
+            },
+            offerConditionsToggleAria: 'Choose an offer condition',
+          },
+          price: {
+            trend: {
+              decrease: 'Price drop of {amount}',
+              increase: 'Price increase of {amount}',
+              stable: 'Price unchanged',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const createWrapper = async (offers: NonNullable<ProductDto['offers']>) =>
+    mountSuspended(ProductHeroPricing, {
+      props: {
+        product: {
+          offers,
+        } as ProductDto,
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          NuxtLink: defineComponent({
+            name: 'NuxtLinkStub',
+            props: { to: { type: [String, Object], required: true } },
+            setup(props, { slots, attrs }) {
+              return () =>
+                h(
+                  'a',
+                  {
+                    class: ['nuxt-link-stub', attrs.class],
+                    href: typeof props.to === 'string' ? props.to : '#',
+                    target: attrs.target as string | undefined,
+                    rel: attrs.rel as string | undefined,
+                  },
+                  slots.default?.(),
+                )
+            },
+          }),
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'client-only-stub' }, slots.default?.())
+            },
+          }),
+          'v-btn': defineComponent({
+            name: 'VBtnStub',
+            setup(_, { slots, attrs }) {
+              return () =>
+                h(
+                  'button',
+                  {
+                    class: ['v-btn-stub', attrs.class],
+                    type: 'button',
+                    onClick: attrs.onClick as ((event: MouseEvent) => void) | undefined,
+                  },
+                  slots.default?.(),
+                )
+            },
+          }),
+          'v-icon': defineComponent({
+            name: 'VIconStub',
+            props: { icon: { type: String, default: '' } },
+            setup(props) {
+              return () => h('span', { class: 'v-icon-stub' }, props.icon)
+            },
+          }),
+        },
+      },
+    })
+
+  it('defaults to occasion offer and toggles to new', async () => {
+    const wrapper = await createWrapper({
+      offersCount: 3,
+      bestPrice: {
+        price: 799,
+        currency: 'EUR',
+        datasourceName: 'Shop',
+        url: 'https://shop.example',
+        favicon: 'https://shop.example/favicon.ico',
+        condition: 'NEW',
+      },
+      bestOccasionOffer: {
+        price: 649,
+        currency: 'EUR',
+        datasourceName: 'Merchant U',
+        url: 'https://merchant-u.example',
+        favicon: 'https://merchant-u.example/favicon.ico',
+        condition: 'OCCASION',
+      },
+      bestNewOffer: {
+        price: 799,
+        currency: 'EUR',
+        datasourceName: 'Shop',
+        url: 'https://shop.example',
+        favicon: 'https://shop.example/favicon.ico',
+        condition: 'NEW',
+      },
+      occasionTrend: {
+        trend: 'PRICE_INCREASE',
+        variation: 5,
+      },
+      newTrend: {
+        trend: 'PRICE_DECREASE',
+        variation: -10,
+      },
+    })
+
+    const chips = wrapper.findAll('.product-hero__price-chip')
+    expect(chips).toHaveLength(2)
+    expect(chips[0]?.classes()).toContain('product-hero__price-chip--active')
+    expect(wrapper.get('.product-hero__price-value').text()).toBe('€649')
+    expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Merchant U')
+
+    await chips[1]?.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(chips[1]?.classes()).toContain('product-hero__price-chip--active')
+    expect(wrapper.get('.product-hero__price-value').text()).toBe('€799')
+    expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Shop')
+
+    await wrapper.unmount()
+  })
+
+  it('uses affiliation redirect for a single offer', async () => {
+    const wrapper = await createWrapper({
+      offersCount: 1,
+      bestPrice: {
+        price: 499,
+        currency: 'EUR',
+        datasourceName: 'OnlyShop',
+        url: 'https://onlyshop.example',
+        favicon: 'https://onlyshop.example/favicon.ico',
+        condition: 'NEW',
+        affiliationToken: 'abc123',
+      },
+      bestNewOffer: {
+        price: 499,
+        currency: 'EUR',
+        datasourceName: 'OnlyShop',
+        url: 'https://onlyshop.example',
+        favicon: 'https://onlyshop.example/favicon.ico',
+        condition: 'NEW',
+        affiliationToken: 'abc123',
+      },
+    })
+
+    const clientOnlyLink = wrapper.get('.client-only-stub .product-hero__price-merchant-link')
+    expect(clientOnlyLink.attributes('href')).toBe('/contrib/abc123')
+    expect(clientOnlyLink.attributes('target')).toBeUndefined()
+
+    await wrapper.unmount()
+  })
+})

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1235,7 +1235,20 @@
         "image": "image",
         "video": "video"
       },
-      "videoBadge": "Video"
+      "videoBadge": "Video",
+      "compare": {
+        "label": "Compare",
+        "selected": "In comparison",
+        "add": "Add to compare",
+        "remove": "Remove from compare",
+        "ariaAdd": "Add {name} to compare",
+        "ariaSelected": "{name} is in your comparison list"
+      },
+      "offerConditions": {
+        "occasion": "Second-hand",
+        "new": "New"
+      },
+      "offerConditionsToggleAria": "Choose which offer condition to highlight"
     },
     "impact": {
       "title": "Environmental impact",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1243,7 +1243,20 @@
         "image": "l’image",
         "video": "la vidéo"
       },
-      "videoBadge": "Vidéo"
+      "videoBadge": "Vidéo",
+      "compare": {
+        "label": "Comparer",
+        "selected": "Comparé",
+        "add": "Ajouter à la comparaison",
+        "remove": "Retirer de la comparaison",
+        "ariaAdd": "Ajouter {name} à la comparaison",
+        "ariaSelected": "{name} est dans la comparaison"
+      },
+      "offerConditions": {
+        "occasion": "Occasion",
+        "new": "Neuf"
+      },
+      "offerConditionsToggleAria": "Sélectionner le type d'offre à afficher"
     },
     "impact": {
       "title": "Impact écologique",


### PR DESCRIPTION
## Summary
- ensure product gallery prioritises videos, stabilises lightbox loading, and reinstates hero click-to-open
- replace legacy GTIN/offer cards with a compare toggle wired to the compare store and i18n labels
- add condition chips for best price, upscale merchant presentation, and cover affiliation link logic with tests

## Testing
- pnpm lint
- pnpm test -- --run --reporter=basic
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff42fdd47c8333b22da2bd4732334a