### PR TITLE
Refactor product impact section layout and add component tests

### DIFF
--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -9,180 +9,54 @@
       </p>
     </header>
 
-    <div class="product-impact__overview">
-      <div class="product-impact__radar" role="img" :aria-label="$t('product.impact.radarAria', { product: productName })">
-        <ClientOnly>
-          <VueECharts
-            v-if="radarOption"
-            :option="radarOption"
-            :autoresize="true"
-            class="product-impact__radar-chart"
-          />
-          <template #fallback>
-            <div class="product-impact__radar-placeholder" />
-          </template>
-        </ClientOnly>
-      </div>
-
-      <div class="product-impact__ranking">
-        <h3>{{ $t('product.impact.rankingTitle') }}</h3>
-        <p v-if="ranking" class="product-impact__ranking-value">
-          {{ $t('product.impact.rankingValue', { position: ranking.position, total: ranking.total }) }}
-        </p>
-        <p v-if="ranking?.globalBest" class="product-impact__ranking-link">
-          <NuxtLink :to="ranking.globalBest.fullSlug">
-            {{ $t('product.impact.bestProduct', { name: ranking.globalBest.bestName }) }}
-          </NuxtLink>
-        </p>
-        <p v-if="ranking?.globalBetter" class="product-impact__ranking-link">
-          <NuxtLink :to="ranking.globalBetter.fullSlug">
-            {{ $t('product.impact.betterProduct', { name: ranking.globalBetter.bestName }) }}
-          </NuxtLink>
-        </p>
-
-        <div v-if="country" class="product-impact__country">
-          <NuxtImg
-            v-if="country.flag"
-            :src="country.flag"
-            :alt="country.name"
-            width="36"
-            height="24"
-            class="product-impact__country-flag"
-          />
-          <span>{{ country.name }}</span>
-        </div>
-      </div>
+    <div class="product-impact__top">
+      <ProductImpactEcoScoreCard :score="primaryScore" />
+      <ProductImpactRankingCard
+        v-if="ranking || country"
+        :ranking="ranking"
+        :country="country"
+      />
     </div>
 
-    <div class="product-impact__scores">
+    <div class="product-impact__analysis">
+      <ProductImpactRadarChart
+        class="product-impact__analysis-radar"
+        :values="radarValues"
+        :product-name="productName"
+      />
+      <ProductImpactDetailsTable
+        class="product-impact__analysis-details"
+        :scores="scores"
+      />
+    </div>
+
+    <div class="product-impact__subscores">
       <v-skeleton-loader
         v-if="loading"
         type="image, article"
         class="product-impact__skeleton"
       />
       <template v-else>
-        <article
-          v-for="score in scores"
+        <ProductImpactSubscoreCard
+          v-for="score in secondaryScores"
           :key="score.id"
-          class="product-impact__score-card"
-        >
-          <header class="product-impact__score-header">
-            <div>
-              <h3 class="product-impact__score-title">{{ score.label }}</h3>
-              <p v-if="score.description" class="product-impact__score-description">
-                {{ score.description }}
-              </p>
-            </div>
-            <div v-if="score.letter" class="product-impact__score-letter">
-              {{ score.letter }}
-            </div>
-          </header>
-
-          <div class="product-impact__score-body">
-            <div class="product-impact__score-chart">
-              <ClientOnly>
-                <VueECharts
-                  v-if="histogramOptions[score.id]"
-                  :option="histogramOptions[score.id]"
-                  :autoresize="true"
-                  class="product-impact__histogram"
-                />
-                <template #fallback>
-                  <div class="product-impact__histogram-placeholder" />
-                </template>
-              </ClientOnly>
-            </div>
-            <ul class="product-impact__score-facts">
-              <li>
-                <strong>{{ $t('product.impact.scoreValue') }}</strong>
-                <span>{{ formatScore(score.relativeValue) }} / 5</span>
-              </li>
-              <li v-if="score.absoluteValue != null">
-                <strong>{{ $t('product.impact.absoluteValue') }}</strong>
-                <span>{{ score.absoluteValue }}</span>
-              </li>
-              <li v-if="score.percent != null">
-                <strong>{{ $t('product.impact.percentile') }}</strong>
-                <span>{{ score.percent }}%</span>
-              </li>
-              <li v-if="score.ranking">
-                <strong>{{ $t('product.impact.scoreRanking') }}</strong>
-                <span>{{ score.ranking }}</span>
-              </li>
-            </ul>
-            <div v-if="score.energyLetter" class="product-impact__score-custom">
-              <span class="product-impact__energy-badge">{{ score.energyLetter }}</span>
-            </div>
-          </div>
-        </article>
+          :score="score"
+          :product-name="productName"
+        />
       </template>
-    </div>
-
-    <div class="product-impact__table">
-      <h3>{{ $t('product.impact.detailsTitle') }}</h3>
-      <v-table density="compact">
-        <thead>
-          <tr>
-            <th scope="col">{{ $t('product.impact.tableHeaders.score') }}</th>
-            <th scope="col">{{ $t('product.impact.tableHeaders.value') }}</th>
-            <th scope="col">{{ $t('product.impact.tableHeaders.ranking') }}</th>
-            <th scope="col">{{ $t('product.impact.tableHeaders.percent') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="score in scores" :key="`${score.id}-table`">
-            <th scope="row">{{ score.label }}</th>
-            <td>{{ formatScore(score.relativeValue) }} / 5</td>
-            <td>{{ score.ranking ?? '—' }}</td>
-            <td>{{ score.percent != null ? `${score.percent}%` : '—' }}</td>
-          </tr>
-        </tbody>
-      </v-table>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, toRefs } from 'vue'
 import type { PropType } from 'vue'
-import VueECharts from 'vue-echarts'
-import { use } from 'echarts/core'
-import { BarChart, RadarChart } from 'echarts/charts'
-import { GridComponent, TooltipComponent, LegendComponent, PolarComponent } from 'echarts/components'
-import { CanvasRenderer } from 'echarts/renderers'
-import type { EChartsOption } from 'echarts'
-
-use([BarChart, RadarChart, GridComponent, TooltipComponent, LegendComponent, PolarComponent, CanvasRenderer])
-
-type DistributionBucket = {
-  label: string
-  value: number
-}
-
-type ScoreView = {
-  id: string
-  label: string
-  description?: string | null
-  relativeValue: number | null
-  absoluteValue?: string | number | null
-  percent?: number | null
-  ranking?: number | string | null
-  letter?: string | null
-  distribution?: DistributionBucket[]
-  energyLetter?: string | null
-}
-
-type RankingInfo = {
-  position: number
-  total: number
-  globalBest?: { fullSlug: string; bestName: string }
-  globalBetter?: { fullSlug: string; bestName: string }
-}
-
-type CountryInfo = {
-  name: string
-  flag?: string | null
-}
+import ProductImpactEcoScoreCard from './impact/ProductImpactEcoScoreCard.vue'
+import ProductImpactRankingCard from './impact/ProductImpactRankingCard.vue'
+import ProductImpactRadarChart from './impact/ProductImpactRadarChart.vue'
+import ProductImpactDetailsTable from './impact/ProductImpactDetailsTable.vue'
+import ProductImpactSubscoreCard from './impact/ProductImpactSubscoreCard.vue'
+import type { CountryInfo, RankingInfo, ScoreView } from './impact/impact-types'
 
 const props = defineProps({
   sectionId: {
@@ -215,133 +89,13 @@ const props = defineProps({
   },
 })
 
-const histogramOptions = computed(() => {
-  return props.scores.reduce<Record<string, EChartsOption>>((accumulator, score) => {
-    const distribution = score.distribution ?? []
-    if (!distribution.length) {
-      return accumulator
-    }
+const { radarValues, productName } = toRefs(props)
 
-    const markPointLabel = (() => {
-      const relativeValue = score.relativeValue
-      if (relativeValue == null) {
-        return null
-      }
-
-      const closest = distribution.reduce<DistributionBucket | null>((candidate, bucket) => {
-        const labelNumber = Number(bucket.label)
-        if (!Number.isFinite(labelNumber)) {
-          return candidate
-        }
-
-        if (!candidate) {
-          return bucket
-        }
-
-        const candidateDistance = Math.abs(labelNumber - relativeValue)
-        const currentDistance = Math.abs(Number(candidate.label) - relativeValue)
-
-        return candidateDistance < currentDistance ? bucket : candidate
-      }, null)
-
-      return closest?.label ?? null
-    })()
-
-    accumulator[score.id] = {
-      grid: { top: 20, left: 40, right: 20, bottom: 40 },
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-      },
-      xAxis: {
-        type: 'category',
-        data: distribution.map((bucket) => bucket.label),
-        axisLabel: { rotate: 35 },
-      },
-      yAxis: {
-        type: 'value',
-      },
-      series: [
-        {
-          type: 'bar',
-          name: score.label,
-          data: distribution.map((bucket) => bucket.value),
-          itemStyle: {
-            color: 'rgba(33, 150, 243, 0.75)',
-          },
-          markLine:
-            score.relativeValue != null && markPointLabel
-              ? {
-                  symbol: 'none',
-                  label: {
-                    formatter: props.productName,
-                    color: '#1f2937',
-                  },
-                  data: [
-                    {
-                      xAxis: markPointLabel,
-                    },
-                  ],
-                }
-              : undefined,
-        },
-      ],
-    }
-
-    return accumulator
-  }, {})
-})
-
-const radarOption = computed(() => {
-  if (!props.radarValues.length) {
-    return null
-  }
-
-  const indicators = props.radarValues.map((entry) => ({
-    name: entry.name,
-    max: 5,
-  }))
-
-  return {
-    tooltip: {},
-    radar: {
-      indicator: indicators,
-      radius: '70%',
-      splitArea: {
-        areaStyle: {
-          color: ['rgba(33, 150, 243, 0.12)', 'rgba(33, 150, 243, 0.05)'],
-        },
-      },
-    },
-    series: [
-      {
-        type: 'radar',
-        data: [
-          {
-            value: props.radarValues.map((entry) => entry.value),
-            name: props.productName,
-            areaStyle: {
-              color: 'rgba(33, 150, 243, 0.35)',
-            },
-            lineStyle: {
-              color: 'rgba(33, 150, 243, 0.85)',
-              width: 2,
-            },
-            symbolSize: 6,
-          },
-        ],
-      },
-    ],
-  }
-})
-
-const formatScore = (value: number | null) => {
-  if (value == null || Number.isNaN(value)) {
-    return '—'
-  }
-
-  return value.toFixed(1)
-}
+const primaryScore = computed(() => props.scores[0] ?? null)
+const secondaryScores = computed(() => props.scores.slice(1))
+const scores = computed(() => props.scores)
+const ranking = computed(() => props.ranking)
+const country = computed(() => props.country)
 </script>
 
 <style scoped>
@@ -367,72 +121,30 @@ const formatScore = (value: number | null) => {
   color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
 }
 
-.product-impact__overview {
+.product-impact__top {
   display: grid;
-  grid-template-columns: 1.4fr 1fr;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1.1fr);
+  gap: 1.5rem;
+}
+
+.product-impact__analysis {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
   gap: 1.5rem;
   align-items: stretch;
 }
 
-.product-impact__radar {
-  background: rgba(var(--v-theme-surface-glass), 0.9);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
+.product-impact__analysis-radar {
+  grid-column: 1 / span 1;
 }
 
-.product-impact__radar-placeholder {
-  height: 320px;
-  border-radius: 18px;
-  background: rgba(148, 163, 184, 0.12);
+.product-impact__analysis-details {
+  grid-column: 2 / span 1;
 }
 
-.product-impact__radar-chart {
-  height: 320px;
-}
-
-.product-impact__ranking {
-  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.85), rgba(var(--v-theme-surface-glass), 0.95));
-  border-radius: 24px;
-  padding: 1.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.product-impact__ranking h3 {
-  margin: 0;
-  font-size: 1.2rem;
-}
-
-.product-impact__ranking-value {
-  font-size: 1.05rem;
-  font-weight: 600;
-}
-
-.product-impact__ranking-link a {
-  color: rgb(var(--v-theme-accent-primary-highlight));
-  text-decoration: none;
-}
-
-.product-impact__country {
-  margin-top: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-weight: 600;
-}
-
-.product-impact__country-flag {
-  border-radius: 6px;
-  width: 36px;
-  height: 24px;
-  object-fit: cover;
-}
-
-.product-impact__scores {
+.product-impact__subscores {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   gap: 1.5rem;
 }
 
@@ -441,110 +153,21 @@ const formatScore = (value: number | null) => {
   min-height: 320px;
 }
 
-.product-impact__score-card {
-  background: rgba(var(--v-theme-surface-glass-strong), 0.94);
-  border-radius: 22px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
+@media (max-width: 1280px) {
+  .product-impact__top,
+  .product-impact__analysis {
+    grid-template-columns: 1fr;
+  }
 
-.product-impact__score-header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.product-impact__score-title {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.product-impact__score-description {
-  font-size: 0.95rem;
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
-}
-
-.product-impact__score-letter {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: rgb(var(--v-theme-accent-supporting));
-}
-
-.product-impact__score-body {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-.product-impact__score-chart {
-  height: 220px;
-}
-
-.product-impact__histogram {
-  height: 220px;
-}
-
-.product-impact__histogram-placeholder {
-  height: 220px;
-  border-radius: 18px;
-  background: rgba(148, 163, 184, 0.15);
-}
-
-.product-impact__score-facts {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.product-impact__score-facts li {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.95rem;
-}
-
-.product-impact__score-facts strong {
-  font-weight: 600;
-}
-
-.product-impact__score-custom {
-  margin-top: 0.75rem;
-}
-
-.product-impact__energy-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 48px;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  background: linear-gradient(135deg, #22c55e, #f97316);
-  color: #ffffff;
-  text-transform: uppercase;
-}
-
-.product-impact__table {
-  background: rgba(var(--v-theme-surface-glass), 0.9);
-  border-radius: 24px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
-}
-
-.product-impact__table h3 {
-  margin-bottom: 1rem;
+  .product-impact__analysis-radar,
+  .product-impact__analysis-details {
+    grid-column: auto;
+  }
 }
 
 @media (max-width: 960px) {
-  .product-impact__overview {
-    grid-template-columns: 1fr;
+  .product-impact__subscores {
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   }
 }
 </style>

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -1,0 +1,55 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductImpactDetailsTable from './ProductImpactDetailsTable.vue'
+import type { ScoreView } from './impact-types'
+
+describe('ProductImpactDetailsTable', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          impact: {
+            detailsTitle: 'Assessment details',
+            tableHeaders: {
+              score: 'Indicator',
+              value: 'Value',
+              ranking: 'Rank',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const scores: ScoreView[] = [
+    { id: 'ECOSCORE', label: 'Eco', relativeValue: 4.5 },
+    { id: 'CO2', label: 'CO2', relativeValue: 3.1, ranking: 12 },
+  ]
+
+  it('renders a table without the percentile column', () => {
+    const wrapper = mount(ProductImpactDetailsTable, {
+      props: { scores },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          'v-table': defineComponent({
+            name: 'VTableStub',
+            setup(_, { slots }) {
+              return () => h('table', { class: 'v-table-stub' }, slots.default?.())
+            },
+          }),
+        },
+      },
+    })
+
+    const headers = wrapper.findAll('th').map((node) => node.text())
+    expect(headers).toContain('Indicator')
+    expect(headers).toContain('Value')
+    expect(headers).toContain('Rank')
+    expect(headers).not.toContain('Percentile')
+  })
+})

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -1,0 +1,63 @@
+<template>
+  <article class="impact-details">
+    <h3 class="impact-details__title">{{ $t('product.impact.detailsTitle') }}</h3>
+    <v-table density="compact" class="impact-details__table">
+      <thead>
+        <tr>
+          <th scope="col">{{ $t('product.impact.tableHeaders.score') }}</th>
+          <th scope="col">{{ $t('product.impact.tableHeaders.value') }}</th>
+          <th scope="col">{{ $t('product.impact.tableHeaders.ranking') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="score in scores" :key="`${score.id}-details`">
+          <th scope="row">{{ score.label }}</th>
+          <td>{{ formatScore(score.relativeValue) }} / 5</td>
+          <td>{{ score.ranking ?? '—' }}</td>
+        </tr>
+      </tbody>
+    </v-table>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ScoreView } from './impact-types'
+
+const props = defineProps<{
+  scores: ScoreView[]
+}>()
+
+const scores = computed(() => props.scores)
+
+const formatScore = (value: number | null) => {
+  if (value == null || Number.isNaN(value)) {
+    return '—'
+  }
+
+  return value.toFixed(1)
+}
+</script>
+
+<style scoped>
+.impact-details {
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
+}
+
+.impact-details__title {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.impact-details__table :deep(thead th) {
+  font-weight: 600;
+}
+
+.impact-details__table :deep(tbody th) {
+  font-weight: 500;
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductImpactEcoScoreCard from './ProductImpactEcoScoreCard.vue'
+import type { ScoreView } from './impact-types'
+
+describe('ProductImpactEcoScoreCard', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          impact: {
+            primaryScoreLabel: 'Overall impact',
+            absoluteValue: 'Absolute value',
+            noPrimaryScore: 'No score',
+          },
+        },
+      },
+    },
+  })
+
+  const stubScore: ScoreView = {
+    id: 'ECOSCORE',
+    label: 'Eco score',
+    description: 'Overall environmental score',
+    relativeValue: 4.2,
+    absoluteValue: 78.123,
+  }
+
+  it('renders the impact score using ImpactScore component', () => {
+    const wrapper = mount(ProductImpactEcoScoreCard, {
+      props: { score: stubScore },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ImpactScore: defineComponent({
+            name: 'ImpactScoreStub',
+            props: ['score', 'max', 'showValue', 'size'],
+            setup(props) {
+              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
+            },
+          }),
+        },
+      },
+    })
+
+    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
+    expect(wrapper.text()).toContain('78.12')
+    expect(wrapper.text()).toContain('Absolute value')
+  })
+
+  it('renders a placeholder message when the score is missing', () => {
+    const wrapper = mount(ProductImpactEcoScoreCard, {
+      props: { score: null },
+      global: { plugins: [i18n] },
+    })
+
+    expect(wrapper.text()).toContain('No score')
+  })
+})

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -1,0 +1,150 @@
+<template>
+  <article v-if="score" class="impact-ecoscore">
+    <header class="impact-ecoscore__header">
+      <div>
+        <span class="impact-ecoscore__eyebrow">{{ $t('product.impact.primaryScoreLabel') }}</span>
+        <h3 class="impact-ecoscore__title">{{ score.label }}</h3>
+        <p v-if="score.description" class="impact-ecoscore__description">{{ score.description }}</p>
+      </div>
+      <div v-if="score.letter" class="impact-ecoscore__letter" aria-hidden="true">
+        {{ score.letter }}
+      </div>
+    </header>
+
+    <div class="impact-ecoscore__score">
+      <ImpactScore :score="relativeScore" :max="5" size="large" show-value />
+    </div>
+
+    <div v-if="absoluteValue" class="impact-ecoscore__absolute">
+      <span class="impact-ecoscore__absolute-label">{{ $t('product.impact.absoluteValue') }}</span>
+      <span class="impact-ecoscore__absolute-value">{{ absoluteValue }}</span>
+    </div>
+  </article>
+  <article v-else class="impact-ecoscore impact-ecoscore--empty">
+    <span class="impact-ecoscore__placeholder">{{ $t('product.impact.noPrimaryScore') }}</span>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import type { ScoreView } from './impact-types'
+
+const props = defineProps<{
+  score: ScoreView | null
+}>()
+
+const { n } = useI18n()
+
+const relativeScore = computed(() => (props.score?.relativeValue ?? 0) || 0)
+
+const absoluteValue = computed(() => {
+  const value = props.score?.absoluteValue
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (typeof value === 'number') {
+    return n(value, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
+  }
+
+  return String(value)
+})
+</script>
+
+<style scoped>
+.impact-ecoscore {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-100), 0.95), rgba(var(--v-theme-surface-glass-strong), 0.9));
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.12);
+  min-height: 100%;
+}
+
+.impact-ecoscore__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.impact-ecoscore__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.85);
+  margin-bottom: 0.25rem;
+}
+
+.impact-ecoscore__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 2rem);
+  font-weight: 700;
+}
+
+.impact-ecoscore__description {
+  margin: 0.5rem 0 0;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+  font-size: 0.95rem;
+}
+
+.impact-ecoscore__letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-on-accent));
+  background: linear-gradient(135deg, rgba(var(--v-theme-accent-supporting), 0.95), rgba(var(--v-theme-accent-primary-highlight), 0.9));
+  box-shadow: 0 10px 30px rgba(var(--v-theme-accent-primary-highlight), 0.25);
+}
+
+.impact-ecoscore__score {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.impact-ecoscore__absolute {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(var(--v-theme-surface-glass), 0.85);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
+}
+
+.impact-ecoscore__absolute-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
+}
+
+.impact-ecoscore__absolute-value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-ecoscore--empty {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.impact-ecoscore__placeholder {
+  font-size: 0.95rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactRadarChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactRadarChart.vue
@@ -1,0 +1,85 @@
+<template>
+  <article class="impact-radar" role="img" :aria-label="ariaLabel">
+    <ClientOnly>
+      <VueECharts
+        v-if="option"
+        :option="option"
+        :autoresize="true"
+        class="impact-radar__chart"
+      />
+      <template #fallback>
+        <div class="impact-radar__placeholder" />
+      </template>
+    </ClientOnly>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import VueECharts from 'vue-echarts'
+import type { EChartsOption } from 'echarts'
+import { useI18n } from 'vue-i18n'
+import { ensureImpactECharts } from './echarts-setup'
+
+const props = defineProps<{ values: Array<{ name: string; value: number }>; productName: string }>()
+
+ensureImpactECharts()
+
+const { t } = useI18n()
+
+const ariaLabel = computed(() => t('product.impact.radarAria', { product: props.productName }))
+
+const option = computed<EChartsOption | null>(() => {
+  if (!props.values.length) {
+    return null
+  }
+
+  return {
+    tooltip: {},
+    radar: {
+      indicator: props.values.map((entry) => ({ name: entry.name, max: 5 })),
+      radius: '70%',
+      splitArea: {
+        areaStyle: {
+          color: ['rgba(33, 150, 243, 0.12)', 'rgba(33, 150, 243, 0.05)'],
+        },
+      },
+    },
+    series: [
+      {
+        type: 'radar',
+        data: [
+          {
+            value: props.values.map((entry) => entry.value),
+            name: props.productName,
+            areaStyle: { color: 'rgba(33, 150, 243, 0.35)' },
+            lineStyle: { color: 'rgba(33, 150, 243, 0.85)', width: 2 },
+            symbolSize: 6,
+          },
+        ],
+      },
+    ],
+  }
+})
+</script>
+
+<style scoped>
+.impact-radar {
+  width: 100%;
+  height: 100%;
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border-radius: 24px;
+  padding: 1.5rem;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
+}
+
+.impact-radar__chart {
+  height: 360px;
+}
+
+.impact-radar__placeholder {
+  height: 360px;
+  border-radius: 18px;
+  background: rgba(148, 163, 184, 0.12);
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactRankingCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactRankingCard.vue
@@ -1,0 +1,94 @@
+<template>
+  <article class="impact-ranking">
+    <header class="impact-ranking__header">
+      <h3 class="impact-ranking__title">{{ $t('product.impact.rankingTitle') }}</h3>
+      <p v-if="ranking" class="impact-ranking__value">
+        {{ $t('product.impact.rankingValue', { position: ranking.position, total: ranking.total }) }}
+      </p>
+    </header>
+
+    <div v-if="ranking?.globalBest" class="impact-ranking__link">
+      <NuxtLink :to="ranking.globalBest.fullSlug">
+        {{ $t('product.impact.bestProduct', { name: ranking.globalBest.bestName }) }}
+      </NuxtLink>
+    </div>
+
+    <div v-if="ranking?.globalBetter" class="impact-ranking__link">
+      <NuxtLink :to="ranking.globalBetter.fullSlug">
+        {{ $t('product.impact.betterProduct', { name: ranking.globalBetter.bestName }) }}
+      </NuxtLink>
+    </div>
+
+    <div v-if="country" class="impact-ranking__country">
+      <NuxtImg
+        v-if="country.flag"
+        :src="country.flag"
+        :alt="country.name"
+        width="36"
+        height="24"
+        class="impact-ranking__country-flag"
+      />
+      <span>{{ country.name }}</span>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { CountryInfo, RankingInfo } from './impact-types'
+
+defineProps<{
+  ranking: RankingInfo | null
+  country: CountryInfo | null
+}>()
+</script>
+
+<style scoped>
+.impact-ranking {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.75rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-glass), 0.92), rgba(var(--v-theme-surface-primary-080), 0.85));
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
+  min-height: 100%;
+}
+
+.impact-ranking__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.impact-ranking__value {
+  margin: 0.35rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.impact-ranking__link a {
+  color: rgb(var(--v-theme-accent-primary-highlight));
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.impact-ranking__link a:hover,
+.impact-ranking__link a:focus {
+  text-decoration: underline;
+}
+
+.impact-ranking__country {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+.impact-ranking__country-flag {
+  border-radius: 6px;
+  width: 36px;
+  height: 24px;
+  object-fit: cover;
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductImpactSubscoreCard from './ProductImpactSubscoreCard.vue'
+import type { ScoreView } from './impact-types'
+
+vi.mock('vue-echarts', () => ({
+  default: defineComponent({
+    name: 'VueEChartsStub',
+    props: ['option'],
+    setup() {
+      return () => h('div', { class: 'echart-stub' })
+    },
+  }),
+}))
+
+describe('ProductImpactSubscoreCard', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          impact: {
+            absoluteValue: 'Absolute value',
+          },
+        },
+      },
+    },
+  })
+
+  const score: ScoreView = {
+    id: 'CO2',
+    label: 'CO2 emissions',
+    description: 'Lower is better',
+    relativeValue: 3.6,
+    absoluteValue: 42.5,
+    energyLetter: 'A',
+    distribution: [
+      { label: '1', value: 5 },
+      { label: '2', value: 10 },
+    ],
+  }
+
+  it('renders score information and energy badge', () => {
+    const wrapper = mount(ProductImpactSubscoreCard, {
+      props: { score, productName: 'Demo Product' },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ImpactScore: defineComponent({
+            name: 'ImpactScoreStub',
+            props: ['score'],
+            setup(props) {
+              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
+            },
+          }),
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => slots.default?.()
+            },
+          }),
+        },
+      },
+    })
+
+    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Absolute value')
+    expect(wrapper.text()).toContain('42.5')
+    expect(wrapper.text()).toContain('A')
+  })
+})

--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
@@ -1,0 +1,238 @@
+<template>
+  <article class="impact-subscore">
+    <header class="impact-subscore__header">
+      <div>
+        <h4 class="impact-subscore__title">{{ score.label }}</h4>
+        <p v-if="score.description" class="impact-subscore__description">{{ score.description }}</p>
+      </div>
+      <span v-if="score.letter" class="impact-subscore__letter">{{ score.letter }}</span>
+    </header>
+
+    <div class="impact-subscore__score">
+      <ImpactScore :score="relativeScore" :max="5" show-value size="medium" />
+    </div>
+
+    <div v-if="absoluteValue" class="impact-subscore__absolute">
+      <span class="impact-subscore__absolute-label">{{ $t('product.impact.absoluteValue') }}</span>
+      <span class="impact-subscore__absolute-value">{{ absoluteValue }}</span>
+    </div>
+
+    <div v-if="score.energyLetter" class="impact-subscore__badge">
+      <span class="impact-subscore__energy">{{ score.energyLetter }}</span>
+    </div>
+
+    <div v-if="hasDistribution" class="impact-subscore__chart">
+      <ClientOnly>
+        <VueECharts
+          v-if="histogramOption"
+          :option="histogramOption"
+          :autoresize="true"
+          class="impact-subscore__echart"
+        />
+        <template #fallback>
+          <div class="impact-subscore__chart-placeholder" />
+        </template>
+      </ClientOnly>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import VueECharts from 'vue-echarts'
+import type { EChartsOption } from 'echarts'
+import { useI18n } from 'vue-i18n'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import type { DistributionBucket, ScoreView } from './impact-types'
+import { ensureImpactECharts } from './echarts-setup'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+
+ensureImpactECharts()
+
+const { n } = useI18n()
+
+const relativeScore = computed(() => (props.score.relativeValue ?? 0) || 0)
+
+const absoluteValue = computed(() => {
+  const value = props.score.absoluteValue
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (typeof value === 'number') {
+    return n(value, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
+  }
+
+  return String(value)
+})
+
+const hasDistribution = computed(() => Boolean(props.score.distribution?.length))
+
+const histogramOption = computed<EChartsOption | null>(() => {
+  const distribution = props.score.distribution ?? []
+  if (!distribution.length) {
+    return null
+  }
+
+  const markPointLabel = (() => {
+    const relativeValue = props.score.relativeValue
+    if (relativeValue == null) {
+      return null
+    }
+
+    const closest = distribution.reduce<DistributionBucket | null>((candidate, bucket) => {
+      const labelNumber = Number(bucket.label)
+      if (!Number.isFinite(labelNumber)) {
+        return candidate
+      }
+
+      if (!candidate) {
+        return bucket
+      }
+
+      const candidateDistance = Math.abs(labelNumber - relativeValue)
+      const currentDistance = Math.abs(Number(candidate.label) - relativeValue)
+
+      return candidateDistance < currentDistance ? bucket : candidate
+    }, null)
+
+    return closest?.label ?? null
+  })()
+
+  return {
+    grid: { top: 20, left: 40, right: 20, bottom: 40 },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    xAxis: {
+      type: 'category',
+      data: distribution.map((bucket) => bucket.label),
+      axisLabel: { rotate: 35 },
+    },
+    yAxis: { type: 'value' },
+    series: [
+      {
+        type: 'bar',
+        name: props.score.label,
+        data: distribution.map((bucket) => bucket.value),
+        itemStyle: {
+          color: 'rgba(33, 150, 243, 0.75)',
+        },
+        markLine:
+          props.score.relativeValue != null && markPointLabel
+            ? {
+                symbol: 'none',
+                label: {
+                  formatter: props.productName,
+                  color: '#1f2937',
+                },
+                data: [
+                  {
+                    xAxis: markPointLabel,
+                  },
+                ],
+              }
+            : undefined,
+      },
+    ],
+  }
+})
+</script>
+
+<style scoped>
+.impact-subscore {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 22px;
+  background: rgba(var(--v-theme-surface-glass-strong), 0.94);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
+  min-height: 100%;
+}
+
+.impact-subscore__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.impact-subscore__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.impact-subscore__description {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.impact-subscore__letter {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-accent-supporting));
+}
+
+.impact-subscore__score {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.impact-subscore__absolute {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border-radius: 16px;
+  padding: 0.6rem 1rem;
+}
+
+.impact-subscore__absolute-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
+}
+
+.impact-subscore__absolute-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.impact-subscore__badge {
+  display: flex;
+}
+
+.impact-subscore__energy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, #22c55e, #f97316);
+  color: #ffffff;
+  text-transform: uppercase;
+}
+
+.impact-subscore__chart {
+  margin-top: auto;
+}
+
+.impact-subscore__echart {
+  height: 220px;
+}
+
+.impact-subscore__chart-placeholder {
+  height: 220px;
+  border-radius: 18px;
+  background: rgba(148, 163, 184, 0.15);
+}
+</style>

--- a/frontend/app/components/product/impact/echarts-setup.ts
+++ b/frontend/app/components/product/impact/echarts-setup.ts
@@ -1,0 +1,15 @@
+import { use } from 'echarts/core'
+import { BarChart, RadarChart } from 'echarts/charts'
+import { CanvasRenderer } from 'echarts/renderers'
+import { GridComponent, TooltipComponent, LegendComponent, PolarComponent } from 'echarts/components'
+
+let registered = false
+
+export const ensureImpactECharts = () => {
+  if (registered) {
+    return
+  }
+
+  use([BarChart, RadarChart, GridComponent, TooltipComponent, LegendComponent, PolarComponent, CanvasRenderer])
+  registered = true
+}

--- a/frontend/app/components/product/impact/impact-types.ts
+++ b/frontend/app/components/product/impact/impact-types.ts
@@ -1,0 +1,29 @@
+export type DistributionBucket = {
+  label: string
+  value: number
+}
+
+export type ScoreView = {
+  id: string
+  label: string
+  description?: string | null
+  relativeValue: number | null
+  absoluteValue?: string | number | null
+  percent?: number | null
+  ranking?: number | string | null
+  letter?: string | null
+  distribution?: DistributionBucket[]
+  energyLetter?: string | null
+}
+
+export type RankingInfo = {
+  position: number
+  total: number
+  globalBest?: { fullSlug: string; bestName: string }
+  globalBetter?: { fullSlug: string; bestName: string }
+}
+
+export type CountryInfo = {
+  name: string
+  flag?: string | null
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1240,6 +1240,8 @@
     "impact": {
       "title": "Environmental impact",
       "subtitle": "Explore how this product scores across ecological and social criteria.",
+      "primaryScoreLabel": "Overall impact",
+      "noPrimaryScore": "Impact score unavailable",
       "radarAria": "Impact radar chart for {product}",
       "rankingTitle": "Ranking",
       "rankingValue": "Position {position} of {total}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1248,6 +1248,8 @@
     "impact": {
       "title": "Impact écologique",
       "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
+      "primaryScoreLabel": "Score global",
+      "noPrimaryScore": "Score indisponible",
       "radarAria": "Radar des scores pour {product}",
       "rankingTitle": "Classement",
       "rankingValue": "Position {position} sur {total}",


### PR DESCRIPTION
## Summary
- split the product impact section into dedicated eco score, ranking, radar, details, and subscore components with refreshed layout
- enhance eco score presentation by reusing the shared ImpactScore UI, wider subscore cards, and simplified details table
- add component tests covering the eco score card, details table, and subscore card behaviours

## Testing
- pnpm lint
- CI=1 pnpm test -- --run --reporter=dot
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff4d1497b88333b7791f230f52f379