### PR TITLE
Fix category blog links and currency display

### DIFF
--- a/frontend/app/components/category/CategoryDocumentationRail.vue
+++ b/frontend/app/components/category/CategoryDocumentationRail.vue
@@ -65,8 +65,26 @@ const resolveWikiUrl = (page: WikiPageConfig) => {
   return page.verticalUrl ?? '#'
 }
 
+const BLOG_POST_PATH_PREFIX = '/blog/'
+
 const resolvePostUrl = (post: BlogPostDto) => {
-  return post.url ?? '#'
+  const rawUrl = post.url?.trim()
+
+  if (!rawUrl) {
+    return '#'
+  }
+
+  if (/^https?:\/\//i.test(rawUrl)) {
+    return rawUrl
+  }
+
+  const normalised = rawUrl.replace(/^\/+/, '')
+
+  if (normalised.startsWith('blog/')) {
+    return `/${normalised}`
+  }
+
+  return `${BLOG_POST_PATH_PREFIX}${normalised}`
 }
 </script>
 


### PR DESCRIPTION
## Summary
- ensure related blog post links in the category documentation rail include the `/blog/` prefix for relative slugs
- append currency symbols derived from the offer currency to product card prices in the category grid

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff754b68d48333a1504dcc4f1743af