### PR TITLE
fix: resolve product page hydration and chart warnings

### DIFF
--- a/frontend/app/components/product/ProductPriceSection.vue
+++ b/frontend/app/components/product/ProductPriceSection.vue
@@ -91,6 +91,7 @@ import {
   TooltipComponent,
   DataZoomComponent,
   LegendComponent,
+  TitleComponent,
 } from 'echarts/components'
 import { CanvasRenderer } from 'echarts/renderers'
 import { useI18n } from 'vue-i18n'
@@ -98,7 +99,7 @@ import { formatDistanceToNow, format } from 'date-fns'
 import { fr, enUS } from 'date-fns/locale'
 import type { ProductDto, CommercialEvent } from '~~/shared/api-client'
 
-use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, LegendComponent, CanvasRenderer])
+use([LineChart, GridComponent, TooltipComponent, DataZoomComponent, LegendComponent, TitleComponent, CanvasRenderer])
 
 const props = defineProps({
   sectionId: {

--- a/frontend/app/components/product/impact/echarts-setup.ts
+++ b/frontend/app/components/product/impact/echarts-setup.ts
@@ -1,7 +1,7 @@
 import { use } from 'echarts/core'
 import { BarChart, RadarChart } from 'echarts/charts'
 import { CanvasRenderer } from 'echarts/renderers'
-import { GridComponent, TooltipComponent, LegendComponent, PolarComponent } from 'echarts/components'
+import { GridComponent, TooltipComponent, LegendComponent, PolarComponent, TitleComponent } from 'echarts/components'
 
 let registered = false
 
@@ -10,6 +10,6 @@ export const ensureImpactECharts = () => {
     return
   }
 
-  use([BarChart, RadarChart, GridComponent, TooltipComponent, LegendComponent, PolarComponent, CanvasRenderer])
+  use([BarChart, RadarChart, GridComponent, TooltipComponent, LegendComponent, PolarComponent, TitleComponent, CanvasRenderer])
   registered = true
 }

--- a/frontend/app/components/shared/ui/PageLoadingOverlay.vue
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.vue
@@ -1,26 +1,28 @@
 <template>
-  <teleport to="body">
-    <div
-      v-if="routeLoading"
-      data-testid="page-loading-overlay"
-      class="page-loading-overlay"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-      :style="{ backgroundColor: scrimColor }"
-    >
-      <div class="page-loading-overlay__content">
-        <v-progress-circular
-          data-testid="page-loading-spinner"
-          color="primary"
-          size="64"
-          indeterminate
-          :aria-label="spinnerLabel"
-        />
-        <span class="visually-hidden">{{ spinnerLabel }}</span>
+  <ClientOnly>
+    <teleport to="body">
+      <div
+        v-if="routeLoading"
+        data-testid="page-loading-overlay"
+        class="page-loading-overlay"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        :style="{ backgroundColor: scrimColor }"
+      >
+        <div class="page-loading-overlay__content">
+          <v-progress-circular
+            data-testid="page-loading-spinner"
+            color="primary"
+            size="64"
+            indeterminate
+            :aria-label="spinnerLabel"
+          />
+          <span class="visually-hidden">{{ spinnerLabel }}</span>
+        </div>
       </div>
-    </div>
-  </teleport>
+    </teleport>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">

--- a/frontend/app/plugins/vue-echarts.client.ts
+++ b/frontend/app/plugins/vue-echarts.client.ts
@@ -2,8 +2,8 @@ import { defineNuxtPlugin } from '#app'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { BarChart } from 'echarts/charts'
-import { AriaComponent, DatasetComponent, GridComponent, TooltipComponent } from 'echarts/components'
+import { AriaComponent, DatasetComponent, GridComponent, TitleComponent, TooltipComponent } from 'echarts/components'
 
 export default defineNuxtPlugin(() => {
-  use([CanvasRenderer, BarChart, GridComponent, TooltipComponent, DatasetComponent, AriaComponent])
+  use([CanvasRenderer, BarChart, GridComponent, TooltipComponent, DatasetComponent, AriaComponent, TitleComponent])
 })

--- a/frontend/types/vue3-picture-swipe.d.ts
+++ b/frontend/types/vue3-picture-swipe.d.ts
@@ -9,6 +9,13 @@ declare module 'vue3-picture-swipe' {
     title?: string
     html?: string
     el?: HTMLElement
+    thumbnail?: string
+    w?: number
+    h?: number
+    alt?: string
+    type?: string
+    open4goodsMeta?: Record<string, unknown>
+    [key: string]: unknown
   }
 
   interface PictureSwipeOptions {

--- a/frontend/types/vue3-picture-swipe/index.d.ts
+++ b/frontend/types/vue3-picture-swipe/index.d.ts
@@ -9,6 +9,13 @@ declare module 'vue3-picture-swipe' {
     title?: string
     html?: string
     el?: HTMLElement
+    thumbnail?: string
+    w?: number
+    h?: number
+    alt?: string
+    type?: string
+    open4goodsMeta?: Record<string, unknown>
+    [key: string]: unknown
   }
 
   interface PictureSwipeOptions {


### PR DESCRIPTION
## Summary
- wrap the page loading overlay in a ClientOnly guard to keep SSR/client markup in sync
- replace runtime-rendered gallery captions with structured lightbox metadata and extend typings
- register the ECharts Title component wherever price or impact charts are initialised

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff76deb44083338f11e187d9a21de1