### PR TITLE
Fix hydration overlay mismatch and suppress state hash scroll warnings

### DIFF
--- a/frontend/app/components/shared/ui/PageLoadingOverlay.vue
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.vue
@@ -1,13 +1,14 @@
 <template>
   <teleport to="body">
     <div
-      v-if="routeLoading"
+      v-show="routeLoading"
       data-testid="page-loading-overlay"
       class="page-loading-overlay"
+      :style="{ backgroundColor: scrimColor }"
       role="status"
       aria-live="polite"
-      aria-busy="true"
-      :style="{ backgroundColor: scrimColor }"
+      :aria-busy="routeLoading ? 'true' : 'false'"
+      :aria-hidden="(!routeLoading).toString()"
     >
       <div class="page-loading-overlay__content">
         <v-progress-circular

--- a/frontend/app/router.options.ts
+++ b/frontend/app/router.options.ts
@@ -1,0 +1,35 @@
+import type { RouterConfig } from '@nuxt/schema'
+
+const isCategoryStateHash = (hash: string): boolean => hash.startsWith('#state-')
+
+export default <RouterConfig>{
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    }
+
+    const { hash } = to
+
+    if (hash) {
+      if (isCategoryStateHash(hash)) {
+        return false
+      }
+
+      if (typeof document !== 'undefined') {
+        try {
+          const target = document.querySelector<HTMLElement>(hash)
+          if (target) {
+            return { el: target, behavior: 'smooth' }
+          }
+        } catch (error) {
+          if (import.meta.dev) {
+            console.warn('Invalid hash selector encountered during navigation.', error)
+          }
+        }
+      }
+    }
+
+    return { left: 0, top: 0 }
+  },
+}
+


### PR DESCRIPTION
## Summary
- render the page loading overlay with v-show so SSR and client markup match while keeping accessibility attributes dynamic
- introduce router options that skip scroll behavior for category state hashes and keep smooth scrolling for other anchors

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff797aa22c8333bcb74dde6ce0f4db