### PR TITLE
Prevent router hash scroll for category state updates

### DIFF
--- a/frontend/app/router.options.ts
+++ b/frontend/app/router.options.ts
@@ -1,0 +1,21 @@
+import type { RouterConfig } from '@nuxt/schema'
+
+const HASH_STATE_PREFIX = '#state-'
+
+export default <RouterConfig>{
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition
+    }
+
+    if (typeof window !== 'undefined' && to.hash?.startsWith(HASH_STATE_PREFIX)) {
+      return false
+    }
+
+    if (to.hash) {
+      return { el: to.hash }
+    }
+
+    return { left: 0, top: 0 }
+  },
+}


### PR DESCRIPTION
## Summary
- add a Nuxt router configuration that skips scroll behaviour for state hash updates used by the category page
- preserve default scrolling for other navigations to keep anchor support intact

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ff83d6dda88333981982965c7695dd