### PR TITLE
feat: redesign product documentation section

### DIFF
--- a/frontend/app/components/product/ProductDocumentationSection.spec.ts
+++ b/frontend/app/components/product/ProductDocumentationSection.spec.ts
@@ -1,0 +1,130 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductDocumentationSection from './ProductDocumentationSection.vue'
+import type { ProductPdfDto } from '~~/shared/api-client'
+
+vi.mock('vue-pdf-embed', () => ({
+  default: defineComponent({
+    name: 'VuePdfEmbedStub',
+    props: {
+      source: {
+        type: [String, Object],
+        default: '',
+      },
+    },
+    setup(props) {
+      return () => h('div', { class: 'vue-pdf-embed-stub', 'data-source': props.source ?? '' })
+    },
+  }),
+}))
+
+const ClientOnlyStub = defineComponent({
+  name: 'ClientOnlyStub',
+  setup(_, { slots }) {
+    return () => slots.default?.() ?? null
+  },
+})
+
+const createI18nPlugin = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en-US',
+    fallbackLocale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          docs: {
+            title: 'Documentation',
+            subtitle: 'Preview and download official documents.',
+            download: 'Download PDF',
+            untitled: 'Untitled document',
+            pageCount: '{count} page(s)',
+            sidebarTitle: 'Available documents',
+            navigationAria: 'Product documentation list',
+            empty: 'No documents are available for this product yet.',
+            previewUnavailable: 'Preview unavailable for this document. Use the download link instead.',
+            loading: 'Loading document preview…',
+          },
+        },
+      },
+    },
+  })
+
+describe('ProductDocumentationSection', () => {
+  const basePdf = (overrides: Partial<ProductPdfDto> = {}): ProductPdfDto => ({
+    cacheKey: 'doc-1',
+    url: 'https://example.com/doc-1.pdf',
+    fileSize: 1_200,
+    numberOfPages: 3,
+    modificationDate: new Date('2024-03-25').getTime(),
+    language: 'fr',
+    author: 'Open4Goods',
+    ...overrides,
+  })
+
+  const mountComponent = (props: { pdfs?: ProductPdfDto[] }) =>
+    mount(ProductDocumentationSection, {
+      props,
+      global: {
+        plugins: [createI18nPlugin()],
+        stubs: { ClientOnly: ClientOnlyStub },
+      },
+    })
+
+  it('renders the first PDF in the viewer by default', async () => {
+    const pdfs = [basePdf(), basePdf({ cacheKey: 'doc-2', url: 'https://example.com/doc-2.pdf', language: 'en' })]
+    const wrapper = mountComponent({ pdfs })
+
+    await flushPromises()
+
+    const viewer = wrapper.get('.vue-pdf-embed-stub')
+    expect(viewer.attributes('data-source')).toBe(pdfs[0].url)
+
+    const activeTab = wrapper.get('[data-testid="product-docs-tab"]')
+    expect(activeTab.classes()).toContain('product-docs__tab--active')
+
+    const meta = wrapper.get('.product-docs__viewer-meta').text()
+    expect(meta).toContain('1.2 KB')
+    expect(meta).toMatch(/3 page\(s\)/)
+    expect(meta).toMatch(/2024/)
+
+    const language = wrapper.get('.product-docs__viewer-language').text()
+    expect(language).toContain('French')
+  })
+
+  it('switches the active PDF when selecting a different tab', async () => {
+    const pdfs = [
+      basePdf(),
+      basePdf({ cacheKey: 'doc-2', url: 'https://example.com/doc-2.pdf', language: 'en', numberOfPages: 8 }),
+    ]
+    const wrapper = mountComponent({ pdfs })
+
+    await flushPromises()
+
+    const tabs = wrapper.findAll('[data-testid="product-docs-tab"]')
+    expect(tabs).toHaveLength(2)
+
+    await tabs[1].trigger('click')
+    await flushPromises()
+
+    const viewer = wrapper.get('.vue-pdf-embed-stub')
+    expect(viewer.attributes('data-source')).toBe(pdfs[1].url)
+    expect(tabs[1].classes()).toContain('product-docs__tab--active')
+  })
+
+  it('falls back to a message when a PDF has no preview URL', async () => {
+    const wrapper = mountComponent({ pdfs: [basePdf({ url: undefined })] })
+
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="product-docs-preview-empty"]').text()).toContain('Preview unavailable')
+  })
+
+  it('renders an empty state when no documents are available', async () => {
+    const wrapper = mountComponent({ pdfs: [] })
+
+    expect(wrapper.get('[data-testid="product-docs-empty"]').text()).toContain('No documents are available')
+  })
+})

--- a/frontend/app/components/product/ProductDocumentationSection.vue
+++ b/frontend/app/components/product/ProductDocumentationSection.vue
@@ -5,43 +5,110 @@
       <p class="product-docs__subtitle">{{ $t('product.docs.subtitle') }}</p>
     </header>
 
-    <div class="product-docs__list">
-      <article v-for="pdf in pdfs" :key="pdf.cacheKey" class="product-docs__item">
-        <header class="product-docs__item-header">
-          <h3>{{ pdfTitle(pdf) }}</h3>
-          <p class="product-docs__meta">
-            {{ formatMeta(pdf) }}
+    <div v-if="hasPdfs" class="product-docs__layout">
+      <div
+        :id="panelId"
+        class="product-docs__viewer-pane"
+        role="tabpanel"
+        :aria-labelledby="activeTabId ?? undefined"
+        data-testid="product-docs-viewer"
+      >
+        <header class="product-docs__viewer-header">
+          <h3 class="product-docs__viewer-title">{{ activePdfTitle }}</h3>
+          <p v-if="activePdfMeta" class="product-docs__viewer-meta">
+            {{ activePdfMeta }}
           </p>
-          <a :href="pdf.url" target="_blank" rel="noopener" class="product-docs__download">
+          <p v-if="activePdfLanguage" class="product-docs__viewer-language">
+            {{ activePdfLanguage }}
+          </p>
+          <a
+            v-if="activePdf?.url"
+            :href="activePdf.url"
+            target="_blank"
+            rel="noopener"
+            class="product-docs__download"
+          >
             {{ $t('product.docs.download') }}
           </a>
         </header>
+
         <ClientOnly>
-          <PdfViewer
-            v-if="pdf.url"
-            class="product-docs__viewer"
-            :src="pdf.url"
-            :style="{ height: viewerHeight }"
-          />
+          <template #default>
+            <VuePdfEmbed
+              v-if="activePdf?.url"
+              :source="activePdf.url"
+              text-layer
+              annotation-layer
+              class="product-docs__viewer-frame"
+              :style="{ height: viewerHeight }"
+            />
+            <p v-else class="product-docs__viewer-empty" data-testid="product-docs-preview-empty">
+              {{ $t('product.docs.previewUnavailable') }}
+            </p>
+          </template>
+          <template #fallback>
+            <p class="product-docs__viewer-loading">
+              {{ $t('product.docs.loading') }}
+            </p>
+          </template>
         </ClientOnly>
-      </article>
+      </div>
+
+      <aside class="product-docs__sidebar" :aria-label="$t('product.docs.navigationAria')">
+        <h3 class="product-docs__sidebar-title">{{ $t('product.docs.sidebarTitle') }}</h3>
+        <div
+          class="product-docs__tabs"
+          role="tablist"
+          :aria-activedescendant="activeTabId ?? undefined"
+        >
+          <button
+            v-for="(pdf, index) in pdfs"
+            :id="tabId(index)"
+            :key="pdf.cacheKey ?? index"
+            type="button"
+            role="tab"
+            class="product-docs__tab"
+            :class="{ 'product-docs__tab--active': index === activePdfIndex }"
+            :aria-selected="index === activePdfIndex"
+            :aria-controls="panelId"
+            data-testid="product-docs-tab"
+            @click="selectPdf(index)"
+            @keydown="onTabKeydown(index, $event)"
+          >
+            <span class="product-docs__tab-title">{{ pdfTitle(pdf) }}</span>
+            <span v-if="formatMeta(pdf)" class="product-docs__tab-meta">
+              {{ formatMeta(pdf) }}
+            </span>
+            <span v-if="formatLanguage(pdf)" class="product-docs__tab-language">
+              {{ formatLanguage(pdf) }}
+            </span>
+          </button>
+        </div>
+      </aside>
     </div>
+
+    <p v-else class="product-docs__empty" data-testid="product-docs-empty">
+      {{ $t('product.docs.empty') }}
+    </p>
   </section>
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent, type PropType } from 'vue'
+import { computed, defineAsyncComponent, type PropType, ref, useId, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { ProductPdfDto } from '~~/shared/api-client'
 
-type PdfViewerComponent = (typeof import('@vue-pdf-viewer/viewer'))['VPdfViewer']
+import 'vue-pdf-embed/dist/styles/annotationLayer.css'
+import 'vue-pdf-embed/dist/styles/textLayer.css'
 
-const PdfViewer = defineAsyncComponent<PdfViewerComponent>(async () => {
-  const module = await import('@vue-pdf-viewer/viewer')
-  return module.VPdfViewer
+type VuePdfEmbedComponent = (typeof import('vue-pdf-embed'))['default']
+
+const VuePdfEmbed = defineAsyncComponent<VuePdfEmbedComponent>(async () => {
+  const module = await import('vue-pdf-embed')
+  return module.default
 })
 
-defineProps({
+const props = defineProps({
   sectionId: {
     type: String,
     default: 'documentation',
@@ -52,30 +119,122 @@ defineProps({
   },
 })
 
-const { n, t } = useI18n()
+const { locale, n, t } = useI18n()
 
-const viewerHeight = '480px'
+const viewerHeight = '600px'
 
-const pdfTitle = (pdf: ProductPdfDto) => {
-  return pdf.extractedTitle ?? pdf.metadataTitle ?? pdf.fileName ?? t('product.docs.untitled')
+const pdfs = computed(() => props.pdfs ?? [])
+
+const activePdfIndex = ref(-1)
+
+watch(
+  pdfs,
+  (nextPdfs) => {
+    if (!nextPdfs.length) {
+      activePdfIndex.value = -1
+      return
+    }
+
+    const clampedIndex = Math.min(Math.max(activePdfIndex.value, 0), nextPdfs.length - 1)
+    activePdfIndex.value = clampedIndex
+  },
+  { immediate: true }
+)
+
+const activePdf = computed(() => (activePdfIndex.value >= 0 ? pdfs.value[activePdfIndex.value] ?? null : null))
+
+const hasPdfs = computed(() => pdfs.value.length > 0)
+
+const sectionUid = useId()
+const panelId = `${sectionUid}-panel`
+const tabId = (index: number) => `${sectionUid}-tab-${index}`
+
+const activeTabId = computed(() => (activePdfIndex.value >= 0 ? tabId(activePdfIndex.value) : null))
+
+const languageDisplayNames = computed(() => {
+  try {
+    return new Intl.DisplayNames([locale.value], { type: 'language' })
+  } catch {
+    return null
+  }
+})
+
+const selectPdf = (index: number) => {
+  if (index < 0 || index >= pdfs.value.length) {
+    return
+  }
+
+  if (index === activePdfIndex.value) {
+    return
+  }
+
+  activePdfIndex.value = index
 }
 
-const formatMeta = (pdf: ProductPdfDto) => {
-  const pages = pdf.numberOfPages ?? 0
-  const size = pdf.fileSize ? formatBytes(pdf.fileSize) : null
-  const author = pdf.author ?? null
+const onTabKeydown = (index: number, event: KeyboardEvent) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    selectPdf(index)
+  }
+}
 
-  const parts = [
-    pages ? t('product.docs.pageCount', { count: pages }) : null,
-    size,
-    author,
-  ].filter(Boolean)
+const pdfTitle = (pdf: ProductPdfDto) => pdf.extractedTitle ?? pdf.metadataTitle ?? pdf.fileName ?? t('product.docs.untitled')
+
+const formatMeta = (pdf: ProductPdfDto) => {
+  const parts: string[] = []
+
+  const size = formatBytes(pdf.fileSize)
+  if (size) {
+    parts.push(size)
+  }
+
+  if (pdf.numberOfPages) {
+    parts.push(t('product.docs.pageCount', { count: pdf.numberOfPages }))
+  }
+
+  const dateLabel = formatDate(pdf)
+  if (dateLabel) {
+    parts.push(dateLabel)
+  }
+
+  if (pdf.author) {
+    parts.push(pdf.author)
+  }
 
   return parts.join(' · ')
 }
 
-const formatBytes = (bytes: number) => {
-  if (!Number.isFinite(bytes) || bytes <= 0) {
+const formatDate = (pdf: ProductPdfDto) => {
+  const timestamp = pdf.modificationDate ?? pdf.creationDate ?? pdf.timeStamp
+  if (!timestamp) {
+    return null
+  }
+
+  try {
+    return new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' }).format(new Date(timestamp))
+  } catch {
+    return null
+  }
+}
+
+const formatLanguage = (pdf: ProductPdfDto) => {
+  const code = pdf.language?.trim()
+  if (!code) {
+    return null
+  }
+
+  const normalized = code.toLowerCase()
+  const displayName = languageDisplayNames.value?.of(normalized) ?? null
+
+  if (!displayName || displayName.toLowerCase() === normalized) {
+    return normalized.toUpperCase()
+  }
+
+  return `${displayName} · ${normalized.toUpperCase()}`
+}
+
+const formatBytes = (bytes?: number) => {
+  if (!Number.isFinite(bytes) || !bytes || bytes <= 0) {
     return null
   }
 
@@ -87,6 +246,10 @@ const formatBytes = (bytes: number) => {
   const mb = kb / 1024
   return `${n(mb, { maximumFractionDigits: 1 })} MB`
 }
+
+const activePdfTitle = computed(() => (activePdf.value ? pdfTitle(activePdf.value) : t('product.docs.title')))
+const activePdfMeta = computed(() => (activePdf.value ? formatMeta(activePdf.value) : null))
+const activePdfLanguage = computed(() => (activePdf.value ? formatLanguage(activePdf.value) : null))
 </script>
 
 <style scoped>
@@ -94,6 +257,12 @@ const formatBytes = (bytes: number) => {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.product-docs__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .product-docs__title {
@@ -105,37 +274,186 @@ const formatBytes = (bytes: number) => {
   color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
 }
 
-.product-docs__list {
-  display: grid;
+.product-docs__layout {
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
 }
 
-.product-docs__item {
+.product-docs__viewer-pane {
+  --product-docs-viewer-height: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   background: rgba(var(--v-theme-surface-glass), 0.92);
   border-radius: 24px;
   padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.06);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
 }
 
-.product-docs__item-header {
+.product-docs__viewer-header {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.product-docs__download {
-  align-self: flex-start;
-  color: rgb(var(--v-theme-accent-primary-highlight));
-  text-decoration: none;
-  font-weight: 600;
+.product-docs__viewer-title {
+  font-size: clamp(1.3rem, 2vw, 1.85rem);
+  font-weight: 700;
 }
 
-.product-docs__viewer {
-  border-radius: 16px;
+.product-docs__viewer-meta {
+  font-size: 0.95rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+}
+
+.product-docs__viewer-language {
+  font-size: 0.9rem;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.95);
+}
+
+.product-docs__download {
+  margin-top: 0.5rem;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  color: rgb(var(--v-theme-text-on-accent));
+  background: rgb(var(--v-theme-accent-primary-highlight));
+  box-shadow: 0 12px 24px rgba(var(--v-theme-shadow-primary-600), 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.product-docs__download:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(var(--v-theme-shadow-primary-600), 0.28);
+}
+
+.product-docs__download:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-primary-highlight), 0.35);
+}
+
+.product-docs__viewer-frame {
+  width: 100%;
+  height: var(--product-docs-viewer-height);
+  border-radius: 18px;
   overflow: hidden;
-  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.12);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  background: rgba(var(--v-theme-surface-default), 0.96);
+}
+
+.product-docs__viewer-empty,
+.product-docs__viewer-loading {
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  font-size: 0.95rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+  background: rgba(var(--v-theme-surface-glass), 0.85);
+  border: 1px dashed rgba(var(--v-theme-border-primary-strong), 0.5);
+  border-radius: 18px;
+}
+
+.product-docs__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.product-docs__sidebar-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.product-docs__tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.product-docs__tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border-radius: 20px;
+  border: 2px solid transparent;
+  background: rgba(var(--v-theme-surface-glass), 0.82);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.product-docs__tab:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.12);
+}
+
+.product-docs__tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-primary-highlight), 0.35);
+}
+
+.product-docs__tab--active {
+  border-color: rgba(var(--v-theme-accent-primary-highlight), 0.9);
+  background: rgba(var(--v-theme-surface-primary-080), 0.9);
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.18);
+}
+
+.product-docs__tab-title {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.product-docs__tab-meta {
+  font-size: 0.9rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+}
+
+.product-docs__tab-language {
+  font-size: 0.85rem;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.95);
+}
+
+.product-docs__empty {
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(var(--v-theme-surface-glass), 0.85);
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+}
+
+@media (min-width: 960px) {
+  .product-docs__layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .product-docs__viewer-pane {
+    flex: 1 1 auto;
+    padding: 2rem;
+  }
+
+  .product-docs__sidebar {
+    flex: 0 0 320px;
+    position: sticky;
+    top: 96px;
+  }
+}
+
+@media (max-width: 959px) {
+  .product-docs__sidebar-title {
+    text-transform: none;
+    letter-spacing: normal;
+  }
 }
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1344,7 +1344,12 @@
       "subtitle": "Preview and download official documents.",
       "download": "Download PDF",
       "untitled": "Untitled document",
-      "pageCount": "{count} page(s)"
+      "pageCount": "{count} page(s)",
+      "sidebarTitle": "Available documents",
+      "navigationAria": "Product documentation list",
+      "empty": "No documents are available for this product yet.",
+      "previewUnavailable": "Preview unavailable for this document. Use the download link instead.",
+      "loading": "Loading document preview…"
     },
     "admin": {
       "title": "Admin section",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1352,7 +1352,12 @@
       "subtitle": "Consultez et téléchargez les documents officiels.",
       "download": "Télécharger le PDF",
       "untitled": "Document sans titre",
-      "pageCount": "{count} page(s)"
+      "pageCount": "{count} page(s)",
+      "sidebarTitle": "Documents disponibles",
+      "navigationAria": "Liste des documents du produit",
+      "empty": "Aucun document n’est encore disponible pour ce produit.",
+      "previewUnavailable": "Aucun aperçu n’est disponible pour ce document. Utilisez le lien de téléchargement.",
+      "loading": "Chargement de l’aperçu du document…"
     },
     "admin": {
       "title": "Section administration",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "@nuxt/image": "1.11.0",
     "@pinia/nuxt": "^0.11.2",
     "@unhead/vue": "^2.0.14",
-    "@vue-pdf-viewer/viewer": "^3.2.2",
     "@vuetify/mcp": "^0.1.1",
     "@vueuse/core": "^13.9.0",
     "@vueuse/nuxt": "^13.9.0",
@@ -53,6 +52,7 @@
     "vue": "3.5.22",
     "vue-echarts": "^8.0.0",
     "vue3-picture-swipe": "^3.0.6",
+    "vue-pdf-embed": "^2.1.3",
     "vuetify-nuxt-module": "^0.18.7"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@unhead/vue':
         specifier: ^2.0.14
         version: 2.0.19(vue@3.5.22(typescript@5.9.2))
-      '@vue-pdf-viewer/viewer':
-        specifier: ^3.2.2
-        version: 3.2.3(pdfjs-dist@4.10.38)(typescript@5.9.2)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.2))
       '@vuetify/mcp':
         specifier: ^0.1.1
         version: 0.1.1
@@ -98,6 +95,9 @@ importers:
       vue-echarts:
         specifier: ^8.0.0
         version: 8.0.1(echarts@6.0.0)(vue@3.5.22(typescript@5.9.2))
+      vue-pdf-embed:
+        specifier: ^2.1.3
+        version: 2.1.3(vue@3.5.22(typescript@5.9.2))
       vue3-picture-swipe:
         specifier: ^3.0.6
         version: 3.0.6
@@ -1587,18 +1587,6 @@ packages:
   '@fingerprintjs/botd@1.9.1':
     resolution: {integrity: sha512-7kv3Yolsx9E56i+L1hCEcupH5yqcI5cmVktxy6B0K7rimaH5qDXwsiA5FL+fkxeUny7XQKn7p13HvK7ofDZB3g==}
 
-  '@floating-ui/core@1.7.3':
-    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
-
-  '@floating-ui/dom@1.7.4':
-    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
-
-  '@floating-ui/utils@0.2.10':
-    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
-
-  '@floating-ui/vue@1.1.9':
-    resolution: {integrity: sha512-BfNqNW6KA83Nexspgb9DZuz578R7HT8MZw1CfK9I6Ah4QReNWEJsXWHN+SdmOVLNGmTPDi+fDT535Df5PzMLbQ==}
-
   '@googlemaps/markerclusterer@2.6.2':
     resolution: {integrity: sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==}
 
@@ -1777,12 +1765,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@internationalized/date@3.10.0':
-    resolution: {integrity: sha512-oxDR/NTEJ1k+UFVQElaNIk65E/Z83HK1z1WI3lQyhTtnNg4R5oVXaPzK3jcpKG8UHKDVuDQHzn+wsxSz8RP3aw==}
-
-  '@internationalized/number@3.6.5':
-    resolution: {integrity: sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==}
 
   '@intlify/bundle-utils@11.0.1':
     resolution: {integrity: sha512-5l10G5wE2cQRsZMS9y0oSFMOLW5IG/SgbkIUltqnwF1EMRrRbUAHFiPabXdGTHeexCsMTcxj/1w9i0rzjJU9IQ==}
@@ -3281,14 +3263,6 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@tanstack/virtual-core@3.13.12':
-    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
-
-  '@tanstack/vue-virtual@3.13.12':
-    resolution: {integrity: sha512-vhF7kEU9EXWXh+HdAwKJ2m3xaOnTTmgcdXcF2pim8g4GvI7eRrk2YRuV5nUlZnd/NbCIX4/Ja2OZu5EjJL06Ww==}
-    peerDependencies:
-      vue: 3.5.22
-
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -3671,18 +3645,6 @@ packages:
       vue:
         optional: true
 
-  '@vue-pdf-viewer/shared@1.1.2':
-    resolution: {integrity: sha512-LwE0j6B1smIa82uNPoQ55YTukth6BqZ+ypb5jWJ50zmE7aB5DwgjhQXFbLCeb41Kh1gVRq7h0yBKir8UuH3yUA==}
-    peerDependencies:
-      vue: 3.5.22
-
-  '@vue-pdf-viewer/viewer@3.2.3':
-    resolution: {integrity: sha512-RSxeYRUiFwi2t+kmiOgjoNrtmQzUaTcMSaS9n45TrXNY79fahtwKsl/iWKRteYnAu+5x3at/aG6YuqGdvWP2ZQ==}
-    engines: {bun: '>=1.0.4', node: '>=18.20.3', npm: '>=9.5.1', pnpm: '>=8.8.0', yarn: '>=1.20.0'}
-    peerDependencies:
-      pdfjs-dist: ^4.10.38
-      vue: 3.5.22
-
   '@vue/babel-helper-vue-transform-on@1.5.0':
     resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
 
@@ -3766,16 +3728,10 @@ packages:
     resolution: {integrity: sha512-pzdnuXMs6yJve3xFeCIG5MH6cfNXAK4wk7QIif4mJ/C/YnBn4ihCunwIExri4uPIjFbW98ms/VoqMPjQ8fHrTw==}
     hasBin: true
 
-  '@vueuse/core@12.8.2':
-    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
-
   '@vueuse/core@13.9.0':
     resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
     peerDependencies:
       vue: 3.5.22
-
-  '@vueuse/metadata@12.8.2':
-    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
 
   '@vueuse/metadata@13.9.0':
     resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
@@ -3785,9 +3741,6 @@ packages:
     peerDependencies:
       nuxt: ^3.0.0 || ^4.0.0-0
       vue: 3.5.22
-
-  '@vueuse/shared@12.8.2':
-    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
   '@vueuse/shared@13.9.0':
     resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
@@ -3933,10 +3886,6 @@ packages:
 
   argv-formatter@1.0.0:
     resolution: {integrity: sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==}
-
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -7722,11 +7671,6 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
-  reka-ui@2.6.0:
-    resolution: {integrity: sha512-NrGMKrABD97l890mFS3TNUzB0BLUfbL3hh0NjcJRIUSUljb288bx3Mzo31nOyUcdiiW0HqFGXJwyCBh9cWgb0w==}
-    peerDependencies:
-      vue: 3.5.22
-
   replace-in-file@6.3.5:
     resolution: {integrity: sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==}
     engines: {node: '>=10'}
@@ -8897,11 +8841,6 @@ packages:
       vue-tsc:
         optional: true
 
-  vite-plugin-css-injected-by-js@3.5.2:
-    resolution: {integrity: sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==}
-    peerDependencies:
-      vite: '>2.0.0-0'
-
   vite-plugin-inspect@11.3.3:
     resolution: {integrity: sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==}
     engines: {node: '>=14'}
@@ -9063,17 +9002,6 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-demi@0.14.10:
-    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: 3.5.22
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
@@ -9092,6 +9020,11 @@ packages:
   vue-i18n@11.1.12:
     resolution: {integrity: sha512-BnstPj3KLHLrsqbVU2UOrPmr0+Mv11bsUZG0PyCOzsawCivk8W00GMXHeVUWIDOgNaScCuZah47CZFE+Wnl8mw==}
     engines: {node: '>= 16'}
+    peerDependencies:
+      vue: 3.5.22
+
+  vue-pdf-embed@2.1.3:
+    resolution: {integrity: sha512-EGgZNb8HRrAloBpb8p8CugDpJpoPbQ8CFfAYdWZgq2e5qBMP9JSeLzVQIAJkXsclHXRIS3O9fp3WQbP9T5Inwg==}
     peerDependencies:
       vue: 3.5.22
 
@@ -10658,26 +10591,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@floating-ui/core@1.7.3':
-    dependencies:
-      '@floating-ui/utils': 0.2.10
-
-  '@floating-ui/dom@1.7.4':
-    dependencies:
-      '@floating-ui/core': 1.7.3
-      '@floating-ui/utils': 0.2.10
-
-  '@floating-ui/utils@0.2.10': {}
-
-  '@floating-ui/vue@1.1.9(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      '@floating-ui/dom': 1.7.4
-      '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.22(typescript@5.9.2))
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - vue
-
   '@googlemaps/markerclusterer@2.6.2':
     dependencies:
       '@types/supercluster': 7.1.3
@@ -10826,14 +10739,6 @@ snapshots:
       iconv-lite: 0.7.0
     optionalDependencies:
       '@types/node': 24.9.1
-
-  '@internationalized/date@3.10.0':
-    dependencies:
-      '@swc/helpers': 0.5.17
-
-  '@internationalized/number@3.6.5':
-    dependencies:
-      '@swc/helpers': 0.5.17
 
   '@intlify/bundle-utils@11.0.1(vue-i18n@11.1.12(vue@3.5.22(typescript@5.9.2)))':
     dependencies:
@@ -12878,13 +12783,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/virtual-core@3.13.12': {}
-
-  '@tanstack/vue-virtual@3.13.12(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      '@tanstack/virtual-core': 3.13.12
-      vue: 3.5.22(typescript@5.9.2)
-
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3
@@ -13324,23 +13222,6 @@ snapshots:
     optionalDependencies:
       vue: 3.5.22(typescript@5.9.2)
 
-  '@vue-pdf-viewer/shared@1.1.2(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      vue: 3.5.22(typescript@5.9.2)
-
-  '@vue-pdf-viewer/viewer@3.2.3(pdfjs-dist@4.10.38)(typescript@5.9.2)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(vue@3.5.22(typescript@5.9.2))':
-    dependencies:
-      '@vue-pdf-viewer/shared': 1.1.2(vue@3.5.22(typescript@5.9.2))
-      '@vueuse/core': 13.9.0(vue@3.5.22(typescript@5.9.2))
-      pdfjs-dist: 4.10.38
-      reka-ui: 2.6.0(typescript@5.9.2)(vue@3.5.22(typescript@5.9.2))
-      vite-plugin-css-injected-by-js: 3.5.2(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
-      vue: 3.5.22(typescript@5.9.2)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - typescript
-      - vite
-
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
 
   '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.28.5)':
@@ -13497,23 +13378,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vueuse/core@12.8.2(typescript@5.9.2)':
-    dependencies:
-      '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.2)
-      vue: 3.5.22(typescript@5.9.2)
-    transitivePeerDependencies:
-      - typescript
-
   '@vueuse/core@13.9.0(vue@3.5.22(typescript@5.9.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 13.9.0
       '@vueuse/shared': 13.9.0(vue@3.5.22(typescript@5.9.2))
       vue: 3.5.22(typescript@5.9.2)
-
-  '@vueuse/metadata@12.8.2': {}
 
   '@vueuse/metadata@13.9.0': {}
 
@@ -13527,12 +13397,6 @@ snapshots:
       vue: 3.5.22(typescript@5.9.2)
     transitivePeerDependencies:
       - magicast
-
-  '@vueuse/shared@12.8.2(typescript@5.9.2)':
-    dependencies:
-      vue: 3.5.22(typescript@5.9.2)
-    transitivePeerDependencies:
-      - typescript
 
   '@vueuse/shared@13.9.0(vue@3.5.22(typescript@5.9.2))':
     dependencies:
@@ -13690,10 +13554,6 @@ snapshots:
   argparse@2.0.1: {}
 
   argv-formatter@1.0.0: {}
-
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -18120,23 +17980,6 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  reka-ui@2.6.0(typescript@5.9.2)(vue@3.5.22(typescript@5.9.2)):
-    dependencies:
-      '@floating-ui/dom': 1.7.4
-      '@floating-ui/vue': 1.1.9(vue@3.5.22(typescript@5.9.2))
-      '@internationalized/date': 3.10.0
-      '@internationalized/number': 3.6.5
-      '@tanstack/vue-virtual': 3.13.12(vue@3.5.22(typescript@5.9.2))
-      '@vueuse/core': 12.8.2(typescript@5.9.2)
-      '@vueuse/shared': 12.8.2(typescript@5.9.2)
-      aria-hidden: 1.2.6
-      defu: 6.1.4
-      ohash: 2.0.11
-      vue: 3.5.22(typescript@5.9.2)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - typescript
-
   replace-in-file@6.3.5:
     dependencies:
       chalk: 4.1.2
@@ -19559,10 +19402,6 @@ snapshots:
       typescript: 5.9.2
       vue-tsc: 3.1.2(typescript@5.9.2)
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
-    dependencies:
-      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-
   vite-plugin-inspect@11.3.3(@nuxt/kit@3.19.3(magicast@0.3.5))(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
       ansis: 4.2.0
@@ -19725,10 +19564,6 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-demi@0.14.10(vue@3.5.22(typescript@5.9.2)):
-    dependencies:
-      vue: 3.5.22(typescript@5.9.2)
-
   vue-devtools-stub@0.1.0: {}
 
   vue-echarts@8.0.1(echarts@6.0.0)(vue@3.5.22(typescript@5.9.2)):
@@ -19753,6 +19588,11 @@ snapshots:
       '@intlify/core-base': 11.1.12
       '@intlify/shared': 11.1.12
       '@vue/devtools-api': 6.6.4
+      vue: 3.5.22(typescript@5.9.2)
+
+  vue-pdf-embed@2.1.3(vue@3.5.22(typescript@5.9.2)):
+    dependencies:
+      pdfjs-dist: 4.10.38
       vue: 3.5.22(typescript@5.9.2)
 
   vue-router@4.6.3(vue@3.5.22(typescript@5.9.2)):


### PR DESCRIPTION
## Summary
- replace the commercial PDF viewer with vue-pdf-embed and rebuild the product documentation layout around a main preview pane and right-hand tab navigation that surfaces metadata, download actions and empty states
- add localisation strings for the new navigation, loading and empty states in both English and French
- create a component test suite for ProductDocumentationSection to cover default rendering, tab switching, preview fallbacks and the empty state

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_68ff9ee9710883339a4574f74b2ddc8f