### PR TITLE
feat: rebuild category impact score page

### DIFF
--- a/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
+++ b/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
@@ -1,0 +1,347 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import type { VerticalConfigFullDto } from '~~/shared/api-client'
+
+const selectCategoryBySlugMock = vi.fn()
+const useSeoMetaMock = vi.hoisted(() => vi.fn())
+const mdAndDown = ref(false)
+const localeRef = ref('en-US')
+
+const messages: Record<string, string> = {
+  'siteIdentity.siteName': 'Nudger',
+  'category.ecoscorePage.breadcrumbLeaf': 'impactscore',
+  'category.ecoscorePage.navigation.ariaLabel': 'Impact Score section navigation',
+  'category.ecoscorePage.navigation.overview': 'Overview',
+  'category.ecoscorePage.navigation.purpose': 'Purpose & data',
+  'category.ecoscorePage.navigation.criteria': 'Criteria',
+  'category.ecoscorePage.navigation.transparency': 'Transparency',
+  'category.ecoscorePage.navigation.aiAudit': 'AI audit',
+  'category.ecoscorePage.sections.overview.eyebrow': 'Introduction',
+  'category.ecoscorePage.sections.overview.title': 'Impact Score for {category}',
+  'category.ecoscorePage.sections.overview.card.subtitle': 'Methodology applied to {category}',
+  'category.ecoscorePage.sections.overview.card.title': 'Nudger Impact Score',
+  'category.ecoscorePage.sections.overview.card.description':
+    'This page details the criteria and weightings used to assess the environmental impact of this category.',
+  'category.ecoscorePage.sections.overview.card.aria': 'Learn more about the global Impact Score methodology',
+  'category.ecoscorePage.sections.overview.card.cta': 'Understand the global methodology',
+  'category.ecoscorePage.sections.overview.card.imageAlt': 'Impact Score illustration for {category}',
+  'category.ecoscorePage.sections.purpose.eyebrow': 'Our approach',
+  'category.ecoscorePage.sections.purpose.title': 'Why and how we score {category}',
+  'category.ecoscorePage.sections.purpose.objectiveTitle': 'Objective',
+  'category.ecoscorePage.sections.purpose.objectiveFallback': 'The objective description will be available soon.',
+  'category.ecoscorePage.sections.purpose.dataTitle': 'Available data',
+  'category.ecoscorePage.sections.purpose.dataFallback': 'Detailed data for each criterion will be available soon.',
+  'category.ecoscorePage.sections.criteria.eyebrow': 'Criteria',
+  'category.ecoscorePage.sections.criteria.title': 'Selected criteria and weights',
+  'category.ecoscorePage.sections.criteria.empty': 'Criteria will be published soon.',
+  'category.ecoscorePage.sections.transparency.eyebrow': 'Transparency',
+  'category.ecoscorePage.sections.transparency.title': 'Transparency and traceability',
+  'category.ecoscorePage.sections.transparency.criticalReviewTitle': 'Critical review',
+  'category.ecoscorePage.sections.transparency.criticalReviewFallback': 'The critical review will be shared soon.',
+  'category.ecoscorePage.sections.transparency.communityTitle': 'Join the discussion',
+  'category.ecoscorePage.sections.transparency.communityBody':
+    'The {category} Impact Score definition is public on GitHub. Share your feedback or suggest adjustments.',
+  'category.ecoscorePage.sections.transparency.communityCta': 'View the configuration',
+  'category.ecoscorePage.sections.transparency.communityIssues': 'Open an issue',
+  'category.ecoscorePage.sections.transparency.intro': 'Nudger is built as an open project:',
+  'category.ecoscorePage.sections.transparency.connector': 'and',
+  'category.ecoscorePage.sections.transparency.openSourceLink': 'open-source',
+  'category.ecoscorePage.sections.transparency.openDataLink': 'open-data',
+  'category.ecoscorePage.sections.transparency.introSuffix':
+    'to guarantee traceability for the {category} scoring methodology.',
+  'category.ecoscorePage.sections.transparency.tableTitle': 'Coefficient summary',
+  'category.ecoscorePage.sections.transparency.tableHelper':
+    'Comparison between the AI-generated proposal and the coefficients currently applied.',
+  'category.ecoscorePage.sections.transparency.tableFallback': 'Detailed coefficients will be published soon.',
+  'category.ecoscorePage.sections.transparency.tableHeaders.name': 'Criterion name',
+  'category.ecoscorePage.sections.transparency.tableHeaders.proposed': 'Proposed coef.',
+  'category.ecoscorePage.sections.transparency.tableHeaders.applied': 'Applied coef.',
+  'category.ecoscorePage.sections.aiAudit.eyebrow': 'AI audit',
+  'category.ecoscorePage.sections.aiAudit.title': 'Impact Score generation audit',
+  'category.ecoscorePage.sections.aiAudit.intro':
+    'Audit the prompts and responses used to configure the {category} Impact Score.',
+  'category.ecoscorePage.sections.aiAudit.promptTitle': 'YAML generation prompt',
+  'category.ecoscorePage.sections.aiAudit.promptHelper':
+    'Instructions sent to the model to produce the configuration.',
+  'category.ecoscorePage.sections.aiAudit.responseTitle': 'Model response',
+  'category.ecoscorePage.sections.aiAudit.responseHelper':
+    'JSON output from the AI used as the basis of the configuration.',
+  'category.ecoscorePage.sections.aiAudit.yamlUnavailable': 'Prompt unavailable.',
+  'category.ecoscorePage.sections.aiAudit.jsonUnavailable': 'AI response unavailable.',
+  'category.ecoscorePage.seo.title': 'Impact Score for {category}',
+  'category.ecoscorePage.seo.description': 'Impact Score insights for {category}.',
+}
+
+const translate = (key: string, params: Record<string, unknown> = {}) => {
+  const template = messages[key] ?? key
+  return template.replace(/\{(\w+)\}/g, (_, match) => String(params[match] ?? ''))
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params: Record<string, unknown> = {}) => translate(key, params),
+    locale: localeRef,
+  }),
+}))
+
+const route = { params: { categorySlug: 'televisions' }, fullPath: '/televisions/ecoscore' }
+
+mockNuxtImport('useRoute', () => () => route)
+mockNuxtImport('useRequestURL', () => () => new URL('https://example.com/televisions/ecoscore'))
+mockNuxtImport('useSeoMeta', () => useSeoMetaMock)
+mockNuxtImport('createError', () => (input: { statusMessage?: string } & Record<string, unknown>) => {
+  const error = new Error(input?.statusMessage ?? 'Error')
+  Object.assign(error, input)
+  return error
+})
+
+vi.mock('vuetify', () => ({
+  useDisplay: () => ({ mdAndDown }),
+}))
+
+vi.mock('~/components/category/CategoryHero.vue', () => ({
+  default: defineComponent({
+    name: 'CategoryHeroStub',
+    props: {
+      breadcrumbs: { type: Array, default: () => [] },
+      title: { type: String, default: '' },
+      description: { type: String, default: '' },
+      image: { type: String, default: '' },
+      eyebrow: { type: String, default: '' },
+    },
+    setup(props) {
+      return () =>
+        h('header', { class: 'category-hero-stub' }, [
+          h(
+            'div',
+            { 'data-test': 'hero-breadcrumbs' },
+            (props.breadcrumbs as Array<{ title?: string }>).map((item) => item.title ?? '').join(' / '),
+          ),
+          h('h1', { class: 'category-hero-stub__title' }, props.title),
+        ])
+    },
+  }),
+}))
+
+vi.mock('~/components/shared/ui/StickySectionNavigation.vue', () => ({
+  default: defineComponent({
+    name: 'StickySectionNavigationStub',
+    props: {
+      sections: { type: Array as () => Array<{ id: string; label: string }>, default: () => [] },
+    },
+    emits: ['navigate'],
+    setup(props, { emit }) {
+      return () =>
+        h(
+          'nav',
+          { class: 'sticky-nav-stub', 'data-test': 'sticky-nav' },
+          (props.sections as Array<{ id: string; label: string }>).map((section) =>
+            h(
+              'button',
+              {
+                type: 'button',
+                class: 'sticky-nav-stub__item',
+                'data-section-id': section.id,
+                onClick: () => emit('navigate', section.id),
+              },
+              section.label,
+            ),
+          ),
+        )
+    },
+  }),
+}))
+
+vi.mock('~/components/domains/content/TextContent.vue', () => ({
+  default: defineComponent({
+    name: 'TextContentStub',
+    props: {
+      blocId: { type: String, default: '' },
+    },
+    setup(props) {
+      return () => h('div', { class: 'text-content-stub' }, `content:${props.blocId}`)
+    },
+  }),
+}))
+
+vi.mock('~/composables/categories/useCategories', () => ({
+  useCategories: () => ({ selectCategoryBySlug: selectCategoryBySlugMock }),
+}))
+
+const categoryFixture = {
+  id: 'tv',
+  verticalHomeTitle: 'Televisions',
+  verticalMetaTitle: 'TV',
+  verticalHomeDescription: 'Find eco responsible televisions.',
+  verticalMetaDescription: 'Eco score methodology for televisions.',
+  imageMedium: 'https://example.com/images/tv-medium.jpg',
+  breadCrumb: [{ title: 'Electronics', link: '/electronics' }],
+  impactScoreConfig: {
+    criteriasPonderation: {
+      POWER: 0.3,
+      REPAIRABILITY: 0.2,
+    },
+    texts: {
+      purpose: 'Purpose text for televisions.',
+      availlableDatas: 'Available data text.',
+      criticalReview: 'Critical review text.',
+      criteriasAnalysis: {
+        POWER: 'Power analysis.',
+        REPAIRABILITY: 'Repairability analysis.',
+      },
+    },
+    yamlPrompt: 'key: value',
+    aiJsonResponse: JSON.stringify({
+      criteriasPonderation: {
+        POWER: 0.35,
+        REPAIRABILITY: 0.25,
+      },
+    }),
+  },
+  availableImpactScoreCriterias: {
+    POWER: { key: 'POWER', title: 'Energy', description: 'Energy consumption.' },
+    REPAIRABILITY: { key: 'REPAIRABILITY', title: 'Repairability', description: 'Repair score.' },
+  },
+  attributesConfig: {
+    configs: [
+      { key: 'POWER', name: 'Energy efficiency', icon: 'mdi-flash' },
+      { key: 'REPAIRABILITY', name: 'Repairability index', icon: 'mdi-tools' },
+    ],
+  },
+} as unknown as VerticalConfigFullDto
+
+const vuetifyStubs = {
+  NuxtLink: defineComponent({
+    name: 'NuxtLinkStub',
+    props: { to: { type: [String, Object], default: undefined } },
+    setup(_props, { slots }) {
+      return () => h('a', { class: 'nuxt-link-stub' }, slots.default?.())
+    },
+  }),
+  'v-container': defineComponent({
+    name: 'VContainerStub',
+    setup(_props, { slots, attrs }) {
+      return () => h('div', { class: 'v-container-stub', ...attrs }, slots.default?.())
+    },
+  }),
+  'v-row': { template: '<div class="v-row-stub"><slot /></div>' },
+  'v-col': { template: '<div class="v-col-stub"><slot /></div>' },
+  'v-sheet': { template: '<div class="v-sheet-stub"><slot /></div>' },
+  'v-card': { template: '<div class="v-card-stub"><slot /></div>' },
+  'v-card-text': { template: '<div class="v-card-text-stub"><slot /></div>' },
+  'v-card-title': { template: '<div class="v-card-title-stub"><slot /></div>' },
+  'v-btn': defineComponent({
+    name: 'VBtnStub',
+    setup(_props, { slots, attrs }) {
+      return () => h('button', { class: 'v-btn-stub', type: 'button', ...attrs }, slots.default?.())
+    },
+  }),
+  'v-icon': { template: '<i class="v-icon-stub"><slot /></i>' },
+  'v-img': defineComponent({
+    name: 'VImgStub',
+    props: { src: { type: String, default: '' }, alt: { type: String, default: '' } },
+    setup(props) {
+      return () => h('img', { class: 'v-img-stub', src: props.src, alt: props.alt })
+    },
+  }),
+  'v-table': defineComponent({
+    name: 'VTableStub',
+    setup(_props, { slots, attrs }) {
+      return () => h('table', { class: 'v-table-stub', ...attrs }, slots.default?.())
+    },
+  }),
+  'v-divider': { template: '<hr class="v-divider-stub" />' },
+  'v-skeleton-loader': { template: '<div class="v-skeleton-loader-stub" />' },
+}
+
+const mountPage = async () => {
+  const component = (await import('./ecoscore.vue')).default
+  return mountSuspended(component, {
+    global: {
+      stubs: vuetifyStubs,
+    },
+  })
+}
+
+beforeAll(() => {
+  class MockIntersectionObserver {
+    callback: IntersectionObserverCallback
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-expect-error override for test environment
+  globalThis.IntersectionObserver = MockIntersectionObserver
+})
+
+beforeEach(() => {
+  mdAndDown.value = false
+  localeRef.value = 'en-US'
+  selectCategoryBySlugMock.mockClear()
+  selectCategoryBySlugMock.mockImplementation(async () => categoryFixture)
+  useSeoMetaMock.mockClear()
+  // @ts-expect-error jsdom window
+  window.scrollTo = vi.fn()
+})
+
+describe('Category ecosystem Impact Score page', () => {
+  it('renders navigation and category-specific sections', async () => {
+    const wrapper = await mountPage()
+    await flushPromises()
+
+    expect(selectCategoryBySlugMock).toHaveBeenCalledWith('televisions')
+
+    const breadcrumbText = wrapper.get('[data-test="hero-breadcrumbs"]').text()
+    expect(breadcrumbText).toContain('impactscore')
+
+    const navItems = wrapper.findAll('.sticky-nav-stub__item')
+    expect(navItems).toHaveLength(5)
+    expect(navItems.map((item) => item.text())).toEqual([
+      'Overview',
+      'Purpose & data',
+      'Criteria',
+      'Transparency',
+      'AI audit',
+    ])
+
+    const criteriaCards = wrapper.findAll('[data-test="impact-criteria-card"]')
+    expect(criteriaCards).toHaveLength(2)
+    expect(criteriaCards[0].text()).toContain('Energy efficiency')
+    expect(criteriaCards[0].text()).toContain('30%')
+
+    const yamlBlock = wrapper.get('[data-test="ai-yaml"]').text()
+    expect(yamlBlock).toContain('key: value')
+
+    const jsonBlock = wrapper.get('[data-test="ai-json"]').text()
+    expect(jsonBlock).toContain('"POWER"')
+    expect(jsonBlock).toContain('0.35')
+
+    const table = wrapper.get('[data-test="comparison-table"]').text()
+    expect(table).toContain('Energy efficiency')
+    expect(table).toContain('0.30')
+    expect(table).toContain('0.35')
+  })
+
+  it('scrolls smoothly to the requested section via sticky navigation', async () => {
+    const wrapper = await mountPage()
+    await flushPromises()
+
+    const scrollSpy = vi.spyOn(window, 'scrollTo')
+    const originalGetElementById = document.getElementById.bind(document)
+    vi.spyOn(document, 'getElementById').mockImplementation((id: string) => {
+      return originalGetElementById(id) ?? (wrapper.element.querySelector(`#${id}`) as HTMLElement | null)
+    })
+
+    const navItems = wrapper.findAll('.sticky-nav-stub__item')
+    await navItems[1].trigger('click')
+
+    expect(scrollSpy).toHaveBeenCalled()
+    const [firstCall] = scrollSpy.mock.calls
+    expect(firstCall?.[0]).toMatchObject({ behavior: 'smooth' })
+  })
+})

--- a/frontend/app/pages/[categorySlug]/ecoscore.vue
+++ b/frontend/app/pages/[categorySlug]/ecoscore.vue
@@ -1,24 +1,409 @@
 <template>
-  <div class="category-ecoscore">
+  <div class="category-ecoscore" data-test="category-ecoscore">
     <CategoryHero
       v-if="category"
       :title="heroTitle"
       :description="heroDescription"
       :image="heroImage"
-      :breadcrumbs="category.breadCrumb ?? []"
+      :breadcrumbs="heroBreadcrumbs"
       :eyebrow="category.verticalMetaTitle"
     />
 
-    <v-container v-if="category" fluid class="py-6 category-ecoscore__container">
-      <v-card class="category-ecoscore__card" rounded="xl" elevation="1">
-        <v-card-title class="category-ecoscore__card-title">
-          {{ placeholderTitle }}
-        </v-card-title>
-        <v-card-text class="category-ecoscore__card-description">
-          {{ placeholderDescription }}
-        </v-card-text>
-      </v-card>
-    </v-container>
+    <div v-if="category" class="category-ecoscore__content">
+      <v-container fluid class="py-10">
+        <div class="category-ecoscore__layout">
+          <aside
+            class="category-ecoscore__nav"
+            :class="{ 'category-ecoscore__nav--mobile': orientation === 'horizontal' }"
+            :aria-label="navAriaLabel"
+          >
+            <StickySectionNavigation
+              data-test="sticky-navigation"
+              :sections="navigationSections"
+              :active-section="activeSection"
+              :orientation="orientation"
+              :aria-label="navAriaLabel"
+              @navigate="scrollToSection"
+            />
+          </aside>
+
+          <main class="category-ecoscore__sections" role="main">
+            <section
+              :id="sectionIds.overview"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.overview}-title`"
+            >
+              <v-sheet class="category-ecoscore__surface" elevation="0" rounded="xl">
+                <header class="category-ecoscore__header">
+                  <span class="category-ecoscore__eyebrow">
+                    {{ t('category.ecoscorePage.sections.overview.eyebrow') }}
+                  </span>
+                  <h2 :id="`${sectionIds.overview}-title`" class="category-ecoscore__title">
+                    {{ t('category.ecoscorePage.sections.overview.title', { category: categoryLabel }) }}
+                  </h2>
+                </header>
+
+                <div class="category-ecoscore__text-block">
+                  <TextContent
+                    class="category-ecoscore__wiki"
+                    bloc-id="pages:impactscore-vertical-jumbotron"
+                    :ipsum-length="220"
+                  />
+                </div>
+
+                <v-card
+                  class="category-ecoscore__intro-card"
+                  elevation="1"
+                  rounded="xl"
+                  variant="elevated"
+                >
+                  <v-row align="stretch" class="ga-4" justify="center">
+                    <v-col cols="12" md="7" class="d-flex flex-column justify-center">
+                      <div class="category-ecoscore__intro-copy">
+                        <p class="category-ecoscore__intro-eyebrow">
+                          {{ t('category.ecoscorePage.sections.overview.card.subtitle', { category: categoryLabel }) }}
+                        </p>
+                        <h3 class="category-ecoscore__intro-title">
+                          {{ t('category.ecoscorePage.sections.overview.card.title') }}
+                        </h3>
+                        <p class="category-ecoscore__intro-description">
+                          {{ t('category.ecoscorePage.sections.overview.card.description', { category: categoryLabel }) }}
+                        </p>
+                        <v-btn
+                          class="category-ecoscore__intro-cta"
+                          color="primary"
+                          size="large"
+                          variant="flat"
+                          :to="{ path: '/impact-score' }"
+                          :aria-label="t('category.ecoscorePage.sections.overview.card.aria')"
+                        >
+                          <v-icon class="me-2" icon="mdi-compass-outline" size="20" />
+                          {{ t('category.ecoscorePage.sections.overview.card.cta') }}
+                        </v-btn>
+                      </div>
+                    </v-col>
+                    <v-col cols="12" md="5" class="d-flex justify-center">
+                      <v-img
+                        v-if="overviewIllustration"
+                        :src="overviewIllustration"
+                        :alt="t('category.ecoscorePage.sections.overview.card.imageAlt', { category: categoryLabel })"
+                        class="category-ecoscore__intro-image"
+                        cover
+                      />
+                    </v-col>
+                  </v-row>
+                </v-card>
+              </v-sheet>
+            </section>
+
+            <section
+              :id="sectionIds.purpose"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.purpose}-title`"
+            >
+              <v-sheet class="category-ecoscore__surface" elevation="0" rounded="xl">
+                <header class="category-ecoscore__header">
+                  <span class="category-ecoscore__eyebrow">
+                    {{ t('category.ecoscorePage.sections.purpose.eyebrow') }}
+                  </span>
+                  <h2 :id="`${sectionIds.purpose}-title`" class="category-ecoscore__title">
+                    {{ t('category.ecoscorePage.sections.purpose.title', { category: categoryLabel }) }}
+                  </h2>
+                </header>
+
+                <v-row class="category-ecoscore__purpose-grid" align="stretch" justify="center">
+                  <v-col cols="12" md="6">
+                    <v-card class="category-ecoscore__info-card" elevation="0" rounded="xl">
+                      <h3 class="category-ecoscore__info-title">
+                        {{ t('category.ecoscorePage.sections.purpose.objectiveTitle') }}
+                      </h3>
+                      <p class="category-ecoscore__info-body">
+                        {{ purposeText ?? t('category.ecoscorePage.sections.purpose.objectiveFallback') }}
+                      </p>
+                    </v-card>
+                  </v-col>
+
+                  <v-col cols="12" md="6">
+                    <v-card class="category-ecoscore__info-card" elevation="0" rounded="xl">
+                      <h3 class="category-ecoscore__info-title">
+                        {{ t('category.ecoscorePage.sections.purpose.dataTitle') }}
+                      </h3>
+                      <p class="category-ecoscore__info-body">
+                        {{ availableDataText ?? t('category.ecoscorePage.sections.purpose.dataFallback') }}
+                      </p>
+
+                      <v-divider class="my-4" role="presentation" />
+
+                      <ul class="category-ecoscore__data-list">
+                        <li
+                          v-for="criterion in availableCriteria"
+                          :key="criterion.key"
+                          class="category-ecoscore__data-item"
+                        >
+                          <strong>{{ criterion.label }}</strong>
+                          <span class="category-ecoscore__data-description">{{ criterion.description }}</span>
+                        </li>
+                      </ul>
+                    </v-card>
+                  </v-col>
+                </v-row>
+              </v-sheet>
+            </section>
+
+            <section
+              :id="sectionIds.criteria"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.criteria}-title`"
+            >
+              <v-sheet class="category-ecoscore__surface" elevation="0" rounded="xl">
+                <header class="category-ecoscore__header">
+                  <span class="category-ecoscore__eyebrow">
+                    {{ t('category.ecoscorePage.sections.criteria.eyebrow') }}
+                  </span>
+                  <h2 :id="`${sectionIds.criteria}-title`" class="category-ecoscore__title">
+                    {{ t('category.ecoscorePage.sections.criteria.title', { category: categoryLabel }) }}
+                  </h2>
+                </header>
+
+                <div class="category-ecoscore__text-block">
+                  <TextContent
+                    class="category-ecoscore__wiki"
+                    bloc-id="pages:impactscore-vertical-criterias"
+                    :ipsum-length="240"
+                  />
+                </div>
+
+                <v-row v-if="criteriaCards.length" class="category-ecoscore__criteria-grid" dense>
+                  <v-col
+                    v-for="criterion in criteriaCards"
+                    :key="criterion.key"
+                    cols="12"
+                    md="6"
+                    lg="4"
+                  >
+                    <article class="category-ecoscore__criteria-card" data-test="impact-criteria-card">
+                      <div class="category-ecoscore__criteria-icon" aria-hidden="true">
+                        <v-icon v-if="criterion.icon" :icon="criterion.icon" size="26" />
+                        <span v-else>{{ criterion.fallback }}</span>
+                      </div>
+                      <div class="category-ecoscore__criteria-content">
+                        <h3 class="category-ecoscore__criteria-title">{{ criterion.label }}</h3>
+                        <p v-if="criterion.description" class="category-ecoscore__criteria-description">
+                          {{ criterion.description }}
+                        </p>
+                        <p v-if="criterion.coefficient !== null" class="category-ecoscore__criteria-coefficient">
+                          {{ formatPercentage(criterion.coefficient) }}
+                        </p>
+                      </div>
+                    </article>
+                  </v-col>
+                </v-row>
+
+                <p v-else class="category-ecoscore__empty">
+                  {{ t('category.ecoscorePage.sections.criteria.empty') }}
+                </p>
+              </v-sheet>
+            </section>
+
+            <section
+              :id="sectionIds.transparency"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.transparency}-title`"
+            >
+              <v-sheet class="category-ecoscore__surface" elevation="0" rounded="xl">
+                <header class="category-ecoscore__header">
+                  <span class="category-ecoscore__eyebrow">
+                    {{ t('category.ecoscorePage.sections.transparency.eyebrow') }}
+                  </span>
+                  <h2 :id="`${sectionIds.transparency}-title`" class="category-ecoscore__title">
+                    {{ t('category.ecoscorePage.sections.transparency.title') }}
+                  </h2>
+                </header>
+
+                <v-row class="category-ecoscore__critical-grid" align="stretch">
+                  <v-col cols="12" lg="8">
+                    <v-card class="category-ecoscore__critical-card" elevation="0" rounded="xl">
+                      <div class="category-ecoscore__critical-media">
+                        <v-img
+                          :src="transparencyIllustration"
+                          alt=""
+                          class="category-ecoscore__critical-image"
+                          cover
+                        />
+                      </div>
+                      <div class="category-ecoscore__critical-body">
+                        <h3 class="category-ecoscore__critical-title">
+                          {{ t('category.ecoscorePage.sections.transparency.criticalReviewTitle') }}
+                        </h3>
+                        <p class="category-ecoscore__critical-text">
+                          {{ criticalReviewText ?? t('category.ecoscorePage.sections.transparency.criticalReviewFallback') }}
+                        </p>
+                      </div>
+                    </v-card>
+                  </v-col>
+
+                  <v-col cols="12" lg="4">
+                    <v-card class="category-ecoscore__community-card" elevation="0" rounded="xl">
+                      <h3 class="category-ecoscore__community-title">
+                        {{ t('category.ecoscorePage.sections.transparency.communityTitle') }}
+                      </h3>
+                      <p class="category-ecoscore__community-text">
+                        {{ t('category.ecoscorePage.sections.transparency.communityBody', { category: categoryLabel }) }}
+                      </p>
+                      <div class="category-ecoscore__community-actions">
+                        <v-btn
+                          v-if="githubConfigUrl"
+                          class="mb-2"
+                          color="primary"
+                          variant="tonal"
+                          :href="githubConfigUrl"
+                          rel="noopener"
+                          target="_blank"
+                        >
+                          <v-icon class="me-2" icon="mdi-github" size="18" />
+                          {{ t('category.ecoscorePage.sections.transparency.communityCta') }}
+                        </v-btn>
+                        <v-btn
+                          color="secondary"
+                          variant="text"
+                          href="https://github.com/open4good/open4goods/issues/new"
+                          rel="noopener"
+                          target="_blank"
+                        >
+                          {{ t('category.ecoscorePage.sections.transparency.communityIssues') }}
+                        </v-btn>
+                      </div>
+                    </v-card>
+                  </v-col>
+                </v-row>
+
+                <div class="category-ecoscore__transparency-intro">
+                  <p class="category-ecoscore__transparency-text">
+                    {{ t('category.ecoscorePage.sections.transparency.intro') }}
+                    <NuxtLink to="/opensource" class="category-ecoscore__inline-link">
+                      {{ t('category.ecoscorePage.sections.transparency.openSourceLink') }}
+                    </NuxtLink>
+                    {{ t('category.ecoscorePage.sections.transparency.connector') }}
+                    <NuxtLink to="/opendata" class="category-ecoscore__inline-link">
+                      {{ t('category.ecoscorePage.sections.transparency.openDataLink') }}
+                    </NuxtLink>
+                    {{ t('category.ecoscorePage.sections.transparency.introSuffix', { category: categoryLabel }) }}
+                  </p>
+                </div>
+
+                <div class="category-ecoscore__table-wrapper">
+                  <h3 class="category-ecoscore__table-title">
+                    {{ t('category.ecoscorePage.sections.transparency.tableTitle') }}
+                  </h3>
+                  <p :id="`${sectionIds.transparency}-table-helper`" class="category-ecoscore__table-helper">
+                    {{ t('category.ecoscorePage.sections.transparency.tableHelper') }}
+                  </p>
+
+                  <v-table
+                    v-if="coefficientComparison.length"
+                    class="category-ecoscore__table"
+                    density="comfortable"
+                    :aria-describedby="`${sectionIds.transparency}-table-helper`"
+                    data-test="comparison-table"
+                  >
+                    <thead>
+                      <tr>
+                        <th scope="col" class="text-left">
+                          {{ t('category.ecoscorePage.sections.transparency.tableHeaders.name') }}
+                        </th>
+                        <th scope="col" class="text-left">
+                          {{ t('category.ecoscorePage.sections.transparency.tableHeaders.proposed') }}
+                        </th>
+                        <th scope="col" class="text-left">
+                          {{ t('category.ecoscorePage.sections.transparency.tableHeaders.applied') }}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="row in coefficientComparison" :key="row.key">
+                        <th scope="row">{{ row.label }}</th>
+                        <td>{{ formatDecimal(row.proposed) }}</td>
+                        <td>{{ formatDecimal(row.applied) }}</td>
+                      </tr>
+                    </tbody>
+                  </v-table>
+
+                  <p v-else class="category-ecoscore__empty">
+                    {{ t('category.ecoscorePage.sections.transparency.tableFallback') }}
+                  </p>
+                </div>
+              </v-sheet>
+            </section>
+
+            <section
+              :id="sectionIds.aiAudit"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.aiAudit}-title`"
+            >
+              <v-sheet class="category-ecoscore__surface" elevation="0" rounded="xl">
+                <header class="category-ecoscore__header">
+                  <span class="category-ecoscore__eyebrow">
+                    {{ t('category.ecoscorePage.sections.aiAudit.eyebrow') }}
+                  </span>
+                  <h2 :id="`${sectionIds.aiAudit}-title`" class="category-ecoscore__title">
+                    {{ t('category.ecoscorePage.sections.aiAudit.title') }}
+                  </h2>
+                </header>
+
+                <p class="category-ecoscore__ai-helper">
+                  {{ t('category.ecoscorePage.sections.aiAudit.intro', { category: categoryLabel }) }}
+                </p>
+
+                <v-row class="category-ecoscore__ai-grid" align="stretch">
+                  <v-col cols="12" lg="6">
+                    <v-card class="category-ecoscore__code-card" elevation="0" rounded="xl">
+                      <h3 class="category-ecoscore__code-title">
+                        {{ t('category.ecoscorePage.sections.aiAudit.promptTitle') }}
+                      </h3>
+                      <p class="category-ecoscore__code-helper">
+                        {{ t('category.ecoscorePage.sections.aiAudit.promptHelper') }}
+                      </p>
+                      <pre
+                        class="category-ecoscore__code-block"
+                        data-test="ai-yaml"
+                        role="region"
+                        aria-live="polite"
+                      >
+{{ formattedYamlPrompt ?? t('category.ecoscorePage.sections.aiAudit.yamlUnavailable') }}
+                      </pre>
+                    </v-card>
+                  </v-col>
+
+                  <v-col cols="12" lg="6">
+                    <v-card class="category-ecoscore__code-card" elevation="0" rounded="xl">
+                      <h3 class="category-ecoscore__code-title">
+                        {{ t('category.ecoscorePage.sections.aiAudit.responseTitle') }}
+                      </h3>
+                      <p class="category-ecoscore__code-helper">
+                        {{ t('category.ecoscorePage.sections.aiAudit.responseHelper') }}
+                      </p>
+                      <pre
+                        class="category-ecoscore__code-block"
+                        data-test="ai-json"
+                        role="region"
+                        aria-live="polite"
+                      >
+{{ formattedAiJson ?? t('category.ecoscorePage.sections.aiAudit.jsonUnavailable') }}
+                      </pre>
+                    </v-card>
+                  </v-col>
+                </v-row>
+              </v-sheet>
+            </section>
+          </main>
+        </div>
+      </v-container>
+    </div>
 
     <v-container v-else fluid class="py-10">
       <v-skeleton-loader type="image, article" />
@@ -27,14 +412,26 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useDisplay } from 'vuetify'
+import { useI18n } from 'vue-i18n'
+import type {
+  AttributeConfigDto,
+  CategoryBreadcrumbItemDto,
+  ImpactScoreCriteriaDto,
+  ImpactScoreConfigDto,
+  VerticalConfigFullDto,
+} from '~~/shared/api-client'
 import CategoryHero from '~/components/category/CategoryHero.vue'
+import TextContent from '~/components/domains/content/TextContent.vue'
+import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
+import { createError, useRequestURL, useRoute, useSeoMeta } from '#imports'
 import { useCategories } from '~/composables/categories/useCategories'
-import type { VerticalConfigFullDto } from '~~/shared/api-client'
 
 const route = useRoute()
 const requestURL = useRequestURL()
 const { t, locale } = useI18n()
+const display = useDisplay()
 
 const categorySlug = computed(() => String(route.params.categorySlug ?? ''))
 
@@ -76,27 +473,320 @@ const heroImage = computed(() => {
 const categoryLabel = computed(
   () => category.value?.verticalHomeTitle ?? category.value?.verticalMetaTitle ?? siteName.value,
 )
-const ecoscoreLabel = computed(() => t('siteIdentity.footer.highlightLinks.ecoscore'))
-const placeholderTitle = computed(() =>
-  t('category.ecoscorePage.title', {
-    category: categoryLabel.value,
-    label: ecoscoreLabel.value,
-  }),
-)
-const placeholderDescription = computed(() =>
-  t('category.ecoscorePage.description', {
-    category: categoryLabel.value,
-  }),
+
+const heroBreadcrumbs = computed<CategoryBreadcrumbItemDto[]>(() => {
+  const base = (category.value?.breadCrumb ?? []).map((item) => ({ ...item }))
+  const leafTitle = t('category.ecoscorePage.breadcrumbLeaf')
+
+  return leafTitle ? [...base, { title: leafTitle }] : base
+})
+
+const impactScoreConfig = computed<ImpactScoreConfigDto | null>(
+  () => category.value?.impactScoreConfig ?? null,
 )
 
+const impactScoreTexts = computed(() => impactScoreConfig.value?.texts ?? {})
+
+const purposeText = computed(() => impactScoreTexts.value?.purpose?.trim() || null)
+const availableDataText = computed(() => impactScoreTexts.value?.availlableDatas?.trim() || null)
+const criticalReviewText = computed(() => impactScoreTexts.value?.criticalReview?.trim() || null)
+
+const availableImpactScoreCriterias = computed<Record<string, ImpactScoreCriteriaDto>>(
+  () => category.value?.availableImpactScoreCriterias ?? {},
+)
+
+const attributeConfigs = computed<AttributeConfigDto[]>(
+  () => category.value?.attributesConfig?.configs ?? [],
+)
+
+const attributeMap = computed(() => {
+  return attributeConfigs.value.reduce((map, attribute) => {
+    if (attribute.key) {
+      map.set(attribute.key, attribute)
+    }
+    return map
+  }, new Map<string, AttributeConfigDto>())
+})
+
+const availableCriteria = computed(() => {
+  return Object.entries(availableImpactScoreCriterias.value).map(([key, criterion]) => {
+    const attribute = attributeMap.value.get(key)
+    return {
+      key,
+      label: attribute?.name ?? criterion.title ?? key,
+      description: criterion.description ?? '',
+    }
+  })
+})
+
+const criteriaCards = computed(() => {
+  const weights = impactScoreConfig.value?.criteriasPonderation ?? {}
+  const analysis = impactScoreTexts.value?.criteriasAnalysis ?? {}
+  const available = availableImpactScoreCriterias.value
+  const keys = new Set<string>([
+    ...Object.keys(weights),
+    ...Object.keys(analysis),
+    ...Object.keys(available ?? {}),
+  ])
+
+  return Array.from(keys).map((key) => {
+    const attribute = attributeMap.value.get(key)
+    const fallbackTitle = available?.[key]?.title ?? key
+    const description = analysis?.[key]?.trim() || available?.[key]?.description || ''
+    const coefficient = typeof weights?.[key] === 'number' ? Number(weights?.[key]) : null
+
+    return {
+      key,
+      label: attribute?.name ?? fallbackTitle,
+      description,
+      coefficient,
+      icon: attribute?.icon ?? null,
+      fallback: fallbackTitle.charAt(0).toUpperCase(),
+    }
+  })
+})
+
+const overviewIllustration = computed(() => {
+  if (!category.value?.id) {
+    return heroImage.value
+  }
+  return `/images/verticals/${category.value.id}.jpg`
+})
+
+const transparencyIllustration = computed(() => '/icons/categories/ecoscore/revue_critique.jpg')
+
+const rawYamlPrompt = computed(() => impactScoreConfig.value?.yamlPrompt?.trim() || '')
+const formattedYamlPrompt = computed(() => (rawYamlPrompt.value.length ? rawYamlPrompt.value : null))
+
+const rawAiJson = computed(() => impactScoreConfig.value?.aiJsonResponse?.trim() || '')
+const parsedAiJson = computed<Record<string, unknown> | null>(() => {
+  if (!rawAiJson.value.length) {
+    return null
+  }
+
+  try {
+    return JSON.parse(rawAiJson.value)
+  } catch (error) {
+    console.warn('Unable to parse AI JSON response for impact score', error)
+    return null
+  }
+})
+
+const formattedAiJson = computed(() => {
+  if (parsedAiJson.value) {
+    return JSON.stringify(parsedAiJson.value, null, 2)
+  }
+  return rawAiJson.value.length ? rawAiJson.value : null
+})
+
+const aiCoefficients = computed<Record<string, number>>(() => {
+  const response = parsedAiJson.value
+  if (!response || typeof response !== 'object') {
+    return {}
+  }
+
+  const coefficients = (response as Record<string, unknown>)?.criteriasPonderation
+  if (coefficients && typeof coefficients === 'object') {
+    return Object.fromEntries(
+      Object.entries(coefficients as Record<string, unknown>).filter(([, value]) => typeof value === 'number'),
+    )
+  }
+
+  return {}
+})
+
+const coefficientComparison = computed(() => {
+  const applied = impactScoreConfig.value?.criteriasPonderation ?? {}
+  const proposed = aiCoefficients.value ?? {}
+  const available = availableImpactScoreCriterias.value
+  const keys = new Set<string>([
+    ...Object.keys(applied ?? {}),
+    ...Object.keys(proposed ?? {}),
+  ])
+
+  return Array.from(keys).map((key) => {
+    const attribute = attributeMap.value.get(key)
+    const fallbackTitle = available?.[key]?.title ?? key
+    return {
+      key,
+      label: attribute?.name ?? fallbackTitle,
+      proposed: typeof proposed?.[key] === 'number' ? Number(proposed?.[key]) : null,
+      applied: typeof applied?.[key] === 'number' ? Number(applied?.[key]) : null,
+    }
+  })
+})
+
+const navAriaLabel = computed(() => t('category.ecoscorePage.navigation.ariaLabel'))
+
+const sectionIds = {
+  overview: 'category-impact-overview',
+  purpose: 'category-impact-purpose',
+  criteria: 'category-impact-criteria',
+  transparency: 'category-impact-transparency',
+  aiAudit: 'category-impact-ai-audit',
+} as const
+
+type SectionId = (typeof sectionIds)[keyof typeof sectionIds]
+
+const navigationSections = computed(() => [
+  {
+    id: sectionIds.overview as SectionId,
+    label: t('category.ecoscorePage.navigation.overview'),
+    icon: 'mdi-information-outline',
+  },
+  {
+    id: sectionIds.purpose as SectionId,
+    label: t('category.ecoscorePage.navigation.purpose'),
+    icon: 'mdi-bullseye-arrow',
+  },
+  {
+    id: sectionIds.criteria as SectionId,
+    label: t('category.ecoscorePage.navigation.criteria'),
+    icon: 'mdi-format-list-bulleted',
+  },
+  {
+    id: sectionIds.transparency as SectionId,
+    label: t('category.ecoscorePage.navigation.transparency'),
+    icon: 'mdi-shield-check-outline',
+  },
+  {
+    id: sectionIds.aiAudit as SectionId,
+    label: t('category.ecoscorePage.navigation.aiAudit'),
+    icon: 'mdi-robot-outline',
+  },
+])
+
+const orientation = computed<'vertical' | 'horizontal'>(() => (display.mdAndDown.value ? 'horizontal' : 'vertical'))
+
+const activeSection = ref<SectionId>(sectionIds.overview)
+const observer = ref<IntersectionObserver | null>(null)
+const visibleSectionRatios = new Map<string, number>()
+const MIN_SECTION_RATIO = 0.35
+
+const refreshActiveSection = () => {
+  if (!visibleSectionRatios.size) {
+    activeSection.value = navigationSections.value[0]?.id ?? sectionIds.overview
+    return
+  }
+
+  const sorted = [...visibleSectionRatios.entries()].sort((a, b) => b[1] - a[1])
+  const [nextActive] = sorted.find(([, ratio]) => ratio >= MIN_SECTION_RATIO) ?? sorted[0] ?? []
+
+  if (nextActive) {
+    activeSection.value = nextActive as SectionId
+  }
+}
+
+const observeSections = () => {
+  if (!import.meta.client) {
+    return
+  }
+
+  observer.value?.disconnect()
+  visibleSectionRatios.clear()
+  refreshActiveSection()
+
+  observer.value = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        const ratio = entry.intersectionRatio
+        if (ratio > 0) {
+          visibleSectionRatios.set(entry.target.id, ratio)
+        } else {
+          visibleSectionRatios.delete(entry.target.id)
+        }
+      })
+
+      refreshActiveSection()
+    },
+    {
+      rootMargin: '-15% 0px -35% 0px',
+      threshold: Array.from({ length: 11 }, (_, index) => index / 10),
+    },
+  )
+
+  nextTick(() => {
+    navigationSections.value.forEach((section) => {
+      const element = document.getElementById(section.id)
+      if (element) {
+        observer.value?.observe(element)
+      }
+    })
+  })
+}
+
+onMounted(() => {
+  observeSections()
+})
+
+onBeforeUnmount(() => {
+  observer.value?.disconnect()
+  visibleSectionRatios.clear()
+})
+
+watch(orientation, () => {
+  nextTick(() => {
+    observeSections()
+  })
+})
+
+watch(
+  () => navigationSections.value.map((section) => `${section.id}-${section.label}`).join('|'),
+  () => {
+    nextTick(() => {
+      observeSections()
+    })
+  },
+)
+
+const scrollToSection = (sectionId: string) => {
+  if (!import.meta.client && typeof window === 'undefined') {
+    return
+  }
+
+  const element = document.getElementById(sectionId)
+  if (!element) {
+    return
+  }
+
+  activeSection.value = sectionId as SectionId
+
+  const offset = orientation.value === 'horizontal' ? 96 : 120
+  const top = element.getBoundingClientRect().top + window.scrollY - offset
+  window.scrollTo({ top, behavior: 'smooth' })
+}
+
+const githubConfigUrl = computed(() =>
+  category.value?.id
+    ? `https://github.com/open4good/open4goods/blob/main/verticals/src/main/resources/verticals/${category.value.id}.yml`
+    : null,
+)
+
+function formatPercentage(value: number | null) {
+  if (value == null || Number.isNaN(value)) {
+    return '—'
+  }
+  return `${Math.round(value * 100)}%`
+}
+
+function formatDecimal(value: number | null) {
+  if (value == null || Number.isNaN(value)) {
+    return '—'
+  }
+  return value.toFixed(2)
+}
+
 const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
-const seoTitle = computed(() => placeholderTitle.value)
-const seoDescription = computed(
-  () =>
+const seoTitle = computed(() => t('category.ecoscorePage.seo.title', { category: categoryLabel.value }))
+const seoDescription = computed(() => {
+  return (
+    purposeText.value ??
+    availableDataText.value ??
     category.value?.verticalMetaDescription ??
     category.value?.verticalHomeDescription ??
-    placeholderDescription.value,
-)
+    t('category.ecoscorePage.seo.description', { category: categoryLabel.value })
+  )
+})
 
 const ogImage = computed(() => {
   if (!heroImage.value) {
@@ -131,25 +821,336 @@ useSeoMeta({
   display: flex
   flex-direction: column
   gap: clamp(2rem, 3vw, 3rem)
-  background: rgb(var(--v-theme-surface-default))
+  background: rgb(var(--v-theme-surface-muted))
+  color: rgb(var(--v-theme-text-neutral-strong))
 
-.category-ecoscore__container
+.category-ecoscore__content
+  width: 100%
+
+.category-ecoscore__layout
+  display: grid
+  grid-template-columns: minmax(0, 1fr)
+  gap: clamp(2rem, 4vw, 3rem)
+
+.category-ecoscore__nav
+  position: relative
+
+.category-ecoscore__sections
   display: flex
-  justify-content: center
+  flex-direction: column
+  gap: clamp(2.5rem, 4vw, 3.5rem)
 
-.category-ecoscore__card
-  max-width: min(720px, 100%)
-  margin-inline: auto
-  background: rgb(var(--v-theme-surface-glass))
-  padding: clamp(1.75rem, 3vw, 2.5rem)
-  text-align: center
+.category-ecoscore__section
+  scroll-margin-top: 140px
 
-.category-ecoscore__card-title
-  font-size: clamp(1.5rem, 2.5vw, 2rem)
+.category-ecoscore__surface
+  background: rgb(var(--v-theme-surface-default))
+  padding: clamp(1.5rem, 2.5vw, 2.75rem)
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.1)
+
+.category-ecoscore__header
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+  margin-bottom: clamp(1.5rem, 3vw, 2.5rem)
+
+.category-ecoscore__eyebrow
+  display: inline-flex
+  align-items: center
+  gap: 0.5rem
+  padding: 0.25rem 0.75rem
+  border-radius: 999px
+  background: rgba(var(--v-theme-surface-primary-100), 0.9)
+  color: rgb(var(--v-theme-accent-primary-highlight))
+  font-size: 0.75rem
+  letter-spacing: 0.08em
+  text-transform: uppercase
+
+.category-ecoscore__title
+  margin: 0
+  font-size: clamp(1.65rem, 1.5vw + 1.1rem, 2.25rem)
+  line-height: 1.2
+  font-weight: 700
+
+.category-ecoscore__text-block
+  margin-bottom: clamp(1.5rem, 3vw, 2.5rem)
+
+.category-ecoscore__wiki :deep(.xwiki-sandbox)
+  font-size: 1.02rem
+  line-height: 1.7
+  color: rgba(var(--v-theme-text-neutral-strong), 0.92)
+
+.category-ecoscore__intro-card
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-050), 0.75), rgba(var(--v-theme-surface-glass), 0.95))
+  padding: clamp(1.5rem, 2vw, 2.5rem)
+
+.category-ecoscore__intro-eyebrow
+  font-size: 0.85rem
+  text-transform: uppercase
+  letter-spacing: 0.08em
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+
+.category-ecoscore__intro-title
+  margin: 0.25rem 0
+  font-size: clamp(1.4rem, 1.2vw + 1rem, 1.85rem)
+  font-weight: 700
+
+.category-ecoscore__intro-description
+  margin-bottom: 1.25rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.96)
+
+.category-ecoscore__intro-image
+  max-width: min(320px, 100%)
+  border-radius: 24px
+  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.12)
+
+.category-ecoscore__purpose-grid
+  gap: clamp(1.5rem, 3vw, 2rem)
+
+.category-ecoscore__info-card
+  background: rgba(var(--v-theme-surface-muted), 0.85)
+  padding: clamp(1.25rem, 2vw, 2rem)
+  height: 100%
+
+.category-ecoscore__info-title
+  margin: 0 0 0.75rem
+  font-size: 1.15rem
   font-weight: 600
 
-.category-ecoscore__card-description
-  margin-top: 0.5rem
-  font-size: clamp(1rem, 1.5vw, 1.2rem)
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.96)
+.category-ecoscore__info-body
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  line-height: 1.6
+
+.category-ecoscore__data-list
+  list-style: none
+  display: flex
+  flex-direction: column
+  gap: 0.85rem
+  padding: 0
+  margin: 0
+
+.category-ecoscore__data-item
+  display: flex
+  flex-direction: column
+  gap: 0.35rem
+
+.category-ecoscore__data-description
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+  line-height: 1.5
+
+.category-ecoscore__criteria-grid
+  gap: clamp(1.25rem, 2vw, 2rem)
+
+.category-ecoscore__criteria-card
+  display: flex
+  gap: 1rem
+  background: rgba(var(--v-theme-surface-glass), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12)
+  border-radius: 18px
+  padding: 1.25rem
+  height: 100%
+
+.category-ecoscore__criteria-icon
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  width: 48px
+  height: 48px
+  border-radius: 16px
+  background: rgba(var(--v-theme-surface-primary-100), 0.9)
+  color: rgb(var(--v-theme-accent-primary-highlight))
+  font-weight: 600
+
+.category-ecoscore__criteria-title
+  margin: 0 0 0.5rem
+  font-size: 1.05rem
+  font-weight: 600
+
+.category-ecoscore__criteria-description
+  margin: 0 0 0.5rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  line-height: 1.5
+
+.category-ecoscore__criteria-coefficient
+  margin: 0
+  font-weight: 700
+  color: rgb(var(--v-theme-accent-supporting))
+
+.category-ecoscore__empty
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+  font-style: italic
+
+.category-ecoscore__critical-grid
+  gap: clamp(1.5rem, 3vw, 2rem)
+
+.category-ecoscore__critical-card
+  display: flex
+  flex-direction: row
+  gap: 1.5rem
+  padding: clamp(1.25rem, 2vw, 2rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.1)
+  height: 100%
+
+.category-ecoscore__critical-media
+  flex: 0 0 clamp(140px, 12vw, 180px)
+  border-radius: 18px
+  overflow: hidden
+
+.category-ecoscore__critical-image
+  width: 100%
+  height: 100%
+
+.category-ecoscore__critical-title
+  margin: 0 0 0.75rem
+  font-size: 1.2rem
+  font-weight: 600
+
+.category-ecoscore__critical-text
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  line-height: 1.6
+
+.category-ecoscore__community-card
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  padding: clamp(1.5rem, 2vw, 2rem)
+  background: rgba(var(--v-theme-surface-muted), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12)
+  height: 100%
+
+.category-ecoscore__community-title
+  margin: 0
+  font-size: 1.2rem
+  font-weight: 600
+
+.category-ecoscore__community-text
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  line-height: 1.6
+
+.category-ecoscore__community-actions
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+
+.category-ecoscore__transparency-intro
+  margin-top: clamp(1.5rem, 2.5vw, 2.5rem)
+
+.category-ecoscore__transparency-text
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.92)
+  line-height: 1.6
+
+.category-ecoscore__inline-link
+  color: rgb(var(--v-theme-accent-primary-highlight))
+  text-decoration: underline
+
+.category-ecoscore__table-wrapper
+  margin-top: clamp(1.5rem, 2.5vw, 2.5rem)
+  background: rgba(var(--v-theme-surface-glass), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.08)
+  border-radius: 18px
+  padding: clamp(1.25rem, 2vw, 2rem)
+
+.category-ecoscore__table-title
+  margin: 0 0 0.75rem
+  font-size: 1.1rem
+  font-weight: 600
+
+.category-ecoscore__table-helper
+  margin: 0 0 1rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+
+.category-ecoscore__table :deep(table)
+  width: 100%
+  border-collapse: collapse
+
+.category-ecoscore__table :deep(th),
+.category-ecoscore__table :deep(td)
+  padding: 0.75rem
+  border-bottom: 1px solid rgba(var(--v-theme-border-primary-strong), 0.1)
+
+.category-ecoscore__ai-helper
+  margin: 0 0 1.5rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.88)
+
+.category-ecoscore__ai-grid
+  gap: clamp(1.5rem, 3vw, 2.25rem)
+
+.category-ecoscore__code-card
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  padding: clamp(1.25rem, 2vw, 2rem)
+  background: rgba(var(--v-theme-surface-muted), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12)
+  height: 100%
+
+.category-ecoscore__code-title
+  margin: 0
+  font-size: 1.1rem
+  font-weight: 600
+
+.category-ecoscore__code-helper
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.86)
+
+.category-ecoscore__code-block
+  flex: 1 1 auto
+  margin: 0
+  padding: 1rem
+  border-radius: 12px
+  background: rgba(var(--v-theme-surface-default), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.14)
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace
+  font-size: 0.85rem
+  line-height: 1.6
+  color: rgba(var(--v-theme-text-neutral-strong), 0.92)
+  white-space: pre-wrap
+  word-break: break-word
+  overflow: auto
+
+@media (min-width: 1280px)
+  .category-ecoscore__layout
+    grid-template-columns: 280px minmax(0, 1fr)
+
+  .category-ecoscore__nav
+    position: sticky
+    top: 112px
+
+  .category-ecoscore__section
+    scroll-margin-top: 140px
+
+@media (max-width: 960px)
+  .category-ecoscore__surface
+    padding: clamp(1.25rem, 4vw, 2rem)
+
+  .category-ecoscore__section
+    scroll-margin-top: 88px
+
+  .category-ecoscore__critical-card
+    flex-direction: column
+
+  .category-ecoscore__critical-media
+    width: 100%
+
+  .category-ecoscore__intro-card
+    padding: clamp(1rem, 4vw, 2rem)
+
+  .category-ecoscore__intro-image
+    max-width: 220px
+
+  .category-ecoscore__code-block
+    max-height: 320px
+    font-size: 0.82rem
+
+@media (prefers-reduced-motion: reduce)
+  .category-ecoscore *
+    transition-duration: 0.01ms !important
+    animation-duration: 0.01ms !important
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -118,7 +118,82 @@
     },
     "ecoscorePage": {
       "title": "{category} – {label}",
-      "description": "We are crafting dedicated eco score insights for {category}. Check back soon!"
+      "description": "We are crafting dedicated eco score insights for {category}. Check back soon!",
+      "impactScoreLabel": "Impact Score",
+      "breadcrumbLeaf": "impactscore",
+      "seo": {
+        "title": "{category} – Impact Score breakdown",
+        "description": "Explore how Nudger computes the Impact Score for {category}: criteria, weights and AI generation audit."
+      },
+      "navigation": {
+        "ariaLabel": "Impact Score section navigation",
+        "overview": "Overview",
+        "purpose": "Purpose & data",
+        "criteria": "Criteria",
+        "transparency": "Transparency",
+        "aiAudit": "AI audit"
+      },
+      "sections": {
+        "overview": {
+          "eyebrow": "Introduction",
+          "title": "Impact Score for {category}",
+          "card": {
+            "title": "Nudger Impact Score",
+            "subtitle": "Methodology applied to {category}",
+            "description": "This page details the criteria and weightings used to assess the environmental impact of this category.",
+            "cta": "Understand the global methodology",
+            "aria": "Learn more about the global Impact Score methodology",
+            "imageAlt": "Impact Score illustration for {category}"
+          }
+        },
+        "purpose": {
+          "eyebrow": "Our approach",
+          "title": "Why and how we score {category}",
+          "objectiveTitle": "Objective",
+          "objectiveFallback": "The objective description will be available soon.",
+          "dataTitle": "Available data",
+          "dataFallback": "Detailed data for each criterion will be available soon."
+        },
+        "criteria": {
+          "eyebrow": "Criteria",
+          "title": "Selected criteria and weights",
+          "empty": "Criteria will be published soon."
+        },
+        "transparency": {
+          "eyebrow": "Transparency",
+          "title": "Transparency and traceability",
+          "criticalReviewTitle": "Critical review",
+          "criticalReviewFallback": "The critical review will be shared soon.",
+          "communityTitle": "Join the discussion",
+          "communityBody": "The {category} Impact Score definition is public on GitHub. Share your feedback or suggest adjustments.",
+          "communityCta": "View the configuration",
+          "communityIssues": "Open an issue",
+          "intro": "Nudger is built as an open project:",
+          "connector": "and",
+          "openSourceLink": "open-source",
+          "openDataLink": "open-data",
+          "introSuffix": "to guarantee traceability for the {category} scoring methodology.",
+          "tableTitle": "Coefficient summary",
+          "tableHelper": "Comparison between the AI-generated proposal and the coefficients currently applied.",
+          "tableFallback": "Detailed coefficients will be published soon.",
+          "tableHeaders": {
+            "name": "Criterion name",
+            "proposed": "Proposed coef.",
+            "applied": "Applied coef."
+          }
+        },
+        "aiAudit": {
+          "eyebrow": "AI audit",
+          "title": "Impact Score generation audit",
+          "intro": "Audit the prompts and responses used to configure the {category} Impact Score.",
+          "promptTitle": "YAML generation prompt",
+          "promptHelper": "Instructions sent to the model to produce the configuration.",
+          "responseTitle": "Model response",
+          "responseHelper": "JSON output from the AI used as the basis of the configuration.",
+          "yamlUnavailable": "Prompt unavailable.",
+          "jsonUnavailable": "AI response unavailable."
+        }
+      }
     },
     "fastFilters": {
       "reset": "Clear fast filters",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -117,7 +117,82 @@
     },
     "ecoscorePage": {
       "title": "{category} – {label}",
-      "description": "Nous préparons un contenu dédié au score éco pour {category}. Revenez bientôt !"
+      "description": "Nous préparons un contenu dédié au score éco pour {category}. Revenez bientôt !",
+      "impactScoreLabel": "Impact Score",
+      "breadcrumbLeaf": "impactscore",
+      "seo": {
+        "title": "{category} – Impact Score détaillé",
+        "description": "Découvrez comment Nudger calcule l'Impact Score des {category} : critères, pondérations et audit de génération IA."
+      },
+      "navigation": {
+        "ariaLabel": "Navigation des sections Impact Score",
+        "overview": "Présentation",
+        "purpose": "Objectif & données",
+        "criteria": "Critères retenus",
+        "transparency": "Transparence",
+        "aiAudit": "Audit IA"
+      },
+      "sections": {
+        "overview": {
+          "eyebrow": "Introduction",
+          "title": "Impact Score des {category}",
+          "card": {
+            "title": "Impact Score Nudger",
+            "subtitle": "Méthodologie appliquée aux {category}",
+            "description": "Cette page détaille les critères et pondérations utilisés pour évaluer l'impact environnemental de cette catégorie.",
+            "cta": "Comprendre notre méthodologie globale",
+            "aria": "Découvrir la méthodologie Impact Score globale",
+            "imageAlt": "Illustration de l'Impact Score pour les {category}"
+          }
+        },
+        "purpose": {
+          "eyebrow": "Notre démarche",
+          "title": "Pourquoi et comment nous évaluons les {category}",
+          "objectiveTitle": "Objectif",
+          "objectiveFallback": "La description de l'objectif sera bientôt disponible.",
+          "dataTitle": "Données disponibles",
+          "dataFallback": "Les données détaillées des critères seront bientôt disponibles."
+        },
+        "criteria": {
+          "eyebrow": "Critères",
+          "title": "Critères retenus et pondérations",
+          "empty": "Les critères seront publiés prochainement."
+        },
+        "transparency": {
+          "eyebrow": "Transparence",
+          "title": "Transparence et traçabilité",
+          "criticalReviewTitle": "Revue critique",
+          "criticalReviewFallback": "La revue critique n'est pas encore disponible.",
+          "communityTitle": "En discuter",
+          "communityBody": "La définition de l'Impact Score {category} est disponible sur GitHub. Partagez vos retours ou proposez des ajustements.",
+          "communityCta": "Consulter la configuration",
+          "communityIssues": "Ouvrir une discussion",
+          "intro": "Nudger est construit dans un modèle ouvert :",
+          "connector": "et",
+          "openSourceLink": "open-source",
+          "openDataLink": "open-data",
+          "introSuffix": "pour garantir la traçabilité de notre méthode d'évaluation des {category}.",
+          "tableTitle": "Synthèse des coefficients",
+          "tableHelper": "Comparaison entre la proposition générée par l'IA et les coefficients actuellement appliqués.",
+          "tableFallback": "Les coefficients détaillés seront publiés prochainement.",
+          "tableHeaders": {
+            "name": "Nom du critère",
+            "proposed": "Coef. proposé",
+            "applied": "Coef. appliqué"
+          }
+        },
+        "aiAudit": {
+          "eyebrow": "Audit IA",
+          "title": "Audit de génération IA",
+          "intro": "Audit des prompts et réponses qui ont servi à configurer l'Impact Score des {category}.",
+          "promptTitle": "Prompt YAML générateur",
+          "promptHelper": "Instructions envoyées au modèle pour produire la configuration.",
+          "responseTitle": "Réponse du modèle",
+          "responseHelper": "Résultat JSON de l'IA ayant servi de base à la configuration.",
+          "yamlUnavailable": "Prompt indisponible.",
+          "jsonUnavailable": "Réponse IA indisponible."
+        }
+      }
     },
     "fastFilters": {
       "reset": "Réinitialiser les filtres rapides",


### PR DESCRIPTION
## Summary
- backport the legacy impact score experience into the Nuxt category page with sticky navigation, wiki-driven sections, transparency table, and AI audit card
- localise the new UI strings in English and French
- add a dedicated vitest suite that exercises the navigation, dynamic data rendering, and smooth-scroll behaviour

## Testing
- pnpm lint
- CI=1 pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_68ffa1c73e9083338218ed19c5d229fb