### PR TITLE
feat: refresh impact score page layout

### DIFF
--- a/frontend/app/pages/impact-score/index.vue
+++ b/frontend/app/pages/impact-score/index.vue
@@ -1,27 +1,19 @@
 <template>
   <div class="impact-score-page">
-    <section class="impact-score-page__hero">
+    <section
+      class="impact-score-page__hero"
+      aria-labelledby="impact-score-hero-title"
+      aria-describedby="impact-score-hero-intro"
+      role="region"
+    >
       <v-container class="py-12">
         <v-row class="impact-score-page__hero-row" align="center" justify="center">
           <v-col cols="12" md="10" lg="8" class="impact-score-page__hero-content">
-            <p class="impact-score-page__eyebrow">Impact environnemental</p>
-            <h1 class="impact-score-page__title">
-              L’Impact Score : évaluation de l'impact environnemental de vos produits
+            <h1 id="impact-score-hero-title" class="impact-score-page__title">
+              {{ t('impactScorePage.hero.title') }}
             </h1>
-            <div class="impact-score-page__intro text-body-1">
+            <div id="impact-score-hero-intro" class="impact-score-page__intro text-body-1">
               <TextContent bloc-id="ECOSCORE:1:" />
-            </div>
-            <div class="impact-score-page__hero-actions">
-              <v-btn
-                class="impact-score-page__hero-button"
-                color="surface"
-                size="large"
-                variant="elevated"
-                prepend-icon="mdi-compass-outline"
-                @click="scrollToSection(sectionIds.overview)"
-              >
-                Explorer la méthodologie
-              </v-btn>
             </div>
           </v-col>
         </v-row>
@@ -33,36 +25,57 @@
         <aside
           class="impact-score-page__nav"
           :class="{ 'impact-score-page__nav--mobile': orientation === 'horizontal' }"
-          aria-label="Plan de page Impact Score"
+          :aria-label="t('impactScorePage.aria.pageOutline')"
         >
           <StickySectionNavigation
             :sections="navigationSections"
             :active-section="activeSection"
             :orientation="orientation"
-            aria-label="Navigation Impact Score"
+            :aria-label="t('impactScorePage.aria.navigation')"
             @navigate="scrollToSection"
           />
         </aside>
 
         <main class="impact-score-page__sections" role="main">
-          <section :id="sectionIds.overview" class="impact-score-section impact-score-section--intro">
+          <section
+            :id="sectionIds.overview"
+            class="impact-score-section impact-score-section--intro"
+            :aria-labelledby="`${sectionIds.overview}-title`"
+            role="region"
+          >
             <v-sheet class="impact-score-section__surface" rounded="xl" elevation="0">
               <header class="impact-score-section__header">
-                <span class="impact-score-section__eyebrow">Présentation</span>
-                <h2 class="impact-score-section__title">Qu’est-ce que l’Impact Score&nbsp;?</h2>
+                <span class="impact-score-section__eyebrow">
+                  {{ t('impactScorePage.sections.overview.eyebrow') }}
+                </span>
+                <h2 :id="`${sectionIds.overview}-title`" class="impact-score-section__title">
+                  {{ t('impactScorePage.sections.overview.title') }}
+                </h2>
               </header>
 
               <v-row class="impact-score-section__row impact-score-section__row--balanced" align="stretch">
-                <v-col cols="12" md="7">
+                <v-col cols="12" lg="7">
                   <div class="impact-score-section__body">
                     <TextContent bloc-id="ECOSCORE:2:" />
                   </div>
                 </v-col>
 
-                <v-col cols="12" md="5" class="impact-score-section__rating">
-                  <v-card variant="flat" class="impact-score-example" elevation="0">
+                <v-col cols="12" lg="5" class="impact-score-section__rating">
+                  <v-card
+                    variant="flat"
+                    class="impact-score-example"
+                    elevation="0"
+                    role="group"
+                    :aria-labelledby="`${sectionIds.overview}-rating-title`"
+                    :aria-describedby="`${sectionIds.overview}-rating-caption`"
+                  >
                     <div class="impact-score-example__header">
-                      <span class="impact-score-example__eyebrow">Évaluation indicative</span>
+                      <span
+                        :id="`${sectionIds.overview}-rating-title`"
+                        class="impact-score-example__eyebrow"
+                      >
+                        {{ t('impactScorePage.sections.overview.sample.title') }}
+                      </span>
                       <strong class="impact-score-example__value">{{ formatCoeff(localRating) }}</strong>
                     </div>
                     <ImpactScore
@@ -71,8 +84,11 @@
                       size="large"
                       show-value
                     />
-                    <p class="impact-score-example__caption">
-                      Évaluation indicative basée sur notre méthodologie
+                    <p
+                      :id="`${sectionIds.overview}-rating-caption`"
+                      class="impact-score-example__caption"
+                    >
+                      {{ t('impactScorePage.sections.overview.sample.caption') }}
                     </p>
                   </v-card>
                 </v-col>
@@ -80,27 +96,34 @@
             </v-sheet>
           </section>
 
-          <section :id="sectionIds.ecoscore" class="impact-score-section">
+          <section
+            :id="sectionIds.ecoscore"
+            class="impact-score-section"
+            :aria-labelledby="`${sectionIds.ecoscore}-title`"
+            role="region"
+          >
             <v-sheet class="impact-score-section__surface impact-score-section__surface--muted" rounded="xl" elevation="0">
               <header class="impact-score-section__header">
-                <span class="impact-score-section__eyebrow">Notre démarche</span>
-                <h2 class="impact-score-section__title">
-                  Notre ecoscore&nbsp;: transparent, innovant et performant
+                <span class="impact-score-section__eyebrow">
+                  {{ t('impactScorePage.sections.approach.eyebrow') }}
+                </span>
+                <h2 :id="`${sectionIds.ecoscore}-title`" class="impact-score-section__title">
+                  {{ t('impactScorePage.sections.approach.title') }}
                 </h2>
               </header>
 
-              <v-row class="impact-score-section__row" align="center">
-                <v-col cols="12" md="5">
-                  <div class="impact-score-section__figure">
+              <v-row class="impact-score-section__row impact-score-section__row--media" align="center">
+                <v-col cols="12" md="5" lg="4" class="impact-score-section__media">
+                  <figure class="impact-score-media" role="presentation">
                     <v-img
-                      src="https://nudger.fr/img/impactscore-illustration.png"
-                      alt="Illustration de notre démarche ecoscore"
-                      aspect-ratio="1"
-                      contain
+                      src="https://nudger.fr/img/impactscore-illustration.webp"
+                      :alt="t('impactScorePage.sections.approach.imageAlt')"
+                      class="impact-score-media__image"
+                      cover
                     />
-                  </div>
+                  </figure>
                 </v-col>
-                <v-col cols="12" md="7">
+                <v-col cols="12" md="7" lg="8">
                   <div class="impact-score-section__body">
                     <TextContent bloc-id="ECOSCORE:3:" />
                   </div>
@@ -109,35 +132,72 @@
             </v-sheet>
           </section>
 
-          <section :id="sectionIds.calculation" class="impact-score-section">
+          <section
+            :id="sectionIds.calculation"
+            class="impact-score-section"
+            :aria-labelledby="`${sectionIds.calculation}-title`"
+            role="region"
+          >
             <v-sheet class="impact-score-section__surface" rounded="xl" elevation="0">
               <header class="impact-score-section__header">
-                <span class="impact-score-section__eyebrow">Méthodologie</span>
-                <h2 class="impact-score-section__title">Comment est calculé l'Impact Score&nbsp;?</h2>
+                <span class="impact-score-section__eyebrow">
+                  {{ t('impactScorePage.sections.methodology.eyebrow') }}
+                </span>
+                <h2 :id="`${sectionIds.calculation}-title`" class="impact-score-section__title">
+                  {{ t('impactScorePage.sections.methodology.title') }}
+                </h2>
               </header>
 
               <div class="impact-score-section__body">
-                <p>
-                  Les règles de calcul de l’ecoscore sont détaillées sur chaque produit (section «&nbsp;bilan écologique&nbsp;»).
-                  Chaque catégorie de produit a ses propres critères et pondérations. Voici les catégories couvertes :
-                </p>
+                <p>{{ t('impactScorePage.sections.methodology.intro') }}</p>
               </div>
 
-              <v-sheet class="impact-score-section__list" rounded="lg" elevation="0">
-                <v-list density="comfortable" bg-color="transparent">
-                  <v-list-item
-                    v-for="v in verticals"
-                    :key="v.url"
-                    :href="v.url"
-                    :title="v.title"
-                    link
+              <div v-if="verticalCards.length" class="impact-score-verticals" role="list">
+                <v-row class="impact-score-verticals__row" align="stretch" justify="start">
+                  <v-col
+                    v-for="vertical in verticalCards"
+                    :key="vertical.id"
+                    cols="12"
+                    sm="6"
+                    md="4"
+                    role="listitem"
                   >
-                    <template #append>
-                      <v-icon icon="mdi-chevron-right" />
-                    </template>
-                  </v-list-item>
-                </v-list>
-              </v-sheet>
+                    <NuxtLink
+                      :to="vertical.href"
+                      class="impact-score-vertical-card"
+                      :aria-label="t('impactScorePage.sections.methodology.verticalCardAria', { vertical: vertical.displayName })"
+                    >
+                      <v-img
+                        v-if="vertical.image"
+                        :src="vertical.image"
+                        :alt="t('impactScorePage.sections.methodology.verticalImageAlt', { vertical: vertical.displayName })"
+                        class="impact-score-vertical-card__image"
+                        cover
+                      />
+                      <div class="impact-score-vertical-card__content">
+                        <span class="impact-score-vertical-card__eyebrow">
+                          {{ t('impactScorePage.sections.methodology.verticalLabel') }}
+                        </span>
+                        <strong class="impact-score-vertical-card__title">{{ vertical.displayName }}</strong>
+                        <span class="impact-score-vertical-card__cta">
+                          {{ t('impactScorePage.sections.methodology.verticalCta') }}
+                        </span>
+                      </div>
+                    </NuxtLink>
+                  </v-col>
+                </v-row>
+              </div>
+              <v-alert
+                v-else
+                type="info"
+                variant="tonal"
+                class="impact-score-verticals__empty"
+                border="start"
+                density="comfortable"
+                :aria-label="t('impactScorePage.sections.methodology.empty')"
+              >
+                {{ t('impactScorePage.sections.methodology.empty') }}
+              </v-alert>
 
               <div class="impact-score-section__body">
                 <TextContent bloc-id="ECOSCORE:4:" />
@@ -145,57 +205,36 @@
             </v-sheet>
           </section>
 
-          <section :id="sectionIds.criteria" class="impact-score-section">
-            <v-sheet class="impact-score-section__surface" rounded="xl" elevation="0">
-              <header class="impact-score-section__header">
-                <span class="impact-score-section__eyebrow">Pondérations</span>
-                <h2 class="impact-score-section__title">
-                  Critères et coefficients de l'ecoscore téléviseurs
-                </h2>
-              </header>
-
-              <v-table class="impact-score-table" density="comfortable">
-                <thead>
-                  <tr>
-                    <th scope="col" class="text-left">Nom du critère</th>
-                    <th scope="col" class="text-left">Coefficient (0–1)</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="(c, i) in criterias" :key="i">
-                    <td>{{ c.name }}</td>
-                    <td>{{ formatCoeff(c.coefficient) }}</td>
-                  </tr>
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <th scope="row">Total</th>
-                    <td><strong>{{ formatCoeff(total) }}</strong></td>
-                  </tr>
-                </tfoot>
-              </v-table>
-            </v-sheet>
-          </section>
-
-          <section :id="sectionIds.dataQuality" class="impact-score-section">
+          <section
+            :id="sectionIds.dataQuality"
+            class="impact-score-section"
+            :aria-labelledby="`${sectionIds.dataQuality}-title`"
+            role="region"
+          >
             <v-sheet class="impact-score-section__surface impact-score-section__surface--muted" rounded="xl" elevation="0">
               <header class="impact-score-section__header">
-                <span class="impact-score-section__eyebrow">Analyse approfondie</span>
-                <h2 class="impact-score-section__title">Relativisation et qualité de la donnée</h2>
+                <span class="impact-score-section__eyebrow">
+                  {{ t('impactScorePage.sections.analysis.eyebrow') }}
+                </span>
+                <h2 :id="`${sectionIds.dataQuality}-title`" class="impact-score-section__title">
+                  {{ t('impactScorePage.sections.analysis.title') }}
+                </h2>
               </header>
 
               <div class="impact-score-insights">
                 <article class="impact-score-insight impact-score-insight--reverse">
                   <div class="impact-score-insight__content">
-                    <h3 class="impact-score-insight__title">Principe de relativisation</h3>
+                    <h3 class="impact-score-insight__title">
+                      {{ t('impactScorePage.sections.analysis.relativisation.title') }}
+                    </h3>
                     <TextContent bloc-id="ECOSCORE:4-1:" />
                   </div>
                   <div class="impact-score-insight__media">
                     <v-img
-                      src="https://nudger.fr/img/relativisation.png"
-                      alt="Illustration du principe de relativisation"
-                      aspect-ratio="1"
-                      contain
+                      src="https://nudger.fr/img/relativisation.webp"
+                      :alt="t('impactScorePage.sections.analysis.relativisation.imageAlt')"
+                      class="impact-score-media__image"
+                      cover
                     />
                   </div>
                 </article>
@@ -203,14 +242,16 @@
                 <article class="impact-score-insight">
                   <div class="impact-score-insight__media">
                     <v-img
-                      src="https://nudger.fr/img/data-quality.png"
-                      alt="Illustration sur la qualité de la donnée"
-                      aspect-ratio="1"
-                      contain
+                      src="https://nudger.fr/img/data-quality.webp"
+                      :alt="t('impactScorePage.sections.analysis.dataQuality.imageAlt')"
+                      class="impact-score-media__image"
+                      cover
                     />
                   </div>
                   <div class="impact-score-insight__content">
-                    <h3 class="impact-score-insight__title">La qualité de la donnée, enjeu majeur</h3>
+                    <h3 class="impact-score-insight__title">
+                      {{ t('impactScorePage.sections.analysis.dataQuality.title') }}
+                    </h3>
                     <TextContent bloc-id="ECOSCORE:4-2:" />
                   </div>
                 </article>
@@ -226,17 +267,70 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useDisplay } from 'vuetify'
+import { useI18n } from 'vue-i18n'
+import type { VerticalConfigDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
 
 const props = defineProps({
   rating: { type: Number, default: 4.5 },
-  verticals: { type: Array, default: () => [] },
-  criterias: { type: Array, default: () => [] },
-  total: { type: Number, default: 1.0 },
 })
 
+const { t, locale } = useI18n()
 const display = useDisplay()
+
+const { data: fetchedVerticals } = await useAsyncData<VerticalConfigDto[]>(
+  'impact-score-verticals',
+  () =>
+    $fetch<VerticalConfigDto[]>('/api/categories', {
+      params: { onlyEnabled: true },
+    }),
+  {
+    default: () => [],
+    server: true,
+  },
+)
+
+type VerticalCard = {
+  id: string
+  href: string
+  image: string | null
+  displayName: string
+}
+
+const normalizedLocale = computed(() => locale.value ?? 'fr-FR')
+
+const verticalCards = computed<VerticalCard[]>(() => {
+  const data = fetchedVerticals.value ?? []
+
+  return data
+    .filter((vertical) => Boolean(vertical?.verticalHomeTitle && vertical?.verticalHomeUrl))
+    .map((vertical) => {
+      const rawUrl = (vertical.verticalHomeUrl ?? '').trim()
+      const trimmedBase = rawUrl.replace(/\/+$/, '')
+      if (!trimmedBase.length) {
+        return null
+      }
+
+      const rawTitle = (vertical.verticalHomeTitle ?? '').trim()
+      if (!rawTitle.length) {
+        return null
+      }
+
+      const hrefBase = trimmedBase.startsWith('/') ? trimmedBase : `/${trimmedBase}`
+      const displayName = rawTitle.toLocaleLowerCase(normalizedLocale.value)
+      const href = `${hrefBase}/ecoscore`
+      const image = vertical.imageSmall ?? null
+
+      return {
+        id: vertical.id ?? href,
+        href,
+        image,
+        displayName,
+      }
+    })
+    .filter((card): card is VerticalCard => Boolean(card))
+})
 
 const localRating = ref(props.rating)
 
@@ -251,17 +345,15 @@ const sectionIds = {
   overview: 'impact-overview',
   ecoscore: 'impact-ecoscore',
   calculation: 'impact-calculation',
-  criteria: 'impact-criteria',
   dataQuality: 'impact-data-quality',
 } as const
 
-const navigationSections = [
-  { id: sectionIds.overview, label: 'Présentation', icon: 'mdi-information-outline' },
-  { id: sectionIds.ecoscore, label: 'Notre démarche', icon: 'mdi-leaf' },
-  { id: sectionIds.calculation, label: 'Calcul', icon: 'mdi-chart-timeline-variant' },
-  { id: sectionIds.criteria, label: 'Critères', icon: 'mdi-table' },
-  { id: sectionIds.dataQuality, label: 'Qualité des données', icon: 'mdi-shield-check-outline' },
-]
+const navigationSections = computed(() => [
+  { id: sectionIds.overview, label: t('impactScorePage.navigation.overview'), icon: 'mdi-information-outline' },
+  { id: sectionIds.ecoscore, label: t('impactScorePage.navigation.approach'), icon: 'mdi-leaf' },
+  { id: sectionIds.calculation, label: t('impactScorePage.navigation.methodology'), icon: 'mdi-chart-timeline-variant' },
+  { id: sectionIds.dataQuality, label: t('impactScorePage.navigation.analysis'), icon: 'mdi-shield-check-outline' },
+])
 
 const orientation = computed<'vertical' | 'horizontal'>(() => (display.mdAndDown.value ? 'horizontal' : 'vertical'))
 
@@ -271,8 +363,9 @@ const visibleSectionRatios = new Map<string, number>()
 const MIN_SECTION_RATIO = 0.4
 
 const refreshActiveSection = () => {
+  const sections = navigationSections.value
   if (!visibleSectionRatios.size) {
-    activeSection.value = navigationSections[0]?.id ?? sectionIds.overview
+    activeSection.value = sections[0]?.id ?? sectionIds.overview
     return
   }
 
@@ -313,7 +406,7 @@ const observeSections = () => {
   )
 
   nextTick(() => {
-    navigationSections.forEach((section) => {
+    navigationSections.value.forEach((section) => {
       const element = document.getElementById(section.id)
       if (element) {
         observer.value?.observe(element)
@@ -331,13 +424,20 @@ onBeforeUnmount(() => {
   visibleSectionRatios.clear()
 })
 
+watch(orientation, () => {
+  nextTick(() => {
+    observeSections()
+  })
+})
+
 watch(
-  orientation,
+  navigationSections,
   () => {
     nextTick(() => {
       observeSections()
     })
   },
+  { deep: true },
 )
 
 const scrollToSection = (sectionId: string) => {
@@ -365,23 +465,37 @@ function formatCoeff(n: number | null | undefined) {
 
 <style scoped>
 .impact-score-page {
-  background: rgb(var(--v-theme-surface-muted));
+  background: linear-gradient(
+      180deg,
+      rgba(var(--v-theme-hero-gradient-start), 0.95) 0%,
+      rgba(var(--v-theme-hero-gradient-end), 0.92) 48%,
+      rgb(var(--v-theme-surface-muted)) 48%
+    );
   color: rgb(var(--v-theme-text-neutral-strong));
+  min-height: 100%;
 }
 
 .impact-score-page__hero {
-  background: linear-gradient(140deg, rgba(var(--v-theme-hero-gradient-start), 0.88), rgba(var(--v-theme-hero-gradient-end), 0.88));
-  color: white;
   position: relative;
+  color: white;
   overflow: hidden;
+}
+
+.impact-score-page__hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(140deg, rgba(var(--v-theme-hero-gradient-start), 0.9), rgba(var(--v-theme-hero-gradient-end), 0.88));
+  z-index: 0;
 }
 
 .impact-score-page__hero::after {
   content: '';
   position: absolute;
-  inset: 10% -20% -40% -20%;
-  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 65%);
+  inset: 12% -25% -45% -25%;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.25), transparent 70%);
   pointer-events: none;
+  z-index: 0;
 }
 
 .impact-score-page__hero-row {
@@ -391,47 +505,26 @@ function formatCoeff(n: number | null | undefined) {
 }
 
 .impact-score-page__hero-content {
+  max-width: 760px;
+  margin-inline: auto;
   text-align: center;
 }
 
-.impact-score-page__eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-  font-size: 0.78rem;
-  margin-bottom: 0.75rem;
-  color: rgba(255, 255, 255, 0.75);
-}
-
 .impact-score-page__title {
-  font-size: clamp(2rem, 3vw, 2.75rem);
+  font-size: clamp(2.15rem, 2.6vw, 3rem);
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.15;
   margin-bottom: 1.5rem;
 }
 
 .impact-score-page__intro :deep(p) {
   margin-bottom: 1rem;
-}
-
-.impact-score-page__hero-actions {
-  margin-top: 2rem;
-  display: flex;
-  justify-content: center;
-}
-
-.impact-score-page__hero-button {
-  font-weight: 600;
-  border-radius: 999px;
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.25);
-}
-
-.impact-score-page__hero-button :deep(.v-icon) {
-  color: rgb(var(--v-theme-accent-supporting));
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 1.05rem;
 }
 
 .impact-score-page__content {
-  margin-top: -64px;
+  margin-top: -72px;
 }
 
 .impact-score-page__layout {
@@ -442,7 +535,7 @@ function formatCoeff(n: number | null | undefined) {
 
 .impact-score-page__nav {
   position: sticky;
-  top: 104px;
+  top: 96px;
   align-self: start;
   height: fit-content;
   z-index: 10;
@@ -465,15 +558,16 @@ function formatCoeff(n: number | null | undefined) {
 }
 
 .impact-score-section__surface {
-  padding: 2.5rem;
+  padding: clamp(1.8rem, 2vw + 1.5rem, 2.6rem);
   box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35);
   background: rgb(var(--v-theme-surface-default));
+  border-radius: 28px;
 }
 
 .impact-score-section__surface--muted {
   background: rgba(var(--v-theme-surface-primary-080), 0.7);
-  border-color: rgba(var(--v-theme-border-primary-strong), 0.2);
+  border-color: rgba(var(--v-theme-border-primary-strong), 0.24);
 }
 
 .impact-score-section__header {
@@ -493,103 +587,162 @@ function formatCoeff(n: number | null | undefined) {
 .impact-score-section__title {
   margin: 0;
   font-weight: 700;
-  font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+  font-size: clamp(1.45rem, 2.4vw, 2rem);
   line-height: 1.3;
 }
 
 .impact-score-section__row {
-  gap: 1.5rem;
+  gap: 1.75rem;
 }
 
 .impact-score-section__row--balanced {
   align-items: stretch;
 }
 
+.impact-score-section__row--media {
+  align-items: center;
+}
+
 .impact-score-section__body :deep(p + p) {
   margin-top: 1rem;
 }
 
-.impact-score-section__figure {
+.impact-score-section__media {
+  display: flex;
+  justify-content: center;
+}
+
+.impact-score-media,
+.impact-score-insight__media {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(var(--v-theme-surface-primary-100), 0.8);
-  border-radius: 20px;
+  background: rgba(var(--v-theme-surface-primary-100), 0.85);
+  border-radius: 24px;
   padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.22);
+  width: 100%;
+  max-width: 320px;
+  margin-inline: auto;
+}
+
+.impact-score-media__image {
+  width: 100%;
+  max-width: 260px;
+  aspect-ratio: 1;
+  border-radius: 18px;
 }
 
 .impact-score-section__rating {
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .impact-score-example {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1.75rem;
-  border-radius: 20px;
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-  background: rgba(var(--v-theme-surface-primary-080), 0.8);
+  gap: 1.25rem;
+  padding: clamp(1.6rem, 2vw + 1rem, 2.2rem);
+  background: rgba(var(--v-theme-surface-primary-080), 0.9);
+  border-radius: 24px;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-surface-primary-100), 0.35);
 }
 
 .impact-score-example__header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .impact-score-example__eyebrow {
+  font-size: 0.82rem;
   text-transform: uppercase;
-  font-size: 0.78rem;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
+  font-weight: 600;
   color: rgb(var(--v-theme-text-neutral-secondary));
 }
 
 .impact-score-example__value {
-  font-size: 2.75rem;
+  font-size: clamp(2.1rem, 2vw + 1.8rem, 2.75rem);
   font-weight: 700;
-  line-height: 1;
-  color: rgb(var(--v-theme-text-neutral-strong));
+  color: rgb(var(--v-theme-accent-primary-highlight));
 }
 
 .impact-score-example__caption {
   margin: 0;
-  font-size: 0.88rem;
+  font-size: 0.92rem;
   color: rgb(var(--v-theme-text-neutral-secondary));
 }
 
-.impact-score-section__list {
-  margin: 1.5rem 0;
-  padding: 0.75rem 0.5rem;
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25);
+.impact-score-verticals {
+  margin: 1.75rem 0;
 }
 
-.impact-score-section__list :deep(.v-list-item) {
-  border-radius: 12px;
-  transition: background 0.25s ease, transform 0.25s ease;
+.impact-score-verticals__row {
+  row-gap: 1.5rem;
 }
 
-.impact-score-section__list :deep(.v-list-item:hover) {
-  background: rgba(var(--v-theme-surface-primary-100), 0.8);
-  transform: translateX(4px);
+.impact-score-vertical-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  height: 100%;
+  padding: 1.75rem;
+  border-radius: 24px;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.28);
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.06);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
-.impact-score-table {
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
+.impact-score-vertical-card:focus-visible,
+.impact-score-vertical-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(var(--v-theme-accent-primary-highlight), 0.55);
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.12);
 }
 
-.impact-score-table thead {
-  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+.impact-score-vertical-card__image {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 18px;
+  background: rgba(var(--v-theme-surface-primary-100), 0.6);
 }
 
-.impact-score-table tfoot {
-  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+.impact-score-vertical-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.impact-score-vertical-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.impact-score-vertical-card__title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.impact-score-vertical-card__cta {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-accent-primary-highlight));
+}
+
+.impact-score-verticals__empty {
+  margin-top: 1.5rem;
 }
 
 .impact-score-insights {
@@ -600,13 +753,13 @@ function formatCoeff(n: number | null | undefined) {
 
 .impact-score-insight {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(200px, 280px);
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(200px, 300px);
+  gap: 1.75rem;
   align-items: center;
 }
 
 .impact-score-insight--reverse {
-  grid-template-columns: minmax(0, 1fr) minmax(200px, 280px);
+  grid-template-columns: minmax(0, 1fr) minmax(200px, 300px);
 }
 
 .impact-score-insight--reverse .impact-score-insight__content {
@@ -624,20 +777,6 @@ function formatCoeff(n: number | null | undefined) {
   color: rgb(var(--v-theme-text-neutral-strong));
 }
 
-.impact-score-insight__media {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(var(--v-theme-surface-primary-100), 0.8);
-  border-radius: 20px;
-  padding: 1.5rem;
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
-}
-
-.impact-score-insight__media .v-img {
-  border-radius: 16px;
-}
-
 .impact-score-insight__content :deep(p + p) {
   margin-top: 1rem;
 }
@@ -653,36 +792,37 @@ function formatCoeff(n: number | null | undefined) {
     z-index: 20;
   }
 
-  .impact-score-page__nav--mobile {
-    position: static;
-    top: auto;
-  }
-
   .impact-score-section {
     scroll-margin-top: 160px;
   }
 }
 
-@media (max-width: 960px) {
-  .impact-score-page__content {
-    margin-top: -32px;
-  }
-
+@media (max-width: 1080px) {
   .impact-score-page__hero-content {
     text-align: left;
   }
 
-  .impact-score-page__hero-actions {
-    justify-content: flex-start;
+  .impact-score-page__title {
+    font-size: clamp(2rem, 2.4vw, 2.5rem);
+  }
+}
+
+@media (max-width: 960px) {
+  .impact-score-page__content {
+    margin-top: -36px;
   }
 
   .impact-score-section__surface {
-    padding: 1.9rem;
+    padding: 1.8rem;
+    border-radius: 24px;
   }
 
-  .impact-score-section__figure,
-  .impact-score-insight__media {
-    padding: 1.25rem;
+  .impact-score-section__row {
+    gap: 1.5rem;
+  }
+
+  .impact-score-section__media {
+    margin-bottom: 0.5rem;
   }
 
   .impact-score-insight {
@@ -701,20 +841,30 @@ function formatCoeff(n: number | null | undefined) {
     border-bottom-right-radius: 28px;
   }
 
+  .impact-score-page__hero-content {
+    text-align: left;
+  }
+
+  .impact-score-page__intro :deep(p) {
+    font-size: 1rem;
+  }
+
   .impact-score-section__surface {
     padding: 1.5rem;
+    border-radius: 20px;
   }
 
   .impact-score-section__title {
     font-size: 1.4rem;
   }
 
-  .impact-score-section__list {
-    padding: 0.5rem 0.25rem;
+  .impact-score-example {
+    padding: 1.6rem;
   }
 
-  .impact-score-example {
+  .impact-score-vertical-card {
     padding: 1.5rem;
   }
 }
 </style>
+

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1,8 +1,319 @@
 {
-  "welcome": "Welcome",
-  "lang": {
-    "fr": "French",
-    "en": "English"
+  "blog": {
+    "article": {
+      "edit": "Edit this article",
+      "empty": "The content of this article will be available soon.",
+      "featuredImageAlt": "Featured image for {title}",
+      "readingTime": "Approx. {minutes} min read",
+      "updated": "Updated {date}"
+    },
+    "hero": {
+      "eyebrow": "Nudger blog",
+      "subtitle": "Short reads on sustainable appliances, nudges and the lessons we learn while building Nudger.",
+      "title": "Fresh insights on responsible shopping"
+    },
+    "list": {
+      "loading": "Loading articles…",
+      "readMore": "Read more",
+      "tagWithCount": "{tag} ({count})",
+      "tagsAll": "All topics",
+      "tagsAriaLabel": "Filter blog posts by tag",
+      "tagsLoading": "Loading tags…",
+      "tagsTitle": "Filter by tag"
+    },
+    "pagination": {
+      "ariaLabel": "Blog pagination links",
+      "info": "Showing page {current} of {total} ({count} articles)",
+      "pageLink": "Blog page {page}"
+    },
+    "seo": {
+      "baseTitle": "Nudger Blog – Impact Score insights",
+      "description": "Explore the latest guides on sustainable appliances and energy-efficient choices from Nudger.",
+      "pageTitle": "{title} – Page {page}",
+      "tagDescription": "Browse {tag} articles on Nudger's blog for sustainable, energy-efficient advice.",
+      "tagTitle": "{tag} articles – Nudger Blog"
+    }
+  },
+  "categories": {
+    "navigation": {
+      "error": {
+        "loadFailed": "We couldn’t load the category navigation. Please try again."
+      },
+      "grid": {
+        "cardAriaLabel": "Category card for {category}",
+        "emptySubtitle": "Try adjusting your search to find relevant categories.",
+        "emptyTitle": "No matching categories",
+        "leafLabel": "Leaf node",
+        "openSubcategory": "Open {category} subcategories",
+        "openSubcategoryCta": "View subcategories",
+        "subtitle": "Select a family to reveal its subcategories or discover our curated guides.",
+        "title": "Continue exploring",
+        "verticalLabel": "Curated guide",
+        "viewVertical": "Open the {category} guide",
+        "viewVerticalCta": "View guide"
+      },
+      "hero": {
+        "breadcrumbAriaLabel": "Category navigation breadcrumb trail",
+        "childDescription": "Explore the subcategories and curated selections inside {category}.",
+        "description": "Discover every product family we analyse and jump directly to the most relevant section.",
+        "resultsSummary": {
+          "one": "{count} category visible",
+          "other": "{count} categories visible"
+        },
+        "rootBreadcrumb": "All categories",
+        "rootProductsTitle": "Available products",
+        "searchLabel": "Search categories",
+        "searchPlaceholder": "Search for a category",
+        "title": "All product categories"
+      },
+      "loading": "Loading category navigation",
+      "verticals": {
+        "eyebrow": "Highlighted guides",
+        "openVertical": "Open the {category} guide",
+        "openVerticalCta": "Discover the guide",
+        "subtitle": "Hand-picked guides to jump straight into popular product families.",
+        "title": "Featured selections",
+        "viewPath": "Open the {category} taxonomy path",
+        "viewPathCta": "Browse taxonomy"
+      }
+    }
+  },
+  "category": {
+    "documentation": {
+      "guidesTitle": "Helpful guides",
+      "postsTitle": "Related articles"
+    },
+    "ecoscorePage": {
+      "breadcrumbLeaf": "impactscore",
+      "description": "We are crafting dedicated eco score insights for {category}. Check back soon!",
+      "impactScoreLabel": "Impact Score",
+      "navigation": {
+        "aiAudit": "AI audit",
+        "ariaLabel": "Impact Score section navigation",
+        "criteria": "Criteria",
+        "overview": "Overview",
+        "purpose": "Purpose & data",
+        "transparency": "Transparency"
+      },
+      "sections": {
+        "aiAudit": {
+          "eyebrow": "AI audit",
+          "intro": "Audit the prompts and responses used to configure the {category} Impact Score.",
+          "jsonUnavailable": "AI response unavailable.",
+          "promptHelper": "Instructions sent to the model to produce the configuration.",
+          "promptTitle": "YAML generation prompt",
+          "responseHelper": "JSON output from the AI used as the basis of the configuration.",
+          "responseTitle": "Model response",
+          "title": "Impact Score generation audit",
+          "yamlUnavailable": "Prompt unavailable."
+        },
+        "criteria": {
+          "empty": "Criteria will be published soon.",
+          "eyebrow": "Criteria",
+          "title": "Selected criteria and weights"
+        },
+        "overview": {
+          "card": {
+            "aria": "Learn more about the global Impact Score methodology",
+            "cta": "Understand the global methodology",
+            "description": "This page details the criteria and weightings used to assess the environmental impact of this category.",
+            "imageAlt": "Impact Score illustration for {category}",
+            "subtitle": "Methodology applied to {category}",
+            "title": "Nudger Impact Score"
+          },
+          "eyebrow": "Introduction",
+          "title": "Impact Score for {category}"
+        },
+        "purpose": {
+          "dataFallback": "Detailed data for each criterion will be available soon.",
+          "dataTitle": "Available data",
+          "eyebrow": "Our approach",
+          "objectiveFallback": "The objective description will be available soon.",
+          "objectiveTitle": "Objective",
+          "title": "Why and how we score {category}"
+        },
+        "transparency": {
+          "communityBody": "The {category} Impact Score definition is public on GitHub. Share your feedback or suggest adjustments.",
+          "communityCta": "View the configuration",
+          "communityIssues": "Open an issue",
+          "communityTitle": "Join the discussion",
+          "connector": "and",
+          "criticalReviewFallback": "The critical review will be shared soon.",
+          "criticalReviewTitle": "Critical review",
+          "eyebrow": "Transparency",
+          "intro": "Nudger is built as an open project:",
+          "introSuffix": "to guarantee traceability for the {category} scoring methodology.",
+          "openDataLink": "open-data",
+          "openSourceLink": "open-source",
+          "tableFallback": "Detailed coefficients will be published soon.",
+          "tableHeaders": {
+            "applied": "Applied coef.",
+            "name": "Criterion name",
+            "proposed": "Proposed coef."
+          },
+          "tableHelper": "Comparison between the AI-generated proposal and the coefficients currently applied.",
+          "tableTitle": "Coefficient summary",
+          "title": "Transparency and traceability"
+        }
+      },
+      "seo": {
+        "description": "Explore how Nudger computes the Impact Score for {category}: criteria, weights and AI generation audit.",
+        "title": "{category} – Impact Score breakdown"
+      },
+      "title": "{category} – {label}"
+    },
+    "fastFilters": {
+      "activeClauses": "Applied subset filters",
+      "groupDefault": "Other quick filters",
+      "groups": {
+        "default": "Other quick filters",
+        "price": "Price",
+        "screen_size": "Screen size"
+      },
+      "navigation": {
+        "next": "Scroll next quick filters",
+        "previous": "Scroll previous quick filters"
+      },
+      "operator": {
+        "greaterThan": "≥ {value}",
+        "lowerThan": "≤ {value}"
+      },
+      "reset": "Clear fast filters"
+    },
+    "filters": {
+      "fields": {
+        "brand": "Brand",
+        "condition": "Offer condition",
+        "country": "GTIN country code",
+        "datasource": "Data sources",
+        "googleTaxonomyId": "Google product category",
+        "offersCount": "Number of offers",
+        "price": "Price range"
+      },
+      "globalTitle": "Global filters",
+      "hideImpact": "Hide impact filters",
+      "hideTechnical": "Hide technical filters",
+      "impactTitle": "Impact filters",
+      "missingLabel": "Unlabelled option",
+      "mobileApply": "Apply filters",
+      "mobileClear": "Clear all filters",
+      "noMatch": "No matching options",
+      "rangeAriaSuffix": "range selection",
+      "searchOptions": "Search options",
+      "showMoreImpact": "Show more impact filters",
+      "showMoreTechnical": "Show more technical filters",
+      "technicalTitle": "Technical filters",
+      "toggle": {
+        "hide": "Hide filters column",
+        "show": "Show filters column"
+      }
+    },
+    "hero": {
+      "breadcrumbAriaLabel": "Category navigation breadcrumb",
+      "breadcrumbDivider": "/",
+      "missingBreadcrumbTitle": "Category"
+    },
+    "products": {
+      "compare": {
+        "addMoreHint": "Select at least two products to start a comparison.",
+        "addToList": "Add to compare",
+        "collapsePanel": "Hide list",
+        "differentCategory": "Only compare products from the same category.",
+        "expandPanel": "Show list",
+        "itemsCount": {
+          "one": "{count} product selected",
+          "other": "{count} products selected"
+        },
+        "launchComparison": "Compare now",
+        "limitReached": "You can compare up to {count} products.",
+        "missingIdentifier": "Cannot compare this product.",
+        "regionLabel": "Products selected for comparison",
+        "removeFromList": "Remove from compare",
+        "removeSingle": "Remove {name}",
+        "title": "Compare products"
+      },
+      "conditions": {
+        "new": "New",
+        "occasion": "Second-hand",
+        "other": "{condition}",
+        "unknown": "Unspecified"
+      },
+      "ecoscoreLabel": "Eco score {letter}",
+      "fetchError": "Unable to load products. Please try again.",
+      "headers": {
+        "bestPrice": "Best price",
+        "brand": "Brand",
+        "compare": "Compare",
+        "ecoscore": "Eco score",
+        "impactScore": "Impact score",
+        "model": "Model",
+        "offers": "Offers",
+        "popularAttributes": "Key details",
+        "remainingAttributes": "Other attributes"
+      },
+      "noResults": "No products match the selected filters.",
+      "notRated": "Not rated",
+      "offerCount": {
+        "one": "{count} offer",
+        "other": "{count} offers"
+      },
+      "openFilters": "Filters",
+      "priceUnavailable": "Price unavailable",
+      "pricing": {
+        "bestOfferLabel": "Best price",
+        "conditionLabel": "Condition: {condition}",
+        "newOfferLabel": "New",
+        "occasionOfferLabel": "Second-hand"
+      },
+      "resultsCount": {
+        "one": "{count} product",
+        "other": "{count} products"
+      },
+      "searchPlaceholder": "Search products",
+      "sort": {
+        "fields": {
+          "brand": "Brand",
+          "impactScore": "Impact score",
+          "model": "Model",
+          "offersCount": "Number of offers",
+          "price": "Lowest price"
+        }
+      },
+      "sortLabel": "Sort by",
+      "sortOrderAsc": "Ascending order",
+      "sortOrderDesc": "Descending order",
+      "tooltips": {
+        "search": "Search within these products",
+        "sortAscending": "Sort products from lowest to highest",
+        "sortDescending": "Sort products from highest to lowest",
+        "sortField": "Change the field used to sort products",
+        "viewCards": "Show products as cards",
+        "viewList": "Show products as a list",
+        "viewTable": "Show products in a table view"
+      },
+      "unknownBrand": "Unknown brand",
+      "untitledProduct": "Unnamed product",
+      "viewCards": "Card view",
+      "viewList": "List view",
+      "viewTable": "Table view"
+    }
+  },
+  "cms": {
+    "page": {
+      "edit": "Edit this page",
+      "error": "We could not load this page. Please try again later.",
+      "loading": "Loading page…"
+    }
+  },
+  "common": {
+    "actions": {
+      "goHome": "Back to homepage",
+      "retry": "Retry"
+    },
+    "boolean": {
+      "false": "No",
+      "true": "Yes"
+    }
   },
   "components": {
     "impactScore": {
@@ -12,1102 +323,61 @@
       "label": "Loading page content"
     }
   },
-  "siteIdentity": {
-    "menu": {
-      "title": "Menu",
-      "closeLabel": "Close menu",
-      "themeToggle": "Toggle theme",
-      "theme": {
-        "lightTooltip": "Switch to light theme",
-        "darkTooltip": "Switch to dark theme",
-        "lightAriaLabel": "Activate light theme",
-        "darkAriaLabel": "Activate dark theme"
-      },
-      "items": {
-        "impactScore": "Impact Score",
-        "products": "Products",
-        "blog": "Blog",
-        "contact": "Contact"
-      }
-    },
-    "links": {
-      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
-    },
-    "footer": {
-      "rightsReserved": "All Rights Reserved",
-      "accessibleTitle": "Footer information",
-      "mission": "nudger.fr is an open approach to assess the environmental impact of consumer goods and partially offset the impact of your online purchases.",
-      "blogLink": "Our blog",
-      "highlightLinks": {
-        "ecoscore": "Environmental assessment",
-        "allProducts": "All products",
-        "compensation": "Ecological contribution"
-      },
-      "comparator": {
-        "title": "Resources",
-        "links": {
-          "openData": "Open data",
-          "openSource": "Open source",
-          "privacy": "Privacy policy",
-          "legal": "Legal notice"
-        }
-      },
-      "community": {
-        "title": "Community",
-        "links": {
-          "team": "Our team",
-          "partners": "Our partners"
-        }
-      },
-      "feedback": {
-        "title": "Get involved",
-        "cta": "Share your feedback",
-        "links": {
-          "contact": "Contact us",
-          "linkedin": "Follow us on LinkedIn"
-        }
-      },
-      "logoAlt": "Nudger orange logo icon",
-      "copyright": "Copyright ©{year} open4goods. Common good product."
-    },
-    "hero": {
-      "mainTitle": "The Comparator That Thinks About Tomorrow",
-      "mainSubtitle": "Your Free and Independent Shopping Assistant",
-      "defaultTitle": "Default Title",
-      "defaultSubtitle": "Video demo hero to show a clean integration in a Vue 3 application.",
-      "defaultCtaText": "Call to Action"
-    },
-    "siteName": "Nudger"
-  },
-  "error": {
-    "page": {
-      "eyebrow": "Unexpected detour",
-      "statusLabel": "Status code {code}",
-      "notFound": {
-        "badge": "Page missing",
-        "title": "We can’t find this page",
-        "description": "The link you followed may be broken or the page may have moved.",
-        "helper": "Use the navigation links below or return to the homepage to continue exploring responsible shopping.",
-        "statusMessage": "Error 404 — the requested resource could not be located."
-      },
-      "generic": {
-        "badge": "We hit a snag",
-        "title": "We're working on a fix",
-        "description": "An unexpected error prevented us from loading this page.",
-        "helper": "Please try another section of Nudger or reach out if the problem persists.",
-        "statusMessage": "Error 500 — something went wrong on our side."
-      },
-      "actions": {
-        "ariaLabel": "Error recovery quick actions",
-        "goHome": "Back to homepage",
-        "contactSupport": "Contact support"
-      },
-      "debug": {
-        "title": "Technical details",
-        "messageLabel": "Error message",
-        "stackLabel": "Stack trace",
-        "empty": "No additional diagnostic information is available."
-      }
-    }
-  },
-  "category": {
-    "hero": {
-      "breadcrumbAriaLabel": "Category navigation breadcrumb",
-      "breadcrumbDivider": "/",
-      "missingBreadcrumbTitle": "Category"
-    },
-    "ecoscorePage": {
-      "title": "{category} – {label}",
-      "description": "We are crafting dedicated eco score insights for {category}. Check back soon!",
-      "impactScoreLabel": "Impact Score",
-      "breadcrumbLeaf": "impactscore",
-      "seo": {
-        "title": "{category} – Impact Score breakdown",
-        "description": "Explore how Nudger computes the Impact Score for {category}: criteria, weights and AI generation audit."
-      },
-      "navigation": {
-        "ariaLabel": "Impact Score section navigation",
-        "overview": "Overview",
-        "purpose": "Purpose & data",
-        "criteria": "Criteria",
-        "transparency": "Transparency",
-        "aiAudit": "AI audit"
-      },
-      "sections": {
-        "overview": {
-          "eyebrow": "Introduction",
-          "title": "Impact Score for {category}",
-          "card": {
-            "title": "Nudger Impact Score",
-            "subtitle": "Methodology applied to {category}",
-            "description": "This page details the criteria and weightings used to assess the environmental impact of this category.",
-            "cta": "Understand the global methodology",
-            "aria": "Learn more about the global Impact Score methodology",
-            "imageAlt": "Impact Score illustration for {category}"
-          }
-        },
-        "purpose": {
-          "eyebrow": "Our approach",
-          "title": "Why and how we score {category}",
-          "objectiveTitle": "Objective",
-          "objectiveFallback": "The objective description will be available soon.",
-          "dataTitle": "Available data",
-          "dataFallback": "Detailed data for each criterion will be available soon."
-        },
-        "criteria": {
-          "eyebrow": "Criteria",
-          "title": "Selected criteria and weights",
-          "empty": "Criteria will be published soon."
-        },
-        "transparency": {
-          "eyebrow": "Transparency",
-          "title": "Transparency and traceability",
-          "criticalReviewTitle": "Critical review",
-          "criticalReviewFallback": "The critical review will be shared soon.",
-          "communityTitle": "Join the discussion",
-          "communityBody": "The {category} Impact Score definition is public on GitHub. Share your feedback or suggest adjustments.",
-          "communityCta": "View the configuration",
-          "communityIssues": "Open an issue",
-          "intro": "Nudger is built as an open project:",
-          "connector": "and",
-          "openSourceLink": "open-source",
-          "openDataLink": "open-data",
-          "introSuffix": "to guarantee traceability for the {category} scoring methodology.",
-          "tableTitle": "Coefficient summary",
-          "tableHelper": "Comparison between the AI-generated proposal and the coefficients currently applied.",
-          "tableFallback": "Detailed coefficients will be published soon.",
-          "tableHeaders": {
-            "name": "Criterion name",
-            "proposed": "Proposed coef.",
-            "applied": "Applied coef."
-          }
-        },
-        "aiAudit": {
-          "eyebrow": "AI audit",
-          "title": "Impact Score generation audit",
-          "intro": "Audit the prompts and responses used to configure the {category} Impact Score.",
-          "promptTitle": "YAML generation prompt",
-          "promptHelper": "Instructions sent to the model to produce the configuration.",
-          "responseTitle": "Model response",
-          "responseHelper": "JSON output from the AI used as the basis of the configuration.",
-          "yamlUnavailable": "Prompt unavailable.",
-          "jsonUnavailable": "AI response unavailable."
-        }
-      }
-    },
-    "fastFilters": {
-      "reset": "Clear fast filters",
-      "activeClauses": "Applied subset filters",
-      "groupDefault": "Other quick filters",
-      "groups": {
-        "price": "Price",
-        "screen_size": "Screen size",
-        "default": "Other quick filters"
-      },
-      "navigation": {
-        "previous": "Scroll previous quick filters",
-        "next": "Scroll next quick filters"
-      },
-      "operator": {
-        "greaterThan": "≥ {value}",
-        "lowerThan": "≤ {value}"
-      }
-    },
-    "filters": {
-      "globalTitle": "Global filters",
-      "impactTitle": "Impact filters",
-      "technicalTitle": "Technical filters",
-      "showMoreImpact": "Show more impact filters",
-      "hideImpact": "Hide impact filters",
-      "showMoreTechnical": "Show more technical filters",
-      "hideTechnical": "Hide technical filters",
-      "rangeAriaSuffix": "range selection",
-      "searchOptions": "Search options",
-      "noMatch": "No matching options",
-      "missingLabel": "Unlabelled option",
-      "mobileApply": "Apply filters",
-      "mobileClear": "Clear all filters",
-      "toggle": {
-        "show": "Show filters column",
-        "hide": "Hide filters column"
-      },
-      "fields": {
-        "price": "Price range",
-        "offersCount": "Number of offers",
-        "condition": "Offer condition",
-        "googleTaxonomyId": "Google product category",
-        "brand": "Brand",
-        "country": "GTIN country code",
-        "datasource": "Data sources"
-      }
-    },
-    "products": {
-      "untitledProduct": "Unnamed product",
-      "unknownBrand": "Unknown brand",
-      "ecoscoreLabel": "Eco score {letter}",
-      "priceUnavailable": "Price unavailable",
-      "tooltips": {
-        "search": "Search within these products",
-        "sortField": "Change the field used to sort products",
-        "sortAscending": "Sort products from lowest to highest",
-        "sortDescending": "Sort products from highest to lowest",
-        "viewCards": "Show products as cards",
-        "viewList": "Show products as a list",
-        "viewTable": "Show products in a table view"
-      },
-      "offerCount": {
-        "one": "{count} offer",
-        "other": "{count} offers"
-      },
-      "notRated": "Not rated",
-      "conditions": {
-        "new": "New",
-        "occasion": "Second-hand",
-        "unknown": "Unspecified",
-        "other": "{condition}"
-      },
-      "pricing": {
-        "newOfferLabel": "New",
-        "occasionOfferLabel": "Second-hand",
-        "bestOfferLabel": "Best price",
-        "conditionLabel": "Condition: {condition}"
-      },
-      "compare": {
-        "title": "Compare products",
-        "expandPanel": "Show list",
-        "collapsePanel": "Hide list",
-        "removeSingle": "Remove {name}",
-        "addMoreHint": "Select at least two products to start a comparison.",
-        "launchComparison": "Compare now",
-        "regionLabel": "Products selected for comparison",
-        "itemsCount": {
-          "one": "{count} product selected",
-          "other": "{count} products selected"
-        },
-        "addToList": "Add to compare",
-        "removeFromList": "Remove from compare",
-        "limitReached": "You can compare up to {count} products.",
-        "differentCategory": "Only compare products from the same category.",
-        "missingIdentifier": "Cannot compare this product."
-      },
-      "fetchError": "Unable to load products. Please try again.",
-      "headers": {
-        "compare": "Compare",
-        "brand": "Brand",
-        "model": "Model",
-        "ecoscore": "Eco score",
-        "impactScore": "Impact score",
-        "bestPrice": "Best price",
-        "offers": "Offers",
-        "popularAttributes": "Key details",
-        "remainingAttributes": "Other attributes"
-      },
-      "resultsCount": {
-        "one": "{count} product",
-        "other": "{count} products"
-      },
-      "searchPlaceholder": "Search products",
-      "sortLabel": "Sort by",
-      "sortOrderAsc": "Ascending order",
-      "sortOrderDesc": "Descending order",
-      "viewCards": "Card view",
-      "viewList": "List view",
-      "viewTable": "Table view",
-      "openFilters": "Filters",
-      "noResults": "No products match the selected filters.",
-      "sort": {
-        "fields": {
-          "price": "Lowest price",
-          "offersCount": "Number of offers",
-          "brand": "Brand",
-          "model": "Model",
-          "impactScore": "Impact score"
-        }
-      }
-    },
-    "documentation": {
-      "guidesTitle": "Helpful guides",
-      "postsTitle": "Related articles"
-    }
-  },
-  "categories": {
-    "navigation": {
-      "loading": "Loading category navigation",
-      "error": {
-        "loadFailed": "We couldn’t load the category navigation. Please try again."
-      },
-      "hero": {
-        "title": "All product categories",
-        "rootProductsTitle": "Available products",
-        "description": "Discover every product family we analyse and jump directly to the most relevant section.",
-        "childDescription": "Explore the subcategories and curated selections inside {category}.",
-        "rootBreadcrumb": "All categories",
-        "searchLabel": "Search categories",
-        "searchPlaceholder": "Search for a category",
-        "breadcrumbAriaLabel": "Category navigation breadcrumb trail",
-        "resultsSummary": {
-          "one": "{count} category visible",
-          "other": "{count} categories visible"
-        }
-      },
-      "grid": {
-        "title": "Continue exploring",
-        "subtitle": "Select a family to reveal its subcategories or discover our curated guides.",
-        "emptyTitle": "No matching categories",
-        "emptySubtitle": "Try adjusting your search to find relevant categories.",
-        "verticalLabel": "Curated guide",
-        "leafLabel": "Leaf node",
-        "openSubcategory": "Open {category} subcategories",
-        "openSubcategoryCta": "View subcategories",
-        "viewVertical": "Open the {category} guide",
-        "viewVerticalCta": "View guide",
-        "cardAriaLabel": "Category card for {category}"
-      },
-      "verticals": {
-        "eyebrow": "Highlighted guides",
-        "title": "Featured selections",
-        "subtitle": "Hand-picked guides to jump straight into popular product families.",
-        "openVertical": "Open the {category} guide",
-        "openVerticalCta": "Discover the guide",
-        "viewPath": "Open the {category} taxonomy path",
-        "viewPathCta": "Browse taxonomy"
-      }
-    }
-  },
-  "blog": {
-    "seo": {
-      "baseTitle": "Nudger Blog – Impact Score insights",
-      "tagTitle": "{tag} articles – Nudger Blog",
-      "pageTitle": "{title} – Page {page}",
-      "description": "Explore the latest guides on sustainable appliances and energy-efficient choices from Nudger.",
-      "tagDescription": "Browse {tag} articles on Nudger's blog for sustainable, energy-efficient advice."
-    },
-    "pagination": {
-      "info": "Showing page {current} of {total} ({count} articles)",
-      "ariaLabel": "Blog pagination links",
-      "pageLink": "Blog page {page}"
-    },
-    "article": {
-      "updated": "Updated {date}",
-      "readingTime": "Approx. {minutes} min read",
-      "featuredImageAlt": "Featured image for {title}",
-      "empty": "The content of this article will be available soon.",
-      "edit": "Edit this article"
-    },
-    "hero": {
-      "eyebrow": "Nudger blog",
-      "title": "Fresh insights on responsible shopping",
-      "subtitle": "Short reads on sustainable appliances, nudges and the lessons we learn while building Nudger."
-    },
-    "list": {
-      "loading": "Loading articles…",
-      "readMore": "Read more",
-      "tagsTitle": "Filter by tag",
-      "tagsAll": "All topics",
-      "tagWithCount": "{tag} ({count})",
-      "tagsLoading": "Loading tags…",
-      "tagsAriaLabel": "Filter blog posts by tag"
-    }
-  },
-  "common": {
-    "actions": {
-      "retry": "Retry",
-      "goHome": "Back to homepage"
-    },
-    "boolean": {
-      "true": "Yes",
-      "false": "No"
-    }
-  },
-  "contrib": {
-    "seo": {
-      "title": "Redirecting you to our partner",
-      "description": "We are validating your secure contribution link before redirecting you to Nudger's partner."
-    },
-    "loading": {
-      "title": "Preparing your redirect…",
-      "message": "Please wait while we validate your contribution link."
-    },
-    "success": {
-      "title": "Ready to redirect",
-      "message": "You will be redirected shortly. If nothing happens, use the button below.",
-      "cta": "Continue to partner site"
-    },
-    "error": {
-      "title": "We could not validate this link",
-      "description": "The contribution link may have expired or is invalid. You can return to the homepage and try again.",
-      "detailsPrefix": "Details:",
-      "cta": "Back to homepage"
-    }
-  },
-  "team": {
-    "seo": {
-      "title": "Meet the Nudger team",
-      "description": "Discover the collective of entrepreneurs, engineers and volunteers building the sustainable shopping assistant Nudger."
-    },
-    "hero": {
-      "eyebrow": "Our collective",
-      "title": "The people behind Nudger",
-      "subtitle": "A passionate crew blending tech, sustainability and social impact."
-    },
-    "loading": "Loading team members…",
-    "errors": {
-      "loadFailed": "We could not load the team roster. Please try again."
-    },
-    "sections": {
-      "empty": "The team roster will be published soon.",
-      "core": {
-        "title": "Core team"
-      },
-      "contributors": {
-        "title": "Contributors"
-      }
-    },
-    "cards": {
-      "portraitAlt": "Portrait of {name}",
-      "linkedIn": "Open {name}'s LinkedIn profile",
-      "connect": "Connect on LinkedIn",
-      "unknownName": "a team member"
-    },
-    "callouts": {
-      "partners": {
-        "title": "Our partners",
-        "cta": "Discover our partners",
-        "link": "/partners"
-      },
-      "contact": {
-        "title": "Curious to chat?",
-        "description": "Want to co-create the future of responsible shopping or ask us something specific? We would love to talk.",
-        "cta": "Contact us"
-      }
-    }
-  },
-  "partners": {
-    "seo": {
-      "title": "Our partners and mentors",
-      "description": "Meet the organisations, marketplaces and mentors helping Nudger accelerate responsible commerce."
-    },
-    "hero": {
-      "eyebrow": "Collective impact",
-      "title": "Partners who amplify Nudger",
-      "subtitle": "A trusted network of retailers, ecosystem builders and mentors committed to fairer shopping.",
-      "description": "Browse affiliation partners you can support, discover the ecosystem backing Nudger and the mentors guiding our mission."
-    },
-    "loading": "Loading partners…",
-    "errors": {
-      "loadFailed": "We could not load partner data. Please try again."
-    },
-    "affiliation": {
-      "title": "They trust Nudger",
-      "subtitle": "Explore the merchants who work with us through affiliation and discover their offers.",
-      "search": {
-        "label": "Search partners",
-        "placeholder": "Search by partner name"
-      },
-      "empty": "No partners match your search yet. Try another term.",
-      "carouselAriaLabel": "Affiliation partners carousel",
-      "linkLabel": "Visit this partner"
-    },
-    "ecosystem": {
-      "title": "Nudger grows within a dynamic ecosystem",
-      "subtitle": "These organisations collaborate with us to build public-interest digital services.",
-      "empty": "Our ecosystem partners will appear here soon.",
-      "carouselAriaLabel": "Ecosystem partners carousel",
-      "linkLabel": "Discover the initiative",
-      "fallbackDescription": "Content about this partner will be published soon."
-    },
-    "mentors": {
-      "title": "They support us",
-      "subtitle": "Entrepreneurship is never simple. These mentors share their experience with kindness.",
-      "empty": "Mentor profiles will arrive shortly.",
-      "carouselAriaLabel": "Mentor carousel",
-      "linkLabel": "Learn more",
-      "fallbackDescription": "More information about this mentor is coming soon."
-    },
-    "cta": {
-      "eyebrow": "Join the movement",
-      "title": "Want to become a partner?",
-      "description": "We are always looking for new allies who want to build responsible shopping with us.",
-      "ctaLabel": "Contact the team"
-    }
-  },
-  "opensource": {
-    "seo": {
-      "title": "Open source at Nudger",
-      "description": "Discover how Nudger shares its code, data and governance to build a responsible shopping commons together.",
-      "imageAlt": "Nudger logomark representing the open source programme"
-    },
-    "hero": {
-      "title": "We build a commons for responsible shopping",
-      "subtitle": "Code, data and governance are transparent so anyone can audit and improve Nudger.",
-      "primaryCta": {
-        "label": "Explore the repositories",
-        "ariaLabel": "Open the Nudger GitHub organization in a new tab"
-      },
-      "ctaGroupLabel": "Primary hero actions",
-      "infoCard": {
-        "highlight": "Open4goods",
-        "description": "grows with everyone. Every pull request, issue or piece of feedback makes the platform more transparent.",
-        "items": {
-          "openLicenses": "Code and data published under open licences",
-          "collaborativeReviews": "Collaborative reviews of contributions",
-          "sharedGovernance": "Shared governance and living documentation"
-        }
-      }
-    },
-    "pillars": {
-      "eyebrow": "Our commitments",
-      "title": "An open ecosystem you can trust",
-      "cards": {
-        "transparency": {
-          "title": "Transparent architecture",
-          "cta": "Browse the source code",
-          "ariaLabel": "Open the Nudger GitHub repository in a new tab"
-        },
-        "methodology": {
-          "title": "Documented methodology",
-          "cta": "Understand the Impact Score",
-          "ariaLabel": "Navigate to the Impact Score page"
-        },
-        "community": {
-          "title": "Inclusive community",
-          "cta": "Meet the team",
-          "ariaLabel": "Navigate to the Nudger team page"
-        }
-      }
-    },
-    "contribution": {
-      "eyebrow": "Contribute",
-      "title": "Join the collective in a few steps",
-      "steps": {
-        "setup": {
-          "title": "Set up the project locally"
-        },
-        "issues": {
-          "title": "Pick an issue that inspires you"
-        },
-        "share": {
-          "title": "Share, review and celebrate"
-        }
-      }
-    },
-    "resources": {
-      "eyebrow": "Resources",
-      "title": "Everything you need to get started",
-      "links": {
-        "guide": {
-          "title": "Contribution guide",
-          "ariaLabel": "Open the Nudger contribution guide on GitHub in a new tab"
-        },
-        "issues": {
-          "title": "Issue tracker",
-          "ariaLabel": "Open the Nudger GitHub issues board in a new tab"
-        },
-        "updates": {
-          "title": "Community updates",
-          "ariaLabel": "Open the Nudger blog"
-        }
-      },
-      "opendata": {
-        "title": "Open data for transparent decisions",
-        "description": "Nudger datasets are published so you can analyse product footprints, cross-check our scoring and build your own projects.",
-        "cta": {
-          "label": "Browse the open data portal",
-          "ariaLabel": "Navigate to the open data page"
-        }
-      },
-      "contact": {
-        "title": "Need a human sparring partner?",
-        "cta": {
-          "label": "Contact the team",
-          "ariaLabel": "Navigate to the contact page"
-        }
-      },
-      "feedback": {
-        "title": "Share feedback and ideas",
-        "description": "Report bugs, submit feature ideas and help us prioritise what matters next.",
-        "points": {
-          "bugs": "Log a bug in just a few clicks",
-          "features": "Suggest new features and improvements",
-          "votes": "Vote on the topics that matter to you"
-        },
-        "cta": {
-          "label": "Open the feedback board",
-          "ariaLabel": "Navigate to the user feedback page"
-        }
-      }
-    }
-  },
-  "opendata": {
-    "seo": {
-      "title": "Nudger open data portal",
-      "description": "Explore GTIN and ISBN datasets curated by Nudger, including weekly exports and download guidance."
-    },
-    "loading": "Loading open data information…",
-    "errors": {
-      "overviewFailed": "We could not load the open data overview. Please try again.",
-      "datasetFailed": "We could not load the dataset details. Please try again."
-    },
-    "hero": {
-      "eyebrow": "Open data",
-      "title": "Transparent product data for responsible commerce",
-      "subtitle": "Download GTIN and ISBN datasets maintained by Nudger to build your own analyses, services and research.",
-      "primaryCta": {
-        "label": "Explore the datasets",
-        "ariaLabel": "Scroll to the open data datasets section"
-      }
-    },
-    "stats": {
-      "accessibilityTitle": "Key open data metrics",
-      "placeholder": "—",
-      "totalProducts": {
-        "label": "Products covered",
-        "description": "Unique products referenced across all exports.",
-        "millions": "+{value} million"
-      },
-      "datasets": {
-        "label": "Published datasets",
-        "description": "Currently available data packages."
-      },
-      "totalSize": {
-        "label": "Combined size",
-        "description": "Total compressed footprint of weekly exports."
-      }
-    },
-    "datasets": {
-      "title": "Two complementary datasets",
-      "subtitle": "Pick the export that matches your project. Both are updated weekly and delivered under the Open Database Licence.",
-      "cards": {
-        "gtin": {
-          "title": "GTIN catalogue",
-          "description": "All products indexed in Nudger with brand, model, price range and category insights.",
-          "features": {
-            "refresh": "Weekly refreshed snapshot",
-            "coverage": "Includes EAN13, UPC and GS1 country metadata",
-            "uses": "Ideal for price comparison, assortment analysis and category monitoring"
-          },
-          "cta": {
-            "label": "View GTIN dataset",
-            "ariaLabel": "Open the GTIN open data page"
-          }
-        },
-        "isbn": {
-          "title": "ISBN library",
-          "description": "Dedicated export for books with pricing, availability and classification information.",
-          "features": {
-            "refresh": "Weekly refreshed snapshot",
-            "catalogue": "Includes publisher, format and Decitre classifications",
-            "research": "Great for catalogue enrichment, research and cultural analytics"
-          },
-          "cta": {
-            "label": "View ISBN dataset",
-            "ariaLabel": "Open the ISBN open data page"
-          }
-        }
-      },
-      "common": {
-        "placeholder": "—",
-        "breadcrumb": {
-          "label": "opendata",
-          "ariaLabel": "Back to the open data overview"
-        },
-        "summary": {
-          "records": "Total records",
-          "updated": "Last updated",
-          "size": "Compressed size"
-        },
-        "columnName": "Column",
-        "columnDescription": "Description",
-        "download": {
-          "fast": {
-            "title": "Fast mirror (data.gouv.fr)",
-            "description": "Download via the official open data portal hosted by the French government.",
-            "badge": "Recommended",
-            "speed": "High bandwidth infrastructure",
-            "cta": {
-              "label": "Download from data.gouv.fr",
-              "ariaLabel": "Open the dataset on data.gouv.fr in a new tab",
-              "href": "https://www.data.gouv.fr/fr/datasets/base-de-codes-barres-noms-et-categories-produits/"
-            }
-          },
-          "direct": {
-            "title": "Direct download from Nudger",
-            "description": "Retrieve the ZIP file directly from Nudger's infrastructure.",
-            "concurrent": "Up to {value} simultaneous downloads",
-            "concurrentUnknown": "Concurrent downloads limited",
-            "speed": "Limited to {value} per client",
-            "speedUnknown": "Download speed limited per client",
-            "cta": {
-              "label": "Download from nudger.fr",
-              "ariaLabel": "Start the direct download from Nudger"
-            }
-          }
-        }
-      },
-      "gtin": {
-        "seo": {
-          "title": "GTIN open data – download the barcode catalogue",
-          "description": "Access Nudger's GTIN dataset with weekly updates, download options and schema details for your barcode data projects."
-        },
-        "hero": {
-          "eyebrow": "GTIN export",
-          "title": "Barcode data for consumer products",
-          "stats": {
-            "records": "Products",
-            "updated": "Last updated",
-            "size": "ZIP size"
-          }
-        },
-        "summary": {
-          "title": "GTIN dataset overview"
-        },
-        "download": {
-          "title": "Download options",
-          "subtitle": "Choose the mirror that matches your bandwidth and automation needs.",
-          "fast": {
-            "highlight": "Curated for broad retail and circular economy use cases"
-          }
-        },
-        "format": {
-          "title": "File format",
-          "description": "Data is delivered as a compressed CSV archive ready for ingestion.",
-          "bullets": {
-            "type": "CSV file compressed as ZIP",
-            "separator": "Field separator: comma (,)",
-            "quote": "Text qualifier: double quotes (\")"
-          }
-        },
-        "columnsTitle": "Columns included in the GTIN dataset",
-        "columnsSubtitle": "Each row represents a product identifier enriched with metadata gathered by Nudger.",
-        "columns": {
-          "gtin": {
-            "label": "gtin",
-            "description": "Global Trade Item Number (EAN13/UPC)."
-          },
-          "brand": {
-            "label": "brand",
-            "description": "Brand declared or inferred for the product."
-          },
-          "model": {
-            "label": "model",
-            "description": "Manufacturer model or SKU reference when available."
-          },
-          "name": {
-            "label": "name",
-            "description": "Marketing name or product title."
-          },
-          "last_updated": {
-            "label": "last_updated",
-            "description": "Epoch timestamp (ms) of the latest update for this product."
-          },
-          "gs1_country": {
-            "label": "gs1_country",
-            "description": "Country code derived from the GS1 prefix."
-          },
-          "gtinType": {
-            "label": "gtinType",
-            "description": "Type of barcode detected (EAN13, UPC, etc.)."
-          },
-          "offers_count": {
-            "label": "offers_count",
-            "description": "Number of commercial offers tracked for the product."
-          },
-          "min_price": {
-            "label": "min_price",
-            "description": "Lowest observed price across all offers."
-          },
-          "min_price_compensation": {
-            "label": "min_price_compensation",
-            "description": "Carbon contribution associated with the lowest price."
-          },
-          "currency": {
-            "label": "currency",
-            "description": "Currency code of the lowest price."
-          },
-          "categories": {
-            "label": "categories",
-            "description": "Product categories aggregated by Nudger (pipe-separated)."
-          },
-          "url": {
-            "label": "url",
-            "description": "Product page URL when public offers are available."
-          }
-        },
-        "faq": {
-          "title": "Frequently asked questions",
-          "subtitle": "Understand how to work with the GTIN dataset.",
-          "items": {
-            "whatIs": {
-              "question": "What is a GTIN and why does it matter?",
-              "answer": "<p><strong>The GTIN (Global Trade Item Number)</strong> is a unique identifier used to recognise products worldwide. It comes in several formats (GTIN-12, GTIN-13, GTIN-14), each tailored to specific product types or regions. For example, GTIN-13 is commonly used in Europe, while GTIN-12 is more frequent in North America. Every GTIN ensures a product can be tracked, identified and catalogued anywhere in the world, enabling efficient stock and sales management.</p>"
-            },
-            "differenceEan": {
-              "question": "What is the difference between GTIN and EAN?",
-              "answer": "<p><strong>The EAN (European Article Number)</strong> used to be the standard identifier in Europe for marking products. Today the term GTIN has replaced EAN to standardise product codes globally. The EAN-13 is now a GTIN-13. In practice the change is mainly a matter of naming and the code structure remains the same. GTIN also covers other identifiers such as the UPC (Universal Product Code) used in North America.</p>"
-            },
-            "formats": {
-              "question": "What are the different GTIN formats?",
-              "answer": "<p><strong>The main GTIN formats</strong> are: GTIN-12 (commonly used in the United States and Canada under the name UPC), GTIN-13 (most common in Europe) and GTIN-14 (for logistic units). These different formats meet the specific needs of each region and supply chain. GTIN-14 is generally used to identify larger logistic units, such as cartons or pallets, rather than single items.</p>"
-            },
-            "differenceUpc": {
-              "question": "What is the difference between GTIN and UPC?",
-              "answer": "<p><strong>The UPC (Universal Product Code)</strong> is a form of GTIN-12 mainly used in North America. The difference between GTIN and UPC is mostly regional usage: GTIN is the broader global term, while UPC refers to a specific code used in a North American context. Both systems are interoperable and, within the GTIN standard, UPC is recognised as a sub-category.</p>"
-            },
-            "ean13": {
-              "question": "What is the EAN-13 format?",
-              "answer": "<p><strong>The EAN-13</strong> is a barcode made up of 13 digits that identifies products internationally, mainly in Europe. EAN-13 is also called GTIN-13 and is widely used at points of sale to scan and track items. It includes a country prefix, a company code, a product code and a check digit that ensures the code is valid.</p>"
-            },
-            "logistics": {
-              "question": "How is GTIN used in logistics?",
-              "answer": "<p><strong>GTIN in logistics</strong> plays an essential role in identifying products across supply chains. For example, the GTIN-14 format makes it possible to identify shipping units such as cartons or pallets, which simplifies stock management and shipping operations. Using GTIN barcodes in logistics allows precise traceability of products throughout their lifecycle, from manufacturer to distributor.</p>"
-            }
-          }
-        }
-      },
-      "isbn": {
-        "seo": {
-          "title": "ISBN open data – download the book metadata export",
-          "description": "Retrieve Nudger's ISBN dataset with weekly refreshes, download mirrors and schema information for publishing analytics."
-        },
-        "hero": {
-          "eyebrow": "ISBN export",
-          "title": "Comprehensive metadata for books",
-          "stats": {
-            "records": "Publications",
-            "updated": "Last updated",
-            "size": "ZIP size"
-          }
-        },
-        "summary": {
-          "title": "ISBN dataset overview"
-        },
-        "download": {
-          "title": "Download options",
-          "subtitle": "Pick the mirror that suits your workflow and traffic needs.",
-          "fast": {
-            "highlight": "Mirror maintained for open culture and library reuse"
-          }
-        },
-        "format": {
-          "title": "File format",
-          "description": "Data is delivered as a compressed CSV archive ready for ingestion.",
-          "bullets": {
-            "type": "CSV file compressed as ZIP",
-            "separator": "Field separator: comma (,)",
-            "quote": "Text qualifier: double quotes (\")"
-          }
-        },
-        "columnsTitle": "Columns included in the ISBN dataset",
-        "columnsSubtitle": "Each row corresponds to a book identified by its ISBN.",
-        "columns": {
-          "isbn": {
-            "label": "isbn",
-            "description": "International Standard Book Number."
-          },
-          "title": {
-            "label": "title",
-            "description": "Book title as provided by sources."
-          },
-          "last_updated": {
-            "label": "last_updated",
-            "description": "Epoch timestamp (ms) of the last update."
-          },
-          "offers_count": {
-            "label": "offers_count",
-            "description": "Number of commercial offers tracked for the book."
-          },
-          "min_price": {
-            "label": "min_price",
-            "description": "Lowest observed retail price."
-          },
-          "min_price_compensation": {
-            "label": "min_price_compensation",
-            "description": "Carbon contribution associated with the lowest price."
-          },
-          "currency": {
-            "label": "currency",
-            "description": "Currency code of the lowest price."
-          },
-          "url": {
-            "label": "url",
-            "description": "Product page URL when offers are available."
-          },
-          "editeur": {
-            "label": "editeur",
-            "description": "Publisher name."
-          },
-          "format": {
-            "label": "format",
-            "description": "Book format (paperback, digital, etc.)."
-          },
-          "nb_page": {
-            "label": "nb_page",
-            "description": "Number of pages."
-          },
-          "classification_decitre_1": {
-            "label": "classification_decitre_1",
-            "description": "Decitre classification – level 1."
-          },
-          "classification_decitre_2": {
-            "label": "classification_decitre_2",
-            "description": "Decitre classification – level 2."
-          },
-          "classification_decitre_3": {
-            "label": "classification_decitre_3",
-            "description": "Decitre classification – level 3."
-          },
-          "souscategorie": {
-            "label": "souscategorie",
-            "description": "Primary subcategory assigned to the book."
-          },
-          "souscategorie2": {
-            "label": "souscategorie2",
-            "description": "Secondary subcategory assigned to the book."
-          }
-        },
-        "faq": {
-          "title": "Frequently asked questions",
-          "subtitle": "Key concepts about the ISBN export.",
-          "items": {
-            "whatIs": {
-              "question": "What is an ISBN?",
-              "answer": "<p>An ISBN (International Standard Book Number) is a unique number that identifies a book worldwide. It is essential for publishers, booksellers, libraries and any platform selling books. ISBNs make it easier to manage inventory, distribution and sales. Each book or edition of the same book has its own ISBN, ensuring unique identification in databases and catalogues. ISBNs are used for both printed books and e-books, helping readers find the exact title they need in library systems and online marketplaces.</p>"
-            },
-            "meaning": {
-              "question": "What does ISBN stand for?",
-              "answer": "<p>ISBN stands for <strong>“International Standard Book Number”</strong>, a standardised international number for books. It uniquely identifies a publication worldwide and simplifies the management of books in storage, distribution and sales systems. The ISBN system is used in many countries and is managed by national agencies. Each ISBN is assigned to a specific title and edition, preventing any confusion between different editions or formats of the same work (for example, between a hardback and a paperback edition).</p>"
-            },
-            "structure": {
-              "question": "How is an ISBN structured?",
-              "answer": "<p>An ISBN consists of 13 digits (or 10 in the former system) split into five segments. These segments include: a prefix (identifying the numbering system), a registration group (representing the country or language area), a publisher number, a title number (identifying a specific work) and a check digit that validates the structure of the ISBN. This structure allows rapid and accurate identification of books, simplifying their management worldwide. The move to ISBN-13 in 2007 aligned the system with global barcode standards, making book distribution even more efficient across retail and library networks.</p>"
-            },
-            "difference": {
-              "question": "What is the difference between ISBN-10 and ISBN-13?",
-              "answer": "<p>ISBN-10 was the original format used until 2007 and consisted of 10 digits. To align with the global EAN-13 barcode standards, the system moved to a 13-digit format: ISBN-13. This change standardised sales and distribution processes worldwide because ISBN-13 codes are compatible with commercial barcode systems used across industries. While ISBN-10 codes still exist for older works, new books published since 2007 exclusively use ISBN-13, which provides greater capacity for future identifiers.</p>"
-            },
-            "assignment": {
-              "question": "How is an ISBN assigned to a book?",
-              "answer": "<p>An ISBN is assigned by a national ISBN agency in each country, responsible for distributing and registering ISBN numbers. Publishers or authors contact this agency to obtain an ISBN for their book. When applying, they provide information about the work, such as the title, author, format and edition. Once assigned, the ISBN is unique to that edition and cannot be reused for another. This ensures efficient management of books in library, sales and distribution systems. It is essential for any work intended for wide circulation or sale.</p>"
-            },
-            "importance": {
-              "question": "Why are ISBNs important?",
-              "answer": "<p>An ISBN is important because it provides a unique, standardised identifier for a book within management, sales and distribution systems. Without an ISBN, a book can be difficult to find in online catalogues or bookshops because distribution systems rely heavily on this identifier. ISBNs also facilitate indexing in library and bookstore databases, improving visibility and accessibility for readers. They are essential for a book to be widely distributed, whether in print or digital format.</p>"
-            },
-            "nonBook": {
-              "question": "Why do I sometimes find non-book products in the database?",
-              "answer": "<p>Sometimes an ISBN is used to identify something other than a book. Several situations can lead to this:</p><ul><li><strong>Lack of understanding of standards</strong>: Some sellers or platforms use the ISBN as a generic identifier, especially when the product is cultural or related to creative hobbies.</li><li><strong>Cost savings</strong>: In certain cases it is cheaper for a small manufacturer to reuse an existing ISBN code, even though it falls outside the standards.</li><li><strong>Code format confusion</strong>: Some marketplaces do not strictly validate standard codes and accept ISBNs for non-book products, which creates ambiguities.</li><li><strong>Reassignment or attribution error</strong>: ISBNs are sometimes used incorrectly for non-editorial products, especially when the manufacturer or distributor does not have an appropriate GTIN barcode.</li></ul>"
-            }
-          }
-        }
-      }
-    },
-    "license": {
-      "title": "Open Database Licence (ODbL)",
-      "description": "You may use, share and adapt the data provided you credit Nudger and share any derivative databases under the same licence.",
-      "cta": {
-        "label": "Read the ODbL licence",
-        "ariaLabel": "Open the Open Database Licence documentation in a new tab",
-        "href": "https://spdx.org/licenses/ODbL-1.0.html#licenseText"
-      }
-    },
-    "faq": {
-      "title": "Frequently asked questions",
-      "subtitle": "Understand our approach to open data.",
-      "items": {
-        "sources": {
-          "question": "Where do the datasets come from?",
-          "answer": "<p>Extractions provided by Nudger stem from our work aggregating product data. We integrate a wide variety of sources that we group into several categories:</p><p><strong>Brand and manufacturer websites:</strong><br>We extract data directly from product sheets made available by brands and manufacturers.</p><p><strong>Institutional websites and open data:</strong> (base eprel, open food facts)<br>We integrate data from public or open repositories.</p><p><strong>Affiliate feeds and marketplaces:</strong> (awin, effinity, affilae, amazon, ..)<br>These come from promotional partnerships between Nudger and the platforms. We include a link in our extract so affiliate tracking applies when active offers exist for the product.</p><p>Nudger aggregates, normalises and resolves conflicts to publish factual, minimal product data. Building and sharing this database follows a commons mindset. We are convinced that sharing these datasets benefits every stakeholder in the consumption chain (manufacturers, retailers, researchers, citizens).</p><p>We are also mindful of intellectual property. Feel free to <a href=\"/contact\">contact us</a> with any question or if, as a data holder, you wish to opt out of this dataset.</p>"
-        },
-        "definition": {
-          "question": "What do we mean by open data?",
-          "answer": "<p>Open data refers to data that is made accessible to everyone without access restrictions and in formats that can be freely reused. They can be reused, modified and redistributed by anyone for personal or professional purposes. The goal is to maximise access to information in order to encourage transparency, innovation and efficiency across sectors. Open data is often provided by public organisations, but some private companies have also started to publish portions of their data. A key aspect of open data is technical accessibility: data must be available in standard, machine-readable formats (such as CSV, JSON or XML) so they can be reused without major technical hurdles. By easing access to data, open data unlocks numerous applications, from mobile apps and visualisations to in-depth analyses.</p>"
-        },
-        "importance": {
-          "question": "Why is open data important for commerce?",
-          "answer": "<p>Open data is crucial for promoting transparency and innovation. By making data accessible, it helps citizens better understand government decisions and participate in public debate with informed arguments. Companies can use these data to develop new products and services, stimulating economic growth. Open data also supports better decision-making because public information can be analysed to improve policies, reduce inefficiencies and make institutions more accountable. Finally, open data fosters collaboration between stakeholders—researchers, entrepreneurs, developers and local communities—who can work together to solve shared challenges creatively.</p>"
-        },
-        "contributors": {
-          "question": "How can contributors help improve the datasets?",
-          "answer": "<p>Nudger aggregates, normalises and resolves conflicts to publish factual product data, but contributions remain essential. You can share additional sources, report issues in the datasets or suggest improvements. Collaborating with manufacturers, distributors, researchers and citizens helps us keep the exports accurate, up to date and useful for everyone.</p>"
-        }
-      }
-    },
-    "opensource": {
-      "title": "Nudger is open source too",
-      "description": "Curious about the code powering these datasets? Discover the services, governance and community behind Nudger.",
-      "cta": {
-        "label": "Visit the open source page",
-        "ariaLabel": "Navigate to the open source page"
-      }
-    }
-  },
   "contact": {
-    "seo": {
-      "title": "Contact Nudger",
-      "description": "Get in touch with the Nudger collective for partnerships, product questions or impact insights.",
-      "imageAlt": "Nudger logomark used for the contact page preview"
-    },
-    "hero": {
-      "eyebrow": "Let's talk",
-      "title": "We would love to hear from you",
-      "subtitle": "Partnerships, product questions or impact insights? Our team is ready.",
-      "description": "Tell us more about your project, your organisation or the way you use Nudger so we can connect you with the right people.",
-      "highlights": {
-        "commitment": "Replies within two working days for most requests.",
-        "expertise": "Product, data and impact experts dedicated to responsible commerce.",
-        "impact": "Every message helps us build a fairer, more sustainable marketplace."
-      },
-      "channels": {
-        "title": "How we can help",
-        "subtitle": "Pick the topic that suits you best—every request reaches the same caring team.",
-        "support": {
-          "label": "Product & user support",
-          "description": "Questions about the comparator or trouble signing in? We will guide you step by step."
-        },
-        "partnerships": {
-          "label": "Partnerships & ecosystem",
-          "description": "Looking to collaborate, integrate Nudger data or co-create initiatives? Let's explore it together."
-        },
-        "trust": {
-          "label": "Press & civic impact",
-          "description": "Media, institutions or researchers can reach us for interviews, testimonies and key figures."
-        }
-      }
-    },
     "details": {
-      "eyebrow": "Stay connected",
-      "title": "Different ways to collaborate",
-      "subtitle": "Our collective unites citizens, entrepreneurs and institutions around responsible consumption.",
       "cards": {
-        "support": {
-          "title": "Need help with the platform?",
-          "description": "Describe your question in the form and share as much context as possible so we can provide an actionable answer.",
-          "cta": "Write to us",
-          "ctaAria": "Scroll to the contact form to write to the Nudger team"
+        "community": {
+          "cta": "Follow us on LinkedIn",
+          "ctaAria": "Open Nudger's LinkedIn page in a new tab",
+          "description": "Follow our updates, product releases and community calls on LinkedIn.",
+          "title": "Join the conversation"
         },
         "partnerships": {
-          "title": "Co-create impactful projects",
-          "description": "From retailers to NGOs and local authorities, we build bridges to accelerate ecological transition.",
           "cta": "Meet the team",
-          "ctaAria": "Discover the Nudger team page"
+          "ctaAria": "Discover the Nudger team page",
+          "description": "From retailers to NGOs and local authorities, we build bridges to accelerate ecological transition.",
+          "title": "Co-create impactful projects"
         },
-        "community": {
-          "title": "Join the conversation",
-          "description": "Follow our updates, product releases and community calls on LinkedIn.",
-          "cta": "Follow us on LinkedIn",
-          "ctaAria": "Open Nudger's LinkedIn page in a new tab"
+        "support": {
+          "cta": "Write to us",
+          "ctaAria": "Scroll to the contact form to write to the Nudger team",
+          "description": "Describe your question in the form and share as much context as possible so we can provide an actionable answer.",
+          "title": "Need help with the platform?"
         }
-      }
+      },
+      "eyebrow": "Stay connected",
+      "subtitle": "Our collective unites citizens, entrepreneurs and institutions around responsible consumption.",
+      "title": "Different ways to collaborate"
     },
     "form": {
-      "eyebrow": "Contact form",
-      "title": "Tell us more about you",
-      "subtitle": "Fill in the information below and we will get back to you as soon as possible.",
-      "fields": {
-        "name": {
-          "label": "Your name",
-          "placeholder": "e.g. Alex Martin"
+      "actions": {
+        "reset": "Clear form",
+        "submit": "Send message"
+      },
+      "errors": {
+        "captchaExpired": "Captcha expired, please try again.",
+        "captchaFailed": "Captcha verification failed. Please refresh and try again.",
+        "email": {
+          "invalid": "Please enter a valid email address.",
+          "required": "Please enter your email address."
         },
+        "message": {
+          "length": "Your message must be at least 10 characters long.",
+          "required": "Please describe your request."
+        },
+        "missingCaptcha": "Please complete the captcha before sending.",
+        "name": {
+          "length": "Your name must contain at least 2 characters.",
+          "required": "Please enter your name."
+        }
+      },
+      "eyebrow": "Contact form",
+      "feedback": {
+        "genericError": "We were unable to send your message. Please try again or contact us later.",
+        "missingSiteKey": "Captcha is not configured yet. Please try again later.",
+        "success": "Thank you! Your message has been sent. We will contact you shortly."
+      },
+      "fields": {
         "email": {
           "label": "Email address",
           "placeholder": "you{'@'}example.org"
@@ -1115,331 +385,1113 @@
         "message": {
           "label": "Message",
           "placeholder": "How can we help?"
+        },
+        "name": {
+          "label": "Your name",
+          "placeholder": "e.g. Alex Martin"
         }
       },
+      "privacy": "We only use your contact details to answer your request and never share them with third parties.",
+      "subtitle": "Fill in the information below and we will get back to you as soon as possible.",
+      "title": "Tell us more about you"
+    },
+    "hero": {
+      "channels": {
+        "partnerships": {
+          "description": "Looking to collaborate, integrate Nudger data or co-create initiatives? Let's explore it together.",
+          "label": "Partnerships & ecosystem"
+        },
+        "subtitle": "Pick the topic that suits you best—every request reaches the same caring team.",
+        "support": {
+          "description": "Questions about the comparator or trouble signing in? We will guide you step by step.",
+          "label": "Product & user support"
+        },
+        "title": "How we can help",
+        "trust": {
+          "description": "Media, institutions or researchers can reach us for interviews, testimonies and key figures.",
+          "label": "Press & civic impact"
+        }
+      },
+      "description": "Tell us more about your project, your organisation or the way you use Nudger so we can connect you with the right people.",
+      "eyebrow": "Let's talk",
+      "highlights": {
+        "commitment": "Replies within two working days for most requests.",
+        "expertise": "Product, data and impact experts dedicated to responsible commerce.",
+        "impact": "Every message helps us build a fairer, more sustainable marketplace."
+      },
+      "subtitle": "Partnerships, product questions or impact insights? Our team is ready.",
+      "title": "We would love to hear from you"
+    },
+    "seo": {
+      "description": "Get in touch with the Nudger collective for partnerships, product questions or impact insights.",
+      "imageAlt": "Nudger logomark used for the contact page preview",
+      "title": "Contact Nudger"
+    }
+  },
+  "contrib": {
+    "error": {
+      "cta": "Back to homepage",
+      "description": "The contribution link may have expired or is invalid. You can return to the homepage and try again.",
+      "detailsPrefix": "Details:",
+      "title": "We could not validate this link"
+    },
+    "loading": {
+      "message": "Please wait while we validate your contribution link.",
+      "title": "Preparing your redirect…"
+    },
+    "seo": {
+      "description": "We are validating your secure contribution link before redirecting you to Nudger's partner.",
+      "title": "Redirecting you to our partner"
+    },
+    "success": {
+      "cta": "Continue to partner site",
+      "message": "You will be redirected shortly. If nothing happens, use the button below.",
+      "title": "Ready to redirect"
+    }
+  },
+  "error": {
+    "page": {
       "actions": {
-        "submit": "Send message",
-        "reset": "Clear form"
+        "ariaLabel": "Error recovery quick actions",
+        "contactSupport": "Contact support",
+        "goHome": "Back to homepage"
       },
-      "feedback": {
-        "success": "Thank you! Your message has been sent. We will contact you shortly.",
-        "genericError": "We were unable to send your message. Please try again or contact us later.",
-        "missingSiteKey": "Captcha is not configured yet. Please try again later."
+      "debug": {
+        "empty": "No additional diagnostic information is available.",
+        "messageLabel": "Error message",
+        "stackLabel": "Stack trace",
+        "title": "Technical details"
       },
-      "errors": {
-        "name": {
-          "required": "Please enter your name.",
-          "length": "Your name must contain at least 2 characters."
-        },
-        "email": {
-          "required": "Please enter your email address.",
-          "invalid": "Please enter a valid email address."
-        },
-        "message": {
-          "required": "Please describe your request.",
-          "length": "Your message must be at least 10 characters long."
-        },
-        "captchaExpired": "Captcha expired, please try again.",
-        "captchaFailed": "Captcha verification failed. Please refresh and try again.",
-        "missingCaptcha": "Please complete the captcha before sending."
+      "eyebrow": "Unexpected detour",
+      "generic": {
+        "badge": "We hit a snag",
+        "description": "An unexpected error prevented us from loading this page.",
+        "helper": "Please try another section of Nudger or reach out if the problem persists.",
+        "statusMessage": "Error 500 — something went wrong on our side.",
+        "title": "We're working on a fix"
       },
-      "privacy": "We only use your contact details to answer your request and never share them with third parties."
+      "notFound": {
+        "badge": "Page missing",
+        "description": "The link you followed may be broken or the page may have moved.",
+        "helper": "Use the navigation links below or return to the homepage to continue exploring responsible shopping.",
+        "statusMessage": "Error 404 — the requested resource could not be located.",
+        "title": "We can’t find this page"
+      },
+      "statusLabel": "Status code {code}"
     }
   },
   "feedback": {
-    "hero": {
-      "eyebrow": "Product feedback",
-      "title": "Shape Nudger with your ideas",
-      "subtitle": "Report bugs, suggest features and vote on the improvements you need next.",
-      "description": "Your feedback steers our roadmap. Discover what others requested, upvote the most useful ideas and submit your own improvements.",
-      "ctaGroupLabel": "Feedback actions",
-      "primaryCta": {
-        "label": "Browse the feedback board",
-        "ariaLabel": "Scroll to the Nudger feedback board"
-      },
-      "secondaryCta": {
-        "label": "Open GitHub issues",
-        "ariaLabel": "Open Nudger's GitHub issues in a new tab"
-      },
-      "stats": {
-        "eyebrow": "How it works",
-        "title": "A living roadmap",
-        "description": "Help us focus on improvements that matter most.",
-        "items": {
-          "iterations": "Weekly iterations on the most upvoted ideas.",
-          "votes": "Three votes per person to highlight key needs.",
-          "transparency": "Public updates for every discussion and decision."
-        }
-      }
-    },
-    "tabs": {
-      "eyebrow": "Community board",
-      "title": "Help us prioritise the roadmap",
-      "description": "Pick a category to explore ongoing discussions, vote for the topics that resonate with you, or open a new one.",
-      "ariaLabel": "Feedback categories",
-      "idea": {
-        "label": "Ideas",
-        "issueTitle": "Community ideas",
-        "description": "Suggest enhancements that would make Nudger more helpful for you or your organisation. We review every idea weekly."
-      },
-      "bug": {
-        "label": "Bugs",
-        "issueTitle": "Reported bugs",
-        "description": "Describe any malfunction or inaccurate behaviour you spotted. Precise reports help us fix issues faster."
-      }
-    },
-    "issues": {
-      "empty": {
-        "idea": "No ideas yet. Be the first to share yours!",
-        "bug": "No bugs reported here right now. Thanks for keeping an eye out."
-      },
-      "loadError": "We couldn't load the feedback board. Please try again."
-    },
-    "voting": {
-      "voteButton": "Vote",
-      "voteButtonAria": "Vote for",
-      "openIssue": "Open discussion",
-      "noVotes": "You have no votes left right now.",
-      "limitReached": "You reached your voting limit for now.",
-      "remaining": "You have {count} votes remaining.",
-      "voteCompleted": "Done"
-    },
-    "form": {
-      "sections": {
-        "idea": {
-          "eyebrow": "Share an idea",
-          "title": "Imagine the next improvement",
-          "subtitle": "Explain how Nudger could better help you or your organisation.",
-          "intro": "Explain the context of your idea, why it matters and how it would improve Nudger for everyone.",
-          "titlePlaceholder": "e.g. Compare the carbon footprint of fridges",
-          "messagePlaceholder": "Describe your idea, the context and the impact you expect."
-        },
-        "bug": {
-          "eyebrow": "Report a bug",
-          "title": "Tell us what went wrong",
-          "subtitle": "The more details you share, the faster we can investigate and fix it.",
-          "intro": "Share the steps to reproduce the bug, what you expected and what actually happened so we can investigate quickly.",
-          "titlePlaceholder": "e.g. Error 500 on the product page",
-          "messagePlaceholder": "List the steps to reproduce, what you expected and what happened."
-        }
-      },
-      "fields": {
-        "author": {
-          "label": "Display name",
-          "placeholder": "How should we credit you?",
-          "default": "Nudger community member"
-        },
-        "title": {
-          "label": "Title"
-        },
-        "message": {
-          "label": "Message"
-        }
-      },
-      "actions": {
-        "submit": "Send feedback",
-        "reset": "Clear form"
-      },
-      "feedback": {
-        "success": "Thank you! Your contribution has been recorded and will appear on the board soon.",
-        "missingSiteKey": "Captcha is not configured yet. Feedback submissions are temporarily disabled."
-      },
-      "errors": {
-        "missingCaptcha": "Please complete the captcha before sending your feedback.",
-        "captchaExpired": "Captcha expired, please try again.",
-        "captchaFailed": "Captcha verification failed. Please retry.",
-        "title": {
-          "length": "The title must contain at least 4 characters."
-        },
-        "message": {
-          "length": "The message must contain at least 20 characters."
-        }
-      },
-      "privacy": "Feedback is public—please avoid sharing personal or sensitive data."
-    },
     "common": {
       "genericError": "Something went wrong. Please try again."
     },
-    "openSource": {
-      "eyebrow": "Open collaboration",
-      "title": "Explore our open source and open data",
-      "description": "We publish our roadmap, code and datasets so anyone can audit, reuse or contribute to Nudger.",
-      "cards": {
-        "opensource": {
-          "title": "Contribute on GitHub",
-          "description": "Browse our repositories, follow ongoing pull requests and submit your own contributions.",
-          "cta": "Visit the open source page",
-          "ariaLabel": "Go to the Nudger open source page"
+    "form": {
+      "actions": {
+        "reset": "Clear form",
+        "submit": "Send feedback"
+      },
+      "errors": {
+        "captchaExpired": "Captcha expired, please try again.",
+        "captchaFailed": "Captcha verification failed. Please retry.",
+        "message": {
+          "length": "The message must contain at least 20 characters."
         },
-        "opendata": {
-          "title": "Analyse our open data",
-          "description": "Download the datasets powering Nudger and reuse them in your research or projects.",
-          "cta": "Visit the open data page",
-          "ariaLabel": "Go to the Nudger open data page"
+        "missingCaptcha": "Please complete the captcha before sending your feedback.",
+        "title": {
+          "length": "The title must contain at least 4 characters."
+        }
+      },
+      "feedback": {
+        "missingSiteKey": "Captcha is not configured yet. Feedback submissions are temporarily disabled.",
+        "success": "Thank you! Your contribution has been recorded and will appear on the board soon."
+      },
+      "fields": {
+        "author": {
+          "default": "Nudger community member",
+          "label": "Display name",
+          "placeholder": "How should we credit you?"
+        },
+        "message": {
+          "label": "Message"
+        },
+        "title": {
+          "label": "Title"
+        }
+      },
+      "privacy": "Feedback is public—please avoid sharing personal or sensitive data.",
+      "sections": {
+        "bug": {
+          "eyebrow": "Report a bug",
+          "intro": "Share the steps to reproduce the bug, what you expected and what actually happened so we can investigate quickly.",
+          "messagePlaceholder": "List the steps to reproduce, what you expected and what happened.",
+          "subtitle": "The more details you share, the faster we can investigate and fix it.",
+          "title": "Tell us what went wrong",
+          "titlePlaceholder": "e.g. Error 500 on the product page"
+        },
+        "idea": {
+          "eyebrow": "Share an idea",
+          "intro": "Explain the context of your idea, why it matters and how it would improve Nudger for everyone.",
+          "messagePlaceholder": "Describe your idea, the context and the impact you expect.",
+          "subtitle": "Explain how Nudger could better help you or your organisation.",
+          "title": "Imagine the next improvement",
+          "titlePlaceholder": "e.g. Compare the carbon footprint of fridges"
         }
       }
     },
+    "hero": {
+      "ctaGroupLabel": "Feedback actions",
+      "description": "Your feedback steers our roadmap. Discover what others requested, upvote the most useful ideas and submit your own improvements.",
+      "eyebrow": "Product feedback",
+      "primaryCta": {
+        "ariaLabel": "Scroll to the Nudger feedback board",
+        "label": "Browse the feedback board"
+      },
+      "secondaryCta": {
+        "ariaLabel": "Open Nudger's GitHub issues in a new tab",
+        "label": "Open GitHub issues"
+      },
+      "stats": {
+        "description": "Help us focus on improvements that matter most.",
+        "eyebrow": "How it works",
+        "items": {
+          "iterations": "Weekly iterations on the most upvoted ideas.",
+          "transparency": "Public updates for every discussion and decision.",
+          "votes": "Three votes per person to highlight key needs."
+        },
+        "title": "A living roadmap"
+      },
+      "subtitle": "Report bugs, suggest features and vote on the improvements you need next.",
+      "title": "Shape Nudger with your ideas"
+    },
+    "issues": {
+      "empty": {
+        "bug": "No bugs reported here right now. Thanks for keeping an eye out.",
+        "idea": "No ideas yet. Be the first to share yours!"
+      },
+      "loadError": "We couldn't load the feedback board. Please try again."
+    },
+    "openSource": {
+      "cards": {
+        "opendata": {
+          "ariaLabel": "Go to the Nudger open data page",
+          "cta": "Visit the open data page",
+          "description": "Download the datasets powering Nudger and reuse them in your research or projects.",
+          "title": "Analyse our open data"
+        },
+        "opensource": {
+          "ariaLabel": "Go to the Nudger open source page",
+          "cta": "Visit the open source page",
+          "description": "Browse our repositories, follow ongoing pull requests and submit your own contributions.",
+          "title": "Contribute on GitHub"
+        }
+      },
+      "description": "We publish our roadmap, code and datasets so anyone can audit, reuse or contribute to Nudger.",
+      "eyebrow": "Open collaboration",
+      "title": "Explore our open source and open data"
+    },
     "seo": {
-      "title": "Feedback & roadmap – Nudger community board",
       "description": "Share ideas, report bugs and vote on Nudger's public roadmap for responsible shopping.",
-      "imageAlt": "Illustration of the Nudger community feedback board."
+      "imageAlt": "Illustration of the Nudger community feedback board.",
+      "title": "Feedback & roadmap – Nudger community board"
+    },
+    "tabs": {
+      "ariaLabel": "Feedback categories",
+      "bug": {
+        "description": "Describe any malfunction or inaccurate behaviour you spotted. Precise reports help us fix issues faster.",
+        "issueTitle": "Reported bugs",
+        "label": "Bugs"
+      },
+      "description": "Pick a category to explore ongoing discussions, vote for the topics that resonate with you, or open a new one.",
+      "eyebrow": "Community board",
+      "idea": {
+        "description": "Suggest enhancements that would make Nudger more helpful for you or your organisation. We review every idea weekly.",
+        "issueTitle": "Community ideas",
+        "label": "Ideas"
+      },
+      "title": "Help us prioritise the roadmap"
+    },
+    "voting": {
+      "limitReached": "You reached your voting limit for now.",
+      "noVotes": "You have no votes left right now.",
+      "openIssue": "Open discussion",
+      "remaining": "You have {count} votes remaining.",
+      "voteButton": "Vote",
+      "voteButtonAria": "Vote for",
+      "voteCompleted": "Done"
+    }
+  },
+  "impactScorePage": {
+    "aria": {
+      "navigation": "Impact Score section navigation",
+      "pageOutline": "Impact Score page outline"
+    },
+    "hero": {
+      "title": "Impact Score: assessing the environmental footprint of your products"
+    },
+    "navigation": {
+      "analysis": "Deep dive",
+      "approach": "Our approach",
+      "methodology": "Methodology",
+      "overview": "Overview"
+    },
+    "sections": {
+      "analysis": {
+        "dataQuality": {
+          "imageAlt": "Visual about data quality",
+          "title": "Data quality, a key requirement"
+        },
+        "eyebrow": "Deep dive",
+        "relativisation": {
+          "imageAlt": "Visual of the relativisation principle",
+          "title": "Relativisation principle"
+        },
+        "title": "Relativisation and data quality"
+      },
+      "approach": {
+        "eyebrow": "Our approach",
+        "imageAlt": "Illustration of our ecoscore approach",
+        "title": "Our ecoscore: transparent, innovative and effective"
+      },
+      "methodology": {
+        "empty": "Categories will be published soon.",
+        "eyebrow": "Methodology",
+        "intro": "The ecoscore calculation rules are detailed on every product (see the “environmental balance” section). Each product category has its own criteria and weights. These categories are currently covered:",
+        "title": "How is the Impact Score calculated?",
+        "verticalCardAria": "Open the ecoscore details for the {vertical} category",
+        "verticalCta": "Open the ecoscore details",
+        "verticalImageAlt": "Illustration for the {vertical} category",
+        "verticalLabel": "Category"
+      },
+      "overview": {
+        "eyebrow": "Overview",
+        "sample": {
+          "caption": "Indicative evaluation based on our methodology",
+          "title": "Indicative rating"
+        },
+        "title": "What is the Impact Score?"
+      }
+    }
+  },
+  "lang": {
+    "en": "English",
+    "fr": "French"
+  },
+  "opendata": {
+    "datasets": {
+      "cards": {
+        "gtin": {
+          "cta": {
+            "ariaLabel": "Open the GTIN open data page",
+            "label": "View GTIN dataset"
+          },
+          "description": "All products indexed in Nudger with brand, model, price range and category insights.",
+          "features": {
+            "coverage": "Includes EAN13, UPC and GS1 country metadata",
+            "refresh": "Weekly refreshed snapshot",
+            "uses": "Ideal for price comparison, assortment analysis and category monitoring"
+          },
+          "title": "GTIN catalogue"
+        },
+        "isbn": {
+          "cta": {
+            "ariaLabel": "Open the ISBN open data page",
+            "label": "View ISBN dataset"
+          },
+          "description": "Dedicated export for books with pricing, availability and classification information.",
+          "features": {
+            "catalogue": "Includes publisher, format and Decitre classifications",
+            "refresh": "Weekly refreshed snapshot",
+            "research": "Great for catalogue enrichment, research and cultural analytics"
+          },
+          "title": "ISBN library"
+        }
+      },
+      "common": {
+        "breadcrumb": {
+          "ariaLabel": "Back to the open data overview",
+          "label": "opendata"
+        },
+        "columnDescription": "Description",
+        "columnName": "Column",
+        "download": {
+          "direct": {
+            "concurrent": "Up to {value} simultaneous downloads",
+            "concurrentUnknown": "Concurrent downloads limited",
+            "cta": {
+              "ariaLabel": "Start the direct download from Nudger",
+              "label": "Download from nudger.fr"
+            },
+            "description": "Retrieve the ZIP file directly from Nudger's infrastructure.",
+            "speed": "Limited to {value} per client",
+            "speedUnknown": "Download speed limited per client",
+            "title": "Direct download from Nudger"
+          },
+          "fast": {
+            "badge": "Recommended",
+            "cta": {
+              "ariaLabel": "Open the dataset on data.gouv.fr in a new tab",
+              "href": "https://www.data.gouv.fr/fr/datasets/base-de-codes-barres-noms-et-categories-produits/",
+              "label": "Download from data.gouv.fr"
+            },
+            "description": "Download via the official open data portal hosted by the French government.",
+            "speed": "High bandwidth infrastructure",
+            "title": "Fast mirror (data.gouv.fr)"
+          }
+        },
+        "placeholder": "—",
+        "summary": {
+          "records": "Total records",
+          "size": "Compressed size",
+          "updated": "Last updated"
+        }
+      },
+      "gtin": {
+        "columns": {
+          "brand": {
+            "description": "Brand declared or inferred for the product.",
+            "label": "brand"
+          },
+          "categories": {
+            "description": "Product categories aggregated by Nudger (pipe-separated).",
+            "label": "categories"
+          },
+          "currency": {
+            "description": "Currency code of the lowest price.",
+            "label": "currency"
+          },
+          "gs1_country": {
+            "description": "Country code derived from the GS1 prefix.",
+            "label": "gs1_country"
+          },
+          "gtin": {
+            "description": "Global Trade Item Number (EAN13/UPC).",
+            "label": "gtin"
+          },
+          "gtinType": {
+            "description": "Type of barcode detected (EAN13, UPC, etc.).",
+            "label": "gtinType"
+          },
+          "last_updated": {
+            "description": "Epoch timestamp (ms) of the latest update for this product.",
+            "label": "last_updated"
+          },
+          "min_price": {
+            "description": "Lowest observed price across all offers.",
+            "label": "min_price"
+          },
+          "min_price_compensation": {
+            "description": "Carbon contribution associated with the lowest price.",
+            "label": "min_price_compensation"
+          },
+          "model": {
+            "description": "Manufacturer model or SKU reference when available.",
+            "label": "model"
+          },
+          "name": {
+            "description": "Marketing name or product title.",
+            "label": "name"
+          },
+          "offers_count": {
+            "description": "Number of commercial offers tracked for the product.",
+            "label": "offers_count"
+          },
+          "url": {
+            "description": "Product page URL when public offers are available.",
+            "label": "url"
+          }
+        },
+        "columnsSubtitle": "Each row represents a product identifier enriched with metadata gathered by Nudger.",
+        "columnsTitle": "Columns included in the GTIN dataset",
+        "download": {
+          "fast": {
+            "highlight": "Curated for broad retail and circular economy use cases"
+          },
+          "subtitle": "Choose the mirror that matches your bandwidth and automation needs.",
+          "title": "Download options"
+        },
+        "faq": {
+          "items": {
+            "differenceEan": {
+              "answer": "<p><strong>The EAN (European Article Number)</strong> used to be the standard identifier in Europe for marking products. Today the term GTIN has replaced EAN to standardise product codes globally. The EAN-13 is now a GTIN-13. In practice the change is mainly a matter of naming and the code structure remains the same. GTIN also covers other identifiers such as the UPC (Universal Product Code) used in North America.</p>",
+              "question": "What is the difference between GTIN and EAN?"
+            },
+            "differenceUpc": {
+              "answer": "<p><strong>The UPC (Universal Product Code)</strong> is a form of GTIN-12 mainly used in North America. The difference between GTIN and UPC is mostly regional usage: GTIN is the broader global term, while UPC refers to a specific code used in a North American context. Both systems are interoperable and, within the GTIN standard, UPC is recognised as a sub-category.</p>",
+              "question": "What is the difference between GTIN and UPC?"
+            },
+            "ean13": {
+              "answer": "<p><strong>The EAN-13</strong> is a barcode made up of 13 digits that identifies products internationally, mainly in Europe. EAN-13 is also called GTIN-13 and is widely used at points of sale to scan and track items. It includes a country prefix, a company code, a product code and a check digit that ensures the code is valid.</p>",
+              "question": "What is the EAN-13 format?"
+            },
+            "formats": {
+              "answer": "<p><strong>The main GTIN formats</strong> are: GTIN-12 (commonly used in the United States and Canada under the name UPC), GTIN-13 (most common in Europe) and GTIN-14 (for logistic units). These different formats meet the specific needs of each region and supply chain. GTIN-14 is generally used to identify larger logistic units, such as cartons or pallets, rather than single items.</p>",
+              "question": "What are the different GTIN formats?"
+            },
+            "logistics": {
+              "answer": "<p><strong>GTIN in logistics</strong> plays an essential role in identifying products across supply chains. For example, the GTIN-14 format makes it possible to identify shipping units such as cartons or pallets, which simplifies stock management and shipping operations. Using GTIN barcodes in logistics allows precise traceability of products throughout their lifecycle, from manufacturer to distributor.</p>",
+              "question": "How is GTIN used in logistics?"
+            },
+            "whatIs": {
+              "answer": "<p><strong>The GTIN (Global Trade Item Number)</strong> is a unique identifier used to recognise products worldwide. It comes in several formats (GTIN-12, GTIN-13, GTIN-14), each tailored to specific product types or regions. For example, GTIN-13 is commonly used in Europe, while GTIN-12 is more frequent in North America. Every GTIN ensures a product can be tracked, identified and catalogued anywhere in the world, enabling efficient stock and sales management.</p>",
+              "question": "What is a GTIN and why does it matter?"
+            }
+          },
+          "subtitle": "Understand how to work with the GTIN dataset.",
+          "title": "Frequently asked questions"
+        },
+        "format": {
+          "bullets": {
+            "quote": "Text qualifier: double quotes (\")",
+            "separator": "Field separator: comma (,)",
+            "type": "CSV file compressed as ZIP"
+          },
+          "description": "Data is delivered as a compressed CSV archive ready for ingestion.",
+          "title": "File format"
+        },
+        "hero": {
+          "eyebrow": "GTIN export",
+          "stats": {
+            "records": "Products",
+            "size": "ZIP size",
+            "updated": "Last updated"
+          },
+          "title": "Barcode data for consumer products"
+        },
+        "seo": {
+          "description": "Access Nudger's GTIN dataset with weekly updates, download options and schema details for your barcode data projects.",
+          "title": "GTIN open data – download the barcode catalogue"
+        },
+        "summary": {
+          "title": "GTIN dataset overview"
+        }
+      },
+      "isbn": {
+        "columns": {
+          "classification_decitre_1": {
+            "description": "Decitre classification – level 1.",
+            "label": "classification_decitre_1"
+          },
+          "classification_decitre_2": {
+            "description": "Decitre classification – level 2.",
+            "label": "classification_decitre_2"
+          },
+          "classification_decitre_3": {
+            "description": "Decitre classification – level 3.",
+            "label": "classification_decitre_3"
+          },
+          "currency": {
+            "description": "Currency code of the lowest price.",
+            "label": "currency"
+          },
+          "editeur": {
+            "description": "Publisher name.",
+            "label": "editeur"
+          },
+          "format": {
+            "description": "Book format (paperback, digital, etc.).",
+            "label": "format"
+          },
+          "isbn": {
+            "description": "International Standard Book Number.",
+            "label": "isbn"
+          },
+          "last_updated": {
+            "description": "Epoch timestamp (ms) of the last update.",
+            "label": "last_updated"
+          },
+          "min_price": {
+            "description": "Lowest observed retail price.",
+            "label": "min_price"
+          },
+          "min_price_compensation": {
+            "description": "Carbon contribution associated with the lowest price.",
+            "label": "min_price_compensation"
+          },
+          "nb_page": {
+            "description": "Number of pages.",
+            "label": "nb_page"
+          },
+          "offers_count": {
+            "description": "Number of commercial offers tracked for the book.",
+            "label": "offers_count"
+          },
+          "souscategorie": {
+            "description": "Primary subcategory assigned to the book.",
+            "label": "souscategorie"
+          },
+          "souscategorie2": {
+            "description": "Secondary subcategory assigned to the book.",
+            "label": "souscategorie2"
+          },
+          "title": {
+            "description": "Book title as provided by sources.",
+            "label": "title"
+          },
+          "url": {
+            "description": "Product page URL when offers are available.",
+            "label": "url"
+          }
+        },
+        "columnsSubtitle": "Each row corresponds to a book identified by its ISBN.",
+        "columnsTitle": "Columns included in the ISBN dataset",
+        "download": {
+          "fast": {
+            "highlight": "Mirror maintained for open culture and library reuse"
+          },
+          "subtitle": "Pick the mirror that suits your workflow and traffic needs.",
+          "title": "Download options"
+        },
+        "faq": {
+          "items": {
+            "assignment": {
+              "answer": "<p>An ISBN is assigned by a national ISBN agency in each country, responsible for distributing and registering ISBN numbers. Publishers or authors contact this agency to obtain an ISBN for their book. When applying, they provide information about the work, such as the title, author, format and edition. Once assigned, the ISBN is unique to that edition and cannot be reused for another. This ensures efficient management of books in library, sales and distribution systems. It is essential for any work intended for wide circulation or sale.</p>",
+              "question": "How is an ISBN assigned to a book?"
+            },
+            "difference": {
+              "answer": "<p>ISBN-10 was the original format used until 2007 and consisted of 10 digits. To align with the global EAN-13 barcode standards, the system moved to a 13-digit format: ISBN-13. This change standardised sales and distribution processes worldwide because ISBN-13 codes are compatible with commercial barcode systems used across industries. While ISBN-10 codes still exist for older works, new books published since 2007 exclusively use ISBN-13, which provides greater capacity for future identifiers.</p>",
+              "question": "What is the difference between ISBN-10 and ISBN-13?"
+            },
+            "importance": {
+              "answer": "<p>An ISBN is important because it provides a unique, standardised identifier for a book within management, sales and distribution systems. Without an ISBN, a book can be difficult to find in online catalogues or bookshops because distribution systems rely heavily on this identifier. ISBNs also facilitate indexing in library and bookstore databases, improving visibility and accessibility for readers. They are essential for a book to be widely distributed, whether in print or digital format.</p>",
+              "question": "Why are ISBNs important?"
+            },
+            "meaning": {
+              "answer": "<p>ISBN stands for <strong>“International Standard Book Number”</strong>, a standardised international number for books. It uniquely identifies a publication worldwide and simplifies the management of books in storage, distribution and sales systems. The ISBN system is used in many countries and is managed by national agencies. Each ISBN is assigned to a specific title and edition, preventing any confusion between different editions or formats of the same work (for example, between a hardback and a paperback edition).</p>",
+              "question": "What does ISBN stand for?"
+            },
+            "nonBook": {
+              "answer": "<p>Sometimes an ISBN is used to identify something other than a book. Several situations can lead to this:</p><ul><li><strong>Lack of understanding of standards</strong>: Some sellers or platforms use the ISBN as a generic identifier, especially when the product is cultural or related to creative hobbies.</li><li><strong>Cost savings</strong>: In certain cases it is cheaper for a small manufacturer to reuse an existing ISBN code, even though it falls outside the standards.</li><li><strong>Code format confusion</strong>: Some marketplaces do not strictly validate standard codes and accept ISBNs for non-book products, which creates ambiguities.</li><li><strong>Reassignment or attribution error</strong>: ISBNs are sometimes used incorrectly for non-editorial products, especially when the manufacturer or distributor does not have an appropriate GTIN barcode.</li></ul>",
+              "question": "Why do I sometimes find non-book products in the database?"
+            },
+            "structure": {
+              "answer": "<p>An ISBN consists of 13 digits (or 10 in the former system) split into five segments. These segments include: a prefix (identifying the numbering system), a registration group (representing the country or language area), a publisher number, a title number (identifying a specific work) and a check digit that validates the structure of the ISBN. This structure allows rapid and accurate identification of books, simplifying their management worldwide. The move to ISBN-13 in 2007 aligned the system with global barcode standards, making book distribution even more efficient across retail and library networks.</p>",
+              "question": "How is an ISBN structured?"
+            },
+            "whatIs": {
+              "answer": "<p>An ISBN (International Standard Book Number) is a unique number that identifies a book worldwide. It is essential for publishers, booksellers, libraries and any platform selling books. ISBNs make it easier to manage inventory, distribution and sales. Each book or edition of the same book has its own ISBN, ensuring unique identification in databases and catalogues. ISBNs are used for both printed books and e-books, helping readers find the exact title they need in library systems and online marketplaces.</p>",
+              "question": "What is an ISBN?"
+            }
+          },
+          "subtitle": "Key concepts about the ISBN export.",
+          "title": "Frequently asked questions"
+        },
+        "format": {
+          "bullets": {
+            "quote": "Text qualifier: double quotes (\")",
+            "separator": "Field separator: comma (,)",
+            "type": "CSV file compressed as ZIP"
+          },
+          "description": "Data is delivered as a compressed CSV archive ready for ingestion.",
+          "title": "File format"
+        },
+        "hero": {
+          "eyebrow": "ISBN export",
+          "stats": {
+            "records": "Publications",
+            "size": "ZIP size",
+            "updated": "Last updated"
+          },
+          "title": "Comprehensive metadata for books"
+        },
+        "seo": {
+          "description": "Retrieve Nudger's ISBN dataset with weekly refreshes, download mirrors and schema information for publishing analytics.",
+          "title": "ISBN open data – download the book metadata export"
+        },
+        "summary": {
+          "title": "ISBN dataset overview"
+        }
+      },
+      "subtitle": "Pick the export that matches your project. Both are updated weekly and delivered under the Open Database Licence.",
+      "title": "Two complementary datasets"
+    },
+    "errors": {
+      "datasetFailed": "We could not load the dataset details. Please try again.",
+      "overviewFailed": "We could not load the open data overview. Please try again."
+    },
+    "faq": {
+      "items": {
+        "contributors": {
+          "answer": "<p>Nudger aggregates, normalises and resolves conflicts to publish factual product data, but contributions remain essential. You can share additional sources, report issues in the datasets or suggest improvements. Collaborating with manufacturers, distributors, researchers and citizens helps us keep the exports accurate, up to date and useful for everyone.</p>",
+          "question": "How can contributors help improve the datasets?"
+        },
+        "definition": {
+          "answer": "<p>Open data refers to data that is made accessible to everyone without access restrictions and in formats that can be freely reused. They can be reused, modified and redistributed by anyone for personal or professional purposes. The goal is to maximise access to information in order to encourage transparency, innovation and efficiency across sectors. Open data is often provided by public organisations, but some private companies have also started to publish portions of their data. A key aspect of open data is technical accessibility: data must be available in standard, machine-readable formats (such as CSV, JSON or XML) so they can be reused without major technical hurdles. By easing access to data, open data unlocks numerous applications, from mobile apps and visualisations to in-depth analyses.</p>",
+          "question": "What do we mean by open data?"
+        },
+        "importance": {
+          "answer": "<p>Open data is crucial for promoting transparency and innovation. By making data accessible, it helps citizens better understand government decisions and participate in public debate with informed arguments. Companies can use these data to develop new products and services, stimulating economic growth. Open data also supports better decision-making because public information can be analysed to improve policies, reduce inefficiencies and make institutions more accountable. Finally, open data fosters collaboration between stakeholders—researchers, entrepreneurs, developers and local communities—who can work together to solve shared challenges creatively.</p>",
+          "question": "Why is open data important for commerce?"
+        },
+        "sources": {
+          "answer": "<p>Extractions provided by Nudger stem from our work aggregating product data. We integrate a wide variety of sources that we group into several categories:</p><p><strong>Brand and manufacturer websites:</strong><br>We extract data directly from product sheets made available by brands and manufacturers.</p><p><strong>Institutional websites and open data:</strong> (base eprel, open food facts)<br>We integrate data from public or open repositories.</p><p><strong>Affiliate feeds and marketplaces:</strong> (awin, effinity, affilae, amazon, ..)<br>These come from promotional partnerships between Nudger and the platforms. We include a link in our extract so affiliate tracking applies when active offers exist for the product.</p><p>Nudger aggregates, normalises and resolves conflicts to publish factual, minimal product data. Building and sharing this database follows a commons mindset. We are convinced that sharing these datasets benefits every stakeholder in the consumption chain (manufacturers, retailers, researchers, citizens).</p><p>We are also mindful of intellectual property. Feel free to <a href=\"/contact\">contact us</a> with any question or if, as a data holder, you wish to opt out of this dataset.</p>",
+          "question": "Where do the datasets come from?"
+        }
+      },
+      "subtitle": "Understand our approach to open data.",
+      "title": "Frequently asked questions"
+    },
+    "hero": {
+      "eyebrow": "Open data",
+      "primaryCta": {
+        "ariaLabel": "Scroll to the open data datasets section",
+        "label": "Explore the datasets"
+      },
+      "subtitle": "Download GTIN and ISBN datasets maintained by Nudger to build your own analyses, services and research.",
+      "title": "Transparent product data for responsible commerce"
+    },
+    "license": {
+      "cta": {
+        "ariaLabel": "Open the Open Database Licence documentation in a new tab",
+        "href": "https://spdx.org/licenses/ODbL-1.0.html#licenseText",
+        "label": "Read the ODbL licence"
+      },
+      "description": "You may use, share and adapt the data provided you credit Nudger and share any derivative databases under the same licence.",
+      "title": "Open Database Licence (ODbL)"
+    },
+    "loading": "Loading open data information…",
+    "opensource": {
+      "cta": {
+        "ariaLabel": "Navigate to the open source page",
+        "label": "Visit the open source page"
+      },
+      "description": "Curious about the code powering these datasets? Discover the services, governance and community behind Nudger.",
+      "title": "Nudger is open source too"
+    },
+    "seo": {
+      "description": "Explore GTIN and ISBN datasets curated by Nudger, including weekly exports and download guidance.",
+      "title": "Nudger open data portal"
+    },
+    "stats": {
+      "accessibilityTitle": "Key open data metrics",
+      "datasets": {
+        "description": "Currently available data packages.",
+        "label": "Published datasets"
+      },
+      "placeholder": "—",
+      "totalProducts": {
+        "description": "Unique products referenced across all exports.",
+        "label": "Products covered",
+        "millions": "+{value} million"
+      },
+      "totalSize": {
+        "description": "Total compressed footprint of weekly exports.",
+        "label": "Combined size"
+      }
+    }
+  },
+  "opensource": {
+    "contribution": {
+      "eyebrow": "Contribute",
+      "steps": {
+        "issues": {
+          "title": "Pick an issue that inspires you"
+        },
+        "setup": {
+          "title": "Set up the project locally"
+        },
+        "share": {
+          "title": "Share, review and celebrate"
+        }
+      },
+      "title": "Join the collective in a few steps"
+    },
+    "hero": {
+      "ctaGroupLabel": "Primary hero actions",
+      "infoCard": {
+        "description": "grows with everyone. Every pull request, issue or piece of feedback makes the platform more transparent.",
+        "highlight": "Open4goods",
+        "items": {
+          "collaborativeReviews": "Collaborative reviews of contributions",
+          "openLicenses": "Code and data published under open licences",
+          "sharedGovernance": "Shared governance and living documentation"
+        }
+      },
+      "primaryCta": {
+        "ariaLabel": "Open the Nudger GitHub organization in a new tab",
+        "label": "Explore the repositories"
+      },
+      "subtitle": "Code, data and governance are transparent so anyone can audit and improve Nudger.",
+      "title": "We build a commons for responsible shopping"
+    },
+    "pillars": {
+      "cards": {
+        "community": {
+          "ariaLabel": "Navigate to the Nudger team page",
+          "cta": "Meet the team",
+          "title": "Inclusive community"
+        },
+        "methodology": {
+          "ariaLabel": "Navigate to the Impact Score page",
+          "cta": "Understand the Impact Score",
+          "title": "Documented methodology"
+        },
+        "transparency": {
+          "ariaLabel": "Open the Nudger GitHub repository in a new tab",
+          "cta": "Browse the source code",
+          "title": "Transparent architecture"
+        }
+      },
+      "eyebrow": "Our commitments",
+      "title": "An open ecosystem you can trust"
+    },
+    "resources": {
+      "contact": {
+        "cta": {
+          "ariaLabel": "Navigate to the contact page",
+          "label": "Contact the team"
+        },
+        "title": "Need a human sparring partner?"
+      },
+      "eyebrow": "Resources",
+      "feedback": {
+        "cta": {
+          "ariaLabel": "Navigate to the user feedback page",
+          "label": "Open the feedback board"
+        },
+        "description": "Report bugs, submit feature ideas and help us prioritise what matters next.",
+        "points": {
+          "bugs": "Log a bug in just a few clicks",
+          "features": "Suggest new features and improvements",
+          "votes": "Vote on the topics that matter to you"
+        },
+        "title": "Share feedback and ideas"
+      },
+      "links": {
+        "guide": {
+          "ariaLabel": "Open the Nudger contribution guide on GitHub in a new tab",
+          "title": "Contribution guide"
+        },
+        "issues": {
+          "ariaLabel": "Open the Nudger GitHub issues board in a new tab",
+          "title": "Issue tracker"
+        },
+        "updates": {
+          "ariaLabel": "Open the Nudger blog",
+          "title": "Community updates"
+        }
+      },
+      "opendata": {
+        "cta": {
+          "ariaLabel": "Navigate to the open data page",
+          "label": "Browse the open data portal"
+        },
+        "description": "Nudger datasets are published so you can analyse product footprints, cross-check our scoring and build your own projects.",
+        "title": "Open data for transparent decisions"
+      },
+      "title": "Everything you need to get started"
+    },
+    "seo": {
+      "description": "Discover how Nudger shares its code, data and governance to build a responsible shopping commons together.",
+      "imageAlt": "Nudger logomark representing the open source programme",
+      "title": "Open source at Nudger"
+    }
+  },
+  "partners": {
+    "affiliation": {
+      "carouselAriaLabel": "Affiliation partners carousel",
+      "empty": "No partners match your search yet. Try another term.",
+      "linkLabel": "Visit this partner",
+      "search": {
+        "label": "Search partners",
+        "placeholder": "Search by partner name"
+      },
+      "subtitle": "Explore the merchants who work with us through affiliation and discover their offers.",
+      "title": "They trust Nudger"
+    },
+    "cta": {
+      "ctaLabel": "Contact the team",
+      "description": "We are always looking for new allies who want to build responsible shopping with us.",
+      "eyebrow": "Join the movement",
+      "title": "Want to become a partner?"
+    },
+    "ecosystem": {
+      "carouselAriaLabel": "Ecosystem partners carousel",
+      "empty": "Our ecosystem partners will appear here soon.",
+      "fallbackDescription": "Content about this partner will be published soon.",
+      "linkLabel": "Discover the initiative",
+      "subtitle": "These organisations collaborate with us to build public-interest digital services.",
+      "title": "Nudger grows within a dynamic ecosystem"
+    },
+    "errors": {
+      "loadFailed": "We could not load partner data. Please try again."
+    },
+    "hero": {
+      "description": "Browse affiliation partners you can support, discover the ecosystem backing Nudger and the mentors guiding our mission.",
+      "eyebrow": "Collective impact",
+      "subtitle": "A trusted network of retailers, ecosystem builders and mentors committed to fairer shopping.",
+      "title": "Partners who amplify Nudger"
+    },
+    "loading": "Loading partners…",
+    "mentors": {
+      "carouselAriaLabel": "Mentor carousel",
+      "empty": "Mentor profiles will arrive shortly.",
+      "fallbackDescription": "More information about this mentor is coming soon.",
+      "linkLabel": "Learn more",
+      "subtitle": "Entrepreneurship is never simple. These mentors share their experience with kindness.",
+      "title": "They support us"
+    },
+    "seo": {
+      "description": "Meet the organisations, marketplaces and mentors helping Nudger accelerate responsible commerce.",
+      "title": "Our partners and mentors"
     }
   },
   "product": {
-    "navigation": {
-      "label": "Product detail navigation",
-      "overview": "Overview",
-      "impact": "Environmental impact",
-      "ai": "AI summary",
-      "price": "Pricing",
-      "attributes": "Specifications",
-      "docs": "Documentation",
-      "admin": "Administration"
+    "admin": {
+      "subtitle": "Full JSON payload of the product.",
+      "title": "Admin section"
+    },
+    "aiReview": {
+      "empty": "Summary not requested yet.",
+      "errors": {
+        "captcha": "Please validate the captcha before continuing.",
+        "generic": "An error occurred while generating the summary."
+      },
+      "generatedAt": "Summary generated on {date}",
+      "requestButton": "Request the summary",
+      "sections": {
+        "cons": "Cons",
+        "details": "In detail",
+        "ecological": "Environmental analysis",
+        "identity": "Identity card",
+        "overall": "Overall summary",
+        "pros": "Pros",
+        "sources": "Consulted sources",
+        "technical": "Technical analysis"
+      },
+      "sources": {
+        "description": "Description",
+        "index": "Ref.",
+        "source": "Source"
+      },
+      "status": {
+        "failed": "Generation failed",
+        "running": "Generation in progress ({step})",
+        "success": "Summary available"
+      },
+      "subtitle": "An AI-written synthesis built from verified sources.",
+      "title": "Test & review summary"
+    },
+    "attributes": {
+      "features": "Highlights",
+      "indexedGroup": "Indexed attributes",
+      "referentialTitle": "Reference identifiers",
+      "searchPlaceholder": "Search a specification",
+      "subtitle": "Browse every specification and filter with keywords.",
+      "title": "Technical specifications",
+      "unfeatures": "Watchouts"
+    },
+    "docs": {
+      "download": "Download PDF",
+      "empty": "No documents are available for this product yet.",
+      "loading": "Loading document preview…",
+      "navigationAria": "Product documentation list",
+      "pageCount": "{count} page(s)",
+      "previewUnavailable": "Preview unavailable for this document. Use the download link instead.",
+      "sidebarTitle": "Available documents",
+      "subtitle": "Preview and download official documents.",
+      "title": "Documentation",
+      "untitled": "Untitled document"
     },
     "hero": {
-      "gtin": "GTIN code",
-      "offersCount": "Number of offers",
       "bestPriceTitle": "Best price",
-      "priceMerchantPrefix": "At",
-      "viewSingleOffer": "View the offer",
-      "viewOffersCount": "View the {count} offers",
       "breadcrumbAriaLabel": "Product breadcrumb",
-      "missingBreadcrumbTitle": "Category",
+      "compare": {
+        "add": "Add to compare",
+        "ariaAdd": "Add {name} to compare",
+        "ariaSelected": "{name} is in your comparison list",
+        "label": "Compare",
+        "remove": "Remove from compare",
+        "selected": "In comparison"
+      },
+      "gtin": "GTIN code",
       "gtinTooltip": "Based on the product GTIN code, this does not necessarily indicate the manufacturing location.",
-      "openGalleryImage": "View image \"{label}\" in fullscreen",
-      "openGalleryVideo": "Play video \"{label}\"",
-      "openGalleryFallback": "Open product media gallery",
-      "thumbnailLabel": "Select {type} {index} of {total}: {label}",
       "mediaType": {
         "image": "image",
         "video": "video"
       },
-      "videoBadge": "Video",
-      "compare": {
-        "label": "Compare",
-        "selected": "In comparison",
-        "add": "Add to compare",
-        "remove": "Remove from compare",
-        "ariaAdd": "Add {name} to compare",
-        "ariaSelected": "{name} is in your comparison list"
-      },
+      "missingBreadcrumbTitle": "Category",
       "offerConditions": {
-        "occasion": "Second-hand",
-        "new": "New"
+        "new": "New",
+        "occasion": "Second-hand"
       },
-      "offerConditionsToggleAria": "Choose which offer condition to highlight"
+      "offerConditionsToggleAria": "Choose which offer condition to highlight",
+      "offersCount": "Number of offers",
+      "openGalleryFallback": "Open product media gallery",
+      "openGalleryImage": "View image \"{label}\" in fullscreen",
+      "openGalleryVideo": "Play video \"{label}\"",
+      "priceMerchantPrefix": "At",
+      "thumbnailLabel": "Select {type} {index} of {total}: {label}",
+      "videoBadge": "Video",
+      "viewOffersCount": "View the {count} offers",
+      "viewSingleOffer": "View the offer"
     },
     "impact": {
-      "title": "Environmental impact",
-      "subtitle": "Explore how this product scores across ecological and social criteria.",
-      "primaryScoreLabel": "Overall impact",
+      "absoluteValue": "Absolute value",
+      "bestProduct": "Best rated product: {name}",
+      "betterProduct": "Next best product: {name}",
+      "detailsTitle": "Assessment details",
       "noPrimaryScore": "Impact score unavailable",
+      "percentile": "Percentile",
+      "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
       "rankingTitle": "Ranking",
       "rankingValue": "Position {position} of {total}",
-      "bestProduct": "Best rated product: {name}",
-      "betterProduct": "Next best product: {name}",
-      "scoreValue": "Relative score",
-      "absoluteValue": "Absolute value",
-      "percentile": "Percentile",
       "scoreRanking": "Factor ranking",
-      "detailsTitle": "Assessment details",
+      "scoreValue": "Relative score",
+      "subtitle": "Explore how this product scores across ecological and social criteria.",
       "tableHeaders": {
-        "score": "Indicator",
-        "value": "Value",
+        "percent": "Percentile",
         "ranking": "Rank",
-        "percent": "Percentile"
-      }
+        "score": "Indicator",
+        "value": "Value"
+      },
+      "title": "Environmental impact"
     },
-    "aiReview": {
-      "title": "Test & review summary",
-      "subtitle": "An AI-written synthesis built from verified sources.",
-      "generatedAt": "Summary generated on {date}",
-      "sections": {
-        "overall": "Overall summary",
-        "details": "In detail",
-        "technical": "Technical analysis",
-        "ecological": "Environmental analysis",
-        "pros": "Pros",
-        "cons": "Cons",
-        "identity": "Identity card",
-        "sources": "Consulted sources"
-      },
-      "sources": {
-        "index": "Ref.",
-        "source": "Source",
-        "description": "Description"
-      },
-      "empty": "Summary not requested yet.",
-      "requestButton": "Request the summary",
-      "status": {
-        "running": "Generation in progress ({step})",
-        "success": "Summary available",
-        "failed": "Generation failed"
-      },
-      "errors": {
-        "captcha": "Please validate the captcha before continuing.",
-        "generic": "An error occurred while generating the summary."
-      }
+    "navigation": {
+      "admin": "Administration",
+      "ai": "AI summary",
+      "attributes": "Specifications",
+      "docs": "Documentation",
+      "impact": "Environmental impact",
+      "label": "Product detail navigation",
+      "overview": "Overview",
+      "price": "Pricing"
     },
     "price": {
-      "title": "Prices and trends",
-      "subtitle": "Track price evolution and compare offers.",
+      "condition": {
+        "new": "New",
+        "occasion": "Second-hand",
+        "refurbished": "Refurbished",
+        "unknown": "Unknown",
+        "used": "Second-hand"
+      },
+      "headers": {
+        "condition": "Condition",
+        "offer": "Offer",
+        "price": "Price",
+        "source": "Source",
+        "updated": "Updated"
+      },
       "newOffers": "New offers",
+      "noOccasionHistory": "No history for second-hand offers.",
       "occasionOffers": "Second-hand offers",
+      "offerList": "Offer list",
+      "subtitle": "Track price evolution and compare offers.",
+      "title": "Prices and trends",
       "trend": {
         "decrease": "Price drop of {amount}",
         "increase": "Price increase of {amount}",
         "stable": "Price unchanged"
-      },
-      "noOccasionHistory": "No history for second-hand offers.",
-      "offerList": "Offer list",
-      "headers": {
-        "source": "Source",
-        "offer": "Offer",
-        "price": "Price",
-        "condition": "Condition",
-        "updated": "Updated"
-      },
-      "condition": {
-        "new": "New",
-        "occasion": "Second-hand",
-        "used": "Second-hand",
-        "refurbished": "Refurbished",
-        "unknown": "Unknown"
       }
-    },
-    "attributes": {
-      "title": "Technical specifications",
-      "subtitle": "Browse every specification and filter with keywords.",
-      "searchPlaceholder": "Search a specification",
-      "referentialTitle": "Reference identifiers",
-      "indexedGroup": "Indexed attributes",
-      "features": "Highlights",
-      "unfeatures": "Watchouts"
-    },
-    "docs": {
-      "title": "Documentation",
-      "subtitle": "Preview and download official documents.",
-      "download": "Download PDF",
-      "untitled": "Untitled document",
-      "pageCount": "{count} page(s)",
-      "sidebarTitle": "Available documents",
-      "navigationAria": "Product documentation list",
-      "empty": "No documents are available for this product yet.",
-      "previewUnavailable": "Preview unavailable for this document. Use the download link instead.",
-      "loading": "Loading document preview…"
-    },
-    "admin": {
-      "title": "Admin section",
-      "subtitle": "Full JSON payload of the product."
     }
   },
-  "cms": {
-    "page": {
-      "loading": "Loading page…",
-      "error": "We could not load this page. Please try again later.",
-      "edit": "Edit this page"
+  "siteIdentity": {
+    "footer": {
+      "accessibleTitle": "Footer information",
+      "blogLink": "Our blog",
+      "community": {
+        "links": {
+          "partners": "Our partners",
+          "team": "Our team"
+        },
+        "title": "Community"
+      },
+      "comparator": {
+        "links": {
+          "legal": "Legal notice",
+          "openData": "Open data",
+          "openSource": "Open source",
+          "privacy": "Privacy policy"
+        },
+        "title": "Resources"
+      },
+      "copyright": "Copyright ©{year} open4goods. Common good product.",
+      "feedback": {
+        "cta": "Share your feedback",
+        "links": {
+          "contact": "Contact us",
+          "linkedin": "Follow us on LinkedIn"
+        },
+        "title": "Get involved"
+      },
+      "highlightLinks": {
+        "allProducts": "All products",
+        "compensation": "Ecological contribution",
+        "ecoscore": "Environmental assessment"
+      },
+      "logoAlt": "Nudger orange logo icon",
+      "mission": "nudger.fr is an open approach to assess the environmental impact of consumer goods and partially offset the impact of your online purchases.",
+      "rightsReserved": "All Rights Reserved"
+    },
+    "hero": {
+      "defaultCtaText": "Call to Action",
+      "defaultSubtitle": "Video demo hero to show a clean integration in a Vue 3 application.",
+      "defaultTitle": "Default Title",
+      "mainSubtitle": "Your Free and Independent Shopping Assistant",
+      "mainTitle": "The Comparator That Thinks About Tomorrow"
+    },
+    "links": {
+      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
+    },
+    "menu": {
+      "closeLabel": "Close menu",
+      "items": {
+        "blog": "Blog",
+        "contact": "Contact",
+        "impactScore": "Impact Score",
+        "products": "Products"
+      },
+      "theme": {
+        "darkAriaLabel": "Activate dark theme",
+        "darkTooltip": "Switch to dark theme",
+        "lightAriaLabel": "Activate light theme",
+        "lightTooltip": "Switch to light theme"
+      },
+      "themeToggle": "Toggle theme",
+      "title": "Menu"
+    },
+    "siteName": "Nudger"
+  },
+  "team": {
+    "callouts": {
+      "contact": {
+        "cta": "Contact us",
+        "description": "Want to co-create the future of responsible shopping or ask us something specific? We would love to talk.",
+        "title": "Curious to chat?"
+      },
+      "partners": {
+        "cta": "Discover our partners",
+        "link": "/partners",
+        "title": "Our partners"
+      }
+    },
+    "cards": {
+      "connect": "Connect on LinkedIn",
+      "linkedIn": "Open {name}'s LinkedIn profile",
+      "portraitAlt": "Portrait of {name}",
+      "unknownName": "a team member"
+    },
+    "errors": {
+      "loadFailed": "We could not load the team roster. Please try again."
+    },
+    "hero": {
+      "eyebrow": "Our collective",
+      "subtitle": "A passionate crew blending tech, sustainability and social impact.",
+      "title": "The people behind Nudger"
+    },
+    "loading": "Loading team members…",
+    "sections": {
+      "contributors": {
+        "title": "Contributors"
+      },
+      "core": {
+        "title": "Core team"
+      },
+      "empty": "The team roster will be published soon."
+    },
+    "seo": {
+      "description": "Discover the collective of entrepreneurs, engineers and volunteers building the sustainable shopping assistant Nudger.",
+      "title": "Meet the Nudger team"
     }
-  }
+  },
+  "welcome": "Welcome"
 }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1,8 +1,319 @@
 {
-  "welcome": "Bienvenue",
-  "lang": {
-    "fr": "Français",
-    "en": "Anglais"
+  "blog": {
+    "article": {
+      "edit": "Modifier cet article",
+      "empty": "Le contenu de cet article sera disponible bientôt.",
+      "featuredImageAlt": "Image mise en avant pour {title}",
+      "readingTime": "Env. {minutes} min de lecture",
+      "updated": "Mis à jour {date}"
+    },
+    "hero": {
+      "eyebrow": "Blog Nudger",
+      "subtitle": "Des articles courts sur la consommation responsable et les coulisses de Nudger.",
+      "title": "L'actualité"
+    },
+    "list": {
+      "loading": "Chargement des articles…",
+      "readMore": "Lire plus",
+      "tagWithCount": "{tag} ({count})",
+      "tagsAll": "Tous les thèmes",
+      "tagsAriaLabel": "Filtrer les articles du blog par tag",
+      "tagsLoading": "Chargement des tags…",
+      "tagsTitle": "Filtrer par tag"
+    },
+    "pagination": {
+      "ariaLabel": "Liens de pagination du blog",
+      "info": "Page {current} sur {total} ({count} articles)",
+      "pageLink": "Page {page} du blog"
+    },
+    "seo": {
+      "baseTitle": "Blog Nudger",
+      "description": "Découvrez les guides et actualités de Nudger.",
+      "pageTitle": "{title} – Page {page}",
+      "tagDescription": "Parcourez les articles {tag} du blog Nudger.",
+      "tagTitle": "Articles {tag} – Blog Nudger"
+    }
+  },
+  "categories": {
+    "navigation": {
+      "error": {
+        "loadFailed": "Impossible de charger la navigation des catégories. Veuillez réessayer."
+      },
+      "grid": {
+        "cardAriaLabel": "Carte de catégorie {category}",
+        "emptySubtitle": "Modifiez votre recherche pour afficher des catégories pertinentes.",
+        "emptyTitle": "Aucune catégorie trouvée",
+        "leafLabel": "Feuille",
+        "openSubcategory": "Ouvrir les sous-catégories de {category}",
+        "openSubcategoryCta": "Voir les sous-catégories",
+        "subtitle": "Choisissez une famille pour afficher ses sous-catégories ou découvrir nos guides.",
+        "title": "Parcourir les catégories",
+        "verticalLabel": "Guide sélectionné",
+        "viewVertical": "Ouvrir le guide {category}",
+        "viewVerticalCta": "Voir le guide"
+      },
+      "hero": {
+        "breadcrumbAriaLabel": "Fil d'Ariane de la navigation par catégories",
+        "childDescription": "Explorez les sous-catégories et les sélections associées aux {category}.",
+        "description": "Découvrez toutes les familles de produits analysées et accédez directement à la plus pertinente.",
+        "resultsSummary": {
+          "one": "{count} catégorie affichée",
+          "other": "{count} catégories affichées"
+        },
+        "rootBreadcrumb": "Toutes les catégories",
+        "rootProductsTitle": "Les produits disponibles",
+        "searchLabel": "Rechercher une catégorie",
+        "searchPlaceholder": "Tapez le nom d'une catégorie",
+        "title": "Toutes les catégories de produits"
+      },
+      "loading": "Chargement de la navigation des catégories",
+      "verticals": {
+        "eyebrow": "Guides mis en avant",
+        "openVertical": "Ouvrir le guide {category}",
+        "openVerticalCta": "Découvrir le guide",
+        "subtitle": "Des guides choisis pour rejoindre rapidement les familles les plus recherchées.",
+        "title": "Catégories populaires",
+        "viewPath": "Ouvrir le chemin taxonomique {category}",
+        "viewPathCta": "Parcourir la taxonomie"
+      }
+    }
+  },
+  "category": {
+    "documentation": {
+      "guidesTitle": "Guides utiles",
+      "postsTitle": "Articles associés"
+    },
+    "ecoscorePage": {
+      "breadcrumbLeaf": "impactscore",
+      "description": "Nous préparons un contenu dédié au score éco pour {category}. Revenez bientôt !",
+      "impactScoreLabel": "Impact Score",
+      "navigation": {
+        "aiAudit": "Audit IA",
+        "ariaLabel": "Navigation des sections Impact Score",
+        "criteria": "Critères retenus",
+        "overview": "Présentation",
+        "purpose": "Objectif & données",
+        "transparency": "Transparence"
+      },
+      "sections": {
+        "aiAudit": {
+          "eyebrow": "Audit IA",
+          "intro": "Audit des prompts et réponses qui ont servi à configurer l'Impact Score des {category}.",
+          "jsonUnavailable": "Réponse IA indisponible.",
+          "promptHelper": "Instructions envoyées au modèle pour produire la configuration.",
+          "promptTitle": "Prompt YAML générateur",
+          "responseHelper": "Résultat JSON de l'IA ayant servi de base à la configuration.",
+          "responseTitle": "Réponse du modèle",
+          "title": "Audit de génération IA",
+          "yamlUnavailable": "Prompt indisponible."
+        },
+        "criteria": {
+          "empty": "Les critères seront publiés prochainement.",
+          "eyebrow": "Critères",
+          "title": "Critères retenus et pondérations"
+        },
+        "overview": {
+          "card": {
+            "aria": "Découvrir la méthodologie Impact Score globale",
+            "cta": "Comprendre notre méthodologie globale",
+            "description": "Cette page détaille les critères et pondérations utilisés pour évaluer l'impact environnemental de cette catégorie.",
+            "imageAlt": "Illustration de l'Impact Score pour les {category}",
+            "subtitle": "Méthodologie appliquée aux {category}",
+            "title": "Impact Score Nudger"
+          },
+          "eyebrow": "Introduction",
+          "title": "Impact Score des {category}"
+        },
+        "purpose": {
+          "dataFallback": "Les données détaillées des critères seront bientôt disponibles.",
+          "dataTitle": "Données disponibles",
+          "eyebrow": "Notre démarche",
+          "objectiveFallback": "La description de l'objectif sera bientôt disponible.",
+          "objectiveTitle": "Objectif",
+          "title": "Pourquoi et comment nous évaluons les {category}"
+        },
+        "transparency": {
+          "communityBody": "La définition de l'Impact Score {category} est disponible sur GitHub. Partagez vos retours ou proposez des ajustements.",
+          "communityCta": "Consulter la configuration",
+          "communityIssues": "Ouvrir une discussion",
+          "communityTitle": "En discuter",
+          "connector": "et",
+          "criticalReviewFallback": "La revue critique n'est pas encore disponible.",
+          "criticalReviewTitle": "Revue critique",
+          "eyebrow": "Transparence",
+          "intro": "Nudger est construit dans un modèle ouvert :",
+          "introSuffix": "pour garantir la traçabilité de notre méthode d'évaluation des {category}.",
+          "openDataLink": "open-data",
+          "openSourceLink": "open-source",
+          "tableFallback": "Les coefficients détaillés seront publiés prochainement.",
+          "tableHeaders": {
+            "applied": "Coef. appliqué",
+            "name": "Nom du critère",
+            "proposed": "Coef. proposé"
+          },
+          "tableHelper": "Comparaison entre la proposition générée par l'IA et les coefficients actuellement appliqués.",
+          "tableTitle": "Synthèse des coefficients",
+          "title": "Transparence et traçabilité"
+        }
+      },
+      "seo": {
+        "description": "Découvrez comment Nudger calcule l'Impact Score des {category} : critères, pondérations et audit de génération IA.",
+        "title": "{category} – Impact Score détaillé"
+      },
+      "title": "{category} – {label}"
+    },
+    "fastFilters": {
+      "activeClauses": "Filtres de sous-ensemble appliqués",
+      "groupDefault": "Autres filtres rapides",
+      "groups": {
+        "default": "Autres filtres rapides",
+        "price": "Prix",
+        "screen_size": "Taille d'écran"
+      },
+      "navigation": {
+        "next": "Défiler vers les filtres rapides suivants",
+        "previous": "Défiler vers les filtres rapides précédents"
+      },
+      "operator": {
+        "greaterThan": "≥ {value}",
+        "lowerThan": "≤ {value}"
+      },
+      "reset": "Réinitialiser les filtres rapides"
+    },
+    "filters": {
+      "fields": {
+        "brand": "Marque",
+        "condition": "État des offres",
+        "country": "Code pays du GTIN",
+        "datasource": "Sources de données",
+        "googleTaxonomyId": "Catégorie produit Google",
+        "offersCount": "Nombre d'offres",
+        "price": "Fourchette de prix"
+      },
+      "globalTitle": "Filtres globaux",
+      "hideImpact": "Masquer les filtres d'impact",
+      "hideTechnical": "Masquer les filtres techniques",
+      "impactTitle": "Filtres d'impact",
+      "missingLabel": "Option sans libellé",
+      "mobileApply": "Appliquer les filtres",
+      "mobileClear": "Effacer les filtres",
+      "noMatch": "Aucune option correspondante",
+      "rangeAriaSuffix": "sélection d'intervalle",
+      "searchOptions": "Rechercher dans les options",
+      "showMoreImpact": "Plus de filtres",
+      "showMoreTechnical": "Plus de filtres",
+      "technicalTitle": "Filtres techniques",
+      "toggle": {
+        "hide": "Masquer la colonne des filtres",
+        "show": "Afficher la colonne des filtres"
+      }
+    },
+    "hero": {
+      "breadcrumbAriaLabel": "Fil d'Ariane des catégories",
+      "breadcrumbDivider": "/",
+      "missingBreadcrumbTitle": "Catégorie"
+    },
+    "products": {
+      "compare": {
+        "addMoreHint": "Sélectionnez au moins deux produits pour lancer une comparaison.",
+        "addToList": "Ajouter à la comparaison",
+        "collapsePanel": "Masquer la liste",
+        "differentCategory": "Comparez uniquement des produits de la même catégorie.",
+        "expandPanel": "Afficher la liste",
+        "itemsCount": {
+          "one": "{count} produit sélectionné",
+          "other": "{count} produits sélectionnés"
+        },
+        "launchComparison": "Comparer maintenant",
+        "limitReached": "Vous pouvez comparer jusqu'à {count} produits.",
+        "missingIdentifier": "Impossible de comparer ce produit.",
+        "regionLabel": "Produits sélectionnés pour la comparaison",
+        "removeFromList": "Retirer de la comparaison",
+        "removeSingle": "Retirer {name}",
+        "title": "Comparer les produits"
+      },
+      "conditions": {
+        "new": "Neuf",
+        "occasion": "Occasion",
+        "other": "Autre ({condition})",
+        "unknown": "Non précisée"
+      },
+      "ecoscoreLabel": "Score éco {letter}",
+      "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
+      "headers": {
+        "bestPrice": "Meilleur prix",
+        "brand": "Marque",
+        "compare": "Comparer",
+        "ecoscore": "Score éco",
+        "impactScore": "Score d'impact",
+        "model": "Modèle",
+        "offers": "Offres",
+        "popularAttributes": "Atouts clés",
+        "remainingAttributes": "Autres attributs"
+      },
+      "noResults": "Aucun produit ne correspond aux filtres sélectionnés.",
+      "notRated": "Non noté",
+      "offerCount": {
+        "one": "{count} offre",
+        "other": "{count} offres"
+      },
+      "openFilters": "Filtres",
+      "priceUnavailable": "Prix non disponible",
+      "pricing": {
+        "bestOfferLabel": "Meilleur prix",
+        "conditionLabel": "Condition : {condition}",
+        "newOfferLabel": "Neuf",
+        "occasionOfferLabel": "Occasion"
+      },
+      "resultsCount": {
+        "one": "{count} produit",
+        "other": "{count} produits"
+      },
+      "searchPlaceholder": "Rechercher des produits",
+      "sort": {
+        "fields": {
+          "brand": "Marque",
+          "impactScore": "Score d'impact",
+          "model": "Modèle",
+          "offersCount": "Nombre d'offres",
+          "price": "Prix le plus bas"
+        }
+      },
+      "sortLabel": "Trier par",
+      "sortOrderAsc": "Ordre croissant",
+      "sortOrderDesc": "Ordre décroissant",
+      "tooltips": {
+        "search": "Rechercher parmi ces produits",
+        "sortAscending": "Trier les produits du plus bas au plus haut",
+        "sortDescending": "Trier les produits du plus haut au plus bas",
+        "sortField": "Modifier le critère de tri des produits",
+        "viewCards": "Afficher les produits sous forme de cartes",
+        "viewList": "Afficher les produits sous forme de liste",
+        "viewTable": "Afficher les produits sous forme de tableau"
+      },
+      "unknownBrand": "Marque inconnue",
+      "untitledProduct": "Produit sans nom",
+      "viewCards": "Vue cartes",
+      "viewList": "Vue liste",
+      "viewTable": "Vue tableau"
+    }
+  },
+  "cms": {
+    "page": {
+      "edit": "Modifier cette page",
+      "error": "Nous n'avons pas pu charger cette page. Veuillez réessayer plus tard.",
+      "loading": "Chargement de la page…"
+    }
+  },
+  "common": {
+    "actions": {
+      "goHome": "Retour à l'accueil",
+      "retry": "Réessayer"
+    },
+    "boolean": {
+      "false": "Non",
+      "true": "Oui"
+    }
   },
   "components": {
     "impactScore": {
@@ -12,1103 +323,61 @@
       "label": "Chargement du contenu"
     }
   },
-  "siteIdentity": {
-    "menu": {
-      "title": "Menu",
-      "closeLabel": "Fermer le menu",
-      "themeToggle": "Changer de thème",
-      "theme": {
-        "lightTooltip": "Passer au thème clair",
-        "darkTooltip": "Passer au thème sombre",
-        "lightAriaLabel": "Activer le thème clair",
-        "darkAriaLabel": "Activer le thème sombre"
-      },
-      "items": {
-        "impactScore": "Impact-score",
-        "products": "Les produits",
-        "blog": "Blog",
-        "contact": "Contact"
-      }
-    },
-    "links": {
-      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
-    },
-    "footer": {
-      "rightsReserved": "Tous droits réservés",
-      "accessibleTitle": "Informations du pied de page",
-      "mission": "nudger.fr est une approche ouverte pour évaluer l'impact écologique et social des biens que nous achetons.",
-      "blogLink": "Notre blog",
-      "highlightLinks": {
-        "ecoscore": "Évaluation environnementale",
-        "allProducts": "Tous nos produits"
-      },
-      "comparator": {
-        "title": "Ressources",
-        "links": {
-          "openData": "Open data",
-          "openSource": "Open source",
-          "privacy": "Politique de confidentialité",
-          "legal": "Mentions légales"
-        }
-      },
-      "community": {
-        "title": "Communauté",
-        "links": {
-          "team": "Notre équipe",
-          "partners": "Nos partenaires"
-        }
-      },
-      "feedback": {
-        "title": "Nous aider",
-        "cta": "Donnez votre avis",
-        "links": {
-          "contact": "Nous contacter",
-          "linkedin": "Nous suivre sur LinkedIn"
-        }
-      },
-      "logoAlt": "Icône Nudger orange",
-      "copyright": "Copyright ©{year} open4goods. Produit de bien commun."
-    },
-    "hero": {
-      "mainTitle": "Le comparateur qui pense à demain",
-      "mainSubtitle": "Ton assistant achat, Libre et Indépendant",
-      "defaultTitle": "Titre par défaut",
-      "defaultSubtitle": "Démo vidéo hero pour montrer une intégration propre dans une application Vue 3.",
-      "defaultCtaText": "Appel à l'action"
-    },
-    "siteName": "Nudger"
-  },
-  "error": {
-    "page": {
-      "eyebrow": "Changement de cap inattendu",
-      "statusLabel": "Code statut {code}",
-      "notFound": {
-        "badge": "Page introuvable",
-        "title": "Nous ne trouvons pas cette page",
-        "description": "Le lien suivi est peut-être obsolète ou la page a été déplacée.",
-        "helper": "Utilisez les liens ci-dessous ou retournez à l’accueil pour poursuivre votre exploration.",
-        "statusMessage": "Erreur 404 — la ressource demandée est introuvable."
-      },
-      "generic": {
-        "badge": "Un contretemps est survenu",
-        "title": "Nous corrigeons le problème",
-        "description": "Une erreur inattendue nous a empêchés de charger cette page.",
-        "helper": "Essayez une autre section de Nudger ou contactez-nous si le problème persiste.",
-        "statusMessage": "Erreur 500 — quelque chose s’est mal passé de notre côté."
-      },
-      "actions": {
-        "ariaLabel": "Actions rapides pour se remettre sur la bonne voie",
-        "goHome": "Retour à l’accueil",
-        "contactSupport": "Contacter le support"
-      },
-      "debug": {
-        "title": "Détails techniques",
-        "messageLabel": "Message d’erreur",
-        "stackLabel": "Trace de la pile",
-        "empty": "Aucune information de diagnostic supplémentaire n’est disponible."
-      }
-    }
-  },
-  "category": {
-    "hero": {
-      "breadcrumbAriaLabel": "Fil d'Ariane des catégories",
-      "breadcrumbDivider": "/",
-      "missingBreadcrumbTitle": "Catégorie"
-    },
-    "ecoscorePage": {
-      "title": "{category} – {label}",
-      "description": "Nous préparons un contenu dédié au score éco pour {category}. Revenez bientôt !",
-      "impactScoreLabel": "Impact Score",
-      "breadcrumbLeaf": "impactscore",
-      "seo": {
-        "title": "{category} – Impact Score détaillé",
-        "description": "Découvrez comment Nudger calcule l'Impact Score des {category} : critères, pondérations et audit de génération IA."
-      },
-      "navigation": {
-        "ariaLabel": "Navigation des sections Impact Score",
-        "overview": "Présentation",
-        "purpose": "Objectif & données",
-        "criteria": "Critères retenus",
-        "transparency": "Transparence",
-        "aiAudit": "Audit IA"
-      },
-      "sections": {
-        "overview": {
-          "eyebrow": "Introduction",
-          "title": "Impact Score des {category}",
-          "card": {
-            "title": "Impact Score Nudger",
-            "subtitle": "Méthodologie appliquée aux {category}",
-            "description": "Cette page détaille les critères et pondérations utilisés pour évaluer l'impact environnemental de cette catégorie.",
-            "cta": "Comprendre notre méthodologie globale",
-            "aria": "Découvrir la méthodologie Impact Score globale",
-            "imageAlt": "Illustration de l'Impact Score pour les {category}"
-          }
-        },
-        "purpose": {
-          "eyebrow": "Notre démarche",
-          "title": "Pourquoi et comment nous évaluons les {category}",
-          "objectiveTitle": "Objectif",
-          "objectiveFallback": "La description de l'objectif sera bientôt disponible.",
-          "dataTitle": "Données disponibles",
-          "dataFallback": "Les données détaillées des critères seront bientôt disponibles."
-        },
-        "criteria": {
-          "eyebrow": "Critères",
-          "title": "Critères retenus et pondérations",
-          "empty": "Les critères seront publiés prochainement."
-        },
-        "transparency": {
-          "eyebrow": "Transparence",
-          "title": "Transparence et traçabilité",
-          "criticalReviewTitle": "Revue critique",
-          "criticalReviewFallback": "La revue critique n'est pas encore disponible.",
-          "communityTitle": "En discuter",
-          "communityBody": "La définition de l'Impact Score {category} est disponible sur GitHub. Partagez vos retours ou proposez des ajustements.",
-          "communityCta": "Consulter la configuration",
-          "communityIssues": "Ouvrir une discussion",
-          "intro": "Nudger est construit dans un modèle ouvert :",
-          "connector": "et",
-          "openSourceLink": "open-source",
-          "openDataLink": "open-data",
-          "introSuffix": "pour garantir la traçabilité de notre méthode d'évaluation des {category}.",
-          "tableTitle": "Synthèse des coefficients",
-          "tableHelper": "Comparaison entre la proposition générée par l'IA et les coefficients actuellement appliqués.",
-          "tableFallback": "Les coefficients détaillés seront publiés prochainement.",
-          "tableHeaders": {
-            "name": "Nom du critère",
-            "proposed": "Coef. proposé",
-            "applied": "Coef. appliqué"
-          }
-        },
-        "aiAudit": {
-          "eyebrow": "Audit IA",
-          "title": "Audit de génération IA",
-          "intro": "Audit des prompts et réponses qui ont servi à configurer l'Impact Score des {category}.",
-          "promptTitle": "Prompt YAML générateur",
-          "promptHelper": "Instructions envoyées au modèle pour produire la configuration.",
-          "responseTitle": "Réponse du modèle",
-          "responseHelper": "Résultat JSON de l'IA ayant servi de base à la configuration.",
-          "yamlUnavailable": "Prompt indisponible.",
-          "jsonUnavailable": "Réponse IA indisponible."
-        }
-      }
-    },
-    "fastFilters": {
-      "reset": "Réinitialiser les filtres rapides",
-      "activeClauses": "Filtres de sous-ensemble appliqués",
-      "groupDefault": "Autres filtres rapides",
-      "groups": {
-        "price": "Prix",
-        "screen_size": "Taille d'écran",
-        "default": "Autres filtres rapides"
-      },
-      "navigation": {
-        "previous": "Défiler vers les filtres rapides précédents",
-        "next": "Défiler vers les filtres rapides suivants"
-      },
-      "operator": {
-        "greaterThan": "≥ {value}",
-        "lowerThan": "≤ {value}"
-      }
-    },
-    "filters": {
-      "globalTitle": "Filtres globaux",
-      "impactTitle": "Filtres d'impact",
-      "technicalTitle": "Filtres techniques",
-      "showMoreImpact": "Plus de filtres",
-      "hideImpact": "Masquer les filtres d'impact",
-      "showMoreTechnical": "Plus de filtres",
-      "hideTechnical": "Masquer les filtres techniques",
-      "rangeAriaSuffix": "sélection d'intervalle",
-      "searchOptions": "Rechercher dans les options",
-      "noMatch": "Aucune option correspondante",
-      "missingLabel": "Option sans libellé",
-      "mobileApply": "Appliquer les filtres",
-      "mobileClear": "Effacer les filtres",
-      "toggle": {
-        "show": "Afficher la colonne des filtres",
-        "hide": "Masquer la colonne des filtres"
-      },
-      "fields": {
-        "price": "Fourchette de prix",
-        "offersCount": "Nombre d'offres",
-        "condition": "État des offres",
-        "googleTaxonomyId": "Catégorie produit Google",
-        "brand": "Marque",
-        "country": "Code pays du GTIN",
-        "datasource": "Sources de données"
-      }
-    },
-    "products": {
-      "untitledProduct": "Produit sans nom",
-      "unknownBrand": "Marque inconnue",
-      "ecoscoreLabel": "Score éco {letter}",
-      "priceUnavailable": "Prix non disponible",
-      "tooltips": {
-        "search": "Rechercher parmi ces produits",
-        "sortField": "Modifier le critère de tri des produits",
-        "sortAscending": "Trier les produits du plus bas au plus haut",
-        "sortDescending": "Trier les produits du plus haut au plus bas",
-        "viewCards": "Afficher les produits sous forme de cartes",
-        "viewList": "Afficher les produits sous forme de liste",
-        "viewTable": "Afficher les produits sous forme de tableau"
-      },
-      "offerCount": {
-        "one": "{count} offre",
-        "other": "{count} offres"
-      },
-      "notRated": "Non noté",
-      "conditions": {
-        "new": "Neuf",
-        "occasion": "Occasion",
-        "unknown": "Non précisée",
-        "other": "Autre ({condition})"
-      },
-      "pricing": {
-        "newOfferLabel": "Neuf",
-        "occasionOfferLabel": "Occasion",
-        "bestOfferLabel": "Meilleur prix",
-        "conditionLabel": "Condition : {condition}"
-      },
-      "compare": {
-        "title": "Comparer les produits",
-        "expandPanel": "Afficher la liste",
-        "collapsePanel": "Masquer la liste",
-        "removeSingle": "Retirer {name}",
-        "addMoreHint": "Sélectionnez au moins deux produits pour lancer une comparaison.",
-        "launchComparison": "Comparer maintenant",
-        "regionLabel": "Produits sélectionnés pour la comparaison",
-        "itemsCount": {
-          "one": "{count} produit sélectionné",
-          "other": "{count} produits sélectionnés"
-        },
-        "addToList": "Ajouter à la comparaison",
-        "removeFromList": "Retirer de la comparaison",
-        "limitReached": "Vous pouvez comparer jusqu'à {count} produits.",
-        "differentCategory": "Comparez uniquement des produits de la même catégorie.",
-        "missingIdentifier": "Impossible de comparer ce produit."
-      },
-      "fetchError": "Impossible de charger les produits. Veuillez réessayer.",
-      "headers": {
-        "compare": "Comparer",
-        "brand": "Marque",
-        "model": "Modèle",
-        "ecoscore": "Score éco",
-        "impactScore": "Score d'impact",
-        "bestPrice": "Meilleur prix",
-        "offers": "Offres",
-        "popularAttributes": "Atouts clés",
-        "remainingAttributes": "Autres attributs"
-      },
-      "resultsCount": {
-        "one": "{count} produit",
-        "other": "{count} produits"
-      },
-      "searchPlaceholder": "Rechercher des produits",
-      "sortLabel": "Trier par",
-      "sortOrderAsc": "Ordre croissant",
-      "sortOrderDesc": "Ordre décroissant",
-      "viewCards": "Vue cartes",
-      "viewList": "Vue liste",
-      "viewTable": "Vue tableau",
-      "openFilters": "Filtres",
-      "noResults": "Aucun produit ne correspond aux filtres sélectionnés.",
-      "sort": {
-        "fields": {
-          "price": "Prix le plus bas",
-          "offersCount": "Nombre d'offres",
-          "brand": "Marque",
-          "model": "Modèle",
-          "impactScore": "Score d'impact"
-        }
-      }
-    },
-    "documentation": {
-      "guidesTitle": "Guides utiles",
-      "postsTitle": "Articles associés"
-    }
-  },
-  "categories": {
-    "navigation": {
-      "loading": "Chargement de la navigation des catégories",
-      "error": {
-        "loadFailed": "Impossible de charger la navigation des catégories. Veuillez réessayer."
-      },
-      "hero": {
-        "title": "Toutes les catégories de produits",
-        "rootProductsTitle": "Les produits disponibles",
-        "description": "Découvrez toutes les familles de produits analysées et accédez directement à la plus pertinente.",
-        "childDescription": "Explorez les sous-catégories et les sélections associées aux {category}.",
-        "rootBreadcrumb": "Toutes les catégories",
-        "searchLabel": "Rechercher une catégorie",
-        "searchPlaceholder": "Tapez le nom d'une catégorie",
-        "breadcrumbAriaLabel": "Fil d'Ariane de la navigation par catégories",
-        "resultsSummary": {
-          "one": "{count} catégorie affichée",
-          "other": "{count} catégories affichées"
-        }
-      },
-      "grid": {
-        "title": "Parcourir les catégories",
-        "subtitle": "Choisissez une famille pour afficher ses sous-catégories ou découvrir nos guides.",
-        "emptyTitle": "Aucune catégorie trouvée",
-        "emptySubtitle": "Modifiez votre recherche pour afficher des catégories pertinentes.",
-        "verticalLabel": "Guide sélectionné",
-        "leafLabel": "Feuille",
-        "openSubcategory": "Ouvrir les sous-catégories de {category}",
-        "openSubcategoryCta": "Voir les sous-catégories",
-        "viewVertical": "Ouvrir le guide {category}",
-        "viewVerticalCta": "Voir le guide",
-        "cardAriaLabel": "Carte de catégorie {category}"
-      },
-      "verticals": {
-        "eyebrow": "Guides mis en avant",
-        "title": "Catégories populaires",
-        "subtitle": "Des guides choisis pour rejoindre rapidement les familles les plus recherchées.",
-        "openVertical": "Ouvrir le guide {category}",
-        "openVerticalCta": "Découvrir le guide",
-        "viewPath": "Ouvrir le chemin taxonomique {category}",
-        "viewPathCta": "Parcourir la taxonomie"
-      }
-    }
-  },
-  "blog": {
-    "seo": {
-      "baseTitle": "Blog Nudger",
-      "tagTitle": "Articles {tag} – Blog Nudger",
-      "pageTitle": "{title} – Page {page}",
-      "description": "Découvrez les guides et actualités de Nudger.",
-      "tagDescription": "Parcourez les articles {tag} du blog Nudger."
-    },
-    "pagination": {
-      "info": "Page {current} sur {total} ({count} articles)",
-      "ariaLabel": "Liens de pagination du blog",
-      "pageLink": "Page {page} du blog"
-    },
-    "article": {
-      "updated": "Mis à jour {date}",
-      "readingTime": "Env. {minutes} min de lecture",
-      "featuredImageAlt": "Image mise en avant pour {title}",
-      "empty": "Le contenu de cet article sera disponible bientôt.",
-      "edit": "Modifier cet article"
-    },
-    "hero": {
-      "eyebrow": "Blog Nudger",
-      "title": "L'actualité",
-      "subtitle": "Des articles courts sur la consommation responsable et les coulisses de Nudger."
-    },
-    "list": {
-      "loading": "Chargement des articles…",
-      "readMore": "Lire plus",
-      "tagsTitle": "Filtrer par tag",
-      "tagsAll": "Tous les thèmes",
-      "tagWithCount": "{tag} ({count})",
-      "tagsLoading": "Chargement des tags…",
-      "tagsAriaLabel": "Filtrer les articles du blog par tag"
-    }
-  },
-  "common": {
-    "actions": {
-      "retry": "Réessayer",
-      "goHome": "Retour à l'accueil"
-    },
-    "boolean": {
-      "true": "Oui",
-      "false": "Non"
-    }
-  },
-  "contrib": {
-    "seo": {
-      "title": "Redirection vers notre partenaire",
-      "description": "Nous vérifions votre lien de contribution sécurisé avant de vous rediriger vers le partenaire de Nudger."
-    },
-    "loading": {
-      "title": "Préparation de votre redirection…",
-      "message": "Veuillez patienter pendant la validation de votre lien de contribution."
-    },
-    "success": {
-      "title": "Prêt pour la redirection",
-      "message": "Vous serez redirigé dans quelques instants. Si rien ne se passe, utilisez le bouton ci-dessous.",
-      "cta": "Continuer vers le site partenaire"
-    },
-    "error": {
-      "title": "Impossible de valider ce lien",
-      "description": "Le lien de contribution a peut-être expiré ou est invalide. Vous pouvez retourner à l'accueil et réessayer.",
-      "detailsPrefix": "Détails :",
-      "cta": "Retour à l'accueil"
-    }
-  },
-  "team": {
-    "seo": {
-      "title": "Découvrez l'équipe Nudger",
-      "description": "Rencontrez les entrepreneuses, ingénieurs et bénévoles qui construisent l'assistant d'achat responsable Nudger."
-    },
-    "hero": {
-      "eyebrow": "Notre collectif",
-      "title": "Les femmes et les hommes derrière Nudger",
-      "subtitle": "Une équipe engagée qui mêle tech, environnement et impact social."
-    },
-    "loading": "Chargement des membres…",
-    "errors": {
-      "loadFailed": "Impossible de charger la liste de l'équipe. Merci de réessayer."
-    },
-    "sections": {
-      "empty": "Les profils seront bientôt disponibles.",
-      "core": {
-        "title": "La core-team",
-        "eyebrow": "Pilotage"
-      },
-      "contributors": {
-        "title": "Les contributeurs",
-        "eyebrow": "Communauté"
-      }
-    },
-    "cards": {
-      "portraitAlt": "Portrait de {name}",
-      "linkedIn": "Ouvrir le profil LinkedIn de {name}",
-      "connect": "Voir sur LinkedIn",
-      "unknownName": "un membre de l'équipe"
-    },
-    "callouts": {
-      "partners": {
-        "title": "Nos partenaires",
-        "cta": "Découvrir les partenaires",
-        "link": "/partenaires"
-      },
-      "contact": {
-        "title": "Envie d'échanger ?",
-        "description": "Vous souhaitez en savoir plus sur le projet ou rejoindre l'aventure ? Parlons-en.",
-        "cta": "Nous contacter"
-      }
-    }
-  },
-  "partners": {
-    "seo": {
-      "title": "Nos partenaires et mentors",
-      "description": "Découvrez les organisations, marketplaces et mentors qui aident Nudger à accélérer le commerce responsable."
-    },
-    "hero": {
-      "eyebrow": "Impact collectif",
-      "title": "Les partenaires de Nudger",
-      "subtitle": "Un réseau de commerçants et un écosystème engagés pour des achats plus responsables.",
-      "description": "Nudger est une aventure collective. Découvrez nos partenaires."
-    },
-    "loading": "Chargement des partenaires…",
-    "errors": {
-      "loadFailed": "Impossible de charger les partenaires. Merci de réessayer."
-    },
-    "affiliation": {
-      "title": "Ils nous font confiance",
-      "subtitle": "Découvrez les marchands qui collaborent avec nous et explorez leurs offres.",
-      "search": {
-        "label": "Rechercher un partenaire",
-        "placeholder": "Rechercher par nom"
-      },
-      "empty": "Aucun partenaire ne correspond à votre recherche.",
-      "carouselAriaLabel": "Carrousel des partenaires affiliés",
-      "linkLabel": "Visiter ce partenaire"
-    },
-    "ecosystem": {
-      "title": "Nudger s'inscrit dans un écosystème dynamique",
-      "subtitle": "Au travers d'échanges ou de partenartiats directs, ils contribuent à la trajectoire de Nudger",
-      "empty": "Les partenaires de l'écosystème seront bientôt listés ici.",
-      "carouselAriaLabel": "Carrousel des partenaires écosystème",
-      "linkLabel": "Découvrir l'initiative",
-      "fallbackDescription": "Le contenu de ce partenaire sera publié prochainement."
-    },
-    "mentors": {
-      "title": "Ils nous aident",
-      "subtitle": "Entreprendre n'est jamais simple. Ces mentors partagent leur expérience avec bienveillance.",
-      "empty": "Les profils mentors seront ajoutés prochainement.",
-      "carouselAriaLabel": "Carrousel des mentors",
-      "linkLabel": "En savoir plus",
-      "fallbackDescription": "Plus d'informations sur ce mentor arrivent bientôt."
-    },
-    "cta": {
-      "eyebrow": "Rejoignez l'aventure",
-      "title": "Envie de devenir partenaire ?",
-      "description": "Nous recherchons des alliés qui souhaitent bâtir avec nous l'achat responsable.",
-      "ctaLabel": "Contacter l'équipe"
-    }
-  },
-  "opensource": {
-    "seo": {
-      "title": "Open source chez Nudger",
-      "description": "Découvrez comment Nudger partage son code, ses données et sa gouvernance pour construire ensemble un bien commun de l'achat responsable.",
-      "imageAlt": "Logotype Nudger représentant le programme open source"
-    },
-    "hero": {
-      "title": "Rien à cacher, tout à partager",
-      "subtitle": "Code, données et gouvernance sont transparents pour que chacun·e puisse auditer et améliorer Nudger.",
-      "primaryCta": {
-        "label": "Explorer les dépôts",
-        "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet"
-      },
-      "ctaGroupLabel": "Appels à action principaux",
-      "infoCard": {
-        "highlight": "Open4goods",
-        "description": "est construit en commun. Chaque pull request, issue ou retour utilisateur façonne une plateforme plus transparente.",
-        "items": {
-          "openLicenses": "Code et données publiés sous licences ouvertes",
-          "collaborativeReviews": "Revue collaborative des contributions",
-          "sharedGovernance": "Gouvernance partagée et documentation vivante"
-        }
-      }
-    },
-    "pillars": {
-      "eyebrow": "Nos engagements",
-      "title": "Un écosystème ouvert et fiable",
-      "cards": {
-        "transparency": {
-          "title": "Architecture transparente",
-          "cta": "Voir le code source",
-          "ariaLabel": "Ouvrir le dépôt GitHub de Nudger dans un nouvel onglet"
-        },
-        "methodology": {
-          "title": "Méthodologie documentée",
-          "cta": "Comprendre l'Impact-score",
-          "ariaLabel": "Aller vers la page Impact-score"
-        },
-        "community": {
-          "title": "Communauté inclusive",
-          "cta": "Rencontrer l'équipe",
-          "ariaLabel": "Aller vers la page de l'équipe Nudger"
-        }
-      }
-    },
-    "contribution": {
-      "eyebrow": "Contribuer",
-      "title": "Rejoignez le collectif en quelques étapes",
-      "steps": {
-        "setup": {
-          "title": "Installer le projet en local"
-        },
-        "issues": {
-          "title": "Choisir une issue qui vous inspire"
-        },
-        "share": {
-          "title": "Partager, relire et célébrer"
-        }
-      }
-    },
-    "resources": {
-      "eyebrow": "Ressources",
-      "title": "Tout pour bien démarrer",
-      "links": {
-        "guide": {
-          "title": "Guide de contribution",
-          "ariaLabel": "Ouvrir le guide de contribution Nudger sur GitHub dans un nouvel onglet"
-        },
-        "issues": {
-          "title": "Tableau des issues",
-          "ariaLabel": "Ouvrir le tableau des issues GitHub de Nudger dans un nouvel onglet"
-        },
-        "updates": {
-          "title": "Actualités de la communauté",
-          "ariaLabel": "Ouvrir le blog Nudger"
-        }
-      },
-      "opendata": {
-        "title": "Des données ouvertes pour vos analyses",
-        "description": "Les jeux de données Nudger sont publiés pour que vous puissiez auditer nos scores, explorer les empreintes produits et créer vos propres projets.",
-        "cta": {
-          "label": "Découvrir l'espace open data",
-          "ariaLabel": "Aller vers la page open data"
-        }
-      },
-      "contact": {
-        "title": "Envie d'un échange humain ?",
-        "cta": {
-          "label": "Contacter l'équipe",
-          "ariaLabel": "Aller vers la page contact"
-        }
-      },
-      "feedback": {
-        "title": "Partagez vos idées et retours",
-        "description": "Soumettez les bugs rencontrés, vos envies de fonctionnalités et aidez-nous à prioriser le produit.",
-        "points": {
-          "bugs": "Signalez un bug en quelques clics",
-          "features": "Proposez des idées de fonctionnalités",
-          "votes": "Votez pour les évolutions qui comptent pour vous"
-        },
-        "cta": {
-          "label": "Accéder au tableau de feedback",
-          "ariaLabel": "Aller vers la page des retours utilisateurs"
-        }
-      }
-    }
-  },
-  "opendata": {
-    "seo": {
-      "title": "Portail open data Nudger",
-      "description": "Découvrez les jeux de données GTIN et ISBN mis à disposition par Nudger, leurs mises à jour hebdomadaires et les modalités de téléchargement."
-    },
-    "loading": "Chargement des informations open data…",
-    "errors": {
-      "overviewFailed": "Impossible de charger la vue d'ensemble open data. Merci de réessayer.",
-      "datasetFailed": "Impossible de charger les détails du jeu de données. Merci de réessayer."
-    },
-    "hero": {
-      "eyebrow": "Open data",
-      "title": "#FreeLesDonnées",
-      "subtitle": "On est des geeks mais on t'explique sans jargon technique. Nos données produits ? Open bar. Nos bases : Téléchargeables (c’est l'happy hour, c'est cadeau). Nos secrets : On en a pas !",
-      "primaryCta": {
-        "label": "Découvre nos produits à nu(dger)",
-        "ariaLabel": "Faire défiler jusqu'à la section des jeux de données open data"
-      }
-    },
-    "stats": {
-      "accessibilityTitle": "Indicateurs clés de l'open data",
-      "placeholder": "—",
-      "totalProducts": {
-        "label": "Produits couverts",
-        "description": "Produits uniques recensés dans l'ensemble des exports.",
-        "millions": "+{value} millions"
-      },
-      "datasets": {
-        "label": "Jeux de données publiés",
-        "description": "Paquets de données actuellement disponibles."
-      },
-      "totalSize": {
-        "label": "Taille cumulée",
-        "description": "Volume compressé total des exports hebdomadaires."
-      }
-    },
-    "datasets": {
-      "title": "Deux jeux de données complémentaires",
-      "subtitle": "Choisissez l'extraction adaptée à votre besoin. Les deux exports sont mis à jour chaque semaine et publiés sous licence ODbL.",
-      "cards": {
-        "gtin": {
-          "title": "Base GTIN",
-          "description": "Tous les produits indexés par Nudger avec marque, modèle, prix et catégories.",
-          "features": {
-            "refresh": "Instantané mis à jour chaque semaine",
-            "coverage": "Inclut les métadonnées EAN13, UPC et préfixes GS1",
-            "uses": "Idéal pour la veille prix, l'analyse d'assortiment et le suivi catégoriel"
-          },
-          "cta": {
-            "label": "Voir le dataset GTIN",
-            "ariaLabel": "Ouvrir la page open data GTIN"
-          }
-        },
-        "isbn": {
-          "title": "Base ISBN",
-          "description": "Export dédié aux livres avec informations de prix, disponibilité et classifications.",
-          "features": {
-            "refresh": "Instantané mis à jour chaque semaine",
-            "catalogue": "Inclut éditeur, format et classifications Decitre",
-            "research": "Parfait pour l'enrichissement de catalogue, la recherche et les analyses culturelles"
-          },
-          "cta": {
-            "label": "Voir le dataset ISBN",
-            "ariaLabel": "Ouvrir la page open data ISBN"
-          }
-        }
-      },
-      "common": {
-        "placeholder": "—",
-        "summary": {
-          "records": "Nombre total d'enregistrements",
-          "updated": "Dernière mise à jour",
-          "size": "Taille compressée"
-        },
-        "columnName": "Colonne",
-        "columnDescription": "Description",
-        "download": {
-          "fast": {
-            "title": "Miroir rapide (data.gouv.fr)",
-            "description": "Téléchargement via le portail open data officiel de l'État français.",
-            "badge": "Recommandé",
-            "speed": "Infrastructure haut débit",
-            "cta": {
-              "label": "Télécharger sur data.gouv.fr",
-              "ariaLabel": "Ouvrir le dataset sur data.gouv.fr dans un nouvel onglet",
-              "href": "https://www.data.gouv.fr/fr/datasets/base-de-codes-barres-noms-et-categories-produits/"
-            }
-          },
-          "direct": {
-            "title": "Téléchargement direct depuis Nudger",
-            "description": "Récupérez le fichier ZIP directement sur l'infrastructure Nudger.",
-            "concurrent": "Jusqu'à {value} téléchargements simultanés",
-            "concurrentUnknown": "Limite de téléchargements simultanés",
-            "speed": "Débit limité à {value} par client",
-            "speedUnknown": "Débit limité par client",
-            "cta": {
-              "label": "Télécharger depuis nudger.fr",
-              "ariaLabel": "Lancer le téléchargement direct depuis Nudger"
-            }
-          }
-        },
-        "breadcrumb": {
-          "label": "opendata",
-          "ariaLabel": "Retour à la page opendata"
-        }
-      },
-      "gtin": {
-        "seo": {
-          "title": "Données ouvertes GTIN – télécharger le catalogue de codes-barres",
-          "description": "Accédez à la base GTIN de Nudger, mise à jour chaque semaine, avec les options de téléchargement et le schéma détaillé pour vos projets data sur les codes-barres."
-        },
-        "hero": {
-          "eyebrow": "Export GTIN",
-          "title": "Base de données de codes-barres",
-          "stats": {
-            "records": "Produits",
-            "updated": "Dernière mise à jour",
-            "size": "Taille du ZIP"
-          }
-        },
-        "summary": {
-          "title": "Vue d'ensemble du dataset GTIN"
-        },
-        "download": {
-          "title": "Options de téléchargement",
-          "subtitle": "Choisissez le miroir adapté à votre bande passante et à vos automatisations.",
-          "fast": {
-            "highlight": "Pensé pour la distribution, l'économie circulaire et les usages grand public"
-          }
-        },
-        "format": {
-          "title": "Format du fichier",
-          "description": "Les données sont fournies dans une archive CSV compressée prête à l'emploi.",
-          "bullets": {
-            "type": "Fichier CSV compressé au format ZIP",
-            "separator": "Séparateur de champs : virgule (,)",
-            "quote": "Délimiteur de texte : guillemet (\")"
-          }
-        },
-        "columnsTitle": "Colonnes présentes dans le dataset GTIN",
-        "columnsSubtitle": "Chaque ligne correspond à un identifiant produit enrichi par Nudger.",
-        "columns": {
-          "gtin": {
-            "label": "gtin",
-            "description": "Identifiant GTIN (EAN13/UPC)."
-          },
-          "brand": {
-            "label": "brand",
-            "description": "Marque déclarée ou déduite pour le produit."
-          },
-          "model": {
-            "label": "model",
-            "description": "Modèle fabricant ou référence SKU lorsque disponible."
-          },
-          "name": {
-            "label": "name",
-            "description": "Nom marketing ou intitulé du produit."
-          },
-          "last_updated": {
-            "label": "last_updated",
-            "description": "Horodatage (EPOCH ms) de la dernière mise à jour de l'article."
-          },
-          "gs1_country": {
-            "label": "gs1_country",
-            "description": "Code pays issu du préfixe GS1."
-          },
-          "gtinType": {
-            "label": "gtinType",
-            "description": "Type de code-barres détecté (EAN13, UPC, etc.)."
-          },
-          "offers_count": {
-            "label": "offers_count",
-            "description": "Nombre d'offres commerciales suivies pour le produit."
-          },
-          "min_price": {
-            "label": "min_price",
-            "description": "Prix le plus bas observé parmi les offres."
-          },
-          "min_price_compensation": {
-            "label": "min_price_compensation",
-            "description": "Contribution carbone associée au prix le plus bas."
-          },
-          "currency": {
-            "label": "currency",
-            "description": "Devise du prix le plus bas."
-          },
-          "categories": {
-            "label": "categories",
-            "description": "Catégories agrégées par Nudger (séparées par |)."
-          },
-          "url": {
-            "label": "url",
-            "description": "URL de fiche produit lorsque des offres sont disponibles."
-          }
-        },
-        "faq": {
-          "title": "Questions fréquentes",
-          "subtitle": "Tout savoir sur l'exploitation du dataset GTIN.",
-          "items": {
-            "whatIs": {
-              "question": "Qu'est-ce qu'un GTIN ?",
-              "answer": "<p><strong>Le GTIN (Global Trade Item Number)</strong> est un identifiant unique utilisé pour identifier des produits à l'échelle mondiale. Il se présente sous plusieurs formats (GTIN-12, GTIN-13, GTIN-14), chaque format étant adapté à différents types de produits ou à des régions spécifiques. Par exemple, le GTIN-13 est couramment utilisé en Europe, tandis que le GTIN-12 est plus fréquent en Amérique du Nord. Chaque GTIN garantit qu’un produit peut être suivi, identifié et catalogué dans n'importe quelle partie du monde, assurant ainsi une gestion efficace des stocks et des ventes.</p>"
-            },
-            "differenceEan": {
-              "question": "Quelle est la différence entre GTIN et EAN ?",
-              "answer": "<p><strong>L’EAN (European Article Number)</strong> était autrefois l'identifiant standard utilisé en Europe pour marquer les produits. Aujourd'hui, le terme GTIN a remplacé l’EAN afin de standardiser les codes de produit à l'échelle mondiale. L'EAN-13 est désormais un GTIN-13. En pratique, la transition de l'EAN au GTIN est surtout une question de nomenclature, et la structure du code reste la même. Le GTIN englobe également d'autres identifiants comme le UPC (Universal Product Code) utilisé en Amérique du Nord.</p>"
-            },
-            "formats": {
-              "question": "Quels sont les différents formats de GTIN ?",
-              "answer": "<p><strong>Les principaux formats de GTIN</strong> sont : GTIN-12 (couramment utilisé aux États-Unis et au Canada sous le nom de UPC), GTIN-13 (le plus courant en Europe), et GTIN-14 (pour les unités logistiques). Ces différents formats permettent de répondre aux besoins spécifiques de chaque région et chaque chaîne d'approvisionnement. Le format GTIN-14 est généralement utilisé pour l'identification d’unités logistiques plus grandes, comme des cartons ou des palettes, plutôt que pour des articles à l’unité.</p>"
-            },
-            "differenceUpc": {
-              "question": "Quelle est la différence entre GTIN et UPC ?",
-              "answer": "<p><strong>L'UPC (Universal Product Code)</strong> est une forme de GTIN-12, utilisé principalement en Amérique du Nord. La différence entre GTIN et UPC réside surtout dans leur utilisation régionale : le GTIN est un terme plus global, tandis que l’UPC se réfère à un code spécifique utilisé dans un contexte nord-américain. Toutefois, les deux systèmes sont interopérables, et dans le cadre de la norme GTIN, l’UPC est reconnu comme une sous-catégorie.</p>"
-            },
-            "ean13": {
-              "question": "Qu'est-ce que le format EAN-13 ?",
-              "answer": "<p><strong>L’EAN-13</strong> est un code-barres constitué de 13 chiffres qui identifie les produits au niveau international, principalement en Europe. L'EAN-13 est aussi appelé GTIN-13 et est largement utilisé dans les points de vente pour scanner et suivre les articles. Il inclut un préfixe de pays, un code d’entreprise, un code produit et une clé de contrôle qui garantit l'exactitude du code.</p>"
-            },
-            "logistics": {
-              "question": "Comment le GTIN est-il utilisé dans la logistique ?",
-              "answer": "<p><strong>Le GTIN dans la logistique</strong> joue un rôle essentiel pour identifier les produits à travers les chaînes d'approvisionnement. Par exemple, le format GTIN-14 permet d'identifier des unités d'expédition comme des cartons ou des palettes, et facilite ainsi la gestion des stocks et des expéditions. L’utilisation des codes-barres GTIN dans la logistique permet une traçabilité précise des produits tout au long de leur cycle de vie, du fabricant au distributeur.</p>"
-            }
-          }
-        }
-      },
-      "isbn": {
-        "seo": {
-          "title": "Données ouvertes ISBN – télécharger l'export de métadonnées livres",
-          "description": "Téléchargez la base ISBN de Nudger, actualisée chaque semaine, avec les miroirs de téléchargement et le schéma détaillé pour vos analyses du secteur du livre."
-        },
-        "hero": {
-          "eyebrow": "Export ISBN",
-          "title": "Base de données livres (ISBN)",
-          "stats": {
-            "records": "Publications",
-            "updated": "Dernière mise à jour",
-            "size": "Taille du ZIP"
-          }
-        },
-        "summary": {
-          "title": "Vue d'ensemble du dataset ISBN"
-        },
-        "download": {
-          "title": "Options de téléchargement",
-          "subtitle": "Sélectionnez le miroir adapté à votre flux et à votre trafic.",
-          "fast": {
-            "highlight": "Miroir pensé pour les usages culturels, bibliothèques et acteurs du livre"
-          }
-        },
-        "format": {
-          "title": "Format du fichier",
-          "description": "Les données sont fournies dans une archive CSV compressée prête à l'emploi.",
-          "bullets": {
-            "type": "Fichier CSV compressé au format ZIP",
-            "separator": "Séparateur de champs : virgule (,)",
-            "quote": "Délimiteur de texte : guillemet (\")"
-          }
-        },
-        "columnsTitle": "Colonnes présentes dans le dataset ISBN",
-        "columnsSubtitle": "Chaque ligne correspond à un livre identifié par son ISBN.",
-        "columns": {
-          "isbn": {
-            "label": "isbn",
-            "description": "Numéro international normalisé du livre (ISBN)."
-          },
-          "title": {
-            "label": "title",
-            "description": "Titre de l'ouvrage tel que fourni par les sources."
-          },
-          "last_updated": {
-            "label": "last_updated",
-            "description": "Horodatage (ms) de la dernière mise à jour."
-          },
-          "offers_count": {
-            "label": "offers_count",
-            "description": "Nombre d'offres commerciales suivies pour le livre."
-          },
-          "min_price": {
-            "label": "min_price",
-            "description": "Prix de vente le plus bas observé."
-          },
-          "min_price_compensation": {
-            "label": "min_price_compensation",
-            "description": "Contribution carbone associée au prix le plus bas."
-          },
-          "currency": {
-            "label": "currency",
-            "description": "Devise du prix le plus bas."
-          },
-          "url": {
-            "label": "url",
-            "description": "URL de fiche produit lorsque disponible."
-          },
-          "editeur": {
-            "label": "editeur",
-            "description": "Nom de l'éditeur."
-          },
-          "format": {
-            "label": "format",
-            "description": "Format de l'ouvrage (broché, numérique, etc.)."
-          },
-          "nb_page": {
-            "label": "nb_page",
-            "description": "Nombre de pages."
-          },
-          "classification_decitre_1": {
-            "label": "classification_decitre_1",
-            "description": "Classification Decitre – niveau 1."
-          },
-          "classification_decitre_2": {
-            "label": "classification_decitre_2",
-            "description": "Classification Decitre – niveau 2."
-          },
-          "classification_decitre_3": {
-            "label": "classification_decitre_3",
-            "description": "Classification Decitre – niveau 3."
-          },
-          "souscategorie": {
-            "label": "souscategorie",
-            "description": "Sous-catégorie principale attribuée au livre."
-          },
-          "souscategorie2": {
-            "label": "souscategorie2",
-            "description": "Seconde sous-catégorie attribuée au livre."
-          }
-        },
-        "faq": {
-          "title": "Questions fréquentes",
-          "subtitle": "Les notions essentielles autour de l'export ISBN.",
-          "items": {
-            "whatIs": {
-              "question": "Qu'est-ce qu'un ISBN ?",
-              "answer": "<p>Un ISBN (International Standard Book Number) est un numéro unique qui permet d'identifier un livre à l'échelle mondiale. C’est un identifiant essentiel pour les éditeurs, librairies, bibliothèques, et toutes les plateformes de vente de livres. L'ISBN facilite la gestion des stocks, la distribution, et la vente des livres. Chaque livre ou édition d'un même livre dispose de son propre ISBN, garantissant une identification unique dans les bases de données et les catalogues. Les ISBN sont utilisés aussi bien pour les livres imprimés que pour les livres numériques (e-books), et permettent aux lecteurs de retrouver facilement l’ouvrage qu’ils cherchent, notamment dans les systèmes de bibliothèques et sur les plateformes de vente en ligne.</p>"
-            },
-            "meaning": {
-              "question": "Quelle est la signification d'ISBN ?",
-              "answer": "<p>ISBN signifie <strong>\"International Standard Book Number\"</strong>, un numéro international normalisé pour les livres. Ce numéro sert à identifier de manière unique une publication dans le monde entier. Il permet de simplifier la gestion des livres dans les systèmes de stockage, de distribution et de vente. Le système ISBN est utilisé dans de nombreux pays et est géré par des agences nationales. Chaque ISBN est attribué spécifiquement à un titre et à une édition particulière, ce qui permet une gestion précise et évite toute confusion entre différentes éditions ou formats d'un même ouvrage (par exemple, entre une version reliée et une version broché).</p>"
-            },
-            "structure": {
-            "question": "Comment un ISBN est-il structuré ?",
-              "answer": "<p>Un ISBN est composé de 13 chiffres (ou 10 dans l’ancien système), répartis en cinq segments. Ces segments incluent : un préfixe (qui identifie le système de numérotation), un groupe d’enregistrement (qui représente le pays ou la région linguistique), un numéro d'éditeur, un numéro de titre (qui identifie un ouvrage spécifique), et enfin, un chiffre de contrôle qui valide la structure de l’ISBN. Cette structure permet une identification rapide et précise des livres, facilitant leur gestion à l’échelle mondiale. Le passage à l'ISBN-13 en 2007 s'est aligné sur les normes mondiales des codes-barres, rendant la distribution des livres encore plus efficace à travers différents systèmes de commerce et de bibliothèque.</p>"
-            },
-            "difference": {
-            "question": "Quelle est la différence entre un ISBN-10 et un ISBN-13 ?",
-              "answer": "<p>L'ISBN-10 était le format d'origine utilisé jusqu'en 2007. Il se composait de 10 chiffres. Cependant, pour s'aligner avec les standards mondiaux des codes-barres EAN-13, le système est passé à un format à 13 chiffres, l'ISBN-13. Ce changement a permis de standardiser les processus de vente et de distribution à l’échelle mondiale, car les ISBN-13 sont compatibles avec les systèmes de codes-barres commerciaux utilisés dans divers secteurs. Bien que les ISBN-10 existent encore pour les anciens ouvrages, les nouveaux livres publiés depuis 2007 utilisent exclusivement le format ISBN-13, qui offre une plus grande capacité pour les identifications futures.</p>"
-            },
-            "assignment": {
-              "question": "Comment un ISBN est-il attribué à un livre ?",
-              "answer": "<p>Un ISBN est attribué par une agence nationale ISBN dans chaque pays, qui gère la distribution et l'enregistrement des numéros ISBN. L'éditeur ou l'auteur doit contacter cette agence pour obtenir un ISBN pour son livre. Lors de la demande, des informations sur l'ouvrage sont fournies, telles que le titre, l’auteur, le format et l’édition. Une fois attribué, l'ISBN est unique pour cette édition et ne peut être réutilisé pour une autre. Cela garantit une gestion efficace des livres dans les systèmes de bibliothèques, de vente, et de distribution. Il est essentiel pour toute œuvre destinée à une large diffusion ou à la vente.</p>"
-            },
-            "importance": {
-              "question": "Importance des ISBN ?",
-              "answer": "<p>Un code ISBN est important car il permet d'identifier un livre de manière unique et standardisée dans les systèmes de gestion, de vente, et de distribution. Sans ISBN, un livre peut être difficile à trouver dans les catalogues en ligne ou en librairie, car les systèmes de distribution reposent en grande partie sur cet identifiant. L'ISBN facilite aussi le référencement dans les bases de données des bibliothèques et des librairies, ce qui améliore sa visibilité et son accessibilité pour le public. Il est essentiel pour qu'un livre puisse être largement distribué, que ce soit sous format imprimé ou numérique.</p>"
-            },
-            "nonBook": {
-            "question": "Pourquoi je retrouve des produits (autres que des livres) dans la base ?",
-              "answer": "<p>Il arrive qu'un ISBN soit utilisé pour identifier autre chose qu'un livre. Cela peut se produire pour plusieurs raisons :</p><ul><li><strong>Manque de compréhension des standards</strong> : Certains vendeurs ou plateformes utilisent l'ISBN comme un identifiant générique, surtout si le produit est culturel ou lié aux loisirs créatifs.</li><li><strong>Économies de coût</strong> : Dans certains cas, il est plus économique pour un petit fabricant de réutiliser un code ISBN existant, bien que cela soit en dehors des normes.</li><li><strong>Confusion de formats de codes</strong> : Certaines plateformes de vente n’étant pas strictes sur la validation des codes standards, elles acceptent des ISBN pour des produits autres que des livres, ce qui crée des ambiguïtés.</li><li><strong>Réaffectation ou erreur d'attribution</strong> : L'ISBN est parfois utilisé incorrectement pour des produits non éditoriaux, surtout si le fabricant ou le distributeur n’a pas de code-barres GTIN adapté.</li></ul>"
-            }
-          }
-        }
-      }
-    },
-    "license": {
-      "title": "Licence Open Database (ODbL)",
-      "description": "Vous pouvez utiliser, partager et adapter ces données en créditant Nudger et en diffusant toute base dérivée sous la même licence.",
-      "cta": {
-        "label": "Consulter la licence ODbL",
-        "ariaLabel": "Ouvrir la licence Open Database dans un nouvel onglet",
-        "href": "https://spdx.org/licenses/ODbL-1.0.html#licenseText"
-      }
-    },
-    "faq": {
-      "title": "Questions fréquentes",
-      "subtitle": "Comprendre notre approche de l'open data.",
-      "items": {
-        "sources": {
-          "question": "Sources de données et contributions",
-          "answer": "<p>Les extractions fournies par Nudger sont issues de nos travaux d'aggrégation des données produits. Nous intégrons une grande variété de sources de données, que l'on peut classer en plusieurs types :</p><p><strong>Sites des marques et fabricants :</strong><br>Nous extrayons directement de la donnée à partir des fiches produits mises à disposition par les marques et fabricants.</p><p><strong>Sites institutionnels et données ouvertes :</strong> (base eprel, open food facts)<br>Nous intégrons des données issues de référentiels publics ou ouverts.</p><p><strong>Flux d'affiliation et plateformes marchandes :</strong> (awin, effinity, affilae, amazon, ..)<br>Dans le cadre de la relation contractuelle de promotion de Nudger et des plateformes. A ce titre, nous intégrons un lien dans notre extraction, permettant de faire jouer l'affiliation si des offres actives existent pour le produit.</p><p>Nudger aggrège, normalise et résout les conflits pour exposer des données factuelles et minimales sur les produits. La constitution et la mise à disposition de cette base sont opérées dans une logique de bien commun. Nous sommes également convaincus que le partage de ces données est au bénéfice de tous les acteurs de la chaîne de consommation (fabricants, distributeurs, chercheurs, citoyens).</p><p>Pour autant, nous sommes soucieux de respecter la propriété intellectuelle, aussi n'hésitez pas à <a href=\"/contact\">nous contacter</a> pour toute question, ou si en tant que dépositaire de données vous souhaitez vous opposer à votre participation à cette base.</p>"
-        },
-        "definition": {
-          "question": "Qu'est-ce que l'open data ?",
-          "answer": "<p>L'open data, ou données ouvertes, désigne des données rendues accessibles à tous, sans restriction d’accès, et sous un format librement exploitable. Elles peuvent être réutilisées, modifiées, redistribuées par n’importe qui, à des fins personnelles ou professionnelles. L'objectif est de maximiser l'accès à l'information pour encourager la transparence, l'innovation et l'efficacité dans différents secteurs. L'open data est souvent fourni par des organismes publics, mais certaines entreprises privées commencent aussi à publier certaines de leurs données. Un aspect clé de l'open data est l'accessibilité technique : les données doivent être disponibles dans des formats standards et lisibles par des machines (comme les fichiers CSV, JSON ou XML) afin de permettre leur réutilisation sans obstacles techniques majeurs. En facilitant l'accès aux données, l'open data ouvre la voie à de nombreuses applications, comme la création d'applications mobiles, de visualisations ou d'analyses approfondies.</p>"
-        },
-        "importance": {
-          "question": "Pourquoi l'open data est-il important ?",
-          "answer": "<p>L'open data est crucial pour promouvoir la transparence et l’innovation. En rendant les données accessibles, il permet aux citoyens de mieux comprendre les décisions des gouvernements et de participer aux discussions publiques de manière informée. Les entreprises peuvent utiliser ces données pour développer de nouveaux produits et services, ce qui stimule la croissance économique. De plus, l'open data permet une meilleure prise de décision, car les données publiques peuvent être analysées pour améliorer les politiques publiques, réduire les inefficacités, et rendre les gouvernements plus responsables de leurs actions. L'open data favorise aussi la collaboration entre différentes parties prenantes, notamment les chercheurs, les entrepreneurs, les développeurs et les collectivités locales, qui peuvent travailler ensemble pour résoudre des problèmes communs en utilisant les données de manière créative.</p>"
-        },
-        "contributors": {
-            "question": "Qui produit et met à disposition les données ouvertes ?",
-          "answer": "<p>Les principales sources de données ouvertes sont généralement les gouvernements, les institutions publiques, les ONG et parfois des entreprises privées. Les gouvernements, à tous les niveaux (national, régional, municipal), sont des acteurs majeurs dans la production de données ouvertes, en publiant des informations relatives à des secteurs tels que l’éducation, la santé, l'environnement, et les finances publiques. Les organisations internationales comme l'ONU ou l'OCDE, ainsi que certaines agences spécialisées, sont aussi d'importants contributeurs. De plus, des entreprises privées dans le domaine de la technologie ou de l'innovation, choisissent parfois de publier leurs données pour encourager la collaboration ou améliorer leur transparence. Enfin, des projets communautaires et collaboratifs permettent également de collecter et de publier des données ouvertes, souvent autour de thématiques spécifiques comme l'écologie ou le développement durable.</p>"
-        }
-      }
-    },
-    "opensource": {
-      "title": "Nudger est aussi open source",
-      "description": "Envie de découvrir le code derrière ces datasets ? Explorez les services, la gouvernance et la communauté Nudger.",
-      "cta": {
-        "label": "Visiter la page open source",
-        "ariaLabel": "Aller vers la page open source"
-      }
-    }
-  },
   "contact": {
-    "seo": {
-      "title": "Nous contacter | Nudger",
-      "description": "Prenez contact avec l'équipe Nudger pour un partenariat, une question produit ou un échange sur l'impact.",
-      "imageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact"
-    },
-    "hero": {
-      "eyebrow": "Entrons en contact",
-      "title": "Échangeons ensemble",
-      "subtitle": "Partenariat, question produit ou retour d'expérience ?",
-      "description": "Parlez-nous de votre projet, de votre organisation ou de votre usage de Nudger afin que nous vous orientions vers la bonne personne.",
-      "highlights": {
-        "commitment": "Une réponse sous deux jours ouvrés pour la plupart des demandes.",
-        "expertise": "Des expertes et experts produit, data et impact engagés pour un commerce responsable.",
-        "impact": "Chaque message nous aide à construire un marché plus juste et durable."
-      },
-      "channels": {
-        "title": "Comment pouvons-nous vous aider ?",
-        "subtitle": "Choisissez le sujet qui vous ressemble : toute demande arrive à la même équipe bienveillante.",
-        "support": {
-          "label": "Support produit & utilisateurs",
-          "description": "Questions sur le comparateur, difficulté de connexion ? On vous accompagne pas à pas."
-        },
-        "partnerships": {
-          "label": "Partenariats & écosystème",
-          "description": "Envie de collaborer, d'intégrer les données Nudger ou de co-construire un dispositif ? Parlons-en."
-        },
-        "trust": {
-          "label": "Presse & impact citoyen",
-          "description": "Journalistes, institutions ou chercheurs : contactez-nous pour interviews, témoignages et chiffres clés."
-        }
-      }
-    },
     "details": {
-      "eyebrow": "Rester en lien",
-      "title": "Des passerelles pour collaborer",
-      "subtitle": "Le collectif rassemble citoyennes, entreprises et territoires autour de la consommation responsable.",
       "cards": {
-        "support": {
-          "title": "Besoin d'un coup de pouce ?",
-          "description": "Décrivez votre question dans le formulaire et donnez un maximum de contexte pour que nous puissions vous répondre concrètement.",
-          "cta": "Nous écrire",
-          "ctaAria": "Aller au formulaire de contact pour écrire à l'équipe Nudger"
+        "community": {
+          "cta": "Nous suivre sur LinkedIn",
+          "ctaAria": "Ouvrir la page LinkedIn de Nudger dans un nouvel onglet",
+          "description": "Suivez nos actualités, sorties produit et appels à contribution sur LinkedIn.",
+          "title": "Rejoindre la communauté"
         },
         "partnerships": {
-          "title": "Co-construire des projets à impact",
-          "description": "De la distribution aux ONG et collectivités, nous créons des passerelles pour accélérer la transition écologique.",
           "cta": "Rencontrer l'équipe",
-          "ctaAria": "Ouvrir la page équipe de Nudger"
+          "ctaAria": "Ouvrir la page équipe de Nudger",
+          "description": "De la distribution aux ONG et collectivités, nous créons des passerelles pour accélérer la transition écologique.",
+          "title": "Co-construire des projets à impact"
         },
-        "community": {
-          "title": "Rejoindre la communauté",
-          "description": "Suivez nos actualités, sorties produit et appels à contribution sur LinkedIn.",
-          "cta": "Nous suivre sur LinkedIn",
-          "ctaAria": "Ouvrir la page LinkedIn de Nudger dans un nouvel onglet"
+        "support": {
+          "cta": "Nous écrire",
+          "ctaAria": "Aller au formulaire de contact pour écrire à l'équipe Nudger",
+          "description": "Décrivez votre question dans le formulaire et donnez un maximum de contexte pour que nous puissions vous répondre concrètement.",
+          "title": "Besoin d'un coup de pouce ?"
         }
-      }
+      },
+      "eyebrow": "Rester en lien",
+      "subtitle": "Le collectif rassemble citoyennes, entreprises et territoires autour de la consommation responsable.",
+      "title": "Des passerelles pour collaborer"
     },
     "form": {
-      "eyebrow": "Formulaire",
-      "title": "Parlez-nous de vous",
-      "subtitle": "Remplissez les informations ci-dessous, nous reviendrons vers vous rapidement.",
-      "fields": {
-        "name": {
-          "label": "Votre nom",
-          "placeholder": "ex. Alex Martin"
+      "actions": {
+        "reset": "Effacer le formulaire",
+        "submit": "Envoyer le message"
+      },
+      "errors": {
+        "captchaExpired": "Le captcha a expiré, merci de recommencer.",
+        "captchaFailed": "La vérification du captcha a échoué. Merci de réessayer.",
+        "email": {
+          "invalid": "Merci de saisir une adresse e-mail valide.",
+          "required": "Merci d'indiquer une adresse e-mail."
         },
+        "message": {
+          "length": "Votre message doit contenir au moins 10 caractères.",
+          "required": "Merci de détailler votre demande."
+        },
+        "missingCaptcha": "Merci de compléter le captcha avant d'envoyer.",
+        "name": {
+          "length": "Votre nom doit contenir au moins 2 caractères.",
+          "required": "Merci d'indiquer votre nom."
+        }
+      },
+      "eyebrow": "Formulaire",
+      "feedback": {
+        "genericError": "Impossible d'envoyer votre message. Merci de réessayer ou de nous contacter plus tard.",
+        "missingSiteKey": "Le captcha n'est pas encore configuré. Merci de réessayer ultérieurement.",
+        "success": "Merci ! Votre message a bien été envoyé. Nous revenons vers vous très vite."
+      },
+      "fields": {
         "email": {
           "label": "Votre e-mail",
           "placeholder": "vous{'@'}exemple.org"
@@ -1116,331 +385,1114 @@
         "message": {
           "label": "Votre message",
           "placeholder": "Comment pouvons-nous vous aider ?"
+        },
+        "name": {
+          "label": "Votre nom",
+          "placeholder": "ex. Alex Martin"
         }
       },
+      "privacy": "Vos coordonnées ne sont utilisées que pour répondre à votre message et ne sont jamais partagées.",
+      "subtitle": "Remplissez les informations ci-dessous, nous reviendrons vers vous rapidement.",
+      "title": "Parlez-nous de vous"
+    },
+    "hero": {
+      "channels": {
+        "partnerships": {
+          "description": "Envie de collaborer, d'intégrer les données Nudger ou de co-construire un dispositif ? Parlons-en.",
+          "label": "Partenariats & écosystème"
+        },
+        "subtitle": "Choisissez le sujet qui vous ressemble : toute demande arrive à la même équipe bienveillante.",
+        "support": {
+          "description": "Questions sur le comparateur, difficulté de connexion ? On vous accompagne pas à pas.",
+          "label": "Support produit & utilisateurs"
+        },
+        "title": "Comment pouvons-nous vous aider ?",
+        "trust": {
+          "description": "Journalistes, institutions ou chercheurs : contactez-nous pour interviews, témoignages et chiffres clés.",
+          "label": "Presse & impact citoyen"
+        }
+      },
+      "description": "Parlez-nous de votre projet, de votre organisation ou de votre usage de Nudger afin que nous vous orientions vers la bonne personne.",
+      "eyebrow": "Entrons en contact",
+      "highlights": {
+        "commitment": "Une réponse sous deux jours ouvrés pour la plupart des demandes.",
+        "expertise": "Des expertes et experts produit, data et impact engagés pour un commerce responsable.",
+        "impact": "Chaque message nous aide à construire un marché plus juste et durable."
+      },
+      "subtitle": "Partenariat, question produit ou retour d'expérience ?",
+      "title": "Échangeons ensemble"
+    },
+    "seo": {
+      "description": "Prenez contact avec l'équipe Nudger pour un partenariat, une question produit ou un échange sur l'impact.",
+      "imageAlt": "Logotype Nudger utilisé pour l'aperçu de la page contact",
+      "title": "Nous contacter | Nudger"
+    }
+  },
+  "contrib": {
+    "error": {
+      "cta": "Retour à l'accueil",
+      "description": "Le lien de contribution a peut-être expiré ou est invalide. Vous pouvez retourner à l'accueil et réessayer.",
+      "detailsPrefix": "Détails :",
+      "title": "Impossible de valider ce lien"
+    },
+    "loading": {
+      "message": "Veuillez patienter pendant la validation de votre lien de contribution.",
+      "title": "Préparation de votre redirection…"
+    },
+    "seo": {
+      "description": "Nous vérifions votre lien de contribution sécurisé avant de vous rediriger vers le partenaire de Nudger.",
+      "title": "Redirection vers notre partenaire"
+    },
+    "success": {
+      "cta": "Continuer vers le site partenaire",
+      "message": "Vous serez redirigé dans quelques instants. Si rien ne se passe, utilisez le bouton ci-dessous.",
+      "title": "Prêt pour la redirection"
+    }
+  },
+  "error": {
+    "page": {
       "actions": {
-        "submit": "Envoyer le message",
-        "reset": "Effacer le formulaire"
+        "ariaLabel": "Actions rapides pour se remettre sur la bonne voie",
+        "contactSupport": "Contacter le support",
+        "goHome": "Retour à l’accueil"
       },
-      "feedback": {
-        "success": "Merci ! Votre message a bien été envoyé. Nous revenons vers vous très vite.",
-        "genericError": "Impossible d'envoyer votre message. Merci de réessayer ou de nous contacter plus tard.",
-        "missingSiteKey": "Le captcha n'est pas encore configuré. Merci de réessayer ultérieurement."
+      "debug": {
+        "empty": "Aucune information de diagnostic supplémentaire n’est disponible.",
+        "messageLabel": "Message d’erreur",
+        "stackLabel": "Trace de la pile",
+        "title": "Détails techniques"
       },
-      "errors": {
-        "name": {
-          "required": "Merci d'indiquer votre nom.",
-          "length": "Votre nom doit contenir au moins 2 caractères."
-        },
-        "email": {
-          "required": "Merci d'indiquer une adresse e-mail.",
-          "invalid": "Merci de saisir une adresse e-mail valide."
-        },
-        "message": {
-          "required": "Merci de détailler votre demande.",
-          "length": "Votre message doit contenir au moins 10 caractères."
-        },
-        "captchaExpired": "Le captcha a expiré, merci de recommencer.",
-        "captchaFailed": "La vérification du captcha a échoué. Merci de réessayer.",
-        "missingCaptcha": "Merci de compléter le captcha avant d'envoyer."
+      "eyebrow": "Changement de cap inattendu",
+      "generic": {
+        "badge": "Un contretemps est survenu",
+        "description": "Une erreur inattendue nous a empêchés de charger cette page.",
+        "helper": "Essayez une autre section de Nudger ou contactez-nous si le problème persiste.",
+        "statusMessage": "Erreur 500 — quelque chose s’est mal passé de notre côté.",
+        "title": "Nous corrigeons le problème"
       },
-      "privacy": "Vos coordonnées ne sont utilisées que pour répondre à votre message et ne sont jamais partagées."
+      "notFound": {
+        "badge": "Page introuvable",
+        "description": "Le lien suivi est peut-être obsolète ou la page a été déplacée.",
+        "helper": "Utilisez les liens ci-dessous ou retournez à l’accueil pour poursuivre votre exploration.",
+        "statusMessage": "Erreur 404 — la ressource demandée est introuvable.",
+        "title": "Nous ne trouvons pas cette page"
+      },
+      "statusLabel": "Code statut {code}"
     }
   },
   "feedback": {
-    "hero": {
-      "eyebrow": "Retours utilisateurs",
-      "title": "Construisons Nudger avec vos idées",
-      "subtitle": "Signalez les bugs, proposez des évolutions et votez pour les priorités qui comptent.",
-      "description": "Vos retours orientent notre feuille de route. Découvrez les demandes déjà déposées, soutenez celles qui vous parlent et proposez les vôtres.",
-      "ctaGroupLabel": "Actions de feedback",
-      "primaryCta": {
-        "label": "Outil de feedback",
-        "ariaLabel": "Faire défiler jusqu'au tableau de feedback Nudger"
-      },
-      "secondaryCta": {
-        "label": "Ouvrir les issues GitHub",
-        "ariaLabel": "Ouvrir les issues GitHub de Nudger dans un nouvel onglet"
-      },
-      "stats": {
-        "eyebrow": "En pratique",
-        "title": "Un backlog collaboratif",
-        "description": "Aidez-nous à concentrer l'équipe sur les améliorations utiles.",
-        "items": {
-          "iterations": "Itérations hebdomadaires sur les sujets les plus soutenus.",
-          "votes": "Votes limités pour mettre en avant les priorités clés.",
-          "transparency": "Suivi public et transparent de chaque proposition."
-        }
-      }
-    },
-    "tabs": {
-      "eyebrow": "Tableau communautaire",
-      "title": "Aidez-nous à prioriser la feuille de route",
-      "description": "Choisissez une catégorie pour explorer les discussions en cours, voter pour les sujets qui vous concernent ou en ouvrir une nouvelle.",
-      "ariaLabel": "Catégories de feedback",
-      "idea": {
-        "label": "Idées",
-        "issueTitle": "Idées de la communauté",
-        "description": "Proposez des améliorations qui rendraient Nudger plus utile pour vous ou votre organisation. Nous passons chaque idée en revue chaque semaine."
-      },
-      "bug": {
-        "label": "Bugs",
-        "issueTitle": "Bugs signalés",
-        "description": "Décrivez toute anomalie ou comportement inattendu observé. Des signalements précis nous aident à corriger plus vite."
-      }
-    },
-    "issues": {
-      "empty": {
-        "idea": "Aucune idée pour le moment. Partagez la vôtre !",
-        "bug": "Aucun bug recensé ici pour l'instant. Merci de nous prévenir si vous en trouvez."
-      },
-      "loadError": "Impossible de charger le tableau de feedback. Merci de réessayer."
-    },
-    "voting": {
-      "voteButton": "Voter",
-      "voteButtonAria": "Voter pour",
-      "openIssue": "Ouvrir la discussion",
-      "noVotes": "Vous n'avez plus de vote disponible.",
-      "limitReached": "Vous avez atteint votre limite de votes pour le moment.",
-      "remaining": "Il vous reste {count} vote(s).",
-      "voteCompleted": "Fait"
-    },
-    "form": {
-      "sections": {
-        "idea": {
-          "eyebrow": "Proposer une idée",
-          "title": "Imaginez la prochaine évolution",
-          "subtitle": "Expliquez comment Nudger pourrait mieux vous aider.",
-          "intro": "Présentez le contexte de votre idée, son importance et la manière dont elle améliorerait Nudger pour toutes et tous.",
-          "titlePlaceholder": "Ex. Comparer l'empreinte carbone des frigos",
-          "messagePlaceholder": "Décrivez votre idée, le contexte et les bénéfices attendus."
-        },
-        "bug": {
-          "eyebrow": "Signaler un bug",
-          "title": "Décrivez le problème rencontré",
-          "subtitle": "Plus vous donnez de détails, plus nous pourrons corriger rapidement.",
-          "intro": "Partagez les étapes pour reproduire le bug, ce que vous attendiez et ce qui s'est réellement produit afin que nous puissions enquêter rapidement.",
-          "titlePlaceholder": "Ex. Erreur 500 sur la fiche produit",
-          "messagePlaceholder": "Précisez les étapes, le comportement attendu et ce qui s'est produit."
-        }
-      },
-      "fields": {
-        "author": {
-          "label": "Nom affiché",
-          "placeholder": "Sous quel nom souhaitez-vous apparaître ?",
-          "default": "Membre de la communauté Nudger"
-        },
-        "title": {
-          "label": "Titre"
-        },
-        "message": {
-          "label": "Message"
-        }
-      },
-      "actions": {
-        "submit": "Envoyer le feedback",
-        "reset": "Réinitialiser le formulaire"
-      },
-      "feedback": {
-        "success": "Merci ! Votre contribution est enregistrée et apparaîtra bientôt sur le tableau.",
-        "missingSiteKey": "Le captcha n'est pas encore configuré : l'envoi de feedback est temporairement indisponible."
-      },
-      "errors": {
-        "missingCaptcha": "Merci de compléter le captcha avant d'envoyer.",
-        "captchaExpired": "Le captcha a expiré, merci de recommencer.",
-        "captchaFailed": "La vérification du captcha a échoué. Merci de réessayer.",
-        "title": {
-          "length": "Le titre doit contenir au moins 4 caractères."
-        },
-        "message": {
-          "length": "Le message doit contenir au moins 20 caractères."
-        }
-      },
-      "privacy": "Les retours sont publics : n'indiquez pas de données personnelles sensibles."
-    },
     "common": {
       "genericError": "Une erreur inattendue est survenue. Merci de réessayer."
     },
-    "openSource": {
-      "eyebrow": "Collaboration ouverte",
-      "title": "Explorez nos communs open source et open data",
-      "description": "Nous publions notre feuille de route, notre code et nos jeux de données pour que chacun puisse auditer, réutiliser ou contribuer à Nudger.",
-      "cards": {
-        "opensource": {
-          "title": "Contribuer sur GitHub",
-          "description": "Parcourez nos dépôts, suivez les pull requests en cours et soumettez vos propres contributions.",
-          "cta": "Voir la page open source",
-          "ariaLabel": "Aller vers la page open source de Nudger"
+    "form": {
+      "actions": {
+        "reset": "Réinitialiser le formulaire",
+        "submit": "Envoyer le feedback"
+      },
+      "errors": {
+        "captchaExpired": "Le captcha a expiré, merci de recommencer.",
+        "captchaFailed": "La vérification du captcha a échoué. Merci de réessayer.",
+        "message": {
+          "length": "Le message doit contenir au moins 20 caractères."
         },
-        "opendata": {
-          "title": "Analyser nos données ouvertes",
-          "description": "Téléchargez les jeux de données qui alimentent Nudger et réutilisez-les dans vos recherches ou projets.",
-          "cta": "Voir la page open data",
-          "ariaLabel": "Aller vers la page open data de Nudger"
+        "missingCaptcha": "Merci de compléter le captcha avant d'envoyer.",
+        "title": {
+          "length": "Le titre doit contenir au moins 4 caractères."
+        }
+      },
+      "feedback": {
+        "missingSiteKey": "Le captcha n'est pas encore configuré : l'envoi de feedback est temporairement indisponible.",
+        "success": "Merci ! Votre contribution est enregistrée et apparaîtra bientôt sur le tableau."
+      },
+      "fields": {
+        "author": {
+          "default": "Membre de la communauté Nudger",
+          "label": "Nom affiché",
+          "placeholder": "Sous quel nom souhaitez-vous apparaître ?"
+        },
+        "message": {
+          "label": "Message"
+        },
+        "title": {
+          "label": "Titre"
+        }
+      },
+      "privacy": "Les retours sont publics : n'indiquez pas de données personnelles sensibles.",
+      "sections": {
+        "bug": {
+          "eyebrow": "Signaler un bug",
+          "intro": "Partagez les étapes pour reproduire le bug, ce que vous attendiez et ce qui s'est réellement produit afin que nous puissions enquêter rapidement.",
+          "messagePlaceholder": "Précisez les étapes, le comportement attendu et ce qui s'est produit.",
+          "subtitle": "Plus vous donnez de détails, plus nous pourrons corriger rapidement.",
+          "title": "Décrivez le problème rencontré",
+          "titlePlaceholder": "Ex. Erreur 500 sur la fiche produit"
+        },
+        "idea": {
+          "eyebrow": "Proposer une idée",
+          "intro": "Présentez le contexte de votre idée, son importance et la manière dont elle améliorerait Nudger pour toutes et tous.",
+          "messagePlaceholder": "Décrivez votre idée, le contexte et les bénéfices attendus.",
+          "subtitle": "Expliquez comment Nudger pourrait mieux vous aider.",
+          "title": "Imaginez la prochaine évolution",
+          "titlePlaceholder": "Ex. Comparer l'empreinte carbone des frigos"
         }
       }
     },
+    "hero": {
+      "ctaGroupLabel": "Actions de feedback",
+      "description": "Vos retours orientent notre feuille de route. Découvrez les demandes déjà déposées, soutenez celles qui vous parlent et proposez les vôtres.",
+      "eyebrow": "Retours utilisateurs",
+      "primaryCta": {
+        "ariaLabel": "Faire défiler jusqu'au tableau de feedback Nudger",
+        "label": "Outil de feedback"
+      },
+      "secondaryCta": {
+        "ariaLabel": "Ouvrir les issues GitHub de Nudger dans un nouvel onglet",
+        "label": "Ouvrir les issues GitHub"
+      },
+      "stats": {
+        "description": "Aidez-nous à concentrer l'équipe sur les améliorations utiles.",
+        "eyebrow": "En pratique",
+        "items": {
+          "iterations": "Itérations hebdomadaires sur les sujets les plus soutenus.",
+          "transparency": "Suivi public et transparent de chaque proposition.",
+          "votes": "Votes limités pour mettre en avant les priorités clés."
+        },
+        "title": "Un backlog collaboratif"
+      },
+      "subtitle": "Signalez les bugs, proposez des évolutions et votez pour les priorités qui comptent.",
+      "title": "Construisons Nudger avec vos idées"
+    },
+    "issues": {
+      "empty": {
+        "bug": "Aucun bug recensé ici pour l'instant. Merci de nous prévenir si vous en trouvez.",
+        "idea": "Aucune idée pour le moment. Partagez la vôtre !"
+      },
+      "loadError": "Impossible de charger le tableau de feedback. Merci de réessayer."
+    },
+    "openSource": {
+      "cards": {
+        "opendata": {
+          "ariaLabel": "Aller vers la page open data de Nudger",
+          "cta": "Voir la page open data",
+          "description": "Téléchargez les jeux de données qui alimentent Nudger et réutilisez-les dans vos recherches ou projets.",
+          "title": "Analyser nos données ouvertes"
+        },
+        "opensource": {
+          "ariaLabel": "Aller vers la page open source de Nudger",
+          "cta": "Voir la page open source",
+          "description": "Parcourez nos dépôts, suivez les pull requests en cours et soumettez vos propres contributions.",
+          "title": "Contribuer sur GitHub"
+        }
+      },
+      "description": "Nous publions notre feuille de route, notre code et nos jeux de données pour que chacun puisse auditer, réutiliser ou contribuer à Nudger.",
+      "eyebrow": "Collaboration ouverte",
+      "title": "Explorez nos communs open source et open data"
+    },
     "seo": {
-      "title": "Feedback & roadmap – Communauté Nudger",
       "description": "Partagez vos idées, signalez les bugs et votez pour les prochaines évolutions de Nudger.",
-      "imageAlt": "Illustration du tableau de feedback de la communauté Nudger."
+      "imageAlt": "Illustration du tableau de feedback de la communauté Nudger.",
+      "title": "Feedback & roadmap – Communauté Nudger"
+    },
+    "tabs": {
+      "ariaLabel": "Catégories de feedback",
+      "bug": {
+        "description": "Décrivez toute anomalie ou comportement inattendu observé. Des signalements précis nous aident à corriger plus vite.",
+        "issueTitle": "Bugs signalés",
+        "label": "Bugs"
+      },
+      "description": "Choisissez une catégorie pour explorer les discussions en cours, voter pour les sujets qui vous concernent ou en ouvrir une nouvelle.",
+      "eyebrow": "Tableau communautaire",
+      "idea": {
+        "description": "Proposez des améliorations qui rendraient Nudger plus utile pour vous ou votre organisation. Nous passons chaque idée en revue chaque semaine.",
+        "issueTitle": "Idées de la communauté",
+        "label": "Idées"
+      },
+      "title": "Aidez-nous à prioriser la feuille de route"
+    },
+    "voting": {
+      "limitReached": "Vous avez atteint votre limite de votes pour le moment.",
+      "noVotes": "Vous n'avez plus de vote disponible.",
+      "openIssue": "Ouvrir la discussion",
+      "remaining": "Il vous reste {count} vote(s).",
+      "voteButton": "Voter",
+      "voteButtonAria": "Voter pour",
+      "voteCompleted": "Fait"
     }
   },
-  "cms": {
-    "page": {
-      "loading": "Chargement de la page…",
-      "error": "Nous n'avons pas pu charger cette page. Veuillez réessayer plus tard.",
-      "edit": "Modifier cette page"
+  "impactScorePage": {
+    "aria": {
+      "navigation": "Navigation des sections Impact Score",
+      "pageOutline": "Plan de la page Impact Score"
+    },
+    "hero": {
+      "title": "L’Impact Score : évaluation de l'impact environnemental de vos produits"
+    },
+    "navigation": {
+      "analysis": "Analyse approfondie",
+      "approach": "Notre démarche",
+      "methodology": "Méthodologie",
+      "overview": "Présentation"
+    },
+    "sections": {
+      "analysis": {
+        "dataQuality": {
+          "imageAlt": "Illustration sur la qualité de la donnée",
+          "title": "La qualité de la donnée, enjeu majeur"
+        },
+        "eyebrow": "Analyse approfondie",
+        "relativisation": {
+          "imageAlt": "Illustration du principe de relativisation",
+          "title": "Principe de relativisation"
+        },
+        "title": "Relativisation et qualité de la donnée"
+      },
+      "approach": {
+        "eyebrow": "Notre démarche",
+        "imageAlt": "Illustration de notre démarche ecoscore",
+        "title": "Notre ecoscore : transparent, innovant et performant"
+      },
+      "methodology": {
+        "empty": "Les catégories seront bientôt disponibles.",
+        "eyebrow": "Méthodologie",
+        "intro": "Les règles de calcul de l’ecoscore sont détaillées sur chaque produit (section « bilan écologique »). Chaque catégorie de produit possède ses propres critères et pondérations. Voici les catégories couvertes :",
+        "title": "Comment est calculé l'Impact Score ?",
+        "verticalCardAria": "Accéder à l’Impact Score détaillé de la catégorie {vertical}",
+        "verticalCta": "Découvrir l’impact détaillé",
+        "verticalImageAlt": "Illustration de la catégorie {vertical}",
+        "verticalLabel": "Catégorie"
+      },
+      "overview": {
+        "eyebrow": "Présentation",
+        "sample": {
+          "caption": "Évaluation indicative basée sur notre méthodologie",
+          "title": "Évaluation indicative"
+        },
+        "title": "Qu’est-ce que l’Impact Score ?"
+      }
+    }
+  },
+  "lang": {
+    "en": "Anglais",
+    "fr": "Français"
+  },
+  "opendata": {
+    "datasets": {
+      "cards": {
+        "gtin": {
+          "cta": {
+            "ariaLabel": "Ouvrir la page open data GTIN",
+            "label": "Voir le dataset GTIN"
+          },
+          "description": "Tous les produits indexés par Nudger avec marque, modèle, prix et catégories.",
+          "features": {
+            "coverage": "Inclut les métadonnées EAN13, UPC et préfixes GS1",
+            "refresh": "Instantané mis à jour chaque semaine",
+            "uses": "Idéal pour la veille prix, l'analyse d'assortiment et le suivi catégoriel"
+          },
+          "title": "Base GTIN"
+        },
+        "isbn": {
+          "cta": {
+            "ariaLabel": "Ouvrir la page open data ISBN",
+            "label": "Voir le dataset ISBN"
+          },
+          "description": "Export dédié aux livres avec informations de prix, disponibilité et classifications.",
+          "features": {
+            "catalogue": "Inclut éditeur, format et classifications Decitre",
+            "refresh": "Instantané mis à jour chaque semaine",
+            "research": "Parfait pour l'enrichissement de catalogue, la recherche et les analyses culturelles"
+          },
+          "title": "Base ISBN"
+        }
+      },
+      "common": {
+        "breadcrumb": {
+          "ariaLabel": "Retour à la page opendata",
+          "label": "opendata"
+        },
+        "columnDescription": "Description",
+        "columnName": "Colonne",
+        "download": {
+          "direct": {
+            "concurrent": "Jusqu'à {value} téléchargements simultanés",
+            "concurrentUnknown": "Limite de téléchargements simultanés",
+            "cta": {
+              "ariaLabel": "Lancer le téléchargement direct depuis Nudger",
+              "label": "Télécharger depuis nudger.fr"
+            },
+            "description": "Récupérez le fichier ZIP directement sur l'infrastructure Nudger.",
+            "speed": "Débit limité à {value} par client",
+            "speedUnknown": "Débit limité par client",
+            "title": "Téléchargement direct depuis Nudger"
+          },
+          "fast": {
+            "badge": "Recommandé",
+            "cta": {
+              "ariaLabel": "Ouvrir le dataset sur data.gouv.fr dans un nouvel onglet",
+              "href": "https://www.data.gouv.fr/fr/datasets/base-de-codes-barres-noms-et-categories-produits/",
+              "label": "Télécharger sur data.gouv.fr"
+            },
+            "description": "Téléchargement via le portail open data officiel de l'État français.",
+            "speed": "Infrastructure haut débit",
+            "title": "Miroir rapide (data.gouv.fr)"
+          }
+        },
+        "placeholder": "—",
+        "summary": {
+          "records": "Nombre total d'enregistrements",
+          "size": "Taille compressée",
+          "updated": "Dernière mise à jour"
+        }
+      },
+      "gtin": {
+        "columns": {
+          "brand": {
+            "description": "Marque déclarée ou déduite pour le produit.",
+            "label": "brand"
+          },
+          "categories": {
+            "description": "Catégories agrégées par Nudger (séparées par |).",
+            "label": "categories"
+          },
+          "currency": {
+            "description": "Devise du prix le plus bas.",
+            "label": "currency"
+          },
+          "gs1_country": {
+            "description": "Code pays issu du préfixe GS1.",
+            "label": "gs1_country"
+          },
+          "gtin": {
+            "description": "Identifiant GTIN (EAN13/UPC).",
+            "label": "gtin"
+          },
+          "gtinType": {
+            "description": "Type de code-barres détecté (EAN13, UPC, etc.).",
+            "label": "gtinType"
+          },
+          "last_updated": {
+            "description": "Horodatage (EPOCH ms) de la dernière mise à jour de l'article.",
+            "label": "last_updated"
+          },
+          "min_price": {
+            "description": "Prix le plus bas observé parmi les offres.",
+            "label": "min_price"
+          },
+          "min_price_compensation": {
+            "description": "Contribution carbone associée au prix le plus bas.",
+            "label": "min_price_compensation"
+          },
+          "model": {
+            "description": "Modèle fabricant ou référence SKU lorsque disponible.",
+            "label": "model"
+          },
+          "name": {
+            "description": "Nom marketing ou intitulé du produit.",
+            "label": "name"
+          },
+          "offers_count": {
+            "description": "Nombre d'offres commerciales suivies pour le produit.",
+            "label": "offers_count"
+          },
+          "url": {
+            "description": "URL de fiche produit lorsque des offres sont disponibles.",
+            "label": "url"
+          }
+        },
+        "columnsSubtitle": "Chaque ligne correspond à un identifiant produit enrichi par Nudger.",
+        "columnsTitle": "Colonnes présentes dans le dataset GTIN",
+        "download": {
+          "fast": {
+            "highlight": "Pensé pour la distribution, l'économie circulaire et les usages grand public"
+          },
+          "subtitle": "Choisissez le miroir adapté à votre bande passante et à vos automatisations.",
+          "title": "Options de téléchargement"
+        },
+        "faq": {
+          "items": {
+            "differenceEan": {
+              "answer": "<p><strong>L’EAN (European Article Number)</strong> était autrefois l'identifiant standard utilisé en Europe pour marquer les produits. Aujourd'hui, le terme GTIN a remplacé l’EAN afin de standardiser les codes de produit à l'échelle mondiale. L'EAN-13 est désormais un GTIN-13. En pratique, la transition de l'EAN au GTIN est surtout une question de nomenclature, et la structure du code reste la même. Le GTIN englobe également d'autres identifiants comme le UPC (Universal Product Code) utilisé en Amérique du Nord.</p>",
+              "question": "Quelle est la différence entre GTIN et EAN ?"
+            },
+            "differenceUpc": {
+              "answer": "<p><strong>L'UPC (Universal Product Code)</strong> est une forme de GTIN-12, utilisé principalement en Amérique du Nord. La différence entre GTIN et UPC réside surtout dans leur utilisation régionale : le GTIN est un terme plus global, tandis que l’UPC se réfère à un code spécifique utilisé dans un contexte nord-américain. Toutefois, les deux systèmes sont interopérables, et dans le cadre de la norme GTIN, l’UPC est reconnu comme une sous-catégorie.</p>",
+              "question": "Quelle est la différence entre GTIN et UPC ?"
+            },
+            "ean13": {
+              "answer": "<p><strong>L’EAN-13</strong> est un code-barres constitué de 13 chiffres qui identifie les produits au niveau international, principalement en Europe. L'EAN-13 est aussi appelé GTIN-13 et est largement utilisé dans les points de vente pour scanner et suivre les articles. Il inclut un préfixe de pays, un code d’entreprise, un code produit et une clé de contrôle qui garantit l'exactitude du code.</p>",
+              "question": "Qu'est-ce que le format EAN-13 ?"
+            },
+            "formats": {
+              "answer": "<p><strong>Les principaux formats de GTIN</strong> sont : GTIN-12 (couramment utilisé aux États-Unis et au Canada sous le nom de UPC), GTIN-13 (le plus courant en Europe), et GTIN-14 (pour les unités logistiques). Ces différents formats permettent de répondre aux besoins spécifiques de chaque région et chaque chaîne d'approvisionnement. Le format GTIN-14 est généralement utilisé pour l'identification d’unités logistiques plus grandes, comme des cartons ou des palettes, plutôt que pour des articles à l’unité.</p>",
+              "question": "Quels sont les différents formats de GTIN ?"
+            },
+            "logistics": {
+              "answer": "<p><strong>Le GTIN dans la logistique</strong> joue un rôle essentiel pour identifier les produits à travers les chaînes d'approvisionnement. Par exemple, le format GTIN-14 permet d'identifier des unités d'expédition comme des cartons ou des palettes, et facilite ainsi la gestion des stocks et des expéditions. L’utilisation des codes-barres GTIN dans la logistique permet une traçabilité précise des produits tout au long de leur cycle de vie, du fabricant au distributeur.</p>",
+              "question": "Comment le GTIN est-il utilisé dans la logistique ?"
+            },
+            "whatIs": {
+              "answer": "<p><strong>Le GTIN (Global Trade Item Number)</strong> est un identifiant unique utilisé pour identifier des produits à l'échelle mondiale. Il se présente sous plusieurs formats (GTIN-12, GTIN-13, GTIN-14), chaque format étant adapté à différents types de produits ou à des régions spécifiques. Par exemple, le GTIN-13 est couramment utilisé en Europe, tandis que le GTIN-12 est plus fréquent en Amérique du Nord. Chaque GTIN garantit qu’un produit peut être suivi, identifié et catalogué dans n'importe quelle partie du monde, assurant ainsi une gestion efficace des stocks et des ventes.</p>",
+              "question": "Qu'est-ce qu'un GTIN ?"
+            }
+          },
+          "subtitle": "Tout savoir sur l'exploitation du dataset GTIN.",
+          "title": "Questions fréquentes"
+        },
+        "format": {
+          "bullets": {
+            "quote": "Délimiteur de texte : guillemet (\")",
+            "separator": "Séparateur de champs : virgule (,)",
+            "type": "Fichier CSV compressé au format ZIP"
+          },
+          "description": "Les données sont fournies dans une archive CSV compressée prête à l'emploi.",
+          "title": "Format du fichier"
+        },
+        "hero": {
+          "eyebrow": "Export GTIN",
+          "stats": {
+            "records": "Produits",
+            "size": "Taille du ZIP",
+            "updated": "Dernière mise à jour"
+          },
+          "title": "Base de données de codes-barres"
+        },
+        "seo": {
+          "description": "Accédez à la base GTIN de Nudger, mise à jour chaque semaine, avec les options de téléchargement et le schéma détaillé pour vos projets data sur les codes-barres.",
+          "title": "Données ouvertes GTIN – télécharger le catalogue de codes-barres"
+        },
+        "summary": {
+          "title": "Vue d'ensemble du dataset GTIN"
+        }
+      },
+      "isbn": {
+        "columns": {
+          "classification_decitre_1": {
+            "description": "Classification Decitre – niveau 1.",
+            "label": "classification_decitre_1"
+          },
+          "classification_decitre_2": {
+            "description": "Classification Decitre – niveau 2.",
+            "label": "classification_decitre_2"
+          },
+          "classification_decitre_3": {
+            "description": "Classification Decitre – niveau 3.",
+            "label": "classification_decitre_3"
+          },
+          "currency": {
+            "description": "Devise du prix le plus bas.",
+            "label": "currency"
+          },
+          "editeur": {
+            "description": "Nom de l'éditeur.",
+            "label": "editeur"
+          },
+          "format": {
+            "description": "Format de l'ouvrage (broché, numérique, etc.).",
+            "label": "format"
+          },
+          "isbn": {
+            "description": "Numéro international normalisé du livre (ISBN).",
+            "label": "isbn"
+          },
+          "last_updated": {
+            "description": "Horodatage (ms) de la dernière mise à jour.",
+            "label": "last_updated"
+          },
+          "min_price": {
+            "description": "Prix de vente le plus bas observé.",
+            "label": "min_price"
+          },
+          "min_price_compensation": {
+            "description": "Contribution carbone associée au prix le plus bas.",
+            "label": "min_price_compensation"
+          },
+          "nb_page": {
+            "description": "Nombre de pages.",
+            "label": "nb_page"
+          },
+          "offers_count": {
+            "description": "Nombre d'offres commerciales suivies pour le livre.",
+            "label": "offers_count"
+          },
+          "souscategorie": {
+            "description": "Sous-catégorie principale attribuée au livre.",
+            "label": "souscategorie"
+          },
+          "souscategorie2": {
+            "description": "Seconde sous-catégorie attribuée au livre.",
+            "label": "souscategorie2"
+          },
+          "title": {
+            "description": "Titre de l'ouvrage tel que fourni par les sources.",
+            "label": "title"
+          },
+          "url": {
+            "description": "URL de fiche produit lorsque disponible.",
+            "label": "url"
+          }
+        },
+        "columnsSubtitle": "Chaque ligne correspond à un livre identifié par son ISBN.",
+        "columnsTitle": "Colonnes présentes dans le dataset ISBN",
+        "download": {
+          "fast": {
+            "highlight": "Miroir pensé pour les usages culturels, bibliothèques et acteurs du livre"
+          },
+          "subtitle": "Sélectionnez le miroir adapté à votre flux et à votre trafic.",
+          "title": "Options de téléchargement"
+        },
+        "faq": {
+          "items": {
+            "assignment": {
+              "answer": "<p>Un ISBN est attribué par une agence nationale ISBN dans chaque pays, qui gère la distribution et l'enregistrement des numéros ISBN. L'éditeur ou l'auteur doit contacter cette agence pour obtenir un ISBN pour son livre. Lors de la demande, des informations sur l'ouvrage sont fournies, telles que le titre, l’auteur, le format et l’édition. Une fois attribué, l'ISBN est unique pour cette édition et ne peut être réutilisé pour une autre. Cela garantit une gestion efficace des livres dans les systèmes de bibliothèques, de vente, et de distribution. Il est essentiel pour toute œuvre destinée à une large diffusion ou à la vente.</p>",
+              "question": "Comment un ISBN est-il attribué à un livre ?"
+            },
+            "difference": {
+              "answer": "<p>L'ISBN-10 était le format d'origine utilisé jusqu'en 2007. Il se composait de 10 chiffres. Cependant, pour s'aligner avec les standards mondiaux des codes-barres EAN-13, le système est passé à un format à 13 chiffres, l'ISBN-13. Ce changement a permis de standardiser les processus de vente et de distribution à l’échelle mondiale, car les ISBN-13 sont compatibles avec les systèmes de codes-barres commerciaux utilisés dans divers secteurs. Bien que les ISBN-10 existent encore pour les anciens ouvrages, les nouveaux livres publiés depuis 2007 utilisent exclusivement le format ISBN-13, qui offre une plus grande capacité pour les identifications futures.</p>",
+              "question": "Quelle est la différence entre un ISBN-10 et un ISBN-13 ?"
+            },
+            "importance": {
+              "answer": "<p>Un code ISBN est important car il permet d'identifier un livre de manière unique et standardisée dans les systèmes de gestion, de vente, et de distribution. Sans ISBN, un livre peut être difficile à trouver dans les catalogues en ligne ou en librairie, car les systèmes de distribution reposent en grande partie sur cet identifiant. L'ISBN facilite aussi le référencement dans les bases de données des bibliothèques et des librairies, ce qui améliore sa visibilité et son accessibilité pour le public. Il est essentiel pour qu'un livre puisse être largement distribué, que ce soit sous format imprimé ou numérique.</p>",
+              "question": "Importance des ISBN ?"
+            },
+            "meaning": {
+              "answer": "<p>ISBN signifie <strong>\"International Standard Book Number\"</strong>, un numéro international normalisé pour les livres. Ce numéro sert à identifier de manière unique une publication dans le monde entier. Il permet de simplifier la gestion des livres dans les systèmes de stockage, de distribution et de vente. Le système ISBN est utilisé dans de nombreux pays et est géré par des agences nationales. Chaque ISBN est attribué spécifiquement à un titre et à une édition particulière, ce qui permet une gestion précise et évite toute confusion entre différentes éditions ou formats d'un même ouvrage (par exemple, entre une version reliée et une version broché).</p>",
+              "question": "Quelle est la signification d'ISBN ?"
+            },
+            "nonBook": {
+              "answer": "<p>Il arrive qu'un ISBN soit utilisé pour identifier autre chose qu'un livre. Cela peut se produire pour plusieurs raisons :</p><ul><li><strong>Manque de compréhension des standards</strong> : Certains vendeurs ou plateformes utilisent l'ISBN comme un identifiant générique, surtout si le produit est culturel ou lié aux loisirs créatifs.</li><li><strong>Économies de coût</strong> : Dans certains cas, il est plus économique pour un petit fabricant de réutiliser un code ISBN existant, bien que cela soit en dehors des normes.</li><li><strong>Confusion de formats de codes</strong> : Certaines plateformes de vente n’étant pas strictes sur la validation des codes standards, elles acceptent des ISBN pour des produits autres que des livres, ce qui crée des ambiguïtés.</li><li><strong>Réaffectation ou erreur d'attribution</strong> : L'ISBN est parfois utilisé incorrectement pour des produits non éditoriaux, surtout si le fabricant ou le distributeur n’a pas de code-barres GTIN adapté.</li></ul>",
+              "question": "Pourquoi je retrouve des produits (autres que des livres) dans la base ?"
+            },
+            "structure": {
+              "answer": "<p>Un ISBN est composé de 13 chiffres (ou 10 dans l’ancien système), répartis en cinq segments. Ces segments incluent : un préfixe (qui identifie le système de numérotation), un groupe d’enregistrement (qui représente le pays ou la région linguistique), un numéro d'éditeur, un numéro de titre (qui identifie un ouvrage spécifique), et enfin, un chiffre de contrôle qui valide la structure de l’ISBN. Cette structure permet une identification rapide et précise des livres, facilitant leur gestion à l’échelle mondiale. Le passage à l'ISBN-13 en 2007 s'est aligné sur les normes mondiales des codes-barres, rendant la distribution des livres encore plus efficace à travers différents systèmes de commerce et de bibliothèque.</p>",
+              "question": "Comment un ISBN est-il structuré ?"
+            },
+            "whatIs": {
+              "answer": "<p>Un ISBN (International Standard Book Number) est un numéro unique qui permet d'identifier un livre à l'échelle mondiale. C’est un identifiant essentiel pour les éditeurs, librairies, bibliothèques, et toutes les plateformes de vente de livres. L'ISBN facilite la gestion des stocks, la distribution, et la vente des livres. Chaque livre ou édition d'un même livre dispose de son propre ISBN, garantissant une identification unique dans les bases de données et les catalogues. Les ISBN sont utilisés aussi bien pour les livres imprimés que pour les livres numériques (e-books), et permettent aux lecteurs de retrouver facilement l’ouvrage qu’ils cherchent, notamment dans les systèmes de bibliothèques et sur les plateformes de vente en ligne.</p>",
+              "question": "Qu'est-ce qu'un ISBN ?"
+            }
+          },
+          "subtitle": "Les notions essentielles autour de l'export ISBN.",
+          "title": "Questions fréquentes"
+        },
+        "format": {
+          "bullets": {
+            "quote": "Délimiteur de texte : guillemet (\")",
+            "separator": "Séparateur de champs : virgule (,)",
+            "type": "Fichier CSV compressé au format ZIP"
+          },
+          "description": "Les données sont fournies dans une archive CSV compressée prête à l'emploi.",
+          "title": "Format du fichier"
+        },
+        "hero": {
+          "eyebrow": "Export ISBN",
+          "stats": {
+            "records": "Publications",
+            "size": "Taille du ZIP",
+            "updated": "Dernière mise à jour"
+          },
+          "title": "Base de données livres (ISBN)"
+        },
+        "seo": {
+          "description": "Téléchargez la base ISBN de Nudger, actualisée chaque semaine, avec les miroirs de téléchargement et le schéma détaillé pour vos analyses du secteur du livre.",
+          "title": "Données ouvertes ISBN – télécharger l'export de métadonnées livres"
+        },
+        "summary": {
+          "title": "Vue d'ensemble du dataset ISBN"
+        }
+      },
+      "subtitle": "Choisissez l'extraction adaptée à votre besoin. Les deux exports sont mis à jour chaque semaine et publiés sous licence ODbL.",
+      "title": "Deux jeux de données complémentaires"
+    },
+    "errors": {
+      "datasetFailed": "Impossible de charger les détails du jeu de données. Merci de réessayer.",
+      "overviewFailed": "Impossible de charger la vue d'ensemble open data. Merci de réessayer."
+    },
+    "faq": {
+      "items": {
+        "contributors": {
+          "answer": "<p>Les principales sources de données ouvertes sont généralement les gouvernements, les institutions publiques, les ONG et parfois des entreprises privées. Les gouvernements, à tous les niveaux (national, régional, municipal), sont des acteurs majeurs dans la production de données ouvertes, en publiant des informations relatives à des secteurs tels que l’éducation, la santé, l'environnement, et les finances publiques. Les organisations internationales comme l'ONU ou l'OCDE, ainsi que certaines agences spécialisées, sont aussi d'importants contributeurs. De plus, des entreprises privées dans le domaine de la technologie ou de l'innovation, choisissent parfois de publier leurs données pour encourager la collaboration ou améliorer leur transparence. Enfin, des projets communautaires et collaboratifs permettent également de collecter et de publier des données ouvertes, souvent autour de thématiques spécifiques comme l'écologie ou le développement durable.</p>",
+          "question": "Qui produit et met à disposition les données ouvertes ?"
+        },
+        "definition": {
+          "answer": "<p>L'open data, ou données ouvertes, désigne des données rendues accessibles à tous, sans restriction d’accès, et sous un format librement exploitable. Elles peuvent être réutilisées, modifiées, redistribuées par n’importe qui, à des fins personnelles ou professionnelles. L'objectif est de maximiser l'accès à l'information pour encourager la transparence, l'innovation et l'efficacité dans différents secteurs. L'open data est souvent fourni par des organismes publics, mais certaines entreprises privées commencent aussi à publier certaines de leurs données. Un aspect clé de l'open data est l'accessibilité technique : les données doivent être disponibles dans des formats standards et lisibles par des machines (comme les fichiers CSV, JSON ou XML) afin de permettre leur réutilisation sans obstacles techniques majeurs. En facilitant l'accès aux données, l'open data ouvre la voie à de nombreuses applications, comme la création d'applications mobiles, de visualisations ou d'analyses approfondies.</p>",
+          "question": "Qu'est-ce que l'open data ?"
+        },
+        "importance": {
+          "answer": "<p>L'open data est crucial pour promouvoir la transparence et l’innovation. En rendant les données accessibles, il permet aux citoyens de mieux comprendre les décisions des gouvernements et de participer aux discussions publiques de manière informée. Les entreprises peuvent utiliser ces données pour développer de nouveaux produits et services, ce qui stimule la croissance économique. De plus, l'open data permet une meilleure prise de décision, car les données publiques peuvent être analysées pour améliorer les politiques publiques, réduire les inefficacités, et rendre les gouvernements plus responsables de leurs actions. L'open data favorise aussi la collaboration entre différentes parties prenantes, notamment les chercheurs, les entrepreneurs, les développeurs et les collectivités locales, qui peuvent travailler ensemble pour résoudre des problèmes communs en utilisant les données de manière créative.</p>",
+          "question": "Pourquoi l'open data est-il important ?"
+        },
+        "sources": {
+          "answer": "<p>Les extractions fournies par Nudger sont issues de nos travaux d'aggrégation des données produits. Nous intégrons une grande variété de sources de données, que l'on peut classer en plusieurs types :</p><p><strong>Sites des marques et fabricants :</strong><br>Nous extrayons directement de la donnée à partir des fiches produits mises à disposition par les marques et fabricants.</p><p><strong>Sites institutionnels et données ouvertes :</strong> (base eprel, open food facts)<br>Nous intégrons des données issues de référentiels publics ou ouverts.</p><p><strong>Flux d'affiliation et plateformes marchandes :</strong> (awin, effinity, affilae, amazon, ..)<br>Dans le cadre de la relation contractuelle de promotion de Nudger et des plateformes. A ce titre, nous intégrons un lien dans notre extraction, permettant de faire jouer l'affiliation si des offres actives existent pour le produit.</p><p>Nudger aggrège, normalise et résout les conflits pour exposer des données factuelles et minimales sur les produits. La constitution et la mise à disposition de cette base sont opérées dans une logique de bien commun. Nous sommes également convaincus que le partage de ces données est au bénéfice de tous les acteurs de la chaîne de consommation (fabricants, distributeurs, chercheurs, citoyens).</p><p>Pour autant, nous sommes soucieux de respecter la propriété intellectuelle, aussi n'hésitez pas à <a href=\"/contact\">nous contacter</a> pour toute question, ou si en tant que dépositaire de données vous souhaitez vous opposer à votre participation à cette base.</p>",
+          "question": "Sources de données et contributions"
+        }
+      },
+      "subtitle": "Comprendre notre approche de l'open data.",
+      "title": "Questions fréquentes"
+    },
+    "hero": {
+      "eyebrow": "Open data",
+      "primaryCta": {
+        "ariaLabel": "Faire défiler jusqu'à la section des jeux de données open data",
+        "label": "Découvre nos produits à nu(dger)"
+      },
+      "subtitle": "On est des geeks mais on t'explique sans jargon technique. Nos données produits ? Open bar. Nos bases : Téléchargeables (c’est l'happy hour, c'est cadeau). Nos secrets : On en a pas !",
+      "title": "#FreeLesDonnées"
+    },
+    "license": {
+      "cta": {
+        "ariaLabel": "Ouvrir la licence Open Database dans un nouvel onglet",
+        "href": "https://spdx.org/licenses/ODbL-1.0.html#licenseText",
+        "label": "Consulter la licence ODbL"
+      },
+      "description": "Vous pouvez utiliser, partager et adapter ces données en créditant Nudger et en diffusant toute base dérivée sous la même licence.",
+      "title": "Licence Open Database (ODbL)"
+    },
+    "loading": "Chargement des informations open data…",
+    "opensource": {
+      "cta": {
+        "ariaLabel": "Aller vers la page open source",
+        "label": "Visiter la page open source"
+      },
+      "description": "Envie de découvrir le code derrière ces datasets ? Explorez les services, la gouvernance et la communauté Nudger.",
+      "title": "Nudger est aussi open source"
+    },
+    "seo": {
+      "description": "Découvrez les jeux de données GTIN et ISBN mis à disposition par Nudger, leurs mises à jour hebdomadaires et les modalités de téléchargement.",
+      "title": "Portail open data Nudger"
+    },
+    "stats": {
+      "accessibilityTitle": "Indicateurs clés de l'open data",
+      "datasets": {
+        "description": "Paquets de données actuellement disponibles.",
+        "label": "Jeux de données publiés"
+      },
+      "placeholder": "—",
+      "totalProducts": {
+        "description": "Produits uniques recensés dans l'ensemble des exports.",
+        "label": "Produits couverts",
+        "millions": "+{value} millions"
+      },
+      "totalSize": {
+        "description": "Volume compressé total des exports hebdomadaires.",
+        "label": "Taille cumulée"
+      }
+    }
+  },
+  "opensource": {
+    "contribution": {
+      "eyebrow": "Contribuer",
+      "steps": {
+        "issues": {
+          "title": "Choisir une issue qui vous inspire"
+        },
+        "setup": {
+          "title": "Installer le projet en local"
+        },
+        "share": {
+          "title": "Partager, relire et célébrer"
+        }
+      },
+      "title": "Rejoignez le collectif en quelques étapes"
+    },
+    "hero": {
+      "ctaGroupLabel": "Appels à action principaux",
+      "infoCard": {
+        "description": "est construit en commun. Chaque pull request, issue ou retour utilisateur façonne une plateforme plus transparente.",
+        "highlight": "Open4goods",
+        "items": {
+          "collaborativeReviews": "Revue collaborative des contributions",
+          "openLicenses": "Code et données publiés sous licences ouvertes",
+          "sharedGovernance": "Gouvernance partagée et documentation vivante"
+        }
+      },
+      "primaryCta": {
+        "ariaLabel": "Ouvrir l'organisation GitHub de Nudger dans un nouvel onglet",
+        "label": "Explorer les dépôts"
+      },
+      "subtitle": "Code, données et gouvernance sont transparents pour que chacun·e puisse auditer et améliorer Nudger.",
+      "title": "Rien à cacher, tout à partager"
+    },
+    "pillars": {
+      "cards": {
+        "community": {
+          "ariaLabel": "Aller vers la page de l'équipe Nudger",
+          "cta": "Rencontrer l'équipe",
+          "title": "Communauté inclusive"
+        },
+        "methodology": {
+          "ariaLabel": "Aller vers la page Impact-score",
+          "cta": "Comprendre l'Impact-score",
+          "title": "Méthodologie documentée"
+        },
+        "transparency": {
+          "ariaLabel": "Ouvrir le dépôt GitHub de Nudger dans un nouvel onglet",
+          "cta": "Voir le code source",
+          "title": "Architecture transparente"
+        }
+      },
+      "eyebrow": "Nos engagements",
+      "title": "Un écosystème ouvert et fiable"
+    },
+    "resources": {
+      "contact": {
+        "cta": {
+          "ariaLabel": "Aller vers la page contact",
+          "label": "Contacter l'équipe"
+        },
+        "title": "Envie d'un échange humain ?"
+      },
+      "eyebrow": "Ressources",
+      "feedback": {
+        "cta": {
+          "ariaLabel": "Aller vers la page des retours utilisateurs",
+          "label": "Accéder au tableau de feedback"
+        },
+        "description": "Soumettez les bugs rencontrés, vos envies de fonctionnalités et aidez-nous à prioriser le produit.",
+        "points": {
+          "bugs": "Signalez un bug en quelques clics",
+          "features": "Proposez des idées de fonctionnalités",
+          "votes": "Votez pour les évolutions qui comptent pour vous"
+        },
+        "title": "Partagez vos idées et retours"
+      },
+      "links": {
+        "guide": {
+          "ariaLabel": "Ouvrir le guide de contribution Nudger sur GitHub dans un nouvel onglet",
+          "title": "Guide de contribution"
+        },
+        "issues": {
+          "ariaLabel": "Ouvrir le tableau des issues GitHub de Nudger dans un nouvel onglet",
+          "title": "Tableau des issues"
+        },
+        "updates": {
+          "ariaLabel": "Ouvrir le blog Nudger",
+          "title": "Actualités de la communauté"
+        }
+      },
+      "opendata": {
+        "cta": {
+          "ariaLabel": "Aller vers la page open data",
+          "label": "Découvrir l'espace open data"
+        },
+        "description": "Les jeux de données Nudger sont publiés pour que vous puissiez auditer nos scores, explorer les empreintes produits et créer vos propres projets.",
+        "title": "Des données ouvertes pour vos analyses"
+      },
+      "title": "Tout pour bien démarrer"
+    },
+    "seo": {
+      "description": "Découvrez comment Nudger partage son code, ses données et sa gouvernance pour construire ensemble un bien commun de l'achat responsable.",
+      "imageAlt": "Logotype Nudger représentant le programme open source",
+      "title": "Open source chez Nudger"
+    }
+  },
+  "partners": {
+    "affiliation": {
+      "carouselAriaLabel": "Carrousel des partenaires affiliés",
+      "empty": "Aucun partenaire ne correspond à votre recherche.",
+      "linkLabel": "Visiter ce partenaire",
+      "search": {
+        "label": "Rechercher un partenaire",
+        "placeholder": "Rechercher par nom"
+      },
+      "subtitle": "Découvrez les marchands qui collaborent avec nous et explorez leurs offres.",
+      "title": "Ils nous font confiance"
+    },
+    "cta": {
+      "ctaLabel": "Contacter l'équipe",
+      "description": "Nous recherchons des alliés qui souhaitent bâtir avec nous l'achat responsable.",
+      "eyebrow": "Rejoignez l'aventure",
+      "title": "Envie de devenir partenaire ?"
+    },
+    "ecosystem": {
+      "carouselAriaLabel": "Carrousel des partenaires écosystème",
+      "empty": "Les partenaires de l'écosystème seront bientôt listés ici.",
+      "fallbackDescription": "Le contenu de ce partenaire sera publié prochainement.",
+      "linkLabel": "Découvrir l'initiative",
+      "subtitle": "Au travers d'échanges ou de partenartiats directs, ils contribuent à la trajectoire de Nudger",
+      "title": "Nudger s'inscrit dans un écosystème dynamique"
+    },
+    "errors": {
+      "loadFailed": "Impossible de charger les partenaires. Merci de réessayer."
+    },
+    "hero": {
+      "description": "Nudger est une aventure collective. Découvrez nos partenaires.",
+      "eyebrow": "Impact collectif",
+      "subtitle": "Un réseau de commerçants et un écosystème engagés pour des achats plus responsables.",
+      "title": "Les partenaires de Nudger"
+    },
+    "loading": "Chargement des partenaires…",
+    "mentors": {
+      "carouselAriaLabel": "Carrousel des mentors",
+      "empty": "Les profils mentors seront ajoutés prochainement.",
+      "fallbackDescription": "Plus d'informations sur ce mentor arrivent bientôt.",
+      "linkLabel": "En savoir plus",
+      "subtitle": "Entreprendre n'est jamais simple. Ces mentors partagent leur expérience avec bienveillance.",
+      "title": "Ils nous aident"
+    },
+    "seo": {
+      "description": "Découvrez les organisations, marketplaces et mentors qui aident Nudger à accélérer le commerce responsable.",
+      "title": "Nos partenaires et mentors"
     }
   },
   "product": {
-    "navigation": {
-      "label": "Navigation de la fiche produit",
-      "overview": "Aperçu",
-      "impact": "Impact écologique",
-      "ai": "Synthèse IA",
-      "price": "Prix",
-      "attributes": "Caractéristiques",
-      "docs": "Documentation",
-      "admin": "Administration"
+    "admin": {
+      "subtitle": "Aperçu JSON complet du produit.",
+      "title": "Section administration"
+    },
+    "aiReview": {
+      "empty": "Synthèse non encore demandée.",
+      "errors": {
+        "captcha": "Merci de valider le captcha avant de continuer.",
+        "generic": "Une erreur est survenue lors de la génération."
+      },
+      "generatedAt": "Synthèse générée le {date}",
+      "requestButton": "Demander la synthèse",
+      "sections": {
+        "cons": "Points faibles",
+        "details": "En détail",
+        "ecological": "Analyse écologique",
+        "identity": "Fiche d'identité",
+        "overall": "Résumé général",
+        "pros": "Points forts",
+        "sources": "Sources consultées",
+        "technical": "Analyse technique"
+      },
+      "sources": {
+        "description": "Description",
+        "index": "Réf.",
+        "source": "Source"
+      },
+      "status": {
+        "failed": "La génération a échoué",
+        "running": "Génération en cours ({step})",
+        "success": "Synthèse disponible"
+      },
+      "subtitle": "Une synthèse rédigée par notre IA à partir de sources vérifiées.",
+      "title": "Synthèse des tests et avis"
+    },
+    "attributes": {
+      "features": "Points forts",
+      "indexedGroup": "Attributs indexés",
+      "referentialTitle": "Identifiants de référence",
+      "searchPlaceholder": "Rechercher une caractéristique",
+      "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
+      "title": "Caractéristiques techniques",
+      "unfeatures": "Points à surveiller"
+    },
+    "docs": {
+      "download": "Télécharger le PDF",
+      "empty": "Aucun document n’est encore disponible pour ce produit.",
+      "loading": "Chargement de l’aperçu du document…",
+      "navigationAria": "Liste des documents du produit",
+      "pageCount": "{count} page(s)",
+      "previewUnavailable": "Aucun aperçu n’est disponible pour ce document. Utilisez le lien de téléchargement.",
+      "sidebarTitle": "Documents disponibles",
+      "subtitle": "Consultez et téléchargez les documents officiels.",
+      "title": "Documentation",
+      "untitled": "Document sans titre"
     },
     "hero": {
-      "gtin": "Code GTIN",
-      "offersCount": "Nombre d'offres",
       "bestPriceTitle": "Meilleur prix",
-      "priceMerchantPrefix": "Chez",
-      "viewSingleOffer": "Voir l'offre",
-      "viewOffersCount": "Voir les {count} offres",
       "breadcrumbAriaLabel": "Fil d'Ariane du produit",
-      "missingBreadcrumbTitle": "Catégorie",
+      "compare": {
+        "add": "Ajouter à la comparaison",
+        "ariaAdd": "Ajouter {name} à la comparaison",
+        "ariaSelected": "{name} est dans la comparaison",
+        "label": "Comparer",
+        "remove": "Retirer de la comparaison",
+        "selected": "Comparé"
+      },
+      "gtin": "Code GTIN",
       "gtinTooltip": "Basé sur le code GTIN du produit, cela n'indique pas nécessairement le lieu de fabrication.",
-      "openGalleryImage": "Afficher l’image « {label} » en plein écran",
-      "openGalleryVideo": "Lire la vidéo « {label} »",
-      "openGalleryFallback": "Ouvrir la galerie média du produit",
-      "thumbnailLabel": "Sélectionner {type} {index} sur {total} : {label}",
       "mediaType": {
         "image": "l’image",
         "video": "la vidéo"
       },
-      "videoBadge": "Vidéo",
-      "compare": {
-        "label": "Comparer",
-        "selected": "Comparé",
-        "add": "Ajouter à la comparaison",
-        "remove": "Retirer de la comparaison",
-        "ariaAdd": "Ajouter {name} à la comparaison",
-        "ariaSelected": "{name} est dans la comparaison"
-      },
+      "missingBreadcrumbTitle": "Catégorie",
       "offerConditions": {
-        "occasion": "Occasion",
-        "new": "Neuf"
+        "new": "Neuf",
+        "occasion": "Occasion"
       },
-      "offerConditionsToggleAria": "Sélectionner le type d'offre à afficher"
+      "offerConditionsToggleAria": "Sélectionner le type d'offre à afficher",
+      "offersCount": "Nombre d'offres",
+      "openGalleryFallback": "Ouvrir la galerie média du produit",
+      "openGalleryImage": "Afficher l’image « {label} » en plein écran",
+      "openGalleryVideo": "Lire la vidéo « {label} »",
+      "priceMerchantPrefix": "Chez",
+      "thumbnailLabel": "Sélectionner {type} {index} sur {total} : {label}",
+      "videoBadge": "Vidéo",
+      "viewOffersCount": "Voir les {count} offres",
+      "viewSingleOffer": "Voir l'offre"
     },
     "impact": {
-      "title": "Impact écologique",
-      "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
-      "primaryScoreLabel": "Score global",
+      "absoluteValue": "Valeur absolue",
+      "bestProduct": "Produit le mieux noté : {name}",
+      "betterProduct": "Produit juste devant : {name}",
+      "detailsTitle": "Détails de l'évaluation",
       "noPrimaryScore": "Score indisponible",
+      "percentile": "Percentile",
+      "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
       "rankingTitle": "Classement",
       "rankingValue": "Position {position} sur {total}",
-      "bestProduct": "Produit le mieux noté : {name}",
-      "betterProduct": "Produit juste devant : {name}",
-      "scoreValue": "Score relatif",
-      "absoluteValue": "Valeur absolue",
-      "percentile": "Percentile",
       "scoreRanking": "Classement du facteur",
-      "detailsTitle": "Détails de l'évaluation",
+      "scoreValue": "Score relatif",
+      "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
       "tableHeaders": {
-        "score": "Indicateur",
-        "value": "Valeur",
+        "percent": "Percentile",
         "ranking": "Rang",
-        "percent": "Percentile"
-      }
+        "score": "Indicateur",
+        "value": "Valeur"
+      },
+      "title": "Impact écologique"
     },
-    "aiReview": {
-      "title": "Synthèse des tests et avis",
-      "subtitle": "Une synthèse rédigée par notre IA à partir de sources vérifiées.",
-      "generatedAt": "Synthèse générée le {date}",
-      "sections": {
-        "overall": "Résumé général",
-        "details": "En détail",
-        "technical": "Analyse technique",
-        "ecological": "Analyse écologique",
-        "pros": "Points forts",
-        "cons": "Points faibles",
-        "identity": "Fiche d'identité",
-        "sources": "Sources consultées"
-      },
-      "sources": {
-        "index": "Réf.",
-        "source": "Source",
-        "description": "Description"
-      },
-      "empty": "Synthèse non encore demandée.",
-      "requestButton": "Demander la synthèse",
-      "status": {
-        "running": "Génération en cours ({step})",
-        "success": "Synthèse disponible",
-        "failed": "La génération a échoué"
-      },
-      "errors": {
-        "captcha": "Merci de valider le captcha avant de continuer.",
-        "generic": "Une erreur est survenue lors de la génération."
-      }
+    "navigation": {
+      "admin": "Administration",
+      "ai": "Synthèse IA",
+      "attributes": "Caractéristiques",
+      "docs": "Documentation",
+      "impact": "Impact écologique",
+      "label": "Navigation de la fiche produit",
+      "overview": "Aperçu",
+      "price": "Prix"
     },
     "price": {
-      "title": "Prix et évolution",
-      "subtitle": "Suivez l’évolution des prix et comparez les offres.",
+      "condition": {
+        "new": "Neuf",
+        "occasion": "Occasion",
+        "refurbished": "Reconditionné",
+        "unknown": "Inconnu",
+        "used": "Occasion"
+      },
+      "headers": {
+        "condition": "État",
+        "offer": "Offre",
+        "price": "Prix",
+        "source": "Source",
+        "updated": "Mise à jour"
+      },
       "newOffers": "Offres neuves",
+      "noOccasionHistory": "Pas d'historique pour les offres d'occasion.",
       "occasionOffers": "Offres d'occasion",
+      "offerList": "Liste des offres",
+      "subtitle": "Suivez l’évolution des prix et comparez les offres.",
+      "title": "Prix et évolution",
       "trend": {
         "decrease": "Baisse de {amount}",
         "increase": "Hausse de {amount}",
         "stable": "Prix stable"
+      }
+    }
+  },
+  "siteIdentity": {
+    "footer": {
+      "accessibleTitle": "Informations du pied de page",
+      "blogLink": "Notre blog",
+      "community": {
+        "links": {
+          "partners": "Nos partenaires",
+          "team": "Notre équipe"
+        },
+        "title": "Communauté"
       },
-      "noOccasionHistory": "Pas d'historique pour les offres d'occasion.",
-      "offerList": "Liste des offres",
-      "headers": {
-        "source": "Source",
-        "offer": "Offre",
-        "price": "Prix",
-        "condition": "État",
-        "updated": "Mise à jour"
+      "comparator": {
+        "links": {
+          "legal": "Mentions légales",
+          "openData": "Open data",
+          "openSource": "Open source",
+          "privacy": "Politique de confidentialité"
+        },
+        "title": "Ressources"
       },
-      "condition": {
-        "new": "Neuf",
-        "occasion": "Occasion",
-        "used": "Occasion",
-        "refurbished": "Reconditionné",
-        "unknown": "Inconnu"
+      "copyright": "Copyright ©{year} open4goods. Produit de bien commun.",
+      "feedback": {
+        "cta": "Donnez votre avis",
+        "links": {
+          "contact": "Nous contacter",
+          "linkedin": "Nous suivre sur LinkedIn"
+        },
+        "title": "Nous aider"
+      },
+      "highlightLinks": {
+        "allProducts": "Tous nos produits",
+        "ecoscore": "Évaluation environnementale"
+      },
+      "logoAlt": "Icône Nudger orange",
+      "mission": "nudger.fr est une approche ouverte pour évaluer l'impact écologique et social des biens que nous achetons.",
+      "rightsReserved": "Tous droits réservés"
+    },
+    "hero": {
+      "defaultCtaText": "Appel à l'action",
+      "defaultSubtitle": "Démo vidéo hero pour montrer une intégration propre dans une application Vue 3.",
+      "defaultTitle": "Titre par défaut",
+      "mainSubtitle": "Ton assistant achat, Libre et Indépendant",
+      "mainTitle": "Le comparateur qui pense à demain"
+    },
+    "links": {
+      "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"
+    },
+    "menu": {
+      "closeLabel": "Fermer le menu",
+      "items": {
+        "blog": "Blog",
+        "contact": "Contact",
+        "impactScore": "Impact-score",
+        "products": "Les produits"
+      },
+      "theme": {
+        "darkAriaLabel": "Activer le thème sombre",
+        "darkTooltip": "Passer au thème sombre",
+        "lightAriaLabel": "Activer le thème clair",
+        "lightTooltip": "Passer au thème clair"
+      },
+      "themeToggle": "Changer de thème",
+      "title": "Menu"
+    },
+    "siteName": "Nudger"
+  },
+  "team": {
+    "callouts": {
+      "contact": {
+        "cta": "Nous contacter",
+        "description": "Vous souhaitez en savoir plus sur le projet ou rejoindre l'aventure ? Parlons-en.",
+        "title": "Envie d'échanger ?"
+      },
+      "partners": {
+        "cta": "Découvrir les partenaires",
+        "link": "/partenaires",
+        "title": "Nos partenaires"
       }
     },
-    "attributes": {
-      "title": "Caractéristiques techniques",
-      "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
-      "searchPlaceholder": "Rechercher une caractéristique",
-      "referentialTitle": "Identifiants de référence",
-      "indexedGroup": "Attributs indexés",
-      "features": "Points forts",
-      "unfeatures": "Points à surveiller"
+    "cards": {
+      "connect": "Voir sur LinkedIn",
+      "linkedIn": "Ouvrir le profil LinkedIn de {name}",
+      "portraitAlt": "Portrait de {name}",
+      "unknownName": "un membre de l'équipe"
     },
-    "docs": {
-      "title": "Documentation",
-      "subtitle": "Consultez et téléchargez les documents officiels.",
-      "download": "Télécharger le PDF",
-      "untitled": "Document sans titre",
-      "pageCount": "{count} page(s)",
-      "sidebarTitle": "Documents disponibles",
-      "navigationAria": "Liste des documents du produit",
-      "empty": "Aucun document n’est encore disponible pour ce produit.",
-      "previewUnavailable": "Aucun aperçu n’est disponible pour ce document. Utilisez le lien de téléchargement.",
-      "loading": "Chargement de l’aperçu du document…"
+    "errors": {
+      "loadFailed": "Impossible de charger la liste de l'équipe. Merci de réessayer."
     },
-    "admin": {
-      "title": "Section administration",
-      "subtitle": "Aperçu JSON complet du produit."
+    "hero": {
+      "eyebrow": "Notre collectif",
+      "subtitle": "Une équipe engagée qui mêle tech, environnement et impact social.",
+      "title": "Les femmes et les hommes derrière Nudger"
+    },
+    "loading": "Chargement des membres…",
+    "sections": {
+      "contributors": {
+        "eyebrow": "Communauté",
+        "title": "Les contributeurs"
+      },
+      "core": {
+        "eyebrow": "Pilotage",
+        "title": "La core-team"
+      },
+      "empty": "Les profils seront bientôt disponibles."
+    },
+    "seo": {
+      "description": "Rencontrez les entrepreneuses, ingénieurs et bénévoles qui construisent l'assistant d'achat responsable Nudger.",
+      "title": "Découvrez l'équipe Nudger"
     }
-  }
+  },
+  "welcome": "Bienvenue"
 }


### PR DESCRIPTION
## Summary
- reworked the Impact Score hero and section layout with improved accessibility and responsive navigation
- render category cards from the categories API and refreshed the analysis visuals and structure
- added scoped styling and new i18n strings to support the updated content in French and English

## Testing
- pnpm lint
- pnpm test -- --run --reporter=dot
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_690085b677688333935d924074f74ace