### PR TITLE
Fix wiki guide page ID normalization

### DIFF
--- a/frontend/app/pages/[categorySlug]/[...guideSlug].vue
+++ b/frontend/app/pages/[categorySlug]/[...guideSlug].vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
 import { useCategories } from '~/composables/categories/useCategories'
+import { normalizeWikiPageId } from '~/utils/_wiki-page'
 import type { VerticalConfigFullDto } from '~~/shared/api-client'
 import { matchProductRouteFromSegments } from '~~/shared/utils/_product-route'
 
@@ -84,7 +85,7 @@ if (!matchedPage) {
   throw createError({ statusCode: 404, statusMessage: 'Guide not found' })
 }
 
-const resolvedPageId = matchedPage.wikiUrl?.trim().replace(/^\/+/, '') ?? null
+const resolvedPageId = normalizeWikiPageId(matchedPage.wikiUrl)
 
 if (!resolvedPageId) {
   throw createError({ statusCode: 404, statusMessage: 'Guide not found' })

--- a/frontend/app/utils/_wiki-page.spec.ts
+++ b/frontend/app/utils/_wiki-page.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeWikiPageId } from './_wiki-page'
+
+describe('normalizeWikiPageId', () => {
+  it('returns null for empty values', () => {
+    expect(normalizeWikiPageId(null)).toBeNull()
+    expect(normalizeWikiPageId(undefined)).toBeNull()
+    expect(normalizeWikiPageId('  ')).toBeNull()
+  })
+
+  it('returns trimmed relative ids as-is', () => {
+    expect(normalizeWikiPageId('verticals/tv/technologies-tv/WebHome')).toBe(
+      'verticals/tv/technologies-tv/WebHome',
+    )
+  })
+
+  it('removes leading slashes', () => {
+    expect(normalizeWikiPageId('/verticals/tv/technologies-tv/WebHome')).toBe(
+      'verticals/tv/technologies-tv/WebHome',
+    )
+  })
+
+  it('decodes percent-encoded segments', () => {
+    expect(
+      normalizeWikiPageId('verticals%2Ftv%2Ftechnologies-tv%2FWebHome'),
+    ).toBe('verticals/tv/technologies-tv/WebHome')
+  })
+
+  it('strips backend origin prefixes', () => {
+    expect(
+      normalizeWikiPageId(
+        'https://wiki.example/pages/verticals%2Ftv%2Ftechnologies-tv%2FWebHome',
+      ),
+    ).toBe('verticals/tv/technologies-tv/WebHome')
+  })
+
+  it('strips explicit pages prefix', () => {
+    expect(
+      normalizeWikiPageId('pages/verticals/tv/technologies-tv/WebHome'),
+    ).toBe('verticals/tv/technologies-tv/WebHome')
+  })
+})

--- a/frontend/app/utils/_wiki-page.ts
+++ b/frontend/app/utils/_wiki-page.ts
@@ -1,0 +1,26 @@
+export const normalizeWikiPageId = (
+  value: string | null | undefined,
+): string | null => {
+  if (!value) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const sanitize = (input: string): string => {
+    const withoutOrigin = input.replace(/^https?:\/\/[^/]+\//i, '')
+    const withoutPagesPrefix = withoutOrigin.replace(/^pages\//i, '')
+
+    return withoutPagesPrefix.replace(/^\/+/, '')
+  }
+
+  try {
+    const decoded = decodeURIComponent(trimmed)
+    return sanitize(decoded)
+  } catch {
+    return sanitize(trimmed)
+  }
+}


### PR DESCRIPTION
## Summary
- add a wiki page id normalizer so guide requests use decoded, origin-free ids
- update category guide page to resolve ids with the normalizer before rendering the XWiki page
- cover the helper with vitest cases for common encoded and prefixed urls

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69008b5c87c08333a6b928bd8d962c66