### PR TITLE
Fix product guide intercept by redirecting category product routes

### DIFF
--- a/frontend/app/pages/[categorySlug]/product-page-redirect.spec.ts
+++ b/frontend/app/pages/[categorySlug]/product-page-redirect.spec.ts
@@ -1,0 +1,47 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const navigateToMock = vi.hoisted(() => vi.fn(() => Promise.resolve()))
+const createErrorMock = vi.hoisted(() => {
+  return vi.fn((input: { statusCode?: number; statusMessage?: string }) => {
+    const error = new Error(input?.statusMessage ?? 'Error')
+    Object.assign(error, input)
+    throw error
+  })
+})
+
+const route = {
+  params: {
+    categorySlug: 'Televiseurs',
+    productSlug: '12345-Television-Samsung',
+  },
+}
+
+mockNuxtImport('useRoute', () => () => route)
+mockNuxtImport('navigateTo', () => navigateToMock)
+mockNuxtImport('createError', () => createErrorMock)
+
+describe('category product redirect page', () => {
+  beforeEach(() => {
+    navigateToMock.mockClear()
+    createErrorMock.mockClear()
+    route.params.categorySlug = 'Televiseurs'
+    route.params.productSlug = '12345-Television-Samsung'
+  })
+
+  it('redirects matching product routes to the catch-all product page', async () => {
+    const component = (await import('./product-page-redirect.vue')).default
+
+    await mountSuspended(component)
+
+    expect(navigateToMock).toHaveBeenCalledWith(
+      {
+        name: 'slug',
+        params: { slug: ['televiseurs', '12345-television-samsung'] },
+      },
+      { replace: true, redirectCode: 301 },
+    )
+    expect(createErrorMock).not.toHaveBeenCalled()
+  })
+
+})

--- a/frontend/app/pages/[categorySlug]/product-page-redirect.vue
+++ b/frontend/app/pages/[categorySlug]/product-page-redirect.vue
@@ -1,0 +1,45 @@
+<route lang="ts">
+export default {
+  name: 'category-product-redirect',
+  path: '/:categorySlug/:productSlug(\\d{5,}[-a-z0-9]*)',
+}
+</route>
+
+<script setup lang="ts">
+import { matchProductRouteFromSegments } from '~~/shared/utils/_product-route'
+
+const route = useRoute()
+
+const rawCategory = route.params.categorySlug
+const rawProduct = route.params.productSlug
+
+const categorySlug = typeof rawCategory === 'string' ? rawCategory.trim() : ''
+const productSlug = typeof rawProduct === 'string' ? rawProduct.trim() : ''
+
+const productMatch = matchProductRouteFromSegments([categorySlug, productSlug])
+
+if (!productMatch) {
+  throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+
+const normalizedCategorySlug = productMatch.categorySlug
+const normalizedProductSegment = `${productMatch.gtin}-${productMatch.slug}`
+
+await navigateTo(
+  {
+    name: 'slug',
+    params: { slug: [normalizedCategorySlug, normalizedProductSegment] },
+  },
+  { replace: true, redirectCode: 301 },
+)
+</script>
+
+<template>
+  <div class="product-route-redirect" />
+</template>
+
+<style scoped>
+.product-route-redirect {
+  display: none;
+}
+</style>

--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -33,6 +33,19 @@ describe('_product-route', () => {
       })
     })
 
+    it('accepts product segments starting with at least five digits', () => {
+      const match = matchProductRouteFromSegments([
+        'audio',
+        '12345-haut-parleur',
+      ])
+
+      expect(match).toEqual({
+        categorySlug: 'audio',
+        gtin: '12345',
+        slug: 'haut-parleur',
+      })
+    })
+
     it('returns null when the route does not contain exactly two segments', () => {
       expect(matchProductRouteFromSegments([])).toBeNull()
       expect(matchProductRouteFromSegments(['only-one'])).toBeNull()
@@ -55,13 +68,11 @@ describe('_product-route', () => {
     })
 
     it('requires the product segment to expose a GTIN and slug separated by a hyphen', () => {
+      expect(matchProductRouteFromSegments(['tech', '1234-produit'])).toBeNull()
       expect(matchProductRouteFromSegments(['tech', '12345'])).toBeNull()
       expect(matchProductRouteFromSegments(['tech', '123456'])).toBeNull()
       expect(
         matchProductRouteFromSegments(['tech', '1234567890'])
-      ).toBeNull()
-      expect(
-        matchProductRouteFromSegments(['tech', '12345-missing-digits'])
       ).toBeNull()
     })
   })

--- a/frontend/shared/utils/_product-route.ts
+++ b/frontend/shared/utils/_product-route.ts
@@ -5,7 +5,7 @@ export interface ProductRouteMatch {
 }
 
 const CATEGORY_SLUG_PATTERN = /^[a-z]+(?:-[a-z]+)*$/
-const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[a-z0-9-]+)$/i
+const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{5,})-(?<slug>[a-z0-9-]+)$/i
 
 export const matchProductRouteFromSegments = (
   segments: readonly string[]
@@ -32,7 +32,7 @@ export const matchProductRouteFromSegments = (
     slug: string
   }
 
-  if (!gtin || gtin.length < 6 || !rawSlug) {
+  if (!gtin || gtin.length < 5 || !rawSlug) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated category product redirect page to handoff matching URLs to the product catch-all route
- relax GTIN detection to accept slugs starting with five digits and update unit tests
- cover the redirect behaviour with a Nuxt component test to ensure canonical navigation

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69008f7af774833382de1128e4c5a952