### PR TITLE
Ensure product guides ignore five-digit product slugs

### DIFF
--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -45,6 +45,16 @@ describe('_product-route', () => {
       ).toBeNull()
     })
 
+    it('accepts product segments that start with at least five digits followed by a hyphen', () => {
+      const match = matchProductRouteFromSegments(['tech', '12345-hyphenated-slug'])
+
+      expect(match).toEqual({
+        categorySlug: 'tech',
+        gtin: '12345',
+        slug: 'hyphenated-slug',
+      })
+    })
+
     it('rejects category slugs with invalid characters', () => {
       expect(
         matchProductRouteFromSegments(['electronics123', '123456-valid-slug'])
@@ -61,7 +71,7 @@ describe('_product-route', () => {
         matchProductRouteFromSegments(['tech', '1234567890'])
       ).toBeNull()
       expect(
-        matchProductRouteFromSegments(['tech', '12345-missing-digits'])
+        matchProductRouteFromSegments(['tech', '1234-missing-digit'])
       ).toBeNull()
     })
   })

--- a/frontend/shared/utils/_product-route.ts
+++ b/frontend/shared/utils/_product-route.ts
@@ -5,7 +5,7 @@ export interface ProductRouteMatch {
 }
 
 const CATEGORY_SLUG_PATTERN = /^[a-z]+(?:-[a-z]+)*$/
-const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[a-z0-9-]+)$/i
+const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{5,})-(?<slug>[a-z0-9-]+)$/i
 
 export const matchProductRouteFromSegments = (
   segments: readonly string[]
@@ -32,7 +32,7 @@ export const matchProductRouteFromSegments = (
     slug: string
   }
 
-  if (!gtin || gtin.length < 6 || !rawSlug) {
+  if (!gtin || gtin.length < 5 || !rawSlug) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- widen the product route matcher so slugs beginning with at least five digits are treated as product URLs instead of guide slugs
- extend the shared utility spec to cover five-digit GTIN cases and maintain invalid segment assertions

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6900c2b50a20833381f2d18a179e80b1