### PR TITLE
Fix reduced motion handling for category results counter

### DIFF
--- a/frontend/app/components/category/CategoryEcoscoreCard.spec.ts
+++ b/frontend/app/components/category/CategoryEcoscoreCard.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createVuetify } from 'vuetify'
+import { defineComponent, h } from 'vue'
+
+import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
+
+describe('CategoryEcoscoreCard', () => {
+  const vuetify = createVuetify()
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        category: {
+          filters: {
+            ecoscore: {
+              title: 'Discover',
+              description: 'Learn more',
+              cta: 'Read more',
+              ariaLabel: 'Open Eco-score guide',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const mountCard = (verticalHomeUrl?: string | null) =>
+    mount(CategoryEcoscoreCard, {
+      props: { verticalHomeUrl: verticalHomeUrl ?? null },
+      global: {
+        plugins: [vuetify, i18n],
+        stubs: {
+          VCard: defineComponent({
+            name: 'VCardStub',
+            inheritAttrs: false,
+            props: {
+              to: {
+                type: [String, Object],
+                default: undefined,
+              },
+            },
+            setup(props, { attrs, slots }) {
+              const resolveHref = () => {
+                if (!props.to) {
+                  return undefined
+                }
+
+                if (typeof props.to === 'string') {
+                  return props.to
+                }
+
+                if (typeof props.to === 'object') {
+                  return (props.to as Record<string, string>).href ?? (props.to as Record<string, string>).path
+                }
+
+                return undefined
+              }
+
+              return () =>
+                h(
+                  'a',
+                  {
+                    ...attrs,
+                    href: resolveHref(),
+                  },
+                  slots.default?.(),
+                )
+            },
+          }),
+          VIcon: defineComponent({
+            name: 'VIconStub',
+            props: {
+              icon: {
+                type: String,
+                default: '',
+              },
+              size: {
+                type: [String, Number],
+                default: 24,
+              },
+            },
+            setup(props) {
+              return () => h('span', { 'data-icon': props.icon })
+            },
+          }),
+        },
+      },
+    })
+
+  it('renders a link to the Eco-score page when the base URL is provided', () => {
+    const wrapper = mountCard('https://example.com/vertical')
+
+    const link = wrapper.get('[data-test="category-ecoscore-card"]')
+    expect(link.attributes('href')).toBe('https://example.com/vertical/ecoscore')
+  })
+
+  it('normalizes trailing slashes when computing the Eco-score link', () => {
+    const wrapper = mountCard('https://example.com/vertical/')
+
+    const link = wrapper.get('[data-test="category-ecoscore-card"]')
+    expect(link.attributes('href')).toBe('https://example.com/vertical/ecoscore')
+  })
+
+  it('does not render anything when the base URL is missing', () => {
+    const wrapper = mountCard(null)
+
+    expect(wrapper.find('[data-test="category-ecoscore-card"]').exists()).toBe(false)
+  })
+})

--- a/frontend/app/components/category/CategoryEcoscoreCard.vue
+++ b/frontend/app/components/category/CategoryEcoscoreCard.vue
@@ -1,0 +1,104 @@
+<template>
+  <v-card
+    v-if="ecoscoreUrl"
+    :to="ecoscoreUrl"
+    class="category-ecoscore-card"
+    variant="tonal"
+    elevation="0"
+    rounded="xl"
+    data-test="category-ecoscore-card"
+    :aria-label="t('category.filters.ecoscore.ariaLabel')"
+  >
+    <div class="category-ecoscore-card__icon" aria-hidden="true">
+      <v-icon icon="mdi-star" size="32" />
+    </div>
+
+    <div class="category-ecoscore-card__content">
+      <p class="category-ecoscore-card__title">
+        {{ t('category.filters.ecoscore.title') }}
+      </p>
+      <p class="category-ecoscore-card__description">
+        {{ t('category.filters.ecoscore.description') }}
+      </p>
+      <span class="category-ecoscore-card__cta">
+        {{ t('category.filters.ecoscore.cta') }}
+        <v-icon icon="mdi-arrow-top-right" size="18" />
+      </span>
+    </div>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  verticalHomeUrl?: string | null
+}>()
+
+const { t } = useI18n()
+
+const ecoscoreUrl = computed(() => {
+  if (!props.verticalHomeUrl) {
+    return null
+  }
+
+  const normalizedBase = props.verticalHomeUrl.endsWith('/')
+    ? props.verticalHomeUrl.slice(0, -1)
+    : props.verticalHomeUrl
+
+  return `${normalizedBase}/ecoscore`
+})
+</script>
+
+<style scoped lang="sass">
+.category-ecoscore-card
+  display: flex
+  align-items: center
+  gap: 1rem
+  padding: 1.25rem
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.95), rgba(var(--v-theme-surface-primary-120), 0.9))
+  color: rgb(var(--v-theme-text-neutral-strong))
+  text-decoration: none
+  transition: transform 0.3s ease, box-shadow 0.3s ease
+
+  &:hover
+    transform: translateY(-2px)
+    box-shadow: 0 18px 28px -24px rgba(var(--v-theme-shadow-primary-600), 0.45)
+
+  &:focus-visible
+    outline: 2px solid rgba(var(--v-theme-accent-primary-highlight), 0.8)
+    outline-offset: 3px
+
+  &__icon
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    width: 48px
+    height: 48px
+    min-width: 48px
+    border-radius: 999px
+    background: rgba(var(--v-theme-primary), 0.12)
+    color: rgb(var(--v-theme-primary))
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 0.35rem
+
+  &__title
+    font-size: 1rem
+    font-weight: 600
+    margin: 0
+
+  &__description
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    font-size: 0.875rem
+    line-height: 1.35
+
+  &__cta
+    display: inline-flex
+    align-items: center
+    gap: 0.35rem
+    font-size: 0.875rem
+    font-weight: 600
+    color: rgb(var(--v-theme-primary))
+</style>

--- a/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createVuetify } from 'vuetify'
+import { defineComponent, h } from 'vue'
+
+import CategoryFiltersSidebar from './CategoryFiltersSidebar.vue'
+import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    resolve: (location: unknown) => {
+      if (typeof location === 'string') {
+        return { href: location }
+      }
+
+      const candidate = location as { href?: string; path?: string }
+      return { href: candidate.href ?? candidate.path ?? '' }
+    },
+  }),
+}))
+
+describe('CategoryFiltersSidebar', () => {
+  const vuetify = createVuetify()
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'fr-FR',
+    messages: {
+      'fr-FR': {
+        category: {
+          filters: {
+            mobileApply: 'Appliquer',
+            mobileClear: 'Effacer',
+            ecoscore: {
+              title: 'Découvrir',
+              description: 'Description',
+              cta: 'Voir',
+              ariaLabel: 'Voir Eco-score',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const baseProps = {
+    filterOptions: null,
+    aggregations: [],
+    baselineAggregations: [],
+    filters: null,
+    impactExpanded: false,
+    technicalExpanded: false,
+    showMobileActions: false,
+    hasDocumentation: true,
+    wikiPages: [],
+    relatedPosts: [],
+    verticalHomeUrl: 'https://open4goods.example/maison',
+    subsetClauses: [],
+  }
+
+  const mountComponent = (overrides: Partial<typeof baseProps> = {}) =>
+    mount(CategoryFiltersSidebar, {
+      props: { ...baseProps, ...overrides },
+      global: {
+        plugins: [vuetify, i18n],
+        stubs: {
+          CategoryFiltersPanel: defineComponent({
+            name: 'CategoryFiltersPanelStub',
+            setup() {
+              return () => h('div', { 'data-test': 'filters-panel-stub' })
+            },
+          }),
+          CategoryDocumentationRail: defineComponent({
+            name: 'CategoryDocumentationRailStub',
+            setup() {
+              return () => h('div', { 'data-test': 'documentation-rail-stub' })
+            },
+          }),
+        },
+      },
+    })
+
+  it('renders the Eco-score card when a vertical home URL is provided', () => {
+    const wrapper = mountComponent()
+
+    const cardComponent = wrapper.findComponent(CategoryEcoscoreCard)
+    expect(cardComponent.exists()).toBe(true)
+    expect(cardComponent.props('verticalHomeUrl')).toBe('https://open4goods.example/maison')
+
+    const card = wrapper.get('[data-test="category-ecoscore-card"]')
+    expect(card.text()).toContain('Découvrir')
+  })
+
+  it('hides the Eco-score card when no vertical home URL is available', () => {
+    const wrapper = mountComponent({ verticalHomeUrl: null })
+
+    expect(wrapper.find('[data-test="category-ecoscore-card"]').exists()).toBe(false)
+  })
+})

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -23,6 +23,12 @@
       </v-btn>
     </div>
 
+    <CategoryEcoscoreCard
+      v-if="ecoscoreLinkAvailable"
+      class="category-page__ecoscore-entry mt-4"
+      :vertical-home-url="props.verticalHomeUrl ?? undefined"
+    />
+
     <template v-if="hasDocumentation">
       <v-divider class="my-4" />
       <CategoryDocumentationRail
@@ -46,8 +52,9 @@ import type {
   WikiPageConfig,
 } from '~~/shared/api-client'
 
-import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
+import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
+import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
 import type { CategorySubsetClause } from '~/types/category-subset'
 
 const props = withDefaults(
@@ -86,4 +93,5 @@ const wikiPages = computed(() => props.wikiPages ?? [])
 const relatedPosts = computed(() => props.relatedPosts ?? [])
 const hasDocumentation = computed(() => props.hasDocumentation)
 const showMobileActions = computed(() => props.showMobileActions)
+const ecoscoreLinkAvailable = computed(() => Boolean(props.verticalHomeUrl))
 </script>

--- a/frontend/app/components/category/CategoryResultsCount.spec.ts
+++ b/frontend/app/components/category/CategoryResultsCount.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { nextTick, ref } from 'vue'
+
+import CategoryResultsCount from './CategoryResultsCount.vue'
+
+const reducedMotionPreference = ref<'reduce' | 'no-preference'>('no-preference')
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
+
+  return {
+    ...actual,
+    usePreferredReducedMotion: () => reducedMotionPreference,
+  }
+})
+
+describe('CategoryResultsCount', () => {
+  let originalRequestAnimationFrame: typeof requestAnimationFrame
+  let originalCancelAnimationFrame: typeof cancelAnimationFrame
+  let currentTime: number
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    currentTime = 0
+    reducedMotionPreference.value = 'no-preference'
+
+    originalRequestAnimationFrame = globalThis.requestAnimationFrame
+    originalCancelAnimationFrame = globalThis.cancelAnimationFrame
+
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      const timeoutId = setTimeout(() => {
+        currentTime += 16
+        callback(currentTime)
+      }, 16)
+
+      return timeoutId as unknown as number
+    }
+
+    globalThis.cancelAnimationFrame = (handle: number) => {
+      clearTimeout(handle)
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame
+  })
+
+  const createWrapper = (count: number) => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en-US',
+      messages: {
+        'en-US': {
+          category: {
+            products: {
+              resultsCount: {
+                one: '{count} product',
+                other: '{count} products',
+              },
+            },
+          },
+          filters: {
+            ecoscore: {
+              title: '',
+              description: '',
+              cta: '',
+              ariaLabel: '',
+            },
+          },
+        },
+      },
+    })
+
+    return mount(CategoryResultsCount, {
+      props: { count },
+      global: { plugins: [i18n] },
+    })
+  }
+
+  it('renders the initial count with pluralisation', () => {
+    const wrapper = createWrapper(1)
+
+    expect(wrapper.text()).toBe('1 product')
+  })
+
+  it('animates toward the next value when the count increases', async () => {
+    const wrapper = createWrapper(5)
+
+    await wrapper.setProps({ count: 12 })
+
+    vi.advanceTimersByTime(620)
+    await nextTick()
+
+    expect(wrapper.text()).toBe('12 products')
+  })
+
+  it('animates toward the next value when the count decreases', async () => {
+    const wrapper = createWrapper(20)
+
+    await wrapper.setProps({ count: 3 })
+
+    vi.advanceTimersByTime(620)
+    await nextTick()
+
+    expect(wrapper.text()).toBe('3 products')
+  })
+
+  it('updates instantly when reduced motion is preferred', async () => {
+    reducedMotionPreference.value = 'reduce'
+    const wrapper = createWrapper(8)
+
+    await wrapper.setProps({ count: 15 })
+    await nextTick()
+
+    expect(wrapper.text()).toBe('15 products')
+  })
+})

--- a/frontend/app/components/category/CategoryResultsCount.vue
+++ b/frontend/app/components/category/CategoryResultsCount.vue
@@ -1,0 +1,127 @@
+<template>
+  <p class="category-page__results-count" aria-live="polite" data-test="category-results-count">
+    {{ label }}
+  </p>
+</template>
+
+<script setup lang="ts">
+import { usePreferredReducedMotion } from '@vueuse/core'
+
+const props = defineProps<{
+  count: number
+}>()
+
+const { translatePlural } = usePluralizedTranslation()
+const { locale } = useI18n()
+
+const animatedCount = ref(Math.max(0, Math.round(props.count)))
+const reducedMotionPreference = usePreferredReducedMotion()
+const isReducedMotionPreferred = computed(() => reducedMotionPreference.value === 'reduce')
+const isMounted = ref(false)
+let animationFrameId: number | null = null
+
+const numberFormatter = computed(
+  () => new Intl.NumberFormat(locale.value, { maximumFractionDigits: 0 }),
+)
+
+const formattedCount = computed(() => numberFormatter.value.format(animatedCount.value))
+
+const label = computed(() =>
+  translatePlural('category.products.resultsCount', animatedCount.value, {
+    count: formattedCount.value,
+  }),
+)
+
+const cancelAnimation = () => {
+  if (animationFrameId !== null && typeof cancelAnimationFrame !== 'undefined') {
+    cancelAnimationFrame(animationFrameId)
+    animationFrameId = null
+  }
+}
+
+const easeOutCubic = (progress: number) => 1 - (1 - progress) ** 3
+
+const updateCountInstantly = (target: number) => {
+  animatedCount.value = Math.max(0, Math.round(target))
+}
+
+const animateCount = (from: number, to: number, duration = 600) => {
+  if (import.meta.server) {
+    updateCountInstantly(to)
+    return
+  }
+
+  if (!isMounted.value || isReducedMotionPreferred.value) {
+    updateCountInstantly(to)
+    return
+  }
+
+  const startValue = Math.max(0, Math.round(from))
+  const targetValue = Math.max(0, Math.round(to))
+
+  if (startValue === targetValue) {
+    animatedCount.value = targetValue
+    return
+  }
+
+  const startTime = performance.now()
+  const delta = targetValue - startValue
+
+  cancelAnimation()
+
+  const step = (timestamp: number) => {
+    const elapsed = timestamp - startTime
+    const progress = Math.min(elapsed / duration, 1)
+    const eased = easeOutCubic(progress)
+
+    animatedCount.value = Math.round(startValue + delta * eased)
+
+    if (progress < 1) {
+      animationFrameId = requestAnimationFrame(step)
+      return
+    }
+
+    animationFrameId = null
+  }
+
+  animationFrameId = requestAnimationFrame(step)
+}
+
+watch(
+  () => props.count,
+  (next, previous = animatedCount.value) => {
+    const previousValue = Math.max(0, Math.round(previous))
+    const nextValue = Math.max(0, Math.round(next))
+
+    if (!isMounted.value) {
+      updateCountInstantly(nextValue)
+      return
+    }
+
+    animateCount(previousValue, nextValue)
+  },
+  { immediate: true },
+)
+
+watch(
+  isReducedMotionPreferred,
+  (current) => {
+    if (!current) {
+      return
+    }
+
+    cancelAnimation()
+    updateCountInstantly(props.count)
+  },
+  { immediate: false },
+)
+
+onMounted(() => {
+  isMounted.value = true
+  updateCountInstantly(props.count)
+})
+
+onBeforeUnmount(() => {
+  cancelAnimation()
+})
+</script>

--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -20,6 +20,7 @@
               class="category-page__fast-filters-toggle"
               :class="{
                 'category-page__fast-filters-toggle--collapsed': filtersCollapsed,
+                'category-page__fast-filters-toggle--expanded': !filtersCollapsed,
               }"
               icon
               variant="text"
@@ -29,9 +30,13 @@
               @click="onToggleFiltersVisibility"
             >
               <v-icon
-                :icon="filtersToggleIcon"
+                icon="mdi-filter-variant"
                 size="40"
                 class="category-page__fast-filters-toggle-icon"
+                :class="{
+                  'category-page__fast-filters-toggle-icon--collapsed': filtersCollapsed,
+                  'category-page__fast-filters-toggle-icon--expanded': !filtersCollapsed,
+                }"
               />
             </v-btn>
           </template>
@@ -144,9 +149,7 @@
                 {{ $t('category.products.openFilters') }}
               </v-btn>
 
-              <p class="category-page__results-count" aria-live="polite">
-                {{ resultsCountLabel }}
-              </p>
+              <CategoryResultsCount :count="resultsCount" />
             </div>
 
             <div class="category-page__toolbar-actions">
@@ -335,6 +338,7 @@ import { AggTypeEnum } from '~~/shared/api-client'
 import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
 import CategoryHero from '~/components/category/CategoryHero.vue'
 import CategoryFiltersSidebar from '~/components/category/CategoryFiltersSidebar.vue'
+import CategoryResultsCount from '~/components/category/CategoryResultsCount.vue'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
 import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
 import CategoryProductTable from '~/components/category/products/CategoryProductTable.vue'
@@ -358,7 +362,6 @@ import { resolveFilterFieldTitle, resolveSortFieldTitle } from '~/utils/_field-l
 const route = useRoute()
 const router = useRouter()
 const { locale, t } = useI18n()
-const { translatePlural } = usePluralizedTranslation()
 const requestURL = useRequestURL()
 
 const MOBILE_USER_AGENT_PATTERN =
@@ -618,9 +621,6 @@ const sortOptions = computed(() => sortOptionsData.value ?? null)
 const isDesktop = computed(() => (isHydrated.value ? display.lgAndUp.value : initialIsDesktop.value))
 const filtersDrawer = ref(false)
 const filtersCollapsed = ref(false)
-const filtersToggleIcon = computed(() =>
-  filtersCollapsed.value ? 'mdi-filter-variant-plus' : 'mdi-filter-variant-minus',
-)
 const filtersToggleLabel = computed(() =>
   filtersCollapsed.value
     ? t('category.filters.toggle.show')
@@ -1203,9 +1203,6 @@ watch(
   { immediate: true },
 )
 
-const resultsCountLabel = computed(() =>
-  translatePlural('category.products.resultsCount', resultsCount.value),
-)
 const pageCount = computed(() => productsData.value?.products?.page?.totalPages ?? 1)
 const currentAggregations = computed<AggregationResponseDto[]>(
   () => productsData.value?.aggregations ?? [],
@@ -1749,8 +1746,24 @@ const clearAllFilters = () => {
     background: rgba(var(--v-theme-surface-primary-080), 0.85)
     color: rgb(var(--v-theme-primary))
 
+  &__fast-filters-toggle--expanded
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
   &__fast-filters-toggle-icon
     color: inherit
+    transform-origin: center
+    transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)
+    will-change: transform
+
+  &__fast-filters-toggle-icon--collapsed
+    transform: rotate(-90deg)
+
+  &__fast-filters-toggle-icon--expanded
+    transform: rotate(90deg)
+
+  @media (prefers-reduced-motion: reduce)
+    &__fast-filters-toggle-icon
+      transition: none
 
   &__fast-filters-groups
     flex: 1 1 auto

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -206,6 +206,12 @@
       "toggle": {
         "hide": "Hide filters column",
         "show": "Show filters column"
+      },
+      "ecoscore": {
+        "title": "Discover the Eco-score",
+        "description": "Understand how we evaluate each product's environmental footprint and the indicators we monitor.",
+        "cta": "Explore the methodology",
+        "ariaLabel": "Open the Eco-score guide"
       }
     },
     "hero": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -206,6 +206,12 @@
       "toggle": {
         "hide": "Masquer la colonne des filtres",
         "show": "Afficher la colonne des filtres"
+      },
+      "ecoscore": {
+        "title": "Découvrir l'Eco-score",
+        "description": "Comprenez comment nous évaluons l'empreinte environnementale de chaque produit et les indicateurs suivis.",
+        "cta": "Explorer la méthodologie",
+        "ariaLabel": "Ouvrir le guide Eco-score"
       }
     },
     "hero": {


### PR DESCRIPTION
## Summary
- respect reduced motion preferences when animating the category results counter and cancel any running animations when users opt out
- extend unit tests to cover the reduced motion branch of the counter animation
- align the Eco-score sidebar card with the requested star iconography

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6900cbe57dbc83339b1896ece1ea1504