### PR TITLE
Add category guide breadcrumb and sticky navigation

### DIFF
--- a/frontend/app/pages/[categorySlug]/[...guideSlug].spec.ts
+++ b/frontend/app/pages/[categorySlug]/[...guideSlug].spec.ts
@@ -1,0 +1,296 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import type { VerticalConfigFullDto } from '~~/shared/api-client'
+
+const selectCategoryBySlugMock = vi.fn<[], Promise<VerticalConfigFullDto>>()
+const routerPushMock = vi.fn()
+const routerReplaceMock = vi.fn()
+const useSeoMetaMock = vi.hoisted(() => vi.fn())
+const mdAndDown = ref(false)
+const localeRef = ref('en-US')
+
+const messages: Record<string, string> = {
+  'siteIdentity.siteName': 'Nudger',
+  'category.guidePage.breadcrumbs.ariaLabel': 'Guide breadcrumb navigation',
+  'category.guidePage.navigation.ariaLabel': 'Guide sections navigation',
+  'category.guidePage.navigation.title': 'More guides',
+  'category.guidePage.cta.title': 'Back to {category}',
+  'category.guidePage.cta.description': 'Return to the {category} overview to browse every resource.',
+  'category.guidePage.cta.button': 'Back to {category}',
+  'category.guidePage.cta.imageAlt': 'Illustration for {category}',
+}
+
+const translate = (key: string, params: Record<string, unknown> = {}) => {
+  const template = messages[key] ?? key
+  return template.replace(/\{(\w+)\}/g, (_, match) => String(params[match] ?? ''))
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params: Record<string, unknown> = {}) => translate(key, params),
+    locale: localeRef,
+  }),
+}))
+
+const route = {
+  params: { categorySlug: 'televisions', guideSlug: ['sustainability', 'best-practices'] },
+  fullPath: '/televisions/sustainability/best-practices',
+}
+
+mockNuxtImport('useRoute', () => () => route)
+mockNuxtImport('useRouter', () => () => ({ push: routerPushMock, replace: routerReplaceMock }))
+mockNuxtImport('useSeoMeta', () => useSeoMetaMock)
+mockNuxtImport('createError', () => (input: { statusMessage?: string } & Record<string, unknown>) => {
+  const error = new Error(input?.statusMessage ?? 'Error')
+  Object.assign(error, input)
+  return error
+})
+
+vi.mock('vuetify', () => ({
+  useDisplay: () => ({ mdAndDown }),
+}))
+
+vi.mock('~/components/category/navigation/CategoryNavigationBreadcrumbs.vue', () => ({
+  default: defineComponent({
+    name: 'CategoryNavigationBreadcrumbsStub',
+    props: {
+      items: { type: Array as () => Array<{ title: string; link?: string }>, default: () => [] },
+      ariaLabel: { type: String, default: '' },
+    },
+    setup(props) {
+      return () =>
+        h(
+          'nav',
+          {
+            'data-test': 'breadcrumbs',
+            'data-aria-label': props.ariaLabel,
+          },
+          (props.items as Array<{ title: string; link?: string }>).map((item, index, all) =>
+            item.link
+              ? h(
+                  'a',
+                  {
+                    'data-breadcrumb-item': 'link',
+                    href: item.link,
+                  },
+                  item.title,
+                )
+              : h(
+                  'span',
+                  {
+                    'data-breadcrumb-item': 'current',
+                    'data-current': index === all.length - 1 ? 'true' : 'false',
+                  },
+                  item.title,
+                ),
+          ),
+        )
+    },
+  }),
+}))
+
+vi.mock('~/components/shared/ui/StickySectionNavigation.vue', () => ({
+  default: defineComponent({
+    name: 'StickySectionNavigationStub',
+    props: {
+      sections: { type: Array as () => Array<{ id: string; label: string }>, default: () => [] },
+      activeSection: { type: String, default: '' },
+      orientation: { type: String, default: 'vertical' },
+      ariaLabel: { type: String, default: '' },
+    },
+    emits: ['navigate'],
+    setup(props, { emit }) {
+      return () =>
+        h(
+          'nav',
+          {
+            'data-test': 'sticky-nav',
+            'data-active': props.activeSection,
+            'data-orientation': props.orientation,
+            'data-sections': JSON.stringify(props.sections),
+            'data-aria-label': props.ariaLabel,
+          },
+          (props.sections as Array<{ id: string; label: string }>).map((section) =>
+            h(
+              'button',
+              {
+                type: 'button',
+                'data-id': section.id,
+                onClick: () => emit('navigate', section.id),
+              },
+              section.label,
+            ),
+          ),
+        )
+    },
+  }),
+}))
+
+vi.mock('~/components/cms/XwikiFullPageRenderer.vue', () => ({
+  default: defineComponent({
+    name: 'XwikiFullPageRendererStub',
+    props: { pageId: { type: String, default: '' } },
+    setup(props) {
+      return () => h('article', { 'data-test': 'xwiki-renderer' }, `page:${props.pageId}`)
+    },
+  }),
+}))
+
+vi.mock('~/composables/categories/useCategories', () => ({
+  useCategories: () => ({
+    selectCategoryBySlug: selectCategoryBySlugMock,
+  }),
+}))
+
+const categoryFixture: VerticalConfigFullDto = {
+  id: 'tv',
+  verticalHomeTitle: 'Televisions',
+  verticalHomeDescription: 'Eco guides for televisions.',
+  imageSmall: 'https://example.com/images/tv-small.jpg',
+  breadCrumb: [
+    { title: 'Electronics', link: '/electronics' },
+    { title: 'Televisions', link: '/televisions' },
+  ],
+  wikiPages: [
+    {
+      title: 'Getting started with energy efficient TVs',
+      verticalUrl: 'getting-started',
+      wikiUrl: 'pages:tv/getting-started',
+    },
+    {
+      title: 'Sustainability guide for televisions and energy conscious households worldwide',
+      verticalUrl: 'sustainability/best-practices',
+      wikiUrl: 'pages:tv/sustainability',
+    },
+  ],
+} as unknown as VerticalConfigFullDto
+
+const vuetifyStubs = {
+  'v-container': defineComponent({
+    name: 'VContainerStub',
+    setup(_props, { slots, attrs }) {
+      return () => h('div', { class: 'v-container-stub', ...attrs }, slots.default?.())
+    },
+  }),
+  'v-card': defineComponent({
+    name: 'VCardStub',
+    setup(_props, { slots, attrs }) {
+      return () => h('div', { class: 'v-card-stub', ...attrs }, slots.default?.())
+    },
+  }),
+  'v-btn': defineComponent({
+    name: 'VBtnStub',
+    props: { to: { type: [String, Object], default: undefined } },
+    setup(props, { slots, attrs }) {
+      return () =>
+        h(
+          'button',
+          {
+            class: 'v-btn-stub',
+            type: 'button',
+            ...attrs,
+            'data-to': typeof props.to === 'string' ? props.to : attrs['data-to'],
+          },
+          slots.default?.(),
+        )
+    },
+  }),
+  'v-icon': defineComponent({
+    name: 'VIconStub',
+    props: { icon: { type: String, default: '' } },
+    setup(props, { slots, attrs }) {
+      return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon, ...attrs }, slots.default?.())
+    },
+  }),
+  'v-img': defineComponent({
+    name: 'VImgStub',
+    props: { src: { type: String, default: '' }, alt: { type: String, default: '' } },
+    setup(props, { attrs }) {
+      return () => h('img', { class: 'v-img-stub', src: props.src, alt: props.alt, ...attrs })
+    },
+  }),
+}
+
+const truncate = (value: string, limit = 54) =>
+  value.length > limit ? `${value.slice(0, limit - 1)}…` : value
+
+const mountGuidePage = async () => {
+  selectCategoryBySlugMock.mockResolvedValueOnce(categoryFixture)
+  const component = (await import('./[...guideSlug].vue')).default
+  const wrapper = await mountSuspended(component, {
+    global: {
+      stubs: vuetifyStubs,
+    },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+describe('Category wiki guide page', () => {
+  beforeEach(() => {
+    selectCategoryBySlugMock.mockReset()
+    routerPushMock.mockReset()
+    routerReplaceMock.mockReset()
+    useSeoMetaMock.mockReset()
+    mdAndDown.value = false
+  })
+
+  it('renders breadcrumb trail with truncated guide leaf', async () => {
+    const wrapper = await mountGuidePage()
+
+    const breadcrumb = wrapper.get('[data-test="breadcrumbs"]')
+    expect(breadcrumb.attributes('data-aria-label')).toBe('Guide breadcrumb navigation')
+
+    const items = breadcrumb.findAll('[data-breadcrumb-item]')
+    expect(items).toHaveLength(3)
+
+    expect(items[0].attributes('href')).toBe('/electronics')
+    expect(items[1].attributes('href')).toBe('/televisions')
+
+    const current = breadcrumb.find('[data-breadcrumb-item="current"]')
+    const expectedTitle = truncate(
+      'Sustainability guide for televisions and energy conscious households worldwide',
+    )
+    expect(current.text()).toBe(expectedTitle)
+  })
+
+  it('provides sticky navigation for other guides and routes when selecting one', async () => {
+    const wrapper = await mountGuidePage()
+
+    const stickyNav = wrapper.get('[data-test="guide-navigation"]')
+    expect(stickyNav.attributes('data-aria-label')).toBe('Guide sections navigation')
+    expect(stickyNav.attributes('data-orientation')).toBe('vertical')
+
+    const sections = JSON.parse(stickyNav.attributes('data-sections') ?? '[]') as Array<{
+      id: string
+      label: string
+    }>
+    expect(sections).toHaveLength(2)
+    expect(sections[0]).toMatchObject({ id: 'getting-started' })
+    expect(stickyNav.attributes('data-active')).toBe('sustainability/best-practices')
+
+    await stickyNav.get('button[data-id="getting-started"]').trigger('click')
+    expect(routerPushMock).toHaveBeenCalledWith({ path: '/televisions/getting-started' })
+  })
+
+  it('displays a CTA linking back to the category overview', async () => {
+    const wrapper = await mountGuidePage()
+
+    const cta = wrapper.get('[data-test="guide-cta"]')
+    expect(cta.text()).toContain('Back to Televisions')
+
+    const button = cta.get('[data-test="guide-cta-button"]')
+    expect(button.text()).toContain('Back to Televisions')
+    expect(button.attributes('data-to')).toBe('/televisions')
+  })
+
+  it('switches navigation orientation on smaller viewports', async () => {
+    mdAndDown.value = true
+    const wrapper = await mountGuidePage()
+
+    const stickyNav = wrapper.get('[data-test="guide-navigation"]')
+    expect(stickyNav.attributes('data-orientation')).toBe('horizontal')
+  })
+})

--- a/frontend/app/pages/[categorySlug]/[...guideSlug].vue
+++ b/frontend/app/pages/[categorySlug]/[...guideSlug].vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useDisplay } from 'vuetify'
 import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
+import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
+import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
 import { useCategories } from '~/composables/categories/useCategories'
-import type { VerticalConfigFullDto } from '~~/shared/api-client'
+import type { CategoryBreadcrumbItemDto, VerticalConfigFullDto, WikiPageConfig } from '~~/shared/api-client'
 import { matchProductRouteFromSegments } from '~~/shared/utils/_product-route'
 
 const normaliseSlug = (value: string | null | undefined) =>
@@ -40,7 +44,10 @@ definePageMeta({
 })
 
 const route = useRoute()
+const router = useRouter()
 const { selectCategoryBySlug } = useCategories()
+const { t } = useI18n()
+const { mdAndDown } = useDisplay()
 
 const categorySlug = computed(() => String(route.params.categorySlug ?? ''))
 
@@ -95,13 +102,342 @@ if (!resolvedPageId) {
 pageId.value = resolvedPageId
 fallbackTitle.value = matchedPage.title ?? null
 fallbackDescription.value = categoryDetail.verticalHomeDescription ?? null
+
+const siteName = computed(() => String(t('siteIdentity.siteName')))
+
+const categoryLabel = computed(
+  () =>
+    categoryDetail.verticalHomeTitle ??
+    categoryDetail.verticalMetaTitle ??
+    categoryDetail.verticalHomeDescription ??
+    siteName.value,
+)
+
+const normalisePathSegment = (value: string | null | undefined) =>
+  value?.trim().replace(/^\/+|\/+$/g, '') ?? ''
+
+const guideTitle = computed(() => {
+  const rawTitle = matchedPage.title?.trim()
+
+  if (rawTitle?.length) {
+    return rawTitle
+  }
+
+  if (fallbackTitle.value?.trim()?.length) {
+    return fallbackTitle.value
+  }
+
+  const lastSegment = slugSegments.at(-1)
+  return lastSegment ? lastSegment.replace(/[-_]+/g, ' ') : normalisedSlug
+})
+
+const MAX_BREADCRUMB_LEAF_LENGTH = 54
+
+const truncatedGuideTitle = computed(() => {
+  const title = guideTitle.value
+  return title.length > MAX_BREADCRUMB_LEAF_LENGTH
+    ? `${title.slice(0, MAX_BREADCRUMB_LEAF_LENGTH - 1)}…`
+    : title
+})
+
+const breadcrumbBase = computed(() => {
+  const rawItems = (categoryDetail.breadCrumb ?? []) as CategoryBreadcrumbItemDto[]
+
+  const mapped = rawItems
+    .map((item) => {
+      const title = item.title?.trim() ?? ''
+      const link = item.link?.trim() ?? ''
+
+      if (!title.length && !link.length) {
+        return null
+      }
+
+      return {
+        title: title.length ? title : link,
+        link: link.length ? link : undefined,
+      }
+    })
+    .filter((item): item is { title: string; link?: string } => Boolean(item?.title?.length))
+
+  if (mapped.length) {
+    return mapped
+  }
+
+  const fallbackTitle = categoryLabel.value?.trim()
+  if (fallbackTitle?.length) {
+    return [
+      {
+        title: fallbackTitle,
+        link: `/${normalisePathSegment(categorySlug.value)}`,
+      },
+    ]
+  }
+
+  return []
+})
+
+const breadcrumbItems = computed(() => {
+  if (!truncatedGuideTitle.value?.length) {
+    return breadcrumbBase.value
+  }
+
+  return [...breadcrumbBase.value, { title: truncatedGuideTitle.value }]
+})
+
+const breadcrumbAriaLabel = computed(() => t('category.guidePage.breadcrumbs.ariaLabel'))
+
+const categoryImage = computed(
+  () => categoryDetail.imageSmall ?? categoryDetail.imageMedium ?? categoryDetail.imageLarge ?? null,
+)
+
+const categoryLink = computed(() => `/${normalisePathSegment(categorySlug.value)}`)
+
+type GuideNavigationItem = {
+  id: string
+  slug: string
+  label: string
+}
+
+const navigationItems = computed<GuideNavigationItem[]>(() => {
+  const pages = (categoryDetail.wikiPages ?? []) as WikiPageConfig[]
+  const seen = new Set<string>()
+
+  return pages
+    .map((page) => {
+      const slug = normalisePathSegment(page.verticalUrl)
+      if (!slug.length) {
+        return null
+      }
+
+      const id = normaliseSlug(slug)
+      if (!id.length || seen.has(id)) {
+        return null
+      }
+
+      seen.add(id)
+      const label = page.title?.trim()?.length ? page.title.trim() : slug.split('/').pop()?.replace(/[-_]+/g, ' ') ?? slug
+
+      return {
+        id,
+        slug,
+        label,
+      }
+    })
+    .filter((item): item is GuideNavigationItem => item !== null)
+})
+
+const navigationSections = computed(() =>
+  navigationItems.value.map((item) => ({
+    id: item.id,
+    label: item.label,
+    icon: 'mdi-file-document-outline',
+  })),
+)
+
+const navigationItemsById = computed(() => new Map(navigationItems.value.map((item) => [item.id, item])))
+
+const activeNavigationId = computed(() => normalisedSlug)
+
+const navigationOrientation = computed<'vertical' | 'horizontal'>(() => (mdAndDown.value ? 'horizontal' : 'vertical'))
+
+const navigationAriaLabel = computed(() => t('category.guidePage.navigation.ariaLabel'))
+
+const hasNavigation = computed(() => navigationSections.value.length > 0)
+
+const onNavigateToGuide = (sectionId: string) => {
+  if (sectionId === activeNavigationId.value) {
+    return
+  }
+
+  const target = navigationItemsById.value.get(sectionId)
+  if (!target) {
+    return
+  }
+
+  router.push({ path: `${categoryLink.value}/${target.slug}` })
+}
+
+const ctaTitle = computed(() => t('category.guidePage.cta.title', { category: categoryLabel.value }))
+const ctaDescription = computed(() =>
+  t('category.guidePage.cta.description', { category: categoryLabel.value }),
+)
+const ctaButtonLabel = computed(() => t('category.guidePage.cta.button', { category: categoryLabel.value }))
+const ctaImageAlt = computed(() => t('category.guidePage.cta.imageAlt', { category: categoryLabel.value }))
 </script>
 
 <template>
-  <XwikiFullPageRenderer
-    v-if="pageId"
-    :page-id="pageId"
-    :fallback-title="fallbackTitle"
-    :fallback-description="fallbackDescription"
-  />
+  <div class="category-guide-page" data-test="category-guide-page">
+    <v-container fluid class="category-guide-page__container py-8">
+      <CategoryNavigationBreadcrumbs
+        v-if="breadcrumbItems.length"
+        class="category-guide-page__breadcrumbs"
+        :items="breadcrumbItems"
+        :aria-label="breadcrumbAriaLabel"
+      />
+
+      <div class="category-guide-page__layout">
+        <aside
+          class="category-guide-page__sidebar"
+          :class="{ 'category-guide-page__sidebar--mobile': navigationOrientation === 'horizontal' }"
+        >
+          <v-card
+            class="category-guide-page__cta"
+            data-test="guide-cta"
+            elevation="2"
+            rounded="xl"
+            variant="elevated"
+          >
+            <v-img
+              v-if="categoryImage"
+              :src="categoryImage"
+              :alt="ctaImageAlt"
+              class="category-guide-page__cta-image"
+              cover
+            />
+
+            <div class="category-guide-page__cta-content">
+              <h2 class="category-guide-page__cta-title">{{ ctaTitle }}</h2>
+              <p class="category-guide-page__cta-description">{{ ctaDescription }}</p>
+              <v-btn
+                class="category-guide-page__cta-button"
+                color="primary"
+                data-test="guide-cta-button"
+                size="large"
+                variant="flat"
+                :to="categoryLink"
+                :data-to="categoryLink"
+              >
+                <v-icon class="me-2" icon="mdi-arrow-left" size="18" />
+                {{ ctaButtonLabel }}
+              </v-btn>
+            </div>
+          </v-card>
+
+          <div v-if="hasNavigation" class="category-guide-page__navigation">
+            <div class="category-guide-page__navigation-header">
+              <v-icon icon="mdi-book-open-page-variant" size="20" />
+              <span>{{ t('category.guidePage.navigation.title') }}</span>
+            </div>
+            <StickySectionNavigation
+              data-test="guide-navigation"
+              :sections="navigationSections"
+              :active-section="activeNavigationId"
+              :orientation="navigationOrientation"
+              :aria-label="navigationAriaLabel"
+              @navigate="onNavigateToGuide"
+            />
+          </div>
+        </aside>
+
+        <main class="category-guide-page__content" role="main">
+          <XwikiFullPageRenderer
+            v-if="pageId"
+            :page-id="pageId"
+            :fallback-title="fallbackTitle"
+            :fallback-description="fallbackDescription"
+          />
+        </main>
+      </div>
+    </v-container>
+  </div>
 </template>
+
+<style scoped lang="sass">
+.category-guide-page
+  display: block
+
+  &__container
+    max-width: 1200px
+
+  &__breadcrumbs
+    margin-bottom: 1.5rem
+
+  &__layout
+    display: grid
+    grid-template-columns: minmax(0, 1fr)
+    gap: 2rem
+
+  &__sidebar
+    display: flex
+    flex-direction: column
+    gap: 1.5rem
+
+  &__sidebar--mobile
+    position: static
+
+  &__cta
+    display: flex
+    flex-direction: column
+    gap: 1rem
+    overflow: hidden
+    background: rgba(var(--v-theme-surface-glass))
+
+  &__cta-image
+    height: 160px
+    object-fit: cover
+
+  &__cta-content
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    padding: 1.25rem
+
+  &__cta-title
+    margin: 0
+    font-size: 1.25rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__cta-description
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    line-height: 1.5
+
+  &__cta-button
+    align-self: flex-start
+
+  &__navigation
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+  &__navigation-header
+    display: inline-flex
+    align-items: center
+    gap: 0.5rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__content
+    min-width: 0
+
+    :deep(.xwiki-page)
+      background: transparent
+
+  @media (min-width: 960px)
+    &__layout
+      grid-template-columns: minmax(220px, 280px) minmax(0, 1fr)
+
+  @media (max-width: 959px)
+    &__layout
+      grid-template-columns: minmax(0, 1fr)
+
+    &__sidebar
+      order: -1
+
+    &__cta-button
+      width: 100%
+
+    &__navigation-header
+      justify-content: center
+      text-align: center
+
+    :deep(.sticky-section-navigation)
+      width: 100%
+
+    :deep(.sticky-section-navigation--horizontal)
+      border-radius: 12px
+
+    :deep(.sticky-section-navigation__list)
+      justify-content: flex-start
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -83,6 +83,21 @@
       "guidesTitle": "Helpful guides",
       "postsTitle": "Related articles"
     },
+    "guidePage": {
+      "breadcrumbs": {
+        "ariaLabel": "Guide breadcrumb navigation"
+      },
+      "navigation": {
+        "ariaLabel": "Navigate between guides in this category",
+        "title": "More guides"
+      },
+      "cta": {
+        "title": "Back to {category}",
+        "description": "Return to the {category} overview to browse every resource.",
+        "button": "Back to {category}",
+        "imageAlt": "Illustration for {category}"
+      }
+    },
     "ecoscorePage": {
       "breadcrumbLeaf": "impactscore",
       "description": "We are crafting dedicated eco score insights for {category}. Check back soon!",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -83,6 +83,21 @@
       "guidesTitle": "Guides utiles",
       "postsTitle": "Articles associés"
     },
+    "guidePage": {
+      "breadcrumbs": {
+        "ariaLabel": "Fil d'Ariane des guides"
+      },
+      "navigation": {
+        "ariaLabel": "Naviguer entre les guides de cette catégorie",
+        "title": "Autres guides"
+      },
+      "cta": {
+        "title": "Retour à {category}",
+        "description": "Revenir à la page {category} pour parcourir toutes les ressources.",
+        "button": "Retour à {category}",
+        "imageAlt": "Illustration pour {category}"
+      }
+    },
     "ecoscorePage": {
       "breadcrumbLeaf": "impactscore",
       "description": "Nous préparons un contenu dédié au score éco pour {category}. Revenez bientôt !",


### PR DESCRIPTION
## Summary
- add localized breadcrumb generation, category CTA, and sticky guide navigation to the category wiki guide page for responsive layouts
- cover the guide page with unit tests ensuring breadcrumbs, navigation, and CTA behavior
- localize the new guide page strings in English and French

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6901cbb4edec83338665a4b12bb8a7c3