### PR TITLE
feat: improve category filters layout and sticky controls

### DIFF
--- a/frontend/app/components/category/CategoryActiveFilters.spec.ts
+++ b/frontend/app/components/category/CategoryActiveFilters.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+
+import CategoryActiveFilters from './CategoryActiveFilters.vue'
+import type { FilterRequestDto, ProductFieldOptionsResponse } from '~~/shared/api-client'
+import type { CategorySubsetClause } from '~/types/category-subset'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const resolveClassList = (value: unknown): string => {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => resolveClassList(entry)).filter(Boolean).join(' ')
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, active]) => Boolean(active))
+      .map(([name]) => name)
+      .join(' ')
+  }
+
+  return String(value)
+}
+
+const VChipStub = defineComponent({
+  name: 'VChip',
+  props: {
+    closable: { type: Boolean, default: false },
+  },
+  emits: ['click:close'],
+  setup(props, { slots, emit, attrs }) {
+    const className = ['v-chip-stub', resolveClassList((attrs as Record<string, unknown>).class)]
+      .filter(Boolean)
+      .join(' ')
+
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: className,
+          type: 'button',
+          'data-closable': props.closable ? 'true' : 'false',
+          onClick: () => emit('click:close'),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  props: { type: { type: String, default: 'button' } },
+  emits: ['click'],
+  setup(props, { slots, emit, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['v-btn-stub', resolveClassList((attrs as Record<string, unknown>).class)].join(' '),
+          type: props.type,
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: { icon: { type: String, default: '' } },
+  setup(props) {
+    return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  props: { text: { type: String, default: '' } },
+  setup(props, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub', 'data-text': props.text }, [
+        slots.activator?.({ props: {} }),
+        slots.default?.(),
+      ])
+  },
+})
+
+describe('CategoryActiveFilters', () => {
+  const filterOptions: ProductFieldOptionsResponse = {
+    global: [
+      { mapping: 'brand', title: 'Brand' },
+      { mapping: 'price.min', title: 'Price min' },
+    ],
+    impact: [],
+    technical: [],
+  }
+
+  const manualFilters: FilterRequestDto = {
+    filters: [
+      { field: 'brand', operator: 'term', terms: ['Nudger'] },
+      { field: 'price.min', operator: 'range', min: 10, max: 100 },
+    ],
+  }
+
+  const subsetClauses: CategorySubsetClause[] = [
+    {
+      id: 'subset-1-0',
+      subsetId: 'subset-1',
+      index: 0,
+      label: 'Circular products',
+      filter: { field: 'recycled', operator: 'term', terms: ['yes'] },
+    },
+  ]
+
+  const mountComponent = () =>
+    mount(CategoryActiveFilters, {
+      props: {
+        filterOptions,
+        filters: manualFilters,
+        subsetClauses,
+      },
+      global: {
+        stubs: {
+          VChip: VChipStub,
+          VBtn: VBtnStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+  it('renders subset and manual filter chips and emits removal events', () => {
+    const wrapper = mountComponent()
+
+    const chips = wrapper.findAll('.v-chip-stub')
+    expect(chips).toHaveLength(3)
+
+    chips[0]?.trigger('click')
+    expect(wrapper.emitted('remove-subset-clause')?.[0]?.[0]).toEqual(subsetClauses[0])
+
+    chips[1]?.trigger('click')
+    expect(wrapper.emitted('remove-manual-filter')?.[0]?.[0]).toEqual({
+      field: 'brand',
+      type: 'term',
+      term: 'Nudger',
+    })
+  })
+
+  it('emits clear-all when the dismiss button is pressed', () => {
+    const wrapper = mountComponent()
+
+    wrapper.get('.v-btn-stub').trigger('click')
+
+    expect(wrapper.emitted('clear-all')).toBeTruthy()
+  })
+})

--- a/frontend/app/components/category/CategoryActiveFilters.vue
+++ b/frontend/app/components/category/CategoryActiveFilters.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="category-active-filters" data-testid="category-active-filters">
+    <div class="category-active-filters__chips">
+      <v-chip
+        v-for="chip in chips"
+        :key="chip.id"
+        class="category-active-filters__chip"
+        closable
+        color="primary"
+        variant="flat"
+        size="small"
+        density="comfortable"
+        @click:close="onRemoveChip(chip)"
+      >
+        <span>{{ chip.label }}</span>
+      </v-chip>
+    </div>
+
+    <div class="category-active-filters__actions">
+      <v-tooltip :text="dismissAllTooltip" location="bottom" :open-delay="125">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            icon
+            variant="text"
+            color="primary"
+            density="comfortable"
+            class="category-active-filters__dismiss"
+            :aria-label="dismissAllLabel"
+            v-bind="tooltipProps"
+            @click="onClearAll"
+          >
+            <v-icon icon="mdi-close-circle-outline" />
+          </v-btn>
+        </template>
+      </v-tooltip>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  FieldMetadataDto,
+  FilterRequestDto,
+  ProductFieldOptionsResponse,
+} from '~~/shared/api-client'
+
+import type { CategorySubsetClause } from '~/types/category-subset'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
+
+type ManualFilterChip = {
+  kind: 'manual'
+  id: string
+  field: string
+  type: 'term' | 'range'
+  term: string | null
+  label: string
+}
+
+type SubsetFilterChip = {
+  kind: 'subset'
+  id: string
+  label: string
+  clause: CategorySubsetClause
+}
+
+type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
+
+type ManualRemovalPayload = {
+  field: string
+  type: 'term' | 'range'
+  term: string | null
+}
+
+const props = defineProps<{
+  filterOptions: ProductFieldOptionsResponse | null
+  filters: FilterRequestDto | null
+  subsetClauses: CategorySubsetClause[]
+}>()
+
+const emit = defineEmits<{
+  'remove-manual-filter': [ManualRemovalPayload]
+  'remove-subset-clause': [CategorySubsetClause]
+  'clear-all': []
+}>()
+
+const { t } = useI18n()
+
+const activeFilters = computed(() => props.filters?.filters ?? [])
+const subsetClauses = computed(() => props.subsetClauses ?? [])
+
+const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(() => {
+  const entries = [
+    ...(props.filterOptions?.global ?? []),
+    ...(props.filterOptions?.impact ?? []),
+    ...(props.filterOptions?.technical ?? []),
+  ]
+
+  return entries.reduce<Record<string, FieldMetadataDto>>((accumulator, field) => {
+    if (field.mapping) {
+      accumulator[String(field.mapping)] = field
+    }
+
+    return accumulator
+  }, {})
+})
+
+const manualFilterChips = computed<ManualFilterChip[]>(() => {
+  return activeFilters.value.map((filter) => {
+    const mapping = filter.field ?? ''
+    const metadata = mapping ? fieldMetadataMap.value[mapping] : undefined
+    const label = resolveFilterFieldTitle(metadata, t, mapping)
+
+    if (filter.operator === 'term') {
+      const term = filter.terms?.[0] ?? ''
+      return {
+        kind: 'manual' as const,
+        id: `${mapping}-${term}`,
+        field: mapping,
+        type: 'term' as const,
+        term,
+        label: term ? `${label}: ${term}` : label,
+      }
+    }
+
+    return {
+      kind: 'manual' as const,
+      id: `${mapping}-range`,
+      field: mapping,
+      type: 'range' as const,
+      term: null,
+      label: `${label}: ${filter.min ?? '–'} → ${filter.max ?? '–'}`,
+    }
+  })
+})
+
+const subsetFilterChips = computed<SubsetFilterChip[]>(() => {
+  return subsetClauses.value.map((clause) => ({
+    kind: 'subset' as const,
+    id: clause.id,
+    label: clause.label,
+    clause,
+  }))
+})
+
+const chips = computed<ActiveFilterChip[]>(() => {
+  return [...subsetFilterChips.value, ...manualFilterChips.value]
+})
+
+const dismissAllLabel = computed(() => t('category.filters.clearAll'))
+const dismissAllTooltip = computed(() => t('category.filters.tooltips.clearAll'))
+
+const onRemoveChip = (chip: ActiveFilterChip) => {
+  if (chip.kind === 'subset') {
+    emit('remove-subset-clause', chip.clause)
+    return
+  }
+
+  emit('remove-manual-filter', {
+    field: chip.field,
+    type: chip.type,
+    term: chip.term,
+  })
+}
+
+const onClearAll = () => {
+  emit('clear-all')
+}
+
+const exposeChips = computed(() => chips.value)
+
+defineExpose({
+  chips: exposeChips,
+})
+</script>
+
+<style scoped lang="sass">
+.category-active-filters
+  display: flex
+  align-items: stretch
+  gap: 0.75rem
+  padding: 0.75rem 1rem
+  border-radius: 1rem
+  background: rgba(var(--v-theme-surface-primary-080), 0.9)
+  box-shadow: 0 18px 38px -28px rgba(var(--v-theme-shadow-primary-600), 0.25)
+
+  &__chips
+    flex: 1 1 auto
+    display: flex
+    flex-wrap: wrap
+    gap: 0.5rem
+
+  &__chip
+    border-radius: 999px
+
+  &__actions
+    flex: 0 0 auto
+    display: flex
+    align-items: center
+
+  &__dismiss
+    color: rgb(var(--v-theme-primary))
+
+  @media (max-width: 959px)
+    flex-direction: column
+    align-items: stretch
+
+    &__actions
+      justify-content: flex-end
+</style>

--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -1,21 +1,5 @@
 <template>
   <div class="category-filters" data-testid="category-filters">
-    <div v-if="activeChips.length" class="category-filters__active">
-      <div class="category-filters__chips">
-        <v-chip
-          v-for="chip in activeChips"
-          :key="chip.id"
-          closable
-          color="primary"
-          variant="flat"
-          size="small"
-          @click:close="onRemoveChip(chip)"
-        >
-          <span>{{ chip.label }}</span>
-        </v-chip>
-      </div>
-    </div>
-
     <v-expansion-panels multiple class="category-filters__panels">
       <v-expansion-panel value="global" expand-icon="mdi-chevron-down">
         <template #title>
@@ -138,26 +122,6 @@ import type {
 import { useI18n } from 'vue-i18n'
 
 import CategoryFilterList from './filters/CategoryFilterList.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
-import { resolveFilterFieldTitle } from '~/utils/_field-localization'
-
-type ManualFilterChip = {
-  kind: 'manual'
-  id: string
-  field: string
-  type: 'term' | 'range'
-  term: string | null
-  label: string
-}
-
-type SubsetFilterChip = {
-  kind: 'subset'
-  id: string
-  label: string
-  clause: CategorySubsetClause
-}
-
-type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
 
 const props = withDefaults(
   defineProps<{
@@ -167,7 +131,6 @@ const props = withDefaults(
     filters: FilterRequestDto | null
     impactExpanded: boolean
     technicalExpanded: boolean
-    subsetClauses: CategorySubsetClause[]
   }>(),
   {
     baselineAggregations: () => [],
@@ -178,11 +141,9 @@ const emit = defineEmits<{
   'update:filters': [FilterRequestDto]
   'update:impactExpanded': [boolean]
   'update:technicalExpanded': [boolean]
-  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const activeFilters = computed(() => props.filters?.filters ?? [])
-const subsetClauses = computed(() => props.subsetClauses ?? [])
 
 const { t } = useI18n()
 
@@ -200,22 +161,6 @@ const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(
   return (props.baselineAggregations ?? []).reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
     if (aggregation.field && !(aggregation.field in accumulator)) {
       accumulator[aggregation.field] = aggregation
-    }
-
-    return accumulator
-  }, {})
-})
-
-const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(() => {
-  const entries = [
-    ...(props.filterOptions?.global ?? []),
-    ...(props.filterOptions?.impact ?? []),
-    ...(props.filterOptions?.technical ?? []),
-  ]
-
-  return entries.reduce<Record<string, FieldMetadataDto>>((accumulator, field) => {
-    if (field.mapping) {
-      accumulator[field.mapping] = field
     }
 
     return accumulator
@@ -242,48 +187,6 @@ const technicalPrimary = computed<FieldMetadataDto[]>(() => {
 const technicalRemaining = computed<FieldMetadataDto[]>(() => {
   const entries = props.filterOptions?.technical ?? []
   return entries.slice(3)
-})
-
-const manualFilterChips = computed<ManualFilterChip[]>(() => {
-  return activeFilters.value.map((filter) => {
-    const mapping = filter.field ?? ''
-    const metadata = mapping ? fieldMetadataMap.value[mapping] : undefined
-    const label = resolveFilterFieldTitle(metadata, t, mapping)
-
-    if (filter.operator === 'term') {
-      const term = filter.terms?.[0] ?? ''
-      return {
-        kind: 'manual' as const,
-        id: `${mapping}-${term}`,
-        field: mapping,
-        type: 'term' as const,
-        term,
-        label: term ? `${label}: ${term}` : label,
-      }
-    }
-
-    return {
-      kind: 'manual' as const,
-      id: `${mapping}-range`,
-      field: mapping,
-      type: 'range' as const,
-      term: null,
-      label: `${label}: ${filter.min ?? '–'} → ${filter.max ?? '–'}`,
-    }
-  })
-})
-
-const subsetFilterChips = computed<SubsetFilterChip[]>(() => {
-  return subsetClauses.value.map((clause) => ({
-    kind: 'subset' as const,
-    id: clause.id,
-    label: clause.label,
-    clause,
-  }))
-})
-
-const activeChips = computed<ActiveFilterChip[]>(() => {
-  return [...subsetFilterChips.value, ...manualFilterChips.value]
 })
 
 const emitFilters = (filters: Filter[]) => {
@@ -327,31 +230,6 @@ const updateTermsFilter = (field: string, terms: string[]) => {
   ])
 }
 
-const removeManualFilter = (field: string, type: 'term' | 'range', term: string | null) => {
-  const next = activeFilters.value.filter((filter) => {
-    if (filter.field !== field) {
-      return true
-    }
-
-    if (type === 'term') {
-      return !(filter.operator === 'term' && filter.terms?.includes(term ?? ''))
-    }
-
-    return !(filter.operator === 'range')
-  })
-
-  emitFilters(next)
-}
-
-const onRemoveChip = (chip: ActiveFilterChip) => {
-  if (chip.kind === 'subset') {
-    emit('remove-subset-clause', chip.clause)
-    return
-  }
-
-  removeManualFilter(chip.field, chip.type, chip.term)
-}
-
 const toggleImpactExpansion = () => {
   emit('update:impactExpanded', !props.impactExpanded)
 }
@@ -360,7 +238,6 @@ const toggleTechnicalExpansion = () => {
   emit('update:technicalExpanded', !props.technicalExpanded)
 }
 
-defineExpose({ activeChips })
 </script>
 
 <style scoped lang="sass">
@@ -368,16 +245,6 @@ defineExpose({ activeChips })
   display: flex
   flex-direction: column
   gap: 1rem
-
-  &__active
-    padding: 0.5rem
-    background: rgb(var(--v-theme-surface-glass))
-    border-radius: 0.75rem
-
-  &__chips
-    display: flex
-    flex-direction: column
-    gap: 0.5rem
 
   &__panels
     background: transparent

--- a/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
@@ -56,7 +56,6 @@ describe('CategoryFiltersSidebar', () => {
     wikiPages: [],
     relatedPosts: [],
     verticalHomeUrl: 'https://open4goods.example/maison',
-    subsetClauses: [],
   }
 
   const mountComponent = (overrides: Partial<typeof baseProps> = {}) =>

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -7,11 +7,9 @@
       :filters="props.filters"
       :impact-expanded="props.impactExpanded"
       :technical-expanded="props.technicalExpanded"
-      :subset-clauses="props.subsetClauses"
       @update:filters="(value) => emit('update:filters', value)"
       @update:impact-expanded="(value) => emit('update:impactExpanded', value)"
       @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
-      @remove-subset-clause="(clause) => emit('remove-subset-clause', clause)"
     />
 
     <div v-if="showMobileActions" class="category-page__filters-actions">
@@ -55,7 +53,6 @@ import type {
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
 import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
 
 const props = withDefaults(
   defineProps<{
@@ -70,7 +67,6 @@ const props = withDefaults(
     wikiPages: WikiPageConfig[]
     relatedPosts: BlogPostDto[]
     verticalHomeUrl?: string | null
-    subsetClauses: CategorySubsetClause[]
   }>(),
   {
     baselineAggregations: () => [],
@@ -84,7 +80,6 @@ const emit = defineEmits<{
   'update:technicalExpanded': [boolean]
   'apply-mobile': []
   'clear-mobile': []
-  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const { t } = useI18n()

--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -639,6 +639,28 @@ const filtersToggleLabel = computed(() =>
 )
 const isFiltersColumnVisible = computed(() => isDesktop.value && !filtersCollapsed.value)
 
+const viewMode = ref<CategoryViewMode>(CATEGORY_DEFAULT_VIEW_MODE)
+const pageNumber = ref(0)
+const searchTerm = ref('')
+const sortField = ref<string | null>(null)
+const sortOrder = ref<'asc' | 'desc'>('desc')
+const activeSubsetIds = ref<string[]>([])
+const manualFilters = ref<FilterRequestDto>({})
+const impactExpanded = ref(false)
+const technicalExpanded = ref(false)
+const lastAppliedDefaultSort = ref<string | null>(null)
+
+type ManualFilterRemovalPayload = {
+  field: string
+  type: 'term' | 'range'
+  term: string | null
+}
+
+const hasActiveFilters = computed(
+  () => (manualFilters.value.filters?.length ?? 0) > 0 || activeSubsetIds.value.length > 0,
+)
+const showControls = computed(() => hasFastFilters.value || isDesktop.value || hasActiveFilters.value)
+
 const FILTERS_PANEL_STORAGE_KEY = 'category-page-filters-width'
 const DEFAULT_FILTERS_PANEL_WIDTH = 300
 const MIN_FILTERS_PANEL_WIDTH = 260
@@ -698,35 +720,6 @@ const filtersStyle = computed(() => {
     width: `${activeWidth}px`,
     maxWidth: `${width}px`,
   }
-})
-
-const updateControlsHeight = () => {
-  if (!isDesktop.value || !showControls.value || !controlsRef.value) {
-    controlsHeight.value = 0
-    return
-  }
-
-  controlsHeight.value = controlsRef.value.getBoundingClientRect().height
-}
-
-useResizeObserver(controlsRef, (entries) => {
-  if (!isDesktop.value || !showControls.value) {
-    return
-  }
-
-  const entry = entries[0]
-  if (entry) {
-    controlsHeight.value = entry.contentRect.height
-  }
-})
-
-watch(showControls, (visible) => {
-  if (!isDesktop.value || !visible) {
-    controlsHeight.value = 0
-    return
-  }
-
-  nextTick(() => updateControlsHeight())
 })
 
 let activePointerId: number | null = null
@@ -813,6 +806,34 @@ const onResizeHandlePointerDown = (event: PointerEvent) => {
   }
 }
 
+const updateControlsHeight = () => {
+  if (!isDesktop.value || !showControls.value || !controlsRef.value) {
+    controlsHeight.value = 0
+    return
+  }
+
+  controlsHeight.value = controlsRef.value.getBoundingClientRect().height
+}
+
+useResizeObserver(controlsRef, (entries) => {
+  if (!isDesktop.value || !showControls.value) {
+    return
+  }
+
+  const entry = entries[0]
+  if (entry) {
+    controlsHeight.value = entry.contentRect.height
+  }
+})
+
+watch(showControls, (visible) => {
+  if (!isDesktop.value || !visible) {
+    controlsHeight.value = 0
+    return
+  }
+
+  nextTick(() => updateControlsHeight())
+})
 
 watch(
   isDesktop,
@@ -851,28 +872,6 @@ watch(filtersCollapsed, (collapsed) => {
 const onToggleFiltersVisibility = () => {
   filtersCollapsed.value = !filtersCollapsed.value
 }
-
-const viewMode = ref<CategoryViewMode>(CATEGORY_DEFAULT_VIEW_MODE)
-const pageNumber = ref(0)
-const searchTerm = ref('')
-const sortField = ref<string | null>(null)
-const sortOrder = ref<'asc' | 'desc'>('desc')
-const activeSubsetIds = ref<string[]>([])
-const manualFilters = ref<FilterRequestDto>({})
-const impactExpanded = ref(false)
-const technicalExpanded = ref(false)
-const lastAppliedDefaultSort = ref<string | null>(null)
-
-type ManualFilterRemovalPayload = {
-  field: string
-  type: 'term' | 'range'
-  term: string | null
-}
-
-const hasActiveFilters = computed(
-  () => (manualFilters.value.filters?.length ?? 0) > 0 || activeSubsetIds.value.length > 0,
-)
-const showControls = computed(() => hasFastFilters.value || isDesktop.value || hasActiveFilters.value)
 
 const areFiltersEqual = (left: FilterRequestDto, right: FilterRequestDto): boolean => {
   const leftFilters = left.filters ?? []

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -197,6 +197,10 @@
       "missingLabel": "Unlabelled option",
       "mobileApply": "Apply filters",
       "mobileClear": "Clear all filters",
+      "clearAll": "Clear all filters",
+      "tooltips": {
+        "clearAll": "Remove all active filters"
+      },
       "noMatch": "No matching options",
       "rangeAriaSuffix": "range selection",
       "searchOptions": "Search options",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -197,6 +197,10 @@
       "missingLabel": "Option sans libellé",
       "mobileApply": "Appliquer les filtres",
       "mobileClear": "Effacer les filtres",
+      "clearAll": "Effacer tous les filtres",
+      "tooltips": {
+        "clearAll": "Supprimer tous les filtres actifs"
+      },
       "noMatch": "Aucune option correspondante",
       "rangeAriaSuffix": "sélection d'intervalle",
       "searchOptions": "Rechercher dans les options",


### PR DESCRIPTION
## Summary
- add a dedicated CategoryActiveFilters component with a dismiss-all action and new tests
- reposition category-page controls and toolbar to provide sticky behavior with the new active-filters zone
- update filter panel/sidebar wiring and locale strings after moving chip rendering responsibilities

## Testing
- pnpm lint
- CI=1 pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6901d0968e30833390b76db6f9195c53