### PR TITLE
feat: add breadcrumbs and sticky sidebar for wiki guides

### DIFF
--- a/frontend/app/components/category/guides/GuideStickySidebar.spec.ts
+++ b/frontend/app/components/category/guides/GuideStickySidebar.spec.ts
@@ -1,0 +1,98 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pushMock = vi.fn()
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const dictionary: Record<string, string> = {
+        'category.documentation.backToCategory': `Back to ${params?.category ?? ''}`.trim(),
+        'category.documentation.guidesTitle': 'Helpful guides',
+        'category.documentation.postsTitle': 'Related articles',
+        'category.documentation.sidebarAria': `${params?.category ?? ''} documentation navigation`.trim(),
+        'category.documentation.guidesAria': `Other guides for ${params?.category ?? ''}`.trim(),
+        'category.documentation.postsAria': `Related blog posts about ${params?.category ?? ''}`.trim(),
+      }
+
+      return dictionary[key] ?? key
+    },
+  }),
+}))
+
+const mountComponent = async (props = {}) => {
+  const module = await import('./GuideStickySidebar.vue')
+  const Component = module.default
+
+  return mount(Component, {
+    props: {
+      categoryName: 'Eco tech',
+      categoryPath: '/electronics',
+      guides: [
+        { title: 'Energy saving tips', to: '/electronics/energy' },
+        { title: 'Zero waste appliances', to: '/electronics/zero-waste' },
+      ],
+      posts: [
+        { title: 'How to reduce consumption', to: '/blog/reduce-consumption' },
+      ],
+      ...props,
+    },
+    global: {
+      stubs: {
+        NuxtLink: { template: '<a><slot /></a>' },
+        VBtn: { template: '<button><slot /></button>' },
+        VIcon: { template: '<i />' },
+      },
+    },
+  })
+}
+
+describe('GuideStickySidebar', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+  })
+
+  it('renders CTA and navigation panels', async () => {
+    const wrapper = await mountComponent()
+
+    const backCta = wrapper.get('[data-test="guide-sidebar-back"] button')
+    expect(backCta.text()).toContain('Back to Eco tech')
+
+    const guidePanel = wrapper.find('[data-test="guide-sidebar-guides"]')
+    expect(guidePanel.text()).toContain('Helpful guides')
+    expect(guidePanel.text()).toContain('Energy saving tips')
+
+    const postPanel = wrapper.find('[data-test="guide-sidebar-posts"]')
+    expect(postPanel.text()).toContain('Related articles')
+    expect(postPanel.text()).toContain('How to reduce consumption')
+  })
+
+  it('navigates to a guide when a guide item is selected', async () => {
+    const wrapper = await mountComponent()
+
+    const firstGuideButton = wrapper.get('[data-test="guide-sidebar-guides"] .sticky-section-navigation__link')
+    await firstGuideButton.trigger('click')
+
+    expect(pushMock).toHaveBeenCalledWith('/electronics/energy')
+  })
+
+  it('truncates long titles in navigation sections', async () => {
+    const longTitle = 'This is a very long guide title that should be truncated gracefully by the sidebar component'
+    const wrapper = await mountComponent({
+      guides: [
+        { title: longTitle, to: '/electronics/long-guide' },
+      ],
+      posts: [],
+    })
+
+    const guideLabel = wrapper.get('.sticky-section-navigation__label')
+    expect(guideLabel.text().endsWith('…')).toBe(true)
+    expect(guideLabel.text().length).toBeLessThan(longTitle.length)
+  })
+})

--- a/frontend/app/components/category/guides/GuideStickySidebar.vue
+++ b/frontend/app/components/category/guides/GuideStickySidebar.vue
@@ -1,0 +1,217 @@
+<template>
+  <aside
+    class="guide-sticky-sidebar"
+    :aria-label="sidebarAriaLabel"
+    data-test="guide-sticky-sidebar"
+  >
+    <div class="guide-sticky-sidebar__inner">
+      <NuxtLink
+        v-if="categoryPath"
+        :to="categoryPath"
+        class="guide-sticky-sidebar__back"
+        data-test="guide-sidebar-back"
+      >
+        <v-btn
+          block
+          color="primary"
+          prepend-icon="mdi-arrow-left"
+          size="small"
+          variant="tonal"
+        >
+          {{ backToCategoryLabel }}
+        </v-btn>
+      </NuxtLink>
+
+      <div
+        v-if="showGuides"
+        class="guide-sticky-sidebar__panel"
+        data-test="guide-sidebar-guides"
+      >
+        <h2 class="guide-sticky-sidebar__title">
+          {{ guidesTitle }}
+        </h2>
+        <StickySectionNavigation
+          :sections="guideSections"
+          :aria-label="guidesAriaLabel"
+          :sticky="false"
+          @navigate="onGuideNavigate"
+        />
+      </div>
+
+      <div
+        v-if="showPosts"
+        class="guide-sticky-sidebar__panel"
+        data-test="guide-sidebar-posts"
+      >
+        <h2 class="guide-sticky-sidebar__title">
+          {{ postsTitle }}
+        </h2>
+        <StickySectionNavigation
+          :sections="postSections"
+          :aria-label="postsAriaLabel"
+          :sticky="false"
+          @navigate="onPostNavigate"
+        />
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
+
+interface NavigationEntry {
+  title: string
+  to: string
+}
+
+const MAX_LABEL_LENGTH = 60
+
+const props = defineProps<{
+  categoryName: string
+  categoryPath?: string | null
+  guides?: NavigationEntry[]
+  posts?: NavigationEntry[]
+}>()
+
+const router = useRouter()
+const { t } = useI18n()
+
+const truncateLabel = (value: string) => {
+  const trimmed = value.trim()
+
+  if (!trimmed.length) {
+    return ''
+  }
+
+  if (trimmed.length <= MAX_LABEL_LENGTH) {
+    return trimmed
+  }
+
+  return `${trimmed.slice(0, MAX_LABEL_LENGTH - 1).trimEnd()}…`
+}
+
+const normalizedGuides = computed(() =>
+  (props.guides ?? [])
+    .filter((item) => item.title?.trim().length && item.to?.trim().length)
+    .map((item) => ({
+      id: item.to,
+      href: item.to,
+      label: truncateLabel(item.title),
+    })),
+)
+
+const normalizedPosts = computed(() =>
+  (props.posts ?? [])
+    .filter((item) => item.title?.trim().length && item.to?.trim().length)
+    .map((item) => ({
+      id: item.to,
+      href: item.to,
+      label: truncateLabel(item.title),
+    })),
+)
+
+const guideSections = computed(() =>
+  normalizedGuides.value.map((item) => ({
+    id: item.id,
+    label: item.label,
+    icon: 'mdi-compass-outline',
+  })),
+)
+
+const postSections = computed(() =>
+  normalizedPosts.value.map((item) => ({
+    id: item.id,
+    label: item.label,
+    icon: 'mdi-post-outline',
+  })),
+)
+
+const guideLookup = computed(() => new Map(normalizedGuides.value.map((item) => [item.id, item.href])))
+const postLookup = computed(() => new Map(normalizedPosts.value.map((item) => [item.id, item.href])))
+
+const showGuides = computed(() => guideSections.value.length > 0)
+const showPosts = computed(() => postSections.value.length > 0)
+
+const sidebarAriaLabel = computed(() =>
+  t('category.documentation.sidebarAria', { category: props.categoryName }),
+)
+
+const guidesTitle = computed(() => t('category.documentation.guidesTitle'))
+const postsTitle = computed(() => t('category.documentation.postsTitle'))
+const guidesAriaLabel = computed(() =>
+  t('category.documentation.guidesAria', { category: props.categoryName }),
+)
+const postsAriaLabel = computed(() =>
+  t('category.documentation.postsAria', { category: props.categoryName }),
+)
+const backToCategoryLabel = computed(() =>
+  t('category.documentation.backToCategory', { category: props.categoryName }),
+)
+
+const onGuideNavigate = (id: string) => {
+  const target = guideLookup.value.get(id)
+
+  if (target) {
+    router.push(target)
+  }
+}
+
+const onPostNavigate = (id: string) => {
+  const target = postLookup.value.get(id)
+
+  if (target) {
+    router.push(target)
+  }
+}
+</script>
+
+<style scoped lang="sass">
+.guide-sticky-sidebar
+  position: relative
+  display: block
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__inner
+    position: sticky
+    top: clamp(80px, 12vw, 104px)
+    display: flex
+    flex-direction: column
+    gap: 1.5rem
+
+  &__back
+    text-decoration: none
+
+  &__panel
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    padding: 1rem
+    border-radius: 20px
+    background: rgba(var(--v-theme-surface-glass), 0.9)
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08)
+    backdrop-filter: blur(10px)
+
+  &__title
+    margin: 0
+    font-size: 0.95rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+@media (max-width: 960px)
+  .guide-sticky-sidebar
+    margin-bottom: 1.5rem
+
+    &__inner
+      position: static
+      gap: 1rem
+
+    &__panel
+      padding: 0.75rem
+      border-radius: 16px
+      box-shadow: none
+      background: rgba(var(--v-theme-surface-glass), 0.85)
+</style>

--- a/frontend/app/components/cms/XwikiFullPageRenderer.spec.ts
+++ b/frontend/app/components/cms/XwikiFullPageRenderer.spec.ts
@@ -1,0 +1,166 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { h, ref } from 'vue'
+
+const useFullPageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~/assets/css/text-content.css', () => ({}))
+
+vi.mock('~/composables/cms/useFullPage', () => ({
+  useFullPage: useFullPageMock,
+}))
+
+vi.mock('~/components/category/navigation/CategoryNavigationBreadcrumbs.vue', () => ({
+  default: {
+    name: 'CategoryNavigationBreadcrumbs',
+    props: {
+      items: {
+        type: Array,
+        default: () => [],
+      },
+      ariaLabel: {
+        type: String,
+        default: '',
+      },
+    },
+    template: `
+      <nav class="category-navigation-breadcrumbs" :aria-label="ariaLabel">
+        <ol>
+          <li
+            v-for="(item, index) in items"
+            :key="index"
+            class="category-navigation-breadcrumbs__item"
+          >
+            <a v-if="item.link" :href="item.link">{{ item.title }}</a>
+            <span v-else>{{ item.title }}</span>
+          </li>
+        </ol>
+      </nav>
+    `,
+  },
+}))
+
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({
+    isLoggedIn: ref(false),
+    hasRole: vi.fn(() => false),
+  }),
+}))
+
+vi.mock('#app', () => ({
+  useRuntimeConfig: () => ({ public: { editRoles: [] } }),
+}))
+
+vi.mock('#imports', () => ({
+  useSeoMeta: vi.fn(),
+  useI18n: () => ({
+    t: (key: string) => {
+      const dictionary: Record<string, string> = {
+        'cms.page.error': 'Unable to load content',
+        'common.actions.retry': 'Retry',
+        'cms.page.loading': 'Loading',
+        'cms.page.edit': 'Edit',
+        'category.hero.breadcrumbAriaLabel': 'Category navigation breadcrumb',
+      }
+
+      return dictionary[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const dictionary: Record<string, string> = {
+        'cms.page.error': 'Unable to load content',
+        'common.actions.retry': 'Retry',
+        'cms.page.loading': 'Loading',
+        'cms.page.edit': 'Edit',
+        'category.hero.breadcrumbAriaLabel': 'Category navigation breadcrumb',
+      }
+
+      return dictionary[key] ?? key
+    },
+  }),
+}))
+
+const createFullPageResponse = () => ({
+  width: ref('container'),
+  pageTitle: ref('Guide Title'),
+  metaTitle: ref('Guide Title'),
+  metaDescription: ref('Meta description'),
+  htmlContent: ref('<p>Guide content</p>'),
+  editLink: ref<string | null>(null),
+  pending: ref(false),
+  error: ref(null),
+  refresh: vi.fn(),
+})
+
+const mountComponent = async (
+  props: Record<string, unknown> = {},
+  slots: Record<string, () => ReturnType<typeof h>> = {},
+) => {
+  const module = await import('./XwikiFullPageRenderer.vue')
+  const Component = module.default
+
+  const wrapper = await mountSuspended(Component, {
+    props: {
+      pageId: 'Main.WebHome',
+      ...props,
+    },
+    slots,
+    global: {
+      stubs: {
+        VContainer: { template: '<div class="v-container"><slot /></div>' },
+        VSheet: { template: '<div class="v-sheet"><slot /></div>' },
+        VBtn: { template: '<button><slot /></button>' },
+        VProgressLinear: { template: '<div class="v-progress-linear" />' },
+        VAlert: { template: '<div class="v-alert"><slot /></div>' },
+        NuxtLink: { template: '<a><slot /></a>' },
+      },
+    },
+  })
+
+  await flushPromises()
+  return wrapper
+}
+
+describe('XwikiFullPageRenderer', () => {
+  beforeEach(() => {
+    useFullPageMock.mockResolvedValue(createFullPageResponse())
+  })
+
+  it('renders hero breadcrumbs when provided', async () => {
+    const wrapper = await mountComponent({
+      breadcrumbs: [
+        { title: 'Home', link: '/' },
+        { title: 'Appliances', link: '/appliances' },
+        { title: 'Deep dive' },
+      ],
+    })
+
+    const breadcrumbItems = wrapper.findAll('.category-navigation-breadcrumbs__item')
+    expect(breadcrumbItems).toHaveLength(3)
+
+    const firstLink = breadcrumbItems.at(0)?.find('a')
+    expect(firstLink?.exists()).toBe(true)
+    expect(firstLink?.text()).toBe('Home')
+
+    const lastItem = breadcrumbItems.at(2)
+    expect(lastItem?.find('a').exists()).toBe(false)
+    expect(lastItem?.text()).toContain('Deep dive')
+  })
+
+  it('renders sidebar content when provided through slot', async () => {
+    const wrapper = await mountComponent({}, {
+      sidebar: () => h('div', { 'data-test': 'sidebar-slot' }, 'Sidebar content'),
+    })
+
+    const layout = wrapper.get('.cms-page__layout')
+    expect(layout.classes()).toContain('cms-page__layout--with-sidebar')
+
+    const sidebar = wrapper.get('.cms-page__sidebar')
+    expect(sidebar.text()).toContain('Sidebar content')
+  })
+})

--- a/frontend/app/components/shared/ui/StickySectionNavigation.vue
+++ b/frontend/app/components/shared/ui/StickySectionNavigation.vue
@@ -1,7 +1,10 @@
 <template>
   <nav
     class="sticky-section-navigation"
-    :class="`sticky-section-navigation--${orientation}`"
+    :class="[
+      `sticky-section-navigation--${orientation}`,
+      { 'sticky-section-navigation--sticky': sticky },
+    ]"
     :aria-label="ariaLabel"
   >
     <ul class="sticky-section-navigation__list">
@@ -49,6 +52,10 @@ const _props = defineProps({
     type: String,
     default: 'Page navigation',
   },
+  sticky: {
+    type: Boolean,
+    default: true,
+  },
 })
 
 const emit = defineEmits<{ navigate: [string] }>()
@@ -60,14 +67,19 @@ const onNavigate = (sectionId: string) => {
 
 <style scoped>
 .sticky-section-navigation {
-  position: sticky;
-  top: 96px;
+  position: relative;
+  top: auto;
   z-index: 10;
   padding: 1.5rem 1rem;
   border-radius: 18px;
   background: rgba(var(--v-theme-surface-glass));
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(10px);
+}
+
+.sticky-section-navigation--sticky {
+  position: sticky;
+  top: 96px;
 }
 
 .sticky-section-navigation--horizontal {
@@ -140,6 +152,10 @@ const onNavigate = (sectionId: string) => {
 
 .sticky-section-navigation--horizontal .sticky-section-navigation__link {
   justify-content: center;
+}
+
+.sticky-section-navigation--horizontal.sticky-section-navigation--sticky {
+  top: 0;
 }
 
 @media (max-width: 960px) {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -81,7 +81,11 @@
   "category": {
     "documentation": {
       "guidesTitle": "Helpful guides",
-      "postsTitle": "Related articles"
+      "postsTitle": "Related articles",
+      "backToCategory": "Back to {category}",
+      "sidebarAria": "{category} documentation navigation",
+      "guidesAria": "Other guides for {category}",
+      "postsAria": "Related blog posts about {category}"
     },
     "ecoscorePage": {
       "breadcrumbLeaf": "impactscore",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -82,7 +82,7 @@
     "documentation": {
       "guidesTitle": "Guides utiles",
       "postsTitle": "Articles associés",
-      "backToCategory": "Retour à {category}",
+      "backToCategory": "Retour aux {category}",
       "sidebarAria": "Navigation de documentation pour {category}",
       "guidesAria": "Autres guides pour {category}",
       "postsAria": "Articles de blog liés à {category}"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -81,7 +81,11 @@
   "category": {
     "documentation": {
       "guidesTitle": "Guides utiles",
-      "postsTitle": "Articles associés"
+      "postsTitle": "Articles associés",
+      "backToCategory": "Retour à {category}",
+      "sidebarAria": "Navigation de documentation pour {category}",
+      "guidesAria": "Autres guides pour {category}",
+      "postsAria": "Articles de blog liés à {category}"
     },
     "ecoscorePage": {
       "breadcrumbLeaf": "impactscore",


### PR DESCRIPTION
## Summary
- add hero breadcrumb data for wiki guides and wire it through the CMS renderer hero
- introduce a reusable guide sticky sidebar with category CTA, guide links, and related posts
- extend sticky navigation options, add i18n strings, and cover the new behaviour with unit tests

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6901d47e71d4833398a75cc2844124de