### PR TITLE
Refine product hero layout and pricing currency

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, onMounted, ref, type PropType } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { createI18n } from 'vue-i18n'
-import type { ProductDto } from '~~/shared/api-client'
+import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import ProductHero from './ProductHero.vue'
 import { useProductCompareStore } from '~/stores/useProductCompareStore'
 
@@ -219,9 +219,14 @@ describe('ProductHero', () => {
     { title: 'Demo Product', link: '/appliances/demo-product' },
   ]
 
+  const popularAttributes = [
+    { key: 'identity.model', name: 'Model' },
+    { key: 'base.gtinInfo.countryName', name: 'Origin' },
+  ] as AttributeConfigDto[]
+
   const mountComponent = async () =>
     await mountSuspended(ProductHero, {
-      props: { product, breadcrumbs },
+      props: { product, breadcrumbs, popularAttributes },
       global: {
         plugins: [i18n],
         stubs: {
@@ -353,6 +358,22 @@ describe('ProductHero', () => {
     await wrapper.unmount()
   })
 
+  it('displays brand, model and popular attributes beneath the title', async () => {
+    const wrapper = await mountComponent()
+
+    expect(wrapper.get('.product-hero__title').text()).toBe('Demo Product')
+    expect(wrapper.get('.product-hero__brand-line').text()).toBe('BrandCo - Model X')
+
+    const attributes = wrapper.findAll('.product-hero__attribute')
+    expect(attributes).toHaveLength(2)
+    expect(attributes[0]?.text()).toContain('Model')
+    expect(attributes[0]?.text()).toContain('Model X')
+    expect(attributes[1]?.text()).toContain('Origin')
+    expect(attributes[1]?.text()).toContain('France')
+
+    await wrapper.unmount()
+  })
+
   it('toggles compare state with visual feedback', async () => {
     const wrapper = await mountComponent()
     const store = useProductCompareStore()
@@ -404,7 +425,8 @@ describe('ProductHero', () => {
     expect(chips[0]?.classes()).toContain('product-hero__price-chip--active')
 
     const priceValue = wrapper.get('.product-hero__price-value')
-    expect(priceValue.text()).toBe('€649')
+    expect(priceValue.text()).toBe('649')
+    expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
 
     const merchantLink = wrapper.get('.product-hero__price-merchant-link')
     expect(merchantLink.text()).toContain('Merchant U')
@@ -422,7 +444,8 @@ describe('ProductHero', () => {
     await wrapper.vm.$nextTick()
 
     expect(chips[1]?.classes()).toContain('product-hero__price-chip--active')
-    expect(priceValue.text()).toBe('€799')
+    expect(priceValue.text()).toBe('799')
+    expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
 
     const refreshedMerchantLink = wrapper.get('.product-hero__price-merchant-link')
     expect(refreshedMerchantLink.text()).toContain('Shop')

--- a/frontend/app/components/product/ProductHeroPricing.spec.ts
+++ b/frontend/app/components/product/ProductHeroPricing.spec.ts
@@ -133,14 +133,16 @@ describe('ProductHeroPricing', () => {
     const chips = wrapper.findAll('.product-hero__price-chip')
     expect(chips).toHaveLength(2)
     expect(chips[0]?.classes()).toContain('product-hero__price-chip--active')
-    expect(wrapper.get('.product-hero__price-value').text()).toBe('€649')
+    expect(wrapper.get('.product-hero__price-value').text()).toBe('649')
+    expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
     expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Merchant U')
 
     await chips[1]?.trigger('click')
     await wrapper.vm.$nextTick()
 
     expect(chips[1]?.classes()).toContain('product-hero__price-chip--active')
-    expect(wrapper.get('.product-hero__price-value').text()).toBe('€799')
+    expect(wrapper.get('.product-hero__price-value').text()).toBe('799')
+    expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
     expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Shop')
 
     await wrapper.unmount()
@@ -172,6 +174,33 @@ describe('ProductHeroPricing', () => {
     const clientOnlyLink = wrapper.get('.client-only-stub .product-hero__price-merchant-link')
     expect(clientOnlyLink.attributes('href')).toBe('/contrib/abc123')
     expect(clientOnlyLink.attributes('target')).toBeUndefined()
+
+    await wrapper.unmount()
+  })
+
+  it('falls back to currency code when highlighting non-euro prices', async () => {
+    const wrapper = await createWrapper({
+      offersCount: 2,
+      bestPrice: {
+        price: 120,
+        currency: 'USD',
+        datasourceName: 'US Shop',
+        url: 'https://us-shop.example',
+        favicon: 'https://us-shop.example/favicon.ico',
+        condition: 'NEW',
+      },
+      bestNewOffer: {
+        price: 120,
+        currency: 'USD',
+        datasourceName: 'US Shop',
+        url: 'https://us-shop.example',
+        favicon: 'https://us-shop.example/favicon.ico',
+        condition: 'NEW',
+      },
+    })
+
+    expect(wrapper.get('.product-hero__price-value').text()).toBe('$120')
+    expect(wrapper.get('.product-hero__price-currency').text()).toBe('USD')
 
     await wrapper.unmount()
   })

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -29,7 +29,11 @@
 
       <main class="product-page__content">
         <section :id="sectionIds.hero" class="product-page__section">
-          <ProductHero :product="product" :breadcrumbs="productBreadcrumbs" />
+          <ProductHero
+            :product="product"
+            :breadcrumbs="productBreadcrumbs"
+            :popular-attributes="heroPopularAttributes"
+          />
         </section>
 
         <section
@@ -288,6 +292,8 @@ const productTitle = computed(() => {
     `GTIN ${product.value?.gtin ?? gtin}`
   )
 })
+
+const heroPopularAttributes = computed(() => categoryDetail.value?.popularAttributes ?? [])
 
 const productBreadcrumbs = computed<ProductHeroBreadcrumb[]>(() => {
   const breadcrumbs = categoryDetail.value?.breadCrumb ?? []


### PR DESCRIPTION
## Summary
- reorder the product hero content so the best name, brand/model line, popular attributes, impact score, origin and compare action appear in the requested order
- derive and render popular attributes from category configuration while keeping accessibility-focused spacing updates in the hero card
- adjust hero pricing to show the euro symbol instead of the ISO code and extend component tests to cover both euro and non-euro pricing

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6901d7318f148333b14a84b1dcae2044