### PR TITLE
feat(frontend): move active filters to standalone bar

### DIFF
--- a/frontend/app/components/category/CategoryActiveFilters.spec.ts
+++ b/frontend/app/components/category/CategoryActiveFilters.spec.ts
@@ -1,0 +1,129 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import CategoryActiveFilters from './CategoryActiveFilters.vue'
+import type { CategorySubsetClause } from '~/types/category-subset'
+import type { FilterRequestDto, ProductFieldOptionsResponse } from '~~/shared/api-client'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const VChipStub = defineComponent({
+  name: 'VChip',
+  emits: ['click:close'],
+  setup(_, { slots, emit, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['v-chip-stub', attrs.class].filter(Boolean).join(' '),
+          type: 'button',
+          onClick: () => emit('click:close'),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  emits: ['click'],
+  setup(_, { slots, emit, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          type: 'button',
+          class: ['v-btn-stub', attrs.class].filter(Boolean).join(' '),
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: { icon: { type: String, default: '' } },
+  setup(props) {
+    return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-tooltip-stub' }, slots.default?.())
+  },
+})
+
+describe('CategoryActiveFilters', () => {
+  const subsetClause: CategorySubsetClause = {
+    id: 'subset-0',
+    subsetId: 'subset',
+    index: 0,
+    label: 'Energy rating A',
+    filter: { field: 'energy', operator: 'term', terms: ['A'] },
+  }
+
+  const manualFilters: FilterRequestDto = {
+    filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
+  }
+
+  const filterOptions: ProductFieldOptionsResponse = {
+    global: [
+      {
+        mapping: 'brand',
+        type: 'keyword',
+        label: 'Brand',
+      },
+    ],
+    impact: [],
+    technical: [],
+  }
+
+  it('renders active filters and emits events for removal and clearing', () => {
+    const wrapper = mount(CategoryActiveFilters, {
+      props: {
+        filters: manualFilters,
+        subsetClauses: [subsetClause],
+        filterOptions,
+      },
+      global: {
+        stubs: {
+          VChip: VChipStub,
+          VBtn: VBtnStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    const chips = wrapper.findAll('.v-chip-stub')
+    expect(chips).toHaveLength(2)
+    expect(chips[0]?.text()).toContain('Energy rating A')
+    expect(chips[1]?.text()).toContain('brand: Acme')
+
+    chips[0]?.trigger('click')
+    const subsetEvents = wrapper.emitted('remove-subset-clause') ?? []
+    expect(subsetEvents).toHaveLength(1)
+    expect(subsetEvents[0]?.[0]).toEqual(subsetClause)
+
+    chips[1]?.trigger('click')
+    const filterEvents = wrapper.emitted('update:filters') ?? []
+    expect(filterEvents).toHaveLength(1)
+    expect(filterEvents[0]?.[0]).toEqual({})
+
+    const clearButton = wrapper.get('.v-btn-stub')
+    clearButton.trigger('click')
+
+    const clearEvents = wrapper.emitted('clear-all') ?? []
+    expect(clearEvents).toHaveLength(1)
+  })
+})

--- a/frontend/app/components/category/CategoryActiveFilters.vue
+++ b/frontend/app/components/category/CategoryActiveFilters.vue
@@ -1,0 +1,217 @@
+<template>
+  <div
+    v-if="activeChips.length"
+    class="category-active-filters"
+    data-testid="category-active-filters"
+    :aria-label="t('category.filters.activeTitle')"
+  >
+    <div class="category-active-filters__chips">
+      <span class="category-active-filters__label">{{ t('category.filters.activeTitle') }}</span>
+
+      <v-chip
+        v-for="chip in activeChips"
+        :key="chip.id"
+        closable
+        color="primary"
+        variant="flat"
+        size="small"
+        class="category-active-filters__chip"
+        @click:close="onRemoveChip(chip)"
+      >
+        <span>{{ chip.label }}</span>
+      </v-chip>
+    </div>
+
+    <div class="category-active-filters__actions">
+      <v-tooltip :text="t('category.filters.clearActive')" location="bottom">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            icon
+            variant="text"
+            color="primary"
+            v-bind="tooltipProps"
+            :aria-label="t('category.filters.clearActive')"
+            @click="emit('clear-all')"
+          >
+            <v-icon icon="mdi-close-circle-outline" />
+          </v-btn>
+        </template>
+      </v-tooltip>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  FieldMetadataDto,
+  Filter,
+  FilterRequestDto,
+  ProductFieldOptionsResponse,
+} from '~~/shared/api-client'
+
+import type { CategorySubsetClause } from '~/types/category-subset'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
+
+type ManualFilterChip = {
+  kind: 'manual'
+  id: string
+  field: string
+  type: 'term' | 'range'
+  term: string | null
+  label: string
+}
+
+type SubsetFilterChip = {
+  kind: 'subset'
+  id: string
+  label: string
+  clause: CategorySubsetClause
+}
+
+type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
+
+const props = withDefaults(
+  defineProps<{
+    filters: FilterRequestDto | null
+    subsetClauses?: CategorySubsetClause[]
+    filterOptions: ProductFieldOptionsResponse | null
+  }>(),
+  {
+    subsetClauses: () => [],
+  },
+)
+
+const emit = defineEmits<{
+  'update:filters': [FilterRequestDto]
+  'remove-subset-clause': [CategorySubsetClause]
+  'clear-all': []
+}>()
+
+const activeFilters = computed(() => props.filters?.filters ?? [])
+const subsetClauses = computed(() => props.subsetClauses ?? [])
+
+const { t } = useI18n()
+
+const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(() => {
+  const entries = [
+    ...(props.filterOptions?.global ?? []),
+    ...(props.filterOptions?.impact ?? []),
+    ...(props.filterOptions?.technical ?? []),
+  ]
+
+  return entries.reduce<Record<string, FieldMetadataDto>>((accumulator, field) => {
+    if (field.mapping) {
+      accumulator[field.mapping] = field
+    }
+
+    return accumulator
+  }, {})
+})
+
+const manualFilterChips = computed<ManualFilterChip[]>(() => {
+  return activeFilters.value.map((filter) => {
+    const mapping = filter.field ?? ''
+    const metadata = mapping ? fieldMetadataMap.value[mapping] : undefined
+    const label = resolveFilterFieldTitle(metadata, t, mapping)
+
+    if (filter.operator === 'term') {
+      const term = filter.terms?.[0] ?? ''
+      return {
+        kind: 'manual' as const,
+        id: `${mapping}-${term}`,
+        field: mapping,
+        type: 'term' as const,
+        term,
+        label: term ? `${label}: ${term}` : label,
+      }
+    }
+
+    return {
+      kind: 'manual' as const,
+      id: `${mapping}-range`,
+      field: mapping,
+      type: 'range' as const,
+      term: null,
+      label: `${label}: ${filter.min ?? '–'} → ${filter.max ?? '–'}`,
+    }
+  })
+})
+
+const subsetFilterChips = computed<SubsetFilterChip[]>(() => {
+  return subsetClauses.value.map((clause) => ({
+    kind: 'subset' as const,
+    id: clause.id,
+    label: clause.label,
+    clause,
+  }))
+})
+
+const activeChips = computed<ActiveFilterChip[]>(() => {
+  return [...subsetFilterChips.value, ...manualFilterChips.value]
+})
+
+const emitFilters = (filters: Filter[]) => {
+  emit('update:filters', filters.length ? { filters } : {})
+}
+
+const removeManualFilter = (field: string, type: 'term' | 'range', term: string | null) => {
+  const next = activeFilters.value.filter((filter) => {
+    if (filter.field !== field) {
+      return true
+    }
+
+    if (type === 'term') {
+      return !(filter.operator === 'term' && filter.terms?.includes(term ?? ''))
+    }
+
+    return !(filter.operator === 'range')
+  })
+
+  emitFilters(next)
+}
+
+const onRemoveChip = (chip: ActiveFilterChip) => {
+  if (chip.kind === 'subset') {
+    emit('remove-subset-clause', chip.clause)
+    return
+  }
+
+  removeManualFilter(chip.field, chip.type, chip.term)
+}
+</script>
+
+<style scoped lang="sass">
+.category-active-filters
+  display: flex
+  flex-wrap: wrap
+  align-items: flex-start
+  gap: 0.75rem
+  padding: 0.75rem
+  border-radius: 0.75rem
+  background: rgb(var(--v-theme-surface-glass))
+
+  &__chips
+    flex: 1 1 auto
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    gap: 0.5rem
+
+  &__label
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__chip
+    --v-chip-height: 32px
+
+  &__actions
+    flex: 0 0 auto
+    display: flex
+    align-items: center
+    margin-left: auto
+
+@media (max-width: 599px)
+  .category-active-filters
+    padding: 0.5rem 0.75rem

--- a/frontend/app/components/category/CategoryFiltersPanel.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersPanel.spec.ts
@@ -2,7 +2,6 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
 import type { FilterRequestDto } from '~~/shared/api-client'
 
 vi.mock('vue-i18n', () => ({
@@ -10,67 +9,6 @@ vi.mock('vue-i18n', () => ({
     t: (key: string) => key,
   }),
 }))
-
-const resolveClassList = (value: unknown): string => {
-  if (!value) {
-    return ''
-  }
-
-  if (typeof value === 'string') {
-    return value
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((entry) => resolveClassList(entry)).filter(Boolean).join(' ')
-  }
-
-  if (typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>)
-      .filter(([, active]) => Boolean(active))
-      .map(([name]) => name)
-      .join(' ')
-  }
-
-  return String(value)
-}
-
-const VChipGroupStub = defineComponent({
-  name: 'VChipGroup',
-  setup(_, { slots, attrs }) {
-    const className = ['v-chip-group-stub', resolveClassList((attrs as Record<string, unknown>).class)]
-      .filter(Boolean)
-      .join(' ')
-
-    return () => h('div', { ...attrs, class: className }, slots.default?.())
-  },
-})
-
-const VChipStub = defineComponent({
-  name: 'VChip',
-  props: {
-    closable: { type: Boolean, default: false },
-    variant: { type: String, default: 'flat' },
-  },
-  emits: ['click:close'],
-  setup(props, { slots, emit, attrs }) {
-    const className = ['v-chip-stub', resolveClassList((attrs as Record<string, unknown>).class)]
-      .filter(Boolean)
-      .join(' ')
-
-    return () =>
-      h(
-        'button',
-        {
-          ...attrs,
-          class: className,
-          type: 'button',
-          'data-closable': props.closable ? 'true' : 'false',
-          onClick: () => emit('click:close'),
-        },
-        slots.default?.(),
-      )
-  },
-})
 
 const VIconStub = defineComponent({
   name: 'VIcon',
@@ -105,7 +43,6 @@ const VBtnStub = defineComponent({
         'button',
         {
           ...attrs,
-          class: ['v-btn-stub', resolveClassList((attrs as Record<string, unknown>).class)].join(' '),
           type: props.type,
           onClick: (event: MouseEvent) => emit('click', event),
         },
@@ -122,19 +59,11 @@ const CategoryFilterListStub = defineComponent({
 })
 
 describe('CategoryFiltersPanel', () => {
-  const subsetClause: CategorySubsetClause = {
-    id: 'subset-0',
-    subsetId: 'subset',
-    index: 0,
-    label: 'Price ≤ 500',
-    filter: { field: 'price.min', operator: 'range', max: 500 },
-  }
-
   const manualFilters: FilterRequestDto = {
     filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
   }
 
-  it('renders subset and manual filter chips together and emits removal events', () => {
+  it('emits updated filters when a range filter changes', () => {
     const wrapper = mount(CategoryFiltersPanel, {
       props: {
         filterOptions: null,
@@ -142,12 +71,9 @@ describe('CategoryFiltersPanel', () => {
         filters: manualFilters,
         impactExpanded: false,
         technicalExpanded: false,
-        subsetClauses: [subsetClause],
       },
       global: {
         stubs: {
-          VChipGroup: VChipGroupStub,
-          VChip: VChipStub,
           VIcon: VIconStub,
           VExpansionPanels: VExpansionPanelsStub,
           VExpansionPanel: VExpansionPanelStub,
@@ -157,16 +83,24 @@ describe('CategoryFiltersPanel', () => {
       },
     })
 
-    const chips = wrapper.findAll('.v-chip-stub')
-    expect(chips).toHaveLength(2)
+    const lists = wrapper.findAllComponents(CategoryFilterListStub)
+    expect(lists).not.toHaveLength(0)
 
-    expect(chips[0]?.text()).toContain('Price ≤ 500')
-    expect(chips[1]?.text()).toContain('brand: Acme')
+    lists[0]?.vm.$emit('update-range', 'price.min', { min: 10 })
 
-    chips[0]?.trigger('click')
+    let emitted = wrapper.emitted('update:filters') ?? []
+    expect(emitted[0]?.[0]).toEqual({
+      filters: [
+        { field: 'brand', operator: 'term', terms: ['Acme'] },
+        { field: 'price.min', operator: 'range', min: 10, max: undefined },
+      ],
+    })
 
-    const removalEvents = wrapper.emitted('remove-subset-clause') ?? []
-    expect(removalEvents).toHaveLength(1)
-    expect(removalEvents[0]?.[0]).toEqual(subsetClause)
+    lists[0]?.vm.$emit('update-range', 'price.min', {})
+
+    emitted = wrapper.emitted('update:filters') ?? []
+    expect(emitted[1]?.[0]).toEqual({
+      filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
+    })
   })
 })

--- a/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
@@ -56,7 +56,6 @@ describe('CategoryFiltersSidebar', () => {
     wikiPages: [],
     relatedPosts: [],
     verticalHomeUrl: 'https://open4goods.example/maison',
-    subsetClauses: [],
   }
 
   const mountComponent = (overrides: Partial<typeof baseProps> = {}) =>

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -7,11 +7,9 @@
       :filters="props.filters"
       :impact-expanded="props.impactExpanded"
       :technical-expanded="props.technicalExpanded"
-      :subset-clauses="props.subsetClauses"
       @update:filters="(value) => emit('update:filters', value)"
       @update:impact-expanded="(value) => emit('update:impactExpanded', value)"
       @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
-      @remove-subset-clause="(clause) => emit('remove-subset-clause', clause)"
     />
 
     <div v-if="showMobileActions" class="category-page__filters-actions">
@@ -55,8 +53,6 @@ import type {
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
 import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
-
 const props = withDefaults(
   defineProps<{
     filterOptions: ProductFieldOptionsResponse | null
@@ -70,7 +66,6 @@ const props = withDefaults(
     wikiPages: WikiPageConfig[]
     relatedPosts: BlogPostDto[]
     verticalHomeUrl?: string | null
-    subsetClauses: CategorySubsetClause[]
   }>(),
   {
     baselineAggregations: () => [],
@@ -84,7 +79,6 @@ const emit = defineEmits<{
   'update:technicalExpanded': [boolean]
   'apply-mobile': []
   'clear-mobile': []
-  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const { t } = useI18n()

--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -51,6 +51,17 @@
         />
       </div>
 
+      <CategoryActiveFilters
+        v-if="hasActiveFilters"
+        class="category-page__active-filters mb-6"
+        :filters="manualFilters"
+        :subset-clauses="activeSubsetClauses"
+        :filter-options="filterOptions"
+        @update:filters="onFiltersChange"
+        @remove-subset-clause="onRemoveSubsetClause"
+        @clear-all="clearActiveFilters"
+      />
+
       <div ref="layoutRef" class="category-page__layout" :style="layoutStyle">
         <template v-if="!isDesktop">
           <v-navigation-drawer
@@ -72,7 +83,6 @@
               :wiki-pages="category?.wikiPages ?? []"
               :related-posts="category?.relatedPosts ?? []"
               :vertical-home-url="category?.verticalHomeUrl ?? null"
-              :subset-clauses="activeSubsetClauses"
               @update:filters="onFiltersChange"
               @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
               @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
@@ -107,7 +117,6 @@
               :wiki-pages="category?.wikiPages ?? []"
               :related-posts="category?.relatedPosts ?? []"
               :vertical-home-url="category?.verticalHomeUrl ?? null"
-              :subset-clauses="activeSubsetClauses"
               @update:filters="onFiltersChange"
               @update:impact-expanded="(value: boolean) => (impactExpanded = value)"
               @update:technical-expanded="(value: boolean) => (technicalExpanded = value)"
@@ -989,6 +998,11 @@ const activeSubsetClauses = computed<CategorySubsetClause[]>(() => {
   })
 })
 
+const hasActiveFilters = computed(() => {
+  const manualCount = manualFilters.value.filters?.length ?? 0
+  return manualCount > 0 || activeSubsetClauses.value.length > 0
+})
+
 const combinedFilters = computed<FilterRequestDto | undefined>(() => {
   const subsetClauses = subsetFilters.value.filters ?? []
   const manualClauses = manualFilters.value.filters ?? []
@@ -1654,6 +1668,11 @@ const onRemoveSubsetClause = (clause: CategorySubsetClause) => {
   manualFilters.value = merged.length ? { filters: merged } : {}
 }
 
+const clearActiveFilters = () => {
+  manualFilters.value = {}
+  activeSubsetIds.value = []
+}
+
 const onResetSubsets = () => {
   activeSubsetIds.value = []
 }
@@ -1768,6 +1787,9 @@ const clearAllFilters = () => {
   &__fast-filters-groups
     flex: 1 1 auto
     min-width: 0
+
+  &__active-filters
+    width: 100%
 
   &__search
     position: relative

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -185,6 +185,8 @@
       "reset": "Clear fast filters"
     },
     "filters": {
+      "activeTitle": "Active filters",
+      "clearActive": "Clear all active filters",
       "fields": {
         "brand": "Brand",
         "condition": "Offer condition",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -185,6 +185,8 @@
       "reset": "Réinitialiser les filtres rapides"
     },
     "filters": {
+      "activeTitle": "Filtres actifs",
+      "clearActive": "Retirer tous les filtres actifs",
       "fields": {
         "brand": "Marque",
         "condition": "État des offres",


### PR DESCRIPTION
## Summary
- add a dedicated CategoryActiveFilters component that lists active manual and subset filters with a global clear control
- remove inline chip rendering from CategoryFiltersPanel and render the new bar beneath the fast filters on the category page
- localize the new labels and update component tests for the revised behaviour

## Testing
- pnpm lint
- pnpm test *(fails: environment provides Node 18 and lacks crypto.hash; requires Node >= 20)*
- pnpm generate *(fails: environment provides Node 18 and lacks crypto.hash; requires Node >= 20)*

------
https://chatgpt.com/codex/tasks/task_e_6901f114f1c48333b9442abc4719083f