### PR TITLE
feat(frontend): reorganize category active filters

### DIFF
--- a/frontend/app/components/category/CategoryActiveFilters.spec.ts
+++ b/frontend/app/components/category/CategoryActiveFilters.spec.ts
@@ -1,0 +1,172 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import CategoryActiveFilters from './CategoryActiveFilters.vue'
+import type { CategorySubsetClause } from '~/types/category-subset'
+import type { FieldMetadataDto, FilterRequestDto } from '~~/shared/api-client'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const resolveClassList = (value: unknown): string => {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => resolveClassList(entry)).filter(Boolean).join(' ')
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, active]) => Boolean(active))
+      .map(([name]) => name)
+      .join(' ')
+  }
+
+  return String(value)
+}
+
+const VChipStub = defineComponent({
+  name: 'VChip',
+  props: { closable: { type: Boolean, default: false } },
+  emits: ['click:close'],
+  setup(props, { attrs, slots, emit }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['v-chip-stub', resolveClassList((attrs as Record<string, unknown>).class)].join(' '),
+          type: 'button',
+          'data-closable': props.closable ? 'true' : 'false',
+          onClick: () => emit('click:close'),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  emits: ['click'],
+  setup(_, { attrs, slots, emit }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: ['v-btn-stub', resolveClassList((attrs as Record<string, unknown>).class)].join(' '),
+          type: 'button',
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: { icon: { type: String, default: '' } },
+  setup(props) {
+    return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  props: { text: { type: String, default: '' } },
+  setup(_, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub' }, [
+        slots.activator?.({ props: {} }),
+        slots.default?.(),
+      ])
+  },
+})
+
+describe('CategoryActiveFilters', () => {
+  const subsetClause: CategorySubsetClause = {
+    id: 'subset-0',
+    subsetId: 'subset',
+    index: 0,
+    label: 'Subset filter',
+    filter: { field: 'price', operator: 'term', terms: ['500'] },
+  }
+
+  const manualFilters: FilterRequestDto = {
+    filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
+  }
+
+  const fieldMetadata: Record<string, FieldMetadataDto> = {
+    brand: { mapping: 'brand', title: 'Brand' } as FieldMetadataDto,
+  }
+
+  type ComponentProps = {
+    filters: FilterRequestDto | null
+    subsetClauses: CategorySubsetClause[]
+    fieldMetadata: Record<string, FieldMetadataDto>
+  }
+
+  const mountComponent = (overrides: Partial<ComponentProps> = {}) =>
+    mount(CategoryActiveFilters, {
+      props: {
+        filters: manualFilters,
+        subsetClauses: [subsetClause],
+        fieldMetadata,
+        ...overrides,
+      },
+      global: {
+        stubs: {
+          VChip: VChipStub,
+          VBtn: VBtnStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+  it('renders subset and manual chips and emits removal events', async () => {
+    const wrapper = mountComponent()
+
+    const chips = wrapper.findAll('.v-chip-stub')
+    expect(chips).toHaveLength(2)
+
+    expect(chips[0]?.text()).toContain('Subset filter')
+    expect(chips[1]?.text()).toContain('Brand: Acme')
+
+    await chips[0]?.trigger('click')
+    await chips[1]?.trigger('click')
+
+    const subsetEvents = wrapper.emitted('remove-subset-clause') ?? []
+    expect(subsetEvents).toHaveLength(1)
+    expect(subsetEvents[0]?.[0]).toEqual(subsetClause)
+
+    const manualEvents = wrapper.emitted('remove-filter') ?? []
+    expect(manualEvents).toHaveLength(1)
+    expect(manualEvents[0]).toEqual(['brand', 'term', 'Acme'])
+  })
+
+  it('emits clear-all when the clear button is clicked', async () => {
+    const wrapper = mountComponent()
+
+    await wrapper.find('.v-btn-stub').trigger('click')
+
+    const events = wrapper.emitted('clear-all') ?? []
+    expect(events).toHaveLength(1)
+  })
+
+  it('renders nothing when there are no active filters', () => {
+    const wrapper = mountComponent({ filters: {}, subsetClauses: [] })
+
+    expect(wrapper.html()).toBe('<!--v-if-->')
+  })
+})

--- a/frontend/app/components/category/CategoryActiveFilters.vue
+++ b/frontend/app/components/category/CategoryActiveFilters.vue
@@ -1,0 +1,193 @@
+<template>
+  <div
+    v-if="activeChips.length"
+    class="category-active-filters"
+    data-testid="category-active-filters"
+  >
+    <div class="category-active-filters__header">
+      <span class="category-active-filters__title">
+        {{ t('category.filters.activeTitle') }}
+      </span>
+
+      <v-tooltip :text="t('category.filters.clearAllTooltip')" location="bottom">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            icon
+            variant="text"
+            color="primary"
+            class="category-active-filters__clear"
+            :aria-label="t('category.filters.clearAllTooltip')"
+            v-bind="tooltipProps"
+            @click="emit('clear-all')"
+          >
+            <v-icon icon="mdi-close-circle-outline" />
+          </v-btn>
+        </template>
+      </v-tooltip>
+    </div>
+
+    <div class="category-active-filters__chips">
+      <v-chip
+        v-for="chip in activeChips"
+        :key="chip.id"
+        closable
+        :color="chip.kind === 'manual' ? 'primary' : undefined"
+        :variant="chip.kind === 'manual' ? 'flat' : 'outlined'"
+        size="small"
+        class="category-active-filters__chip"
+        :data-kind="chip.kind"
+        @click:close="onRemoveChip(chip)"
+      >
+        <span>{{ chip.label }}</span>
+      </v-chip>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  FieldMetadataDto,
+  Filter,
+  FilterRequestDto,
+} from '~~/shared/api-client'
+
+import type { CategorySubsetClause } from '~/types/category-subset'
+import { resolveFilterFieldTitle } from '~/utils/_field-localization'
+
+type ManualFilterChip = {
+  kind: 'manual'
+  id: string
+  field: string
+  type: 'term' | 'range'
+  term: string | null
+  label: string
+}
+
+type SubsetFilterChip = {
+  kind: 'subset'
+  id: string
+  label: string
+  clause: CategorySubsetClause
+}
+
+type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
+
+const props = defineProps<{
+  filters: FilterRequestDto | null
+  subsetClauses: CategorySubsetClause[]
+  fieldMetadata: Record<string, FieldMetadataDto>
+}>()
+
+const emit = defineEmits<{
+  'remove-filter': [field: string, type: 'term' | 'range', term: string | null]
+  'remove-subset-clause': [CategorySubsetClause]
+  'clear-all': []
+}>()
+
+const { t } = useI18n()
+
+const activeFilters = computed(() => props.filters?.filters ?? [])
+const subsetClauses = computed(() => props.subsetClauses ?? [])
+const metadata = computed(() => props.fieldMetadata ?? {})
+
+const createManualLabel = (filter: Filter) => {
+  const mapping = filter.field ?? ''
+  const fieldLabel = resolveFilterFieldTitle(metadata.value[mapping], t, mapping)
+
+  if (filter.operator === 'term') {
+    const term = filter.terms?.[0] ?? ''
+    return term ? `${fieldLabel}: ${term}` : fieldLabel
+  }
+
+  const minLabel = filter.min ?? '–'
+  const maxLabel = filter.max ?? '–'
+  return `${fieldLabel}: ${minLabel} → ${maxLabel}`
+}
+
+const manualFilterChips = computed<ManualFilterChip[]>(() => {
+  return activeFilters.value.map((filter) => {
+    const mapping = filter.field ?? ''
+
+    if (filter.operator === 'term') {
+      const term = filter.terms?.[0] ?? ''
+      return {
+        kind: 'manual' as const,
+        id: `${mapping}-${term}`,
+        field: mapping,
+        type: 'term' as const,
+        term,
+        label: createManualLabel(filter),
+      }
+    }
+
+    return {
+      kind: 'manual' as const,
+      id: `${mapping}-range`,
+      field: mapping,
+      type: 'range' as const,
+      term: null,
+      label: createManualLabel(filter),
+    }
+  })
+})
+
+const subsetFilterChips = computed<SubsetFilterChip[]>(() => {
+  return subsetClauses.value.map((clause) => ({
+    kind: 'subset' as const,
+    id: clause.id,
+    label: clause.label,
+    clause,
+  }))
+})
+
+const activeChips = computed<ActiveFilterChip[]>(() => {
+  return [...subsetFilterChips.value, ...manualFilterChips.value]
+})
+
+const onRemoveChip = (chip: ActiveFilterChip) => {
+  if (chip.kind === 'subset') {
+    emit('remove-subset-clause', chip.clause)
+    return
+  }
+
+  emit('remove-filter', chip.field, chip.type, chip.term)
+}
+
+</script>
+
+<style scoped lang="sass">
+.category-active-filters
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  padding: 0.75rem 1rem
+  background: rgb(var(--v-theme-surface-glass))
+  border-radius: 0.75rem
+
+  &__header
+    display: flex
+    align-items: center
+    justify-content: space-between
+    gap: 0.75rem
+
+  &__title
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__chips
+    display: flex
+    flex-wrap: wrap
+    gap: 0.5rem
+
+  &__chip
+    --v-chip-padding-x: 0.75rem
+
+  &__clear
+    margin-left: auto
+
+@media (max-width: 599px)
+  .category-active-filters
+    padding: 0.75rem
+</style>

--- a/frontend/app/components/category/CategoryFiltersPanel.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersPanel.spec.ts
@@ -1,9 +1,8 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
+
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
-import type { FilterRequestDto } from '~~/shared/api-client'
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -33,44 +32,6 @@ const resolveClassList = (value: unknown): string => {
 
   return String(value)
 }
-
-const VChipGroupStub = defineComponent({
-  name: 'VChipGroup',
-  setup(_, { slots, attrs }) {
-    const className = ['v-chip-group-stub', resolveClassList((attrs as Record<string, unknown>).class)]
-      .filter(Boolean)
-      .join(' ')
-
-    return () => h('div', { ...attrs, class: className }, slots.default?.())
-  },
-})
-
-const VChipStub = defineComponent({
-  name: 'VChip',
-  props: {
-    closable: { type: Boolean, default: false },
-    variant: { type: String, default: 'flat' },
-  },
-  emits: ['click:close'],
-  setup(props, { slots, emit, attrs }) {
-    const className = ['v-chip-stub', resolveClassList((attrs as Record<string, unknown>).class)]
-      .filter(Boolean)
-      .join(' ')
-
-    return () =>
-      h(
-        'button',
-        {
-          ...attrs,
-          class: className,
-          type: 'button',
-          'data-closable': props.closable ? 'true' : 'false',
-          onClick: () => emit('click:close'),
-        },
-        slots.default?.(),
-      )
-  },
-})
 
 const VIconStub = defineComponent({
   name: 'VIcon',
@@ -116,38 +77,28 @@ const VBtnStub = defineComponent({
 
 const CategoryFilterListStub = defineComponent({
   name: 'CategoryFilterList',
-  setup(_, { slots }) {
-    return () => h('div', { class: 'category-filter-list-stub' }, slots.default?.())
+  emits: ['update-terms'],
+  setup(_, { emit }) {
+    return () =>
+      h('div', {
+        class: 'category-filter-list-stub',
+        onClick: () => emit('update-terms', 'brand', ['Acme']),
+      })
   },
 })
 
 describe('CategoryFiltersPanel', () => {
-  const subsetClause: CategorySubsetClause = {
-    id: 'subset-0',
-    subsetId: 'subset',
-    index: 0,
-    label: 'Price ≤ 500',
-    filter: { field: 'price.min', operator: 'range', max: 500 },
-  }
-
-  const manualFilters: FilterRequestDto = {
-    filters: [{ field: 'brand', operator: 'term', terms: ['Acme'] }],
-  }
-
-  it('renders subset and manual filter chips together and emits removal events', () => {
+  it('emits updated filters when CategoryFilterList triggers a terms update', async () => {
     const wrapper = mount(CategoryFiltersPanel, {
       props: {
         filterOptions: null,
         aggregations: [],
-        filters: manualFilters,
+        filters: { filters: [] },
         impactExpanded: false,
         technicalExpanded: false,
-        subsetClauses: [subsetClause],
       },
       global: {
         stubs: {
-          VChipGroup: VChipGroupStub,
-          VChip: VChipStub,
           VIcon: VIconStub,
           VExpansionPanels: VExpansionPanelsStub,
           VExpansionPanel: VExpansionPanelStub,
@@ -157,16 +108,18 @@ describe('CategoryFiltersPanel', () => {
       },
     })
 
-    const chips = wrapper.findAll('.v-chip-stub')
-    expect(chips).toHaveLength(2)
+    await wrapper.find('.category-filter-list-stub').trigger('click')
 
-    expect(chips[0]?.text()).toContain('Price ≤ 500')
-    expect(chips[1]?.text()).toContain('brand: Acme')
-
-    chips[0]?.trigger('click')
-
-    const removalEvents = wrapper.emitted('remove-subset-clause') ?? []
-    expect(removalEvents).toHaveLength(1)
-    expect(removalEvents[0]?.[0]).toEqual(subsetClause)
+    const events = wrapper.emitted('update:filters') ?? []
+    expect(events).toHaveLength(1)
+    expect(events[0]?.[0]).toEqual({
+      filters: [
+        {
+          field: 'brand',
+          operator: 'term',
+          terms: ['Acme'],
+        },
+      ],
+    })
   })
 })

--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -1,21 +1,5 @@
 <template>
   <div class="category-filters" data-testid="category-filters">
-    <div v-if="activeChips.length" class="category-filters__active">
-      <div class="category-filters__chips">
-        <v-chip
-          v-for="chip in activeChips"
-          :key="chip.id"
-          closable
-          color="primary"
-          variant="flat"
-          size="small"
-          @click:close="onRemoveChip(chip)"
-        >
-          <span>{{ chip.label }}</span>
-        </v-chip>
-      </div>
-    </div>
-
     <v-expansion-panels multiple class="category-filters__panels">
       <v-expansion-panel value="global" expand-icon="mdi-chevron-down">
         <template #title>
@@ -138,27 +122,6 @@ import type {
 import { useI18n } from 'vue-i18n'
 
 import CategoryFilterList from './filters/CategoryFilterList.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
-import { resolveFilterFieldTitle } from '~/utils/_field-localization'
-
-type ManualFilterChip = {
-  kind: 'manual'
-  id: string
-  field: string
-  type: 'term' | 'range'
-  term: string | null
-  label: string
-}
-
-type SubsetFilterChip = {
-  kind: 'subset'
-  id: string
-  label: string
-  clause: CategorySubsetClause
-}
-
-type ActiveFilterChip = ManualFilterChip | SubsetFilterChip
-
 const props = withDefaults(
   defineProps<{
     filterOptions: ProductFieldOptionsResponse | null
@@ -167,7 +130,6 @@ const props = withDefaults(
     filters: FilterRequestDto | null
     impactExpanded: boolean
     technicalExpanded: boolean
-    subsetClauses: CategorySubsetClause[]
   }>(),
   {
     baselineAggregations: () => [],
@@ -178,11 +140,9 @@ const emit = defineEmits<{
   'update:filters': [FilterRequestDto]
   'update:impactExpanded': [boolean]
   'update:technicalExpanded': [boolean]
-  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const activeFilters = computed(() => props.filters?.filters ?? [])
-const subsetClauses = computed(() => props.subsetClauses ?? [])
 
 const { t } = useI18n()
 
@@ -200,22 +160,6 @@ const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(
   return (props.baselineAggregations ?? []).reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
     if (aggregation.field && !(aggregation.field in accumulator)) {
       accumulator[aggregation.field] = aggregation
-    }
-
-    return accumulator
-  }, {})
-})
-
-const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(() => {
-  const entries = [
-    ...(props.filterOptions?.global ?? []),
-    ...(props.filterOptions?.impact ?? []),
-    ...(props.filterOptions?.technical ?? []),
-  ]
-
-  return entries.reduce<Record<string, FieldMetadataDto>>((accumulator, field) => {
-    if (field.mapping) {
-      accumulator[field.mapping] = field
     }
 
     return accumulator
@@ -242,48 +186,6 @@ const technicalPrimary = computed<FieldMetadataDto[]>(() => {
 const technicalRemaining = computed<FieldMetadataDto[]>(() => {
   const entries = props.filterOptions?.technical ?? []
   return entries.slice(3)
-})
-
-const manualFilterChips = computed<ManualFilterChip[]>(() => {
-  return activeFilters.value.map((filter) => {
-    const mapping = filter.field ?? ''
-    const metadata = mapping ? fieldMetadataMap.value[mapping] : undefined
-    const label = resolveFilterFieldTitle(metadata, t, mapping)
-
-    if (filter.operator === 'term') {
-      const term = filter.terms?.[0] ?? ''
-      return {
-        kind: 'manual' as const,
-        id: `${mapping}-${term}`,
-        field: mapping,
-        type: 'term' as const,
-        term,
-        label: term ? `${label}: ${term}` : label,
-      }
-    }
-
-    return {
-      kind: 'manual' as const,
-      id: `${mapping}-range`,
-      field: mapping,
-      type: 'range' as const,
-      term: null,
-      label: `${label}: ${filter.min ?? '–'} → ${filter.max ?? '–'}`,
-    }
-  })
-})
-
-const subsetFilterChips = computed<SubsetFilterChip[]>(() => {
-  return subsetClauses.value.map((clause) => ({
-    kind: 'subset' as const,
-    id: clause.id,
-    label: clause.label,
-    clause,
-  }))
-})
-
-const activeChips = computed<ActiveFilterChip[]>(() => {
-  return [...subsetFilterChips.value, ...manualFilterChips.value]
 })
 
 const emitFilters = (filters: Filter[]) => {
@@ -327,31 +229,6 @@ const updateTermsFilter = (field: string, terms: string[]) => {
   ])
 }
 
-const removeManualFilter = (field: string, type: 'term' | 'range', term: string | null) => {
-  const next = activeFilters.value.filter((filter) => {
-    if (filter.field !== field) {
-      return true
-    }
-
-    if (type === 'term') {
-      return !(filter.operator === 'term' && filter.terms?.includes(term ?? ''))
-    }
-
-    return !(filter.operator === 'range')
-  })
-
-  emitFilters(next)
-}
-
-const onRemoveChip = (chip: ActiveFilterChip) => {
-  if (chip.kind === 'subset') {
-    emit('remove-subset-clause', chip.clause)
-    return
-  }
-
-  removeManualFilter(chip.field, chip.type, chip.term)
-}
-
 const toggleImpactExpansion = () => {
   emit('update:impactExpanded', !props.impactExpanded)
 }
@@ -360,7 +237,6 @@ const toggleTechnicalExpansion = () => {
   emit('update:technicalExpanded', !props.technicalExpanded)
 }
 
-defineExpose({ activeChips })
 </script>
 
 <style scoped lang="sass">
@@ -368,16 +244,6 @@ defineExpose({ activeChips })
   display: flex
   flex-direction: column
   gap: 1rem
-
-  &__active
-    padding: 0.5rem
-    background: rgb(var(--v-theme-surface-glass))
-    border-radius: 0.75rem
-
-  &__chips
-    display: flex
-    flex-direction: column
-    gap: 0.5rem
 
   &__panels
     background: transparent

--- a/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
+++ b/frontend/app/components/category/CategoryFiltersSidebar.spec.ts
@@ -56,7 +56,6 @@ describe('CategoryFiltersSidebar', () => {
     wikiPages: [],
     relatedPosts: [],
     verticalHomeUrl: 'https://open4goods.example/maison',
-    subsetClauses: [],
   }
 
   const mountComponent = (overrides: Partial<typeof baseProps> = {}) =>

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -7,11 +7,9 @@
       :filters="props.filters"
       :impact-expanded="props.impactExpanded"
       :technical-expanded="props.technicalExpanded"
-      :subset-clauses="props.subsetClauses"
       @update:filters="(value) => emit('update:filters', value)"
       @update:impact-expanded="(value) => emit('update:impactExpanded', value)"
       @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
-      @remove-subset-clause="(clause) => emit('remove-subset-clause', clause)"
     />
 
     <div v-if="showMobileActions" class="category-page__filters-actions">
@@ -55,8 +53,6 @@ import type {
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
 import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
-import type { CategorySubsetClause } from '~/types/category-subset'
-
 const props = withDefaults(
   defineProps<{
     filterOptions: ProductFieldOptionsResponse | null
@@ -70,7 +66,6 @@ const props = withDefaults(
     wikiPages: WikiPageConfig[]
     relatedPosts: BlogPostDto[]
     verticalHomeUrl?: string | null
-    subsetClauses: CategorySubsetClause[]
   }>(),
   {
     baselineAggregations: () => [],
@@ -84,7 +79,6 @@ const emit = defineEmits<{
   'update:technicalExpanded': [boolean]
   'apply-mobile': []
   'clear-mobile': []
-  'remove-subset-clause': [CategorySubsetClause]
 }>()
 
 const { t } = useI18n()

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -198,6 +198,8 @@
       "hideImpact": "Hide impact filters",
       "hideTechnical": "Hide technical filters",
       "impactTitle": "Impact filters",
+      "activeTitle": "Active filters",
+      "clearAllTooltip": "Clear all filters",
       "missingLabel": "Unlabelled option",
       "mobileApply": "Apply filters",
       "mobileClear": "Clear all filters",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -198,6 +198,8 @@
       "hideImpact": "Masquer les filtres d'impact",
       "hideTechnical": "Masquer les filtres techniques",
       "impactTitle": "Filtres d'impact",
+      "activeTitle": "Filtres actifs",
+      "clearAllTooltip": "Effacer tous les filtres",
       "missingLabel": "Option sans libellé",
       "mobileApply": "Appliquer les filtres",
       "mobileClear": "Effacer les filtres",


### PR DESCRIPTION
## Summary
- add a dedicated `CategoryActiveFilters` component to render active manual and subset filters with a clear-all control
- update the category page layout and styles so the active filters live beneath the fast filters and expose manual removal helpers
- simplify the filters panel/sidebar props and refresh unit tests and translations for the new UX

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69021d8ef8f4833385f4bc46a8f7d904