### PR TITLE
Adjust impact section layout and eco score card

### DIFF
--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -123,13 +123,13 @@ const country = computed(() => props.country)
 
 .product-impact__top {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1.1fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   gap: 1.5rem;
 }
 
 .product-impact__analysis {
   display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.5rem;
   align-items: stretch;
 }

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
@@ -48,8 +48,8 @@ describe('ProductImpactEcoScoreCard', () => {
     })
 
     expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
-    expect(wrapper.text()).toContain('78.12')
-    expect(wrapper.text()).toContain('Absolute value')
+    expect(wrapper.text()).toContain('score:4.2')
+    expect(wrapper.text()).not.toContain('Absolute value')
   })
 
   it('renders a placeholder message when the score is missing', () => {

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -1,23 +1,13 @@
 <template>
   <article v-if="score" class="impact-ecoscore">
     <header class="impact-ecoscore__header">
-      <div>
-        <span class="impact-ecoscore__eyebrow">{{ $t('product.impact.primaryScoreLabel') }}</span>
-        <h3 class="impact-ecoscore__title">{{ score.label }}</h3>
-        <p v-if="score.description" class="impact-ecoscore__description">{{ score.description }}</p>
-      </div>
-      <div v-if="score.letter" class="impact-ecoscore__letter" aria-hidden="true">
-        {{ score.letter }}
-      </div>
+      <span class="impact-ecoscore__eyebrow">{{ $t('product.impact.primaryScoreLabel') }}</span>
+      <h3 class="impact-ecoscore__title">{{ score.label }}</h3>
+      <p v-if="score.description" class="impact-ecoscore__description">{{ score.description }}</p>
     </header>
 
     <div class="impact-ecoscore__score">
       <ImpactScore :score="relativeScore" :max="5" size="large" show-value />
-    </div>
-
-    <div v-if="absoluteValue" class="impact-ecoscore__absolute">
-      <span class="impact-ecoscore__absolute-label">{{ $t('product.impact.absoluteValue') }}</span>
-      <span class="impact-ecoscore__absolute-value">{{ absoluteValue }}</span>
     </div>
   </article>
   <article v-else class="impact-ecoscore impact-ecoscore--empty">
@@ -27,7 +17,6 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import type { ScoreView } from './impact-types'
 
@@ -35,29 +24,14 @@ const props = defineProps<{
   score: ScoreView | null
 }>()
 
-const { n } = useI18n()
-
 const relativeScore = computed(() => (props.score?.relativeValue ?? 0) || 0)
-
-const absoluteValue = computed(() => {
-  const value = props.score?.absoluteValue
-  if (value == null || value === '') {
-    return null
-  }
-
-  if (typeof value === 'number') {
-    return n(value, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
-  }
-
-  return String(value)
-})
 </script>
 
 <style scoped>
 .impact-ecoscore {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
   padding: 2rem;
   border-radius: 26px;
   background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-100), 0.95), rgba(var(--v-theme-surface-glass-strong), 0.9));
@@ -67,9 +41,8 @@ const absoluteValue = computed(() => {
 
 .impact-ecoscore__header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .impact-ecoscore__eyebrow {
@@ -94,47 +67,9 @@ const absoluteValue = computed(() => {
   font-size: 0.95rem;
 }
 
-.impact-ecoscore__letter {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 64px;
-  height: 64px;
-  border-radius: 18px;
-  font-size: 1.75rem;
-  font-weight: 700;
-  color: rgb(var(--v-theme-text-on-accent));
-  background: linear-gradient(135deg, rgba(var(--v-theme-accent-supporting), 0.95), rgba(var(--v-theme-accent-primary-highlight), 0.9));
-  box-shadow: 0 10px 30px rgba(var(--v-theme-accent-primary-highlight), 0.25);
-}
-
 .impact-ecoscore__score {
   display: flex;
   justify-content: flex-start;
-}
-
-.impact-ecoscore__absolute {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.25rem;
-  padding: 0.75rem 1.25rem;
-  border-radius: 18px;
-  background: rgba(var(--v-theme-surface-glass), 0.85);
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
-}
-
-.impact-ecoscore__absolute-label {
-  font-size: 0.8rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
-}
-
-.impact-ecoscore__absolute-value {
-  font-size: 1.35rem;
-  font-weight: 700;
-  color: rgb(var(--v-theme-text-neutral-strong));
 }
 
 .impact-ecoscore--empty {


### PR DESCRIPTION
## Summary
- rebalance the impact header grid so the eco-score card caps at one third and the ranking card fills the remaining space while radar/details split evenly
- streamline the eco-score card markup by dropping the letter and absolute value block for a lighter presentation
- update the eco-score unit test to reflect the simplified rendering

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6902354788308333864b07f2c150dca8