### PR TITLE
feat: add product comparison page and supporting services

### DIFF
--- a/frontend/app/pages/compare/index.spec.ts
+++ b/frontend/app/pages/compare/index.spec.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { reactive } from 'vue'
+import { createI18n } from 'vue-i18n'
+import { createVuetify } from 'vuetify'
+import type { CompareProductEntry } from '~/services/compare/CompareService'
+import type {
+  AttributeConfigDto,
+  ProductDto,
+  VerticalConfigFullDto,
+} from '~~/shared/api-client'
+
+vi.mock('~/composables/usePluralizedTranslation', () => ({
+  usePluralizedTranslation: () => ({
+    translatePlural: (_key: string, count: number) => (count === 1 ? '1 offer' : `${count} offers`),
+  }),
+}))
+
+const routerPush = vi.fn(async () => {})
+const routerReplace = vi.fn(async () => {})
+
+const route = reactive({
+  path: '/compare',
+  hash: '#123Vs456',
+})
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: routerPush,
+    replace: routerReplace,
+  }),
+  useRoute: () => route,
+}))
+
+vi.mock('~~/shared/utils/localized-routes', () => ({
+  resolveLocalizedRoutePath: () => '/compare',
+}))
+
+const entries: CompareProductEntry[] = [
+  {
+    gtin: '123',
+    product: {
+      gtin: 123,
+      base: {
+        vertical: 'electronics',
+        bestName: 'Product A',
+        gtinInfo: { countryName: 'France', countryFlagUrl: '/flags/fr.svg' },
+      },
+      identity: { brand: 'Brand A', model: 'Model A', bestName: 'Product A' },
+      resources: { coverImagePath: '/images/a.jpg' },
+      offers: {
+        bestNewOffer: { price: 100, currency: 'EUR' },
+        bestOccasionOffer: { price: 80, currency: 'EUR' },
+        offersCount: 5,
+      },
+      scores: {
+        ecoscore: { percent: 60 },
+        scores: {
+          BRAND_SUSTAINABILITY: { percent: 70 },
+          DATA_QUALITY: { percent: 40 },
+        },
+      },
+      attributes: {
+        indexedAttributes: {
+          POWER: { name: 'Power', value: '500', numericValue: 500 },
+          ECO: { name: 'Eco attr', value: '40', numericValue: 40 },
+        },
+        classifiedAttributes: [
+          {
+            name: 'Dimensions',
+            attributes: [{ name: 'Height', value: '10 cm' }],
+          },
+        ],
+      },
+      aiReview: {
+        review: {
+          description: '<p>A strong product.</p>',
+          pros: ['<strong>Efficient</strong>'],
+          cons: ['<em>Heavy</em>'],
+        },
+      },
+    } as ProductDto,
+    verticalId: 'electronics',
+    title: 'Product A',
+    brand: 'Brand A',
+    model: 'Model A',
+    coverImage: '/images/a.jpg',
+    impactScore: 3,
+    review: {
+      description: 'A strong product.',
+      pros: ['<strong>Efficient</strong>'],
+      cons: ['<em>Heavy</em>'],
+    },
+    country: { name: 'France', flag: '/flags/fr.svg' },
+  },
+  {
+    gtin: '456',
+    product: {
+      gtin: 456,
+      base: {
+        vertical: 'electronics',
+        bestName: 'Product B',
+        gtinInfo: { countryName: 'Germany', countryFlagUrl: '/flags/de.svg' },
+      },
+      identity: { brand: 'Brand B', model: 'Model B', bestName: 'Product B' },
+      resources: { coverImagePath: '/images/b.jpg' },
+      offers: {
+        bestNewOffer: { price: 120, currency: 'EUR' },
+        bestOccasionOffer: { price: 90, currency: 'EUR' },
+        offersCount: 3,
+      },
+      scores: {
+        ecoscore: { percent: 75 },
+        scores: {
+          BRAND_SUSTAINABILITY: { percent: 65 },
+          DATA_QUALITY: { percent: 55 },
+        },
+      },
+      attributes: {
+        indexedAttributes: {
+          POWER: { name: 'Power', value: '450', numericValue: 450 },
+          ECO: { name: 'Eco attr', value: '35', numericValue: 35 },
+        },
+        classifiedAttributes: [
+          {
+            name: 'Dimensions',
+            attributes: [{ name: 'Height', value: '11 cm' }],
+          },
+        ],
+      },
+      aiReview: {
+        review: {
+          description: '<p>An efficient model.</p>',
+          pros: ['<strong>Silent</strong>'],
+          cons: ['<em>Bulky</em>'],
+        },
+      },
+    } as ProductDto,
+    verticalId: 'electronics',
+    title: 'Product B',
+    brand: 'Brand B',
+    model: 'Model B',
+    coverImage: '/images/b.jpg',
+    impactScore: 4,
+    review: {
+      description: 'An efficient model.',
+      pros: ['<strong>Silent</strong>'],
+      cons: ['<em>Bulky</em>'],
+    },
+    country: { name: 'Germany', flag: '/flags/de.svg' },
+  },
+]
+
+const powerConfig: AttributeConfigDto = {
+  key: 'POWER',
+  name: 'Power',
+  icon: 'mdi-flash',
+  unit: 'W',
+  betterIs: 'GREATER',
+}
+
+const ecoConfig: AttributeConfigDto = {
+  key: 'ECO',
+  name: 'Eco attribute',
+  icon: 'mdi-leaf',
+  asScore: true,
+  betterIs: 'LOWER',
+}
+
+const verticalConfig: VerticalConfigFullDto = {
+  attributesConfig: {
+    configs: [powerConfig, ecoConfig],
+  },
+  popularAttributes: [powerConfig],
+} as VerticalConfigFullDto
+
+vi.mock('~/services/compare/CompareService', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('~/services/compare/CompareService')
+  return {
+    ...actual,
+    createCompareService: () => ({
+      loadProducts: vi.fn().mockResolvedValue(entries),
+      loadVertical: vi.fn().mockResolvedValue(verticalConfig),
+      hasMixedVerticals: vi.fn().mockReturnValue(false),
+    }),
+  }
+})
+
+const mountPage = async () => {
+  const module = await import('./index.vue')
+  const ComparePage = module.default
+  const pinia = createPinia()
+  setActivePinia(pinia)
+
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        compare: {
+          title: 'Product comparison',
+          subtitle: 'subtitle',
+          alerts: { verticalMismatch: 'Mismatch' },
+          states: { loading: 'Loading…' },
+          empty: { title: 'Empty', description: 'desc' },
+          sections: {
+            overview: 'Overview',
+            pricing: 'Pricing',
+            ecological: 'Ecological',
+            technical: 'Technical',
+            technicalGroupFallback: 'Other specs',
+          },
+          a11y: { featureColumn: 'Feature column' },
+          actions: { remove: 'Remove {name}', removeShort: 'Remove' },
+          textual: { description: 'Description', pros: 'Pros', cons: 'Cons', empty: 'N/A' },
+          pricing: { newPrice: 'New price', occasionPrice: 'Second-hand price', offersCount: 'Offer count' },
+          ecological: {
+            ecoscore: 'Ecoscore',
+            brandSustainability: 'Brand sustainability',
+            dataQuality: 'Data quality',
+          },
+          errors: { loadFailed: 'Error' },
+        },
+      },
+    },
+  })
+
+  const vuetify = createVuetify()
+
+  return mount(ComparePage, {
+    global: {
+      plugins: [pinia, i18n, vuetify],
+      stubs: {
+        VAlert: { template: '<div class="v-alert"><slot /></div>' },
+        VProgressLinear: { template: '<div class="v-progress" />' },
+        VIcon: { template: '<span class="v-icon"><slot /></span>' },
+        VBtn: { template: '<button><slot /></button>' },
+        VTooltip: { template: '<div><slot name="activator" :props="{}"></slot><slot /></div>' },
+        NuxtImg: { template: '<img />' },
+        ImpactScore: { template: '<div class="impact-score" />' },
+      },
+    },
+  })
+}
+
+describe('Compare page', () => {
+  beforeEach(() => {
+    routerPush.mockReset()
+    routerReplace.mockReset()
+    routerPush.mockResolvedValue(undefined)
+    routerReplace.mockResolvedValue(undefined)
+  })
+
+  it('renders fetched products and textual data', async () => {
+    const wrapper = await mountPage()
+    await flushPromises()
+
+    const productHeaders = wrapper.findAll('.compare-grid__product')
+    expect(productHeaders).toHaveLength(2)
+    expect(wrapper.text()).toContain('Model A')
+    expect(wrapper.text()).toContain('Model B')
+    expect(wrapper.text()).toContain('A strong product.')
+    expect(wrapper.findAll('.compare-grid__list-item')).toHaveLength(4)
+  })
+
+  it('updates the hash when removing a product', async () => {
+    const wrapper = await mountPage()
+    await flushPromises()
+
+    const removeButton = wrapper.get('.compare-grid__product-remove')
+    await removeButton.trigger('click')
+    expect(routerReplace).toHaveBeenCalled()
+  })
+})

--- a/frontend/app/pages/compare/index.vue
+++ b/frontend/app/pages/compare/index.vue
@@ -1,0 +1,1013 @@
+<template>
+  <div class="compare-page">
+    <header class="compare-page__hero" :aria-labelledby="heroId">
+      <h1 :id="heroId" class="compare-page__title">{{ t('compare.title') }}</h1>
+      <p class="compare-page__subtitle">{{ t('compare.subtitle') }}</p>
+    </header>
+
+    <v-alert
+      v-if="loadError"
+      type="error"
+      variant="tonal"
+      border="start"
+      class="mb-6"
+      role="alert"
+    >
+      {{ loadError }}
+    </v-alert>
+
+    <v-alert
+      v-else-if="hasMixedVerticals"
+      type="warning"
+      variant="tonal"
+      border="start"
+      class="mb-6"
+      role="alert"
+    >
+      {{ t('compare.alerts.verticalMismatch') }}
+    </v-alert>
+
+    <v-progress-linear
+      v-if="loading"
+      indeterminate
+      color="primary"
+      class="mb-10"
+      :aria-label="t('compare.states.loading')"
+    />
+
+    <div v-else-if="!products.length" class="compare-page__empty">
+      <v-icon icon="mdi-compare-horizontal" size="64" class="compare-page__empty-icon" />
+      <h2 class="compare-page__empty-title">{{ t('compare.empty.title') }}</h2>
+      <p class="compare-page__empty-text">{{ t('compare.empty.description') }}</p>
+    </div>
+
+    <div v-else class="compare-page__content">
+      <section class="compare-section">
+        <h2 class="compare-section__title">{{ t('compare.sections.overview') }}</h2>
+        <div class="compare-grid" role="table">
+          <div class="compare-grid__header" role="row">
+            <div class="compare-grid__feature compare-grid__feature--header" role="columnheader">
+              <span class="sr-only">{{ t('compare.a11y.featureColumn') }}</span>
+            </div>
+            <div class="compare-grid__products" role="rowgroup">
+              <article
+                v-for="product in products"
+                :key="product.gtin"
+                class="compare-grid__product"
+                role="columnheader"
+              >
+                <div class="compare-grid__product-media">
+                  <NuxtImg
+                    v-if="product.coverImage"
+                    :src="product.coverImage"
+                    :alt="product.title"
+                    width="180"
+                    height="180"
+                    format="webp"
+                    class="compare-grid__product-image"
+                  />
+                  <div v-else class="compare-grid__product-placeholder" aria-hidden="true">
+                    {{ productInitials(product.title) }}
+                  </div>
+                </div>
+                <ImpactScore
+                  v-if="product.impactScore !== null"
+                  :score="product.impactScore"
+                  :max="5"
+                  size="small"
+                  class="compare-grid__product-impact"
+                />
+                <p class="compare-grid__product-model">{{ product.model ?? '—' }}</p>
+                <p class="compare-grid__product-brand">{{ product.brand ?? '—' }}</p>
+                <div v-if="product.country" class="compare-grid__product-country">
+                  <v-tooltip :text="product.country.name" location="bottom">
+                    <template #activator="{ props: tooltipProps }">
+                      <span class="compare-grid__product-country-flag" v-bind="tooltipProps">
+                        <NuxtImg
+                          v-if="product.country.flag"
+                          :src="product.country.flag"
+                          :alt="product.country.name"
+                          width="24"
+                          height="16"
+                          class="compare-grid__flag"
+                        />
+                        <span class="compare-grid__country-label">{{ product.country.name }}</span>
+                      </span>
+                    </template>
+                  </v-tooltip>
+                </div>
+                <v-btn
+                  variant="text"
+                  size="small"
+                  color="error"
+                  class="compare-grid__product-remove"
+                  :aria-label="t('compare.actions.remove', { name: product.title })"
+                  @click="handleRemove(product.gtin)"
+                >
+                  {{ t('compare.actions.removeShort') }}
+                </v-btn>
+              </article>
+            </div>
+          </div>
+
+          <div v-for="row in textualRows" :key="row.key" class="compare-grid__row" role="row">
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(value, columnIndex) in row.values"
+                :key="`${row.key}-${products[columnIndex]!.gtin}`"
+                class="compare-grid__value"
+              >
+                <template v-if="row.type === 'text'">
+                  <p class="compare-grid__value-text">
+                    {{ value || t('compare.textual.empty') }}
+                  </p>
+                </template>
+                <template v-else>
+                  <!-- eslint-disable vue/no-v-html -->
+                  <ul
+                    v-if="Array.isArray(value) && value.length"
+                    class="compare-grid__list compare-grid__list--pros-cons"
+                    role="list"
+                  >
+                    <li
+                      v-for="item in value"
+                      :key="item"
+                      class="compare-grid__list-item"
+                      role="listitem"
+                      v-html="item"
+                    />
+                  </ul>
+                  <!-- eslint-enable vue/no-v-html -->
+                  <p v-else class="compare-grid__value-text">{{ t('compare.textual.empty') }}</p>
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="compare-section">
+        <h2 class="compare-section__title">{{ t('compare.sections.pricing') }}</h2>
+        <div class="compare-grid compare-grid--compact" role="table">
+          <div
+            v-for="row in priceRows"
+            :key="row.key"
+            class="compare-grid__row"
+            role="row"
+          >
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(cell, index) in row.values"
+                :key="`${row.key}-${products[index]!.gtin}`"
+                class="compare-grid__value"
+                :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+              >
+                <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="compare-section">
+        <h2 class="compare-section__title">{{ t('compare.sections.ecological') }}</h2>
+        <div class="compare-grid compare-grid--compact" role="table">
+          <div
+            v-for="row in ecologicalScoreRows"
+            :key="row.key"
+            class="compare-grid__row"
+            role="row"
+          >
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(cell, index) in row.values"
+                :key="`${row.key}-${products[index]!.gtin}`"
+                class="compare-grid__value"
+                :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+              >
+                <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-for="row in ecologicalAttributeRows"
+            :key="row.key"
+            class="compare-grid__row"
+            role="row"
+          >
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(cell, index) in row.values"
+                :key="`${row.key}-${products[index]!.gtin}`"
+                class="compare-grid__value"
+                :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+              >
+                <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="compare-section">
+        <h2 class="compare-section__title">{{ t('compare.sections.technical') }}</h2>
+        <div class="compare-grid compare-grid--compact" role="table">
+          <div
+            v-for="row in popularAttributeRows"
+            :key="row.key"
+            class="compare-grid__row"
+            role="row"
+          >
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(cell, index) in row.values"
+                :key="`${row.key}-${products[index]!.gtin}`"
+                class="compare-grid__value"
+                :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+              >
+                <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-for="row in indexedAttributeRows"
+            :key="row.key"
+            class="compare-grid__row"
+            role="row"
+          >
+            <div class="compare-grid__feature" role="rowheader">
+              <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+              <span class="compare-grid__feature-label">{{ row.label }}</span>
+            </div>
+            <div class="compare-grid__values" role="cell">
+              <div
+                v-for="(cell, index) in row.values"
+                :key="`${row.key}-${products[index]!.gtin}`"
+                class="compare-grid__value"
+                :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+              >
+                <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-for="group in classifiedAttributeGroups"
+            :key="group.name"
+            class="compare-grid__group"
+          >
+            <h3 class="compare-grid__group-title">{{ group.name }}</h3>
+            <div
+              v-for="row in group.rows"
+              :key="row.key"
+              class="compare-grid__row"
+              role="row"
+            >
+              <div class="compare-grid__feature" role="rowheader">
+                <v-icon :icon="row.icon" size="20" class="compare-grid__feature-icon" />
+                <span class="compare-grid__feature-label">{{ row.label }}</span>
+              </div>
+              <div class="compare-grid__values" role="cell">
+                <div
+                  v-for="(cell, index) in row.values"
+                  :key="`${row.key}-${products[index]!.gtin}`"
+                  class="compare-grid__value"
+                  :class="{ 'compare-grid__value--highlight': row.highlight.has(index) }"
+                >
+                  <p class="compare-grid__value-text">{{ cell ?? t('compare.textual.empty') }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useId } from '#imports'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import { createCompareService, type CompareProductEntry } from '~/services/compare/CompareService'
+import { useProductCompareStore } from '~/stores/useProductCompareStore'
+import { buildCompareHashFragment, parseCompareHash } from '~/utils/_compare-url'
+import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
+import {
+  formatAttributeValue,
+  resolveAttributeRawValueByKey,
+  type ResolvedProductAttribute,
+} from '~/utils/_product-attributes'
+import { usePluralizedTranslation } from '~/composables/usePluralizedTranslation'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+import type {
+  AttributeConfigDto,
+  ProductAggregatedPriceDto,
+  ProductDto,
+  ProductScoreDto,
+  VerticalConfigFullDto,
+} from '~~/shared/api-client'
+
+interface TextualRow {
+  key: string
+  icon: string
+  label: string
+  type: 'text' | 'list'
+  values: Array<string | string[] | null>
+}
+
+interface AttributeRow {
+  key: string
+  icon: string
+  label: string
+  values: Array<string | null>
+  highlight: Set<number>
+}
+
+interface ClassifiedGroup {
+  name: string
+  rows: AttributeRow[]
+}
+
+const service = createCompareService()
+const compareStore = useProductCompareStore()
+
+const { t, locale, n } = useI18n()
+const { translatePlural } = usePluralizedTranslation()
+const router = useRouter()
+const route = useRoute()
+const heroId = useId()
+
+definePageMeta({
+  name: 'compare',
+  ssr: false,
+})
+
+const loading = ref(false)
+const loadError = ref<string | null>(null)
+const products = ref<CompareProductEntry[]>([])
+const verticalConfig = ref<VerticalConfigFullDto | null>(null)
+const requestedGtins = ref<string[]>([])
+
+const comparePath = computed(() => resolveLocalizedRoutePath('compare', locale.value))
+
+const productCount = computed(() => products.value.length)
+
+const hasMixedVerticals = computed(() => service.hasMixedVerticals(products.value))
+
+const productEntries = computed(() => products.value)
+
+const attributeConfigs = computed(() => verticalConfig.value?.attributesConfig?.configs ?? [])
+
+const attributeConfigMap = computed(() => {
+  return attributeConfigs.value.reduce<Map<string, AttributeConfigDto>>((map, config) => {
+    if (config?.key) {
+      map.set(config.key, config)
+    }
+    return map
+  }, new Map<string, AttributeConfigDto>())
+})
+
+const popularAttributeConfigs = computed(() => verticalConfig.value?.popularAttributes ?? [])
+
+const scoringAttributeConfigs = computed(() =>
+  attributeConfigs.value.filter((config) => config.asScore && config.key),
+)
+
+const normalizeNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0
+  }
+
+  if (typeof value === 'string') {
+    const normalised = value.replace(/[^0-9,.-]/g, '').replace(',', '.')
+    const parsed = Number.parseFloat(normalised)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+const computeHighlightSet = (values: Array<number | null>, preference: 'higher' | 'lower'): Set<number> => {
+  const entries = values
+    .map((value, index) => ({ index, value }))
+    .filter((entry): entry is { index: number; value: number } => entry.value != null)
+
+  if (!entries.length) {
+    return new Set()
+  }
+
+  const targetValue = preference === 'higher'
+    ? Math.max(...entries.map((entry) => entry.value))
+    : Math.min(...entries.map((entry) => entry.value))
+
+  return new Set(entries.filter((entry) => entry.value === targetValue).map((entry) => entry.index))
+}
+
+const formatPrice = (offer: ProductAggregatedPriceDto | undefined, product: ProductDto): string | null => {
+  if (!offer) {
+    return null
+  }
+
+  const price = offer.price
+  const currency = offer.currency ?? product.offers?.bestPrice?.currency
+  const shortPrice = offer.shortPrice?.trim()
+
+  if (shortPrice) {
+    return shortPrice
+  }
+
+  if (price == null) {
+    return null
+  }
+
+  if (currency) {
+    try {
+      return n(price, { style: 'currency', currency })
+    } catch {
+      return `${n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`.trim()
+    }
+  }
+
+  return n(price, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+const resolveScoreValue = (score: ProductScoreDto | null | undefined): { display: string | null; numeric: number | null } => {
+  if (!score) {
+    return { display: null, numeric: null }
+  }
+
+  if (score.percent != null && Number.isFinite(score.percent)) {
+    return {
+      display: n(score.percent, { maximumFractionDigits: 0 }),
+      numeric: score.percent,
+    }
+  }
+
+  if (score.on20 != null && Number.isFinite(score.on20)) {
+    return {
+      display: n(score.on20, { maximumFractionDigits: 1 }),
+      numeric: score.on20,
+    }
+  }
+
+  if (score.value != null && Number.isFinite(score.value)) {
+    return {
+      display: n(score.value, { maximumFractionDigits: 1 }),
+      numeric: score.value,
+    }
+  }
+
+  return { display: score.absoluteValue ?? null, numeric: null }
+}
+
+const syncHash = async (hash: string) => {
+  loading.value = true
+  loadError.value = null
+
+  try {
+    const parsedGtins = parseCompareHash(hash)
+    requestedGtins.value = parsedGtins
+
+    if (!parsedGtins.length) {
+      products.value = []
+      verticalConfig.value = null
+      compareStore.clear()
+      loading.value = false
+      return
+    }
+
+    const loadedProducts = await service.loadProducts(parsedGtins)
+    products.value = loadedProducts
+
+    compareStore.clear()
+    loadedProducts.forEach((entry) => {
+      compareStore.addProduct(entry.product)
+    })
+
+    const verticalId = loadedProducts.find((entry) => entry.verticalId)?.verticalId ?? null
+    verticalConfig.value = await service.loadVertical(verticalId)
+  } catch (error) {
+    console.error('Failed to load comparison', error)
+    loadError.value = t('compare.errors.loadFailed')
+    products.value = []
+    verticalConfig.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  await syncHash(route.hash)
+})
+
+watch(
+  () => route.hash,
+  async (next) => {
+    await syncHash(next)
+  },
+)
+
+const textualRows = computed<TextualRow[]>(() => {
+  return [
+    {
+      key: 'description',
+      icon: 'mdi-text-box-outline',
+      label: t('compare.textual.description'),
+      type: 'text',
+      values: productEntries.value.map((entry) => entry.review.description),
+    },
+    {
+      key: 'pros',
+      icon: 'mdi-thumb-up-outline',
+      label: t('compare.textual.pros'),
+      type: 'list',
+      values: productEntries.value.map((entry) => entry.review.pros),
+    },
+    {
+      key: 'cons',
+      icon: 'mdi-thumb-down-outline',
+      label: t('compare.textual.cons'),
+      type: 'list',
+      values: productEntries.value.map((entry) => entry.review.cons),
+    },
+  ]
+})
+
+const priceRows = computed<AttributeRow[]>(() => {
+  const newPrices = productEntries.value.map((entry) => entry.product.offers?.bestNewOffer?.price ?? null)
+  const occasionPrices = productEntries.value.map((entry) => entry.product.offers?.bestOccasionOffer?.price ?? null)
+  const offersCounts = productEntries.value.map((entry) => entry.product.offers?.offersCount ?? null)
+
+  return [
+    {
+      key: 'new-price',
+      icon: 'mdi-currency-eur',
+      label: t('compare.pricing.newPrice'),
+      values: productEntries.value.map((entry) =>
+        formatPrice(entry.product.offers?.bestNewOffer, entry.product) ?? formatBestPrice(entry.product, t, n),
+      ),
+      highlight: computeHighlightSet(newPrices, 'lower'),
+    },
+    {
+      key: 'occasion-price',
+      icon: 'mdi-rotate-orbit',
+      label: t('compare.pricing.occasionPrice'),
+      values: productEntries.value.map((entry) =>
+        formatPrice(entry.product.offers?.bestOccasionOffer, entry.product) ?? t('compare.textual.empty'),
+      ),
+      highlight: computeHighlightSet(occasionPrices, 'lower'),
+    },
+    {
+      key: 'offers-count',
+      icon: 'mdi-store-outline',
+      label: t('compare.pricing.offersCount'),
+      values: productEntries.value.map((entry) => formatOffersCount(entry.product, translatePlural)),
+      highlight: computeHighlightSet(offersCounts, 'higher'),
+    },
+  ]
+})
+
+const ecologicalScoreRows = computed<AttributeRow[]>(() => {
+  const ecoscoreData = productEntries.value.map((entry) => resolveScoreValue(entry.product.scores?.ecoscore ?? null))
+  const brandScoreData = productEntries.value.map((entry) =>
+    resolveScoreValue(entry.product.scores?.scores?.BRAND_SUSTAINABILITY ?? null),
+  )
+  const dataQualityData = productEntries.value.map((entry) =>
+    resolveScoreValue(entry.product.scores?.scores?.DATA_QUALITY ?? null),
+  )
+
+  return [
+    {
+      key: 'ecoscore',
+      icon: 'mdi-leaf',
+      label: t('compare.ecological.ecoscore'),
+      values: ecoscoreData.map((entry) => entry.display),
+      highlight: computeHighlightSet(ecoscoreData.map((entry) => entry.numeric), 'higher'),
+    },
+    {
+      key: 'brand-sustainability',
+      icon: 'mdi-earth',
+      label: t('compare.ecological.brandSustainability'),
+      values: brandScoreData.map((entry) => entry.display),
+      highlight: computeHighlightSet(brandScoreData.map((entry) => entry.numeric), 'higher'),
+    },
+    {
+      key: 'data-quality',
+      icon: 'mdi-shield-check-outline',
+      label: t('compare.ecological.dataQuality'),
+      values: dataQualityData.map((entry) => entry.display),
+      highlight: computeHighlightSet(dataQualityData.map((entry) => entry.numeric), 'higher'),
+    },
+  ]
+})
+
+const resolveAttributeRow = (config: AttributeConfigDto | null, key: string, label?: string): AttributeRow => {
+  const icon = config?.icon ?? 'mdi-tune'
+  const betterIs = config?.betterIs === 'LOWER' ? 'lower' : 'higher'
+
+  const rawValues = productEntries.value.map((entry) => resolveAttributeRawValueByKey(entry.product, key))
+  const resolvedAttributes = rawValues.map<ResolvedProductAttribute>((raw) => ({
+    key,
+    label: label ?? config?.name ?? key,
+    rawValue: raw,
+    unit: config?.unit,
+    icon: config?.icon,
+    suffix: config?.suffix ?? null,
+  }))
+
+  const formattedValues = resolvedAttributes.map((attribute) => formatAttributeValue(attribute, t, n))
+  const numericValues = rawValues.map((raw) => normalizeNumericValue(raw))
+
+  return {
+    key,
+    icon,
+    label: label ?? config?.name ?? key,
+    values: formattedValues,
+    highlight: computeHighlightSet(numericValues, betterIs),
+  }
+}
+
+const ecologicalAttributeRows = computed<AttributeRow[]>(() => {
+  return scoringAttributeConfigs.value.map((config) => resolveAttributeRow(config, config.key ?? '', config.name))
+})
+
+const popularAttributeRows = computed<AttributeRow[]>(() => {
+  return popularAttributeConfigs.value.map((config) => resolveAttributeRow(config, config.key ?? '', config.name))
+})
+
+const indexedAttributeRows = computed<AttributeRow[]>(() => {
+  const seenKeys = new Set<string>()
+  const popularKeys = new Set(popularAttributeConfigs.value.map((config) => config.key).filter(Boolean) as string[])
+
+  productEntries.value.forEach((entry) => {
+    const indexed = entry.product.attributes?.indexedAttributes ?? {}
+    Object.keys(indexed).forEach((key) => {
+      if (!popularKeys.has(key)) {
+        seenKeys.add(key)
+      }
+    })
+  })
+
+  const orderedKeys = Array.from(seenKeys).sort((a, b) => {
+    const indexA = attributeConfigs.value.findIndex((config) => config.key === a)
+    const indexB = attributeConfigs.value.findIndex((config) => config.key === b)
+
+    if (indexA === -1 && indexB === -1) {
+      return a.localeCompare(b)
+    }
+
+    if (indexA === -1) {
+      return 1
+    }
+
+    if (indexB === -1) {
+      return -1
+    }
+
+    return indexA - indexB
+  })
+
+  return orderedKeys.map((key) => resolveAttributeRow(attributeConfigMap.value.get(key) ?? null, key, attributeConfigMap.value.get(key)?.name ?? key))
+})
+
+const classifiedAttributeGroups = computed<ClassifiedGroup[]>(() => {
+  const groups = new Map<string, { name: string; rows: Map<string, AttributeRow> }>()
+
+  productEntries.value.forEach((entry, index) => {
+    const groupEntries = entry.product.attributes?.classifiedAttributes ?? []
+    groupEntries.forEach((group) => {
+      const groupName = group.name ?? t('compare.sections.technicalGroupFallback')
+      if (!groups.has(groupName)) {
+        groups.set(groupName, { name: groupName, rows: new Map() })
+      }
+
+      const currentGroup = groups.get(groupName)!
+      const attributes = group.attributes ?? []
+
+      attributes.forEach((attribute) => {
+        const attributeName = attribute?.name ?? attribute?.value ?? '—'
+        const key = `${groupName}:${attributeName}`
+        if (!currentGroup.rows.has(key)) {
+          const config = attributeConfigMap.value.get(attributeName ?? '') ?? null
+          currentGroup.rows.set(key, {
+            key,
+            icon: config?.icon ?? 'mdi-tune',
+            label: attributeName,
+            values: Array(productCount.value).fill<string | null>(null),
+            highlight: new Set(),
+          })
+        }
+
+        const row = currentGroup.rows.get(key)!
+        row.values[index] = attribute?.value ?? null
+        const numericValues = row.values.map((value) => normalizeNumericValue(value))
+        const preference = attributeConfigMap.value.get(attributeName ?? '')?.betterIs === 'LOWER' ? 'lower' : 'higher'
+        row.highlight = computeHighlightSet(numericValues, preference)
+      })
+    })
+  })
+
+  return Array.from(groups.values()).map((group) => ({
+    name: group.name,
+    rows: Array.from(group.rows.values()),
+  }))
+})
+
+const handleRemove = (gtin: string) => {
+  compareStore.removeById(gtin)
+  const remaining = requestedGtins.value.filter((value) => value !== gtin)
+  const fragment = buildCompareHashFragment(remaining)
+
+  if (fragment) {
+    router.replace({ path: comparePath.value, hash: fragment })
+  } else {
+    router.replace({ path: comparePath.value })
+  }
+}
+
+const productInitials = (title: string) => {
+  return title
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .slice(0, 2)
+    .join('')
+}
+</script>
+
+<style scoped lang="sass">
+.compare-page
+  display: flex
+  flex-direction: column
+  gap: 2.5rem
+  padding-bottom: 3rem
+
+.compare-page__hero
+  text-align: center
+  padding-block: 2rem 1rem
+
+.compare-page__title
+  font-size: clamp(2rem, 3vw, 2.75rem)
+  font-weight: 700
+  margin-bottom: 0.75rem
+
+.compare-page__subtitle
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+  max-width: 720px
+  margin: 0 auto
+
+.compare-page__content
+  display: flex
+  flex-direction: column
+  gap: 3rem
+
+.compare-page__empty
+  display: flex
+  flex-direction: column
+  align-items: center
+  text-align: center
+  gap: 1rem
+  padding-block: 4rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+
+.compare-page__empty-icon
+  color: rgb(var(--v-theme-accent-supporting))
+
+.compare-page__empty-title
+  font-size: 1.5rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.compare-page__empty-text
+  max-width: 480px
+
+.compare-section
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+.compare-section__title
+  font-size: clamp(1.5rem, 2.2vw, 2rem)
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.compare-grid
+  overflow-x: auto
+  background: rgb(var(--v-theme-surface-glass))
+  border-radius: 20px
+  padding: 1.5rem
+  display: flex
+  flex-direction: column
+  gap: 1rem
+
+.compare-grid--compact
+  padding-inline: 1rem
+
+.compare-grid__header
+  display: grid
+  grid-template-columns: minmax(180px, 220px) repeat(auto-fit, minmax(220px, 1fr))
+  gap: 1rem
+  position: sticky
+  top: 0
+  z-index: 2
+  background: rgba(var(--v-theme-surface-glass), 0.95)
+  border-radius: 12px
+  padding: 1rem
+
+.compare-grid__feature--header
+  display: flex
+  align-items: center
+  justify-content: center
+
+.compare-grid__products
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr))
+  gap: 1rem
+
+.compare-grid__product
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 0.5rem
+  text-align: center
+
+.compare-grid__product-media
+  display: flex
+  align-items: center
+  justify-content: center
+  width: 100%
+  height: 180px
+  background: rgb(var(--v-theme-surface-default))
+  border-radius: 16px
+  overflow: hidden
+
+.compare-grid__product-image
+  object-fit: contain
+  max-width: 100%
+  max-height: 100%
+
+.compare-grid__product-placeholder
+  font-size: 2rem
+  font-weight: 600
+  color: rgba(var(--v-theme-text-neutral-soft), 0.75)
+
+.compare-grid__product-impact
+  margin-top: 0.25rem
+
+.compare-grid__product-model
+  font-weight: 600
+  margin: 0
+
+.compare-grid__product-brand
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85)
+  margin: 0
+
+.compare-grid__product-country
+  display: flex
+  justify-content: center
+
+.compare-grid__product-country-flag
+  display: inline-flex
+  align-items: center
+  gap: 0.5rem
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.compare-grid__flag
+  border-radius: 4px
+
+.compare-grid__product-remove
+  margin-top: 0.5rem
+
+.compare-grid__row
+  display: grid
+  grid-template-columns: minmax(180px, 220px) repeat(auto-fit, minmax(220px, 1fr))
+  gap: 1rem
+  align-items: stretch
+
+.compare-grid__group
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  padding-top: 1rem
+  border-top: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+
+.compare-grid__group-title
+  font-size: 1.1rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+  margin: 0
+
+.compare-grid__feature
+  display: flex
+  align-items: flex-start
+  gap: 0.75rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.compare-grid__feature-icon
+  color: rgb(var(--v-theme-accent-supporting))
+
+.compare-grid__values
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr))
+  gap: 1rem
+
+.compare-grid__value
+  background: rgb(var(--v-theme-surface-default))
+  border-radius: 16px
+  padding: 1rem
+  min-height: 100%
+  display: flex
+  align-items: flex-start
+
+.compare-grid__value--highlight
+  border: 2px solid rgba(var(--v-theme-accent-supporting), 0.6)
+  box-shadow: 0 0 0 2px rgba(var(--v-theme-accent-supporting), 0.2)
+
+.compare-grid__value-text
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.compare-grid__list
+  list-style: none
+  margin: 0
+  padding: 0
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+
+.compare-grid__list-item
+  position: relative
+  padding-inline-start: 1.5rem
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.compare-grid__list-item::before
+  content: ''
+  position: absolute
+  inset-inline-start: 0
+  inset-block-start: 0.4rem
+  width: 0.75rem
+  height: 0.75rem
+  border-radius: 50%
+  background: rgba(var(--v-theme-accent-supporting), 0.7)
+
+.compare-grid__values > .compare-grid__value
+  min-height: 120px
+
+.sr-only
+  position: absolute
+  width: 1px
+  height: 1px
+  padding: 0
+  margin: -1px
+  overflow: hidden
+  clip: rect(0, 0, 0, 0)
+  white-space: nowrap
+  border: 0
+
+@media (max-width: 960px)
+  .compare-grid__header
+    position: static
+    grid-template-columns: 1fr
+
+  .compare-grid__row
+    grid-template-columns: 1fr
+
+  .compare-grid__values
+    grid-template-columns: 1fr
+
+  .compare-grid__value
+    min-height: auto
+
+  .compare-grid__products
+    grid-template-columns: 1fr
+</style>

--- a/frontend/app/services/compare/CompareService.spec.ts
+++ b/frontend/app/services/compare/CompareService.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ProductDto, VerticalConfigFullDto } from '~~/shared/api-client'
+import { createCompareService } from './CompareService'
+import type { CompareProductEntry } from './CompareService'
+
+describe('CompareService', () => {
+  const buildProduct = (overrides: Partial<ProductDto> = {}): ProductDto => ({
+    gtin: 1234567890123,
+    base: {
+      vertical: 'VERTICAL',
+      gtinInfo: {
+        countryName: 'France',
+        countryFlagUrl: 'https://example.com/fr.svg',
+      },
+    },
+    identity: {
+      brand: 'Brand',
+      model: 'Model X',
+      bestName: 'Brand Model X',
+    },
+    resources: {
+      coverImagePath: 'https://example.com/cover.jpg',
+    },
+    aiReview: {
+      review: {
+        description: '<p>Great <strong>product</strong></p>',
+        pros: ['<b>Efficient</b>'],
+        cons: ['<i>Pricey</i>'],
+      },
+    },
+    scores: overrides.scores,
+    ...overrides,
+  }) as ProductDto
+
+  const minimalEntry = (verticalId: string | null): CompareProductEntry => ({
+    gtin: '1',
+    product: buildProduct(),
+    verticalId,
+    title: 'Stub',
+    brand: null,
+    model: null,
+    coverImage: null,
+    impactScore: null,
+    review: { description: null, pros: [], cons: [] },
+    country: null,
+  })
+
+  it('loads and normalises product entries', async () => {
+    const product = buildProduct()
+    const fetchProduct = vi.fn().mockResolvedValue(product)
+    const service = createCompareService({ fetchProduct })
+
+    const [entry] = await service.loadProducts(['1234567890123'])
+    expect(fetchProduct).toHaveBeenCalledWith('1234567890123')
+    expect(entry.gtin).toBe('1234567890123')
+    expect(entry.title).toBe('Brand Model X')
+    expect(entry.review.description).toBe('Great product')
+    expect(entry.review.pros[0]).toContain('<b>Efficient</b>')
+    expect(entry.country?.name).toBe('France')
+    expect(entry.impactScore).toBeNull()
+  })
+
+  it('detects mixed verticals', async () => {
+    const service = createCompareService({ fetchProduct: vi.fn() })
+    const mixed = service.hasMixedVerticals([
+      minimalEntry('A'),
+      minimalEntry('B'),
+    ])
+    expect(mixed).toBe(true)
+    const uniform = service.hasMixedVerticals([
+      minimalEntry('A'),
+      minimalEntry('A'),
+    ])
+    expect(uniform).toBe(false)
+  })
+
+  it('returns null when vertical id missing', async () => {
+    const fetchVertical = vi.fn()
+    const service = createCompareService({ fetchVertical })
+    await expect(service.loadVertical(null)).resolves.toBeNull()
+    expect(fetchVertical).not.toHaveBeenCalled()
+  })
+
+  it('loads vertical configuration when id provided', async () => {
+    const vertical = { id: 'VERTICAL' } as VerticalConfigFullDto
+    const fetchVertical = vi.fn().mockResolvedValue(vertical)
+    const service = createCompareService({ fetchVertical })
+
+    await expect(service.loadVertical('VERTICAL')).resolves.toBe(vertical)
+    expect(fetchVertical).toHaveBeenCalledWith('VERTICAL')
+  })
+})

--- a/frontend/app/services/compare/CompareService.ts
+++ b/frontend/app/services/compare/CompareService.ts
@@ -1,0 +1,178 @@
+import DOMPurify from 'isomorphic-dompurify'
+import type { ProductDto, VerticalConfigFullDto, AiReviewDto } from '~~/shared/api-client'
+import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
+
+export interface CompareProductReview {
+  description: string | null
+  pros: string[]
+  cons: string[]
+}
+
+export interface CompareProductEntry {
+  gtin: string
+  product: ProductDto
+  verticalId: string | null
+  title: string
+  brand: string | null
+  model: string | null
+  coverImage: string | null
+  impactScore: number | null
+  review: CompareProductReview
+  country: { name: string; flag?: string } | null
+}
+
+export type FetchProductFn = (gtin: string) => Promise<ProductDto>
+export type FetchVerticalFn = (verticalId: string) => Promise<VerticalConfigFullDto>
+
+export interface CompareServiceOptions {
+  fetchProduct?: FetchProductFn
+  fetchVertical?: FetchVerticalFn
+}
+
+const stripHtml = (content: string | null): string | null => {
+  if (!content) {
+    return null
+  }
+
+  const sanitized = DOMPurify.sanitize(content, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim()
+  const stripped = sanitized.replace(/<[^>]+>/g, '').trim()
+
+  return stripped.length ? stripped : null
+}
+
+const sanitizeHtml = (content: string | null): string | null => {
+  if (!content) {
+    return null
+  }
+
+  return DOMPurify.sanitize(content, { ADD_ATTR: ['target', 'rel', 'class'] })
+}
+
+const normaliseReview = (review: AiReviewDto | null | undefined): CompareProductReview => {
+  if (!review) {
+    return {
+      description: null,
+      pros: [],
+      cons: [],
+    }
+  }
+
+  const description = stripHtml(review.description ?? null)
+  const pros = Array.isArray(review.pros)
+    ? review.pros
+        .map((entry) => sanitizeHtml(String(entry)))
+        .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+    : []
+  const cons = Array.isArray(review.cons)
+    ? review.cons
+        .map((entry) => sanitizeHtml(String(entry)))
+        .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+    : []
+
+  return { description, pros, cons }
+}
+
+const resolveTitle = (product: ProductDto): string => {
+  return (
+    product.identity?.bestName ??
+    product.base?.bestName ??
+    product.names?.h1Title ??
+    product.names?.longestOfferName ??
+    product.identity?.model ??
+    product.identity?.brand ??
+    '#'
+  )
+}
+
+const resolveCoverImage = (product: ProductDto): string | null => {
+  return (
+    product.resources?.coverImagePath ??
+    product.resources?.externalCover ??
+    product.resources?.images?.[0]?.url ??
+    product.base?.coverImagePath ??
+    null
+  )
+}
+
+const resolveCountry = (product: ProductDto): { name: string; flag?: string } | null => {
+  const info = product.base?.gtinInfo
+  if (!info?.countryName) {
+    return null
+  }
+
+  return {
+    name: info.countryName,
+    flag: info.countryFlagUrl ?? undefined,
+  }
+}
+
+const defaultFetchProduct: FetchProductFn = async (gtin) => {
+  return await $fetch<ProductDto>(`/api/products/${gtin}`)
+}
+
+const defaultFetchVertical: FetchVerticalFn = async (verticalId) => {
+  return await $fetch<VerticalConfigFullDto>(`/api/categories/${encodeURIComponent(verticalId)}`)
+}
+
+export const createCompareService = (options: CompareServiceOptions = {}) => {
+  const fetchProduct = options.fetchProduct ?? defaultFetchProduct
+  const fetchVertical = options.fetchVertical ?? defaultFetchVertical
+
+  const loadProducts = async (gtins: string[]): Promise<CompareProductEntry[]> => {
+    const uniqueGtins = Array.from(new Set(gtins.filter((gtin) => gtin.length > 0)))
+    if (!uniqueGtins.length) {
+      return []
+    }
+
+    const products = await Promise.all(
+      uniqueGtins.map(async (gtin) => {
+        const product = await fetchProduct(gtin)
+        const verticalId = product.base?.vertical ?? null
+        const review = normaliseReview(product.aiReview?.review)
+
+        return {
+          gtin,
+          product,
+          verticalId,
+          title: resolveTitle(product),
+          brand: product.identity?.brand ?? null,
+          model: product.identity?.model ?? null,
+          coverImage: resolveCoverImage(product),
+          impactScore: resolvePrimaryImpactScore(product),
+          review,
+          country: resolveCountry(product),
+        }
+      }),
+    )
+
+    return products
+  }
+
+  const loadVertical = async (verticalId: string | null): Promise<VerticalConfigFullDto | null> => {
+    if (!verticalId) {
+      return null
+    }
+
+    return await fetchVertical(verticalId)
+  }
+
+  const hasMixedVerticals = (entries: CompareProductEntry[]): boolean => {
+    const ids = entries
+      .map((entry) => entry.verticalId)
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+
+    if (!ids.length) {
+      return false
+    }
+
+    return new Set(ids).size > 1
+  }
+
+  return {
+    loadProducts,
+    loadVertical,
+    hasMixedVerticals,
+  }
+}
+
+export type CompareService = ReturnType<typeof createCompareService>

--- a/frontend/app/utils/_compare-url.spec.ts
+++ b/frontend/app/utils/_compare-url.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { buildCompareHash, buildCompareHashFragment, parseCompareHash } from './_compare-url'
+
+describe('compare url helpers', () => {
+  it('parses hash fragments ignoring case and duplicates', () => {
+    expect(parseCompareHash('#123Vs456vs123')).toEqual(['123', '456'])
+    expect(parseCompareHash('')).toEqual([])
+    expect(parseCompareHash('#not-a-number')).toEqual([])
+  })
+
+  it('limits parsed gtins to the compare cap', () => {
+    expect(parseCompareHash('#1Vs2Vs3Vs4Vs5')).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('builds hash fragments from gtins', () => {
+    expect(buildCompareHashFragment(['00123', '456'])).toBe('00123Vs456')
+    expect(buildCompareHashFragment(['foo', 'bar'])).toBe('')
+  })
+
+  it('wraps hash fragments with # when building hash', () => {
+    expect(buildCompareHash(['1', '2'])).toBe('#1Vs2')
+    expect(buildCompareHash([])).toBe('')
+  })
+})

--- a/frontend/app/utils/_compare-url.ts
+++ b/frontend/app/utils/_compare-url.ts
@@ -1,0 +1,66 @@
+import { MAX_COMPARE_ITEMS } from '~/stores/useProductCompareStore'
+
+const HASH_SEPARATOR = 'Vs'
+
+const sanitizeGtins = (values: Array<string | number | null | undefined>): string[] => {
+  const normalized = values
+    .map((value) => {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return Math.trunc(value).toString()
+      }
+
+      if (typeof value === 'string') {
+        return value.trim()
+      }
+
+      return ''
+    })
+    .map((value) => value.replace(/[^0-9]/g, ''))
+    .filter((value) => value.length > 0)
+
+  const seen = new Set<string>()
+
+  return normalized.filter((value) => {
+    if (seen.has(value)) {
+      return false
+    }
+
+    seen.add(value)
+    return true
+  })
+}
+
+export const parseCompareHash = (hash: string | null | undefined): string[] => {
+  if (!hash) {
+    return []
+  }
+
+  const fragment = hash.startsWith('#') ? hash.slice(1) : hash
+  if (!fragment) {
+    return []
+  }
+
+  const parts = fragment.split(/vs/i)
+  const gtins = sanitizeGtins(parts)
+
+  if (!gtins.length) {
+    return []
+  }
+
+  return gtins.slice(0, MAX_COMPARE_ITEMS)
+}
+
+export const buildCompareHashFragment = (gtins: Array<string | number | null | undefined>): string => {
+  const sanitized = sanitizeGtins(gtins).slice(0, MAX_COMPARE_ITEMS)
+
+  if (!sanitized.length) {
+    return ''
+  }
+
+  return sanitized.join(HASH_SEPARATOR)
+}
+
+export const buildCompareHash = (gtins: Array<string | number | null | undefined>): string => {
+  const fragment = buildCompareHashFragment(gtins)
+  return fragment ? `#${fragment}` : ''
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1246,6 +1246,53 @@
       "title": "Our partners and mentors"
     }
   },
+  "compare": {
+    "title": "Product comparison",
+    "subtitle": "Contrast specifications, pricing and ecological indicators across the products you selected.",
+    "alerts": {
+      "verticalMismatch": "These products belong to different categories. Some metrics may not be comparable."
+    },
+    "states": {
+      "loading": "Loading product comparison…"
+    },
+    "empty": {
+      "title": "Add products to start comparing",
+      "description": "Use the compare buttons on product or category pages to build your comparison table."
+    },
+    "sections": {
+      "overview": "Overview",
+      "pricing": "Pricing",
+      "ecological": "Ecological impact",
+      "technical": "Technical attributes",
+      "technicalGroupFallback": "Additional specifications"
+    },
+    "a11y": {
+      "featureColumn": "Comparison criteria"
+    },
+    "actions": {
+      "remove": "Remove {name} from comparison",
+      "removeShort": "Remove"
+    },
+    "textual": {
+      "description": "Description",
+      "pros": "Pros",
+      "cons": "Cons",
+      "empty": "Not available"
+    },
+    "pricing": {
+      "newPrice": "Best new price",
+      "occasionPrice": "Best second-hand price",
+      "offersCount": "Offer count"
+    },
+    "ecological": {
+      "ecoscore": "Ecoscore",
+      "brandSustainability": "Brand sustainability",
+      "dataQuality": "Data quality"
+    },
+    "errors": {
+      "loadFailed": "We could not load the comparison. Please refresh and try again."
+    }
+  },
   "product": {
     "admin": {
       "subtitle": "Full JSON payload of the product.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1246,6 +1246,53 @@
       "title": "Nos partenaires et mentors"
     }
   },
+  "compare": {
+    "title": "Comparateur de produits",
+    "subtitle": "Analysez les fiches techniques, les prix et les indicateurs écologiques des produits sélectionnés.",
+    "alerts": {
+      "verticalMismatch": "Ces produits appartiennent à des catégories différentes. Certaines données ne sont pas comparables."
+    },
+    "states": {
+      "loading": "Chargement du comparateur…"
+    },
+    "empty": {
+      "title": "Ajoutez des produits pour commencer",
+      "description": "Depuis les pages produits ou catégories, utilisez le bouton comparer pour bâtir votre tableau."
+    },
+    "sections": {
+      "overview": "Vue d’ensemble",
+      "pricing": "Tarifs",
+      "ecological": "Impact écologique",
+      "technical": "Caractéristiques techniques",
+      "technicalGroupFallback": "Autres caractéristiques"
+    },
+    "a11y": {
+      "featureColumn": "Critères de comparaison"
+    },
+    "actions": {
+      "remove": "Retirer {name} de la comparaison",
+      "removeShort": "Retirer"
+    },
+    "textual": {
+      "description": "Description",
+      "pros": "Atouts",
+      "cons": "Limites",
+      "empty": "Non communiqué"
+    },
+    "pricing": {
+      "newPrice": "Meilleur prix neuf",
+      "occasionPrice": "Meilleur prix d’occasion",
+      "offersCount": "Nombre d’offres"
+    },
+    "ecological": {
+      "ecoscore": "Ecoscore",
+      "brandSustainability": "Durabilité de la marque",
+      "dataQuality": "Qualité des données"
+    },
+    "errors": {
+      "loadFailed": "Impossible de charger la comparaison. Actualisez la page et réessayez."
+    }
+  },
   "product": {
     "admin": {
       "subtitle": "Aperçu JSON complet du produit.",

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -4,7 +4,8 @@ import { DEFAULT_NUXT_LOCALE } from './domain-language'
 const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
 
 export type LocalizedRouteName =
-   'partners'
+   'compare'
+   | 'partners'
    | 'team'
    | LocalizedWikiRouteName
 
@@ -58,6 +59,10 @@ const mapWikiRoutesToLocalizedPaths = <T extends Record<string, Record<NuxtLocal
 const LOCALIZED_WIKI_ROUTE_PATHS = mapWikiRoutesToLocalizedPaths(LOCALIZED_WIKI_PATHS)
 
 export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
+  compare: {
+    'fr-FR': '/comparer',
+    'en-US': '/compare',
+  },
   partners: {
     'fr-FR': '/partenaires',
     'en-US': '/partners',


### PR DESCRIPTION
## Summary
- add a dedicated client-side comparison page with overview, pricing, ecological, and technical tables
- provide compare service utilities and store/hash helpers to load GTIN products consistently across locales
- extend i18n messages and localized routes for the new compare experience

## Testing
- pnpm lint
- pnpm vitest run app/utils/_compare-url.spec.ts app/services/compare/CompareService.spec.ts app/components/category/products/CategoryComparePanel.spec.ts app/pages/compare/index.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690229be47fc8333b991df425f8909a7