### PR TITLE
Fix product hero gallery lightbox visibility

### DIFF
--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -944,12 +944,22 @@ onBeforeUnmount(() => {
 }
 
 .product-gallery__lightbox {
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+.product-gallery__lightbox :deep(.my-gallery) {
   position: absolute;
   width: 1px;
   height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  opacity: 0;
-  pointer-events: none;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
 }
 
 .product-gallery__sr-only {


### PR DESCRIPTION
## Summary
- stop hiding the PhotoSwipe lightbox container so the product hero gallery can surface full-screen media
- keep the library-provided thumbnail markup visually hidden without blocking the overlay

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6902398fe28083339b733c21563a7b86