### PR TITLE
feat(compare): refresh hero and comparison UX

### DIFF
--- a/frontend/app/components/category/products/CategoryComparePanel.spec.ts
+++ b/frontend/app/components/category/products/CategoryComparePanel.spec.ts
@@ -208,7 +208,7 @@ const mountPanel = async () => {
     await firstRemoveButton.trigger('click')
     await nextTick()
     expect(store.items).toHaveLength(1)
-    expect(routerReplace).toHaveBeenCalled()
+    expect(routerReplace).toHaveBeenLastCalledWith('/compare#102')
   })
 
   it('emits launch event when comparison is triggered', async () => {
@@ -229,7 +229,7 @@ const mountPanel = async () => {
     const emitted = wrapper.emitted('launch-comparison') as unknown[][] | undefined
     expect(emitted).toBeTruthy()
     expect(emitted?.[0]?.[0]).toHaveLength(2)
-    expect(routerPush).toHaveBeenCalled()
+    expect(routerPush).toHaveBeenLastCalledWith('/compare#201Vs202')
   })
 
   it('links to the product detail page when a slug is available', async () => {

--- a/frontend/app/components/category/products/CategoryComparePanel.vue
+++ b/frontend/app/components/category/products/CategoryComparePanel.vue
@@ -95,7 +95,7 @@ import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
-import { buildCompareHashFragment } from '~/utils/_compare-url'
+import { buildCompareHash } from '~/utils/_compare-url'
 import { useProductCompareStore, type CompareListItem } from '~/stores/useProductCompareStore'
 
 const emit = defineEmits<{
@@ -128,12 +128,8 @@ const remove = (id: string) => {
   compareStore.removeById(id)
 
   if (route.path === comparePath.value) {
-    const hashFragment = buildCompareHashFragment(items.value.map((item) => item.gtin))
-    if (hashFragment) {
-      router.replace({ path: comparePath.value, hash: hashFragment })
-    } else {
-      router.replace({ path: comparePath.value })
-    }
+    const hash = buildCompareHash(items.value.map((item) => item.gtin))
+    router.replace(hash ? `${comparePath.value}${hash}` : comparePath.value)
   }
 }
 
@@ -147,13 +143,13 @@ const launchComparison = () => {
   }
 
   const gtins = items.value.map((item) => item.gtin)
-  const hashFragment = buildCompareHashFragment(gtins)
+  const hash = buildCompareHash(gtins)
 
-  if (!hashFragment) {
+  if (!hash) {
     return
   }
 
-  router.push({ path: comparePath.value, hash: hashFragment })
+  router.push(`${comparePath.value}${hash}`)
   emit('launch-comparison', [...items.value])
 }
 

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -32,13 +32,19 @@
       </template>
     </TheMainFooter>
 
-    <CategoryComparePanel />
+    <CategoryComparePanel v-if="showComparePanel" />
   </v-app>
 </template>
 
 <script setup lang="ts">
 const drawer = useState('mobileDrawer', () => false)
 const drawerStore = useState("mobileDrawer", () => false);
+const route = useRoute()
+
+const showComparePanel = computed(() => {
+  const routeName = route.name?.toString() ?? ''
+  return !routeName.startsWith('compare')
+})
 
 const toggleDrawer = () => {
   drawerStore.value = !drawerStore.value;

--- a/frontend/app/pages/compare/index.spec.ts
+++ b/frontend/app/pages/compare/index.spec.ts
@@ -211,7 +211,11 @@ const mountPage = async () => {
             technical: 'Technical',
             technicalGroupFallback: 'Other specs',
           },
-          a11y: { featureColumn: 'Feature column' },
+          a11y: {
+            featureColumn: 'Feature column',
+            viewProduct: 'View {name}',
+            bestValue: 'Best value',
+          },
           actions: { remove: 'Remove {name}', removeShort: 'Remove' },
           textual: { description: 'Description', pros: 'Pros', cons: 'Cons', empty: 'N/A' },
           pricing: { newPrice: 'New price', occasionPrice: 'Second-hand price', offersCount: 'Offer count' },

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1267,7 +1267,9 @@
       "technicalGroupFallback": "Additional specifications"
     },
     "a11y": {
-      "featureColumn": "Comparison criteria"
+      "featureColumn": "Comparison criteria",
+      "viewProduct": "View {name} product page",
+      "bestValue": "Best value for this criterion"
     },
     "actions": {
       "remove": "Remove {name} from comparison",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1267,7 +1267,9 @@
       "technicalGroupFallback": "Autres caractéristiques"
     },
     "a11y": {
-      "featureColumn": "Critères de comparaison"
+      "featureColumn": "Critères de comparaison",
+      "viewProduct": "Voir la fiche produit de {name}",
+      "bestValue": "Meilleure valeur pour ce critère"
     },
     "actions": {
       "remove": "Retirer {name} de la comparaison",


### PR DESCRIPTION
## Summary
- ensure compare routes consistently include the hash fragment when navigating from the panel and update specs
- hide the floating compare panel on the comparison page itself
- redesign the comparison page hero and grid with product links, best-value indicators, data filtering, and currency formatting plus the required i18n additions

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69023fcf07b08333974b10a8fac56c05