### PR TITLE
feat(frontend): improve product price analytics

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1432,9 +1432,17 @@
       },
       "newOffers": "New offers",
       "noOccasionHistory": "No history for second-hand offers.",
-      "occasionOffers": "Second-hand offers",
-      "offerList": "Offer list",
-      "subtitle": "Track price evolution and compare offers.",
+  "occasionOffers": "Second-hand offers",
+  "offerList": "Offer list",
+  "metrics": {
+    "average": "Average price",
+    "bestOffer": "Best offer",
+    "highest": "Highest price",
+    "lowest": "Lowest price",
+    "unknownSource": "Unknown source"
+  },
+  "noHistory": "Price history is not yet available for this product.",
+  "subtitle": "Track price evolution and compare offers.",
       "title": "Prices and trends",
       "trend": {
         "decrease": "Price drop of {amount}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1432,9 +1432,17 @@
       },
       "newOffers": "Offres neuves",
       "noOccasionHistory": "Pas d'historique pour les offres d'occasion.",
-      "occasionOffers": "Offres d'occasion",
-      "offerList": "Liste des offres",
-      "subtitle": "Suivez l’évolution des prix et comparez les offres.",
+  "occasionOffers": "Offres d'occasion",
+  "offerList": "Liste des offres",
+  "metrics": {
+    "average": "Prix moyen",
+    "bestOffer": "Meilleure offre",
+    "highest": "Prix le plus haut",
+    "lowest": "Prix le plus bas",
+    "unknownSource": "Source inconnue"
+  },
+  "noHistory": "L'historique des prix n'est pas encore disponible pour ce produit.",
+  "subtitle": "Suivez l’évolution des prix et comparez les offres.",
       "title": "Prix et évolution",
       "trend": {
         "decrease": "Baisse de {amount}",


### PR DESCRIPTION
## Summary
- switch the product price history visuals to conditional bar charts and collapse the grid when one series is missing
- add localized metrics panels under each visible chart with best-offer details and min/avg/max price aggregates
- extend the component test coverage for the new bar charts, metrics rendering, and empty-state behaviour

## Testing
- pnpm lint
- pnpm vitest run app/components/product/ProductPriceSection.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69031e2b6ce48333ad3af08f5eb124e8