### PR TITLE
Enhance product documentation viewer layout

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1361,16 +1361,10 @@
       "title": "Documentation",
       "untitled": "Untitled document",
       "controls": {
-        "fit": "Fit width",
-        "fitWidth": "Fit to width",
-        "reset": "Reset",
-        "resetView": "Reset view",
         "rotate": "Rotate document",
         "rotateLabel": "Rotate",
         "scrollLeft": "Scroll left",
-        "scrollRight": "Scroll right",
-        "zoomIn": "Zoom in",
-        "zoomOut": "Zoom out"
+        "scrollRight": "Scroll right"
       }
     },
     "hero": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1361,16 +1361,10 @@
       "title": "Documentation",
       "untitled": "Document sans titre",
       "controls": {
-        "fit": "Ajuster",
-        "fitWidth": "Ajuster à la largeur",
-        "reset": "Réinitialiser",
-        "resetView": "Réinitialiser la vue",
         "rotate": "Pivoter le document",
         "rotateLabel": "Pivoter",
         "scrollLeft": "Faire défiler vers la gauche",
-        "scrollRight": "Faire défiler vers la droite",
-        "zoomIn": "Zoom avant",
-        "zoomOut": "Zoom arrière"
+        "scrollRight": "Faire défiler vers la droite"
       }
     },
     "hero": {


### PR DESCRIPTION
## Summary
- align the viewer heading with tab truncation and provide a localized fallback title for untitled documents
- remove manual zoom/reset controls from the PDF viewer and double its height for better readability
- update the accompanying unit tests and translations to reflect the streamlined controls

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69046bcd23908333b7756924f7ee3f68