### PR TITLE
feat: polish product hero layout and impact badge

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -151,6 +151,8 @@ describe('ProductHero', () => {
       gtinInfo: { countryName: 'France', countryFlagUrl: '/flag.png' },
       coverImagePath: '/cover.jpg',
     },
+    slug: 'demo-product',
+    fullSlug: 'appliances/demo-product',
     offers: {
       offersCount: 4,
       bestPrice: {
@@ -370,6 +372,19 @@ describe('ProductHero', () => {
     expect(attributes[0]?.text()).toContain('Model X')
     expect(attributes[1]?.text()).toContain('Origin')
     expect(attributes[1]?.text()).toContain('France')
+
+    await wrapper.unmount()
+  })
+
+  it('renders the impact badge with formatted score and learn-more link', async () => {
+    const wrapper = await mountComponent()
+
+    const impactCard = wrapper.get('.product-hero__impact-card')
+    expect(impactCard.get('.product-hero__impact-title').text()).toBe('Impact score: 3.5')
+
+    const learnMoreLink = impactCard.get('.product-hero__impact-link')
+    expect(learnMoreLink.attributes('href')).toBe('/appliances/ecoscore')
+    expect(learnMoreLink.text()).toBe('Learn more')
 
     await wrapper.unmount()
   })

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -39,47 +39,60 @@
         </li>
       </ul>
 
-      <ImpactScore
-        v-if="impactScore !== null"
-        :score="impactScore"
-        :max="5"
-        size="large"
-        :show-value="true"
-        class="product-hero__impact"
-      />
+      <div class="product-hero__meta-group">
+        <div class="product-hero__meta-top">
+          <v-tooltip v-if="gtinCountry" location="bottom" :text="t('product.hero.gtinTooltip')">
+            <template #activator="{ props: tooltipProps }">
+              <span v-bind="tooltipProps" class="product-hero__origin">
+                <NuxtImg
+                  v-if="gtinCountry.flag"
+                  :src="gtinCountry.flag"
+                  :alt="gtinCountry.name"
+                  width="32"
+                  height="24"
+                  class="product-hero__flag"
+                />
+                <span>{{ gtinCountry.name }}</span>
+              </span>
+            </template>
+          </v-tooltip>
+        </div>
 
-      <v-tooltip v-if="gtinCountry" location="bottom" :text="t('product.hero.gtinTooltip')">
-        <template #activator="{ props: tooltipProps }">
-          <span v-bind="tooltipProps" class="product-hero__origin">
-            <NuxtImg
-              v-if="gtinCountry.flag"
-              :src="gtinCountry.flag"
-              :alt="gtinCountry.name"
-              width="32"
-              height="24"
-              class="product-hero__flag"
-            />
-            <span>{{ gtinCountry.name }}</span>
-          </span>
-        </template>
-      </v-tooltip>
+        <div v-if="impactScore !== null" class="product-hero__meta-middle">
+          <div class="product-hero__impact-card">
+            <p class="product-hero__impact-title">{{ impactBadgeTitle }}</p>
 
-      <div class="product-hero__spacer" aria-hidden="true"></div>
+            <div class="product-hero__impact-score">
+              <ImpactScore :score="impactScore" :max="5" size="large" :show-value="true" />
+            </div>
 
-      <v-btn
-        class="product-hero__compare-button"
-        :class="{ 'product-hero__compare-button--active': isCompareSelected }"
-        color="primary"
-        variant="flat"
-        :aria-pressed="isCompareSelected"
-        :aria-label="compareButtonAriaLabel"
-        :title="compareButtonTitle"
-        :disabled="isCompareDisabled"
-        @click="toggleCompare"
-      >
-        <v-icon :icon="compareButtonIcon" size="20" class="product-hero__compare-icon" />
-        <span class="product-hero__compare-label">{{ compareButtonText }}</span>
-      </v-btn>
+            <NuxtLink
+              v-if="impactScoreLearnMoreLink"
+              :to="impactScoreLearnMoreLink"
+              class="product-hero__impact-link"
+            >
+              {{ impactBadgeLinkLabel }}
+            </NuxtLink>
+          </div>
+        </div>
+
+        <div class="product-hero__meta-bottom">
+          <v-btn
+            class="product-hero__compare-button"
+            :class="{ 'product-hero__compare-button--active': isCompareSelected }"
+            color="primary"
+            variant="flat"
+            :aria-pressed="isCompareSelected"
+            :aria-label="compareButtonAriaLabel"
+            :title="compareButtonTitle"
+            :disabled="isCompareDisabled"
+            @click="toggleCompare"
+          >
+            <v-icon :icon="compareButtonIcon" size="20" class="product-hero__compare-icon" />
+            <span class="product-hero__compare-label">{{ compareButtonText }}</span>
+          </v-btn>
+        </div>
+      </div>
     </div>
 
     <aside class="product-hero__pricing">
@@ -331,6 +344,96 @@ const impactScore = computed(() => {
   const relative = props.product.scores?.ecoscore?.relativeValue
   return typeof relative === 'number' ? relative : null
 })
+
+const impactScoreFormatted = computed(() => {
+  if (impactScore.value === null) {
+    return null
+  }
+
+  const value = impactScore.value
+  const hasFraction = Math.abs(value % 1) > 0.001
+
+  return n(value, {
+    style: 'decimal',
+    minimumFractionDigits: hasFraction ? 1 : 0,
+    maximumFractionDigits: hasFraction ? 1 : 0,
+  })
+})
+
+const impactBadgeTitle = computed(() => {
+  if (impactScoreFormatted.value === null) {
+    return ''
+  }
+
+  if (te('product.hero.impactBadge.title')) {
+    return t('product.hero.impactBadge.title', { score: impactScoreFormatted.value })
+  }
+
+  if (te('product.hero.impactScoreLabel')) {
+    return `${t('product.hero.impactScoreLabel')}: ${impactScoreFormatted.value}`
+  }
+
+  return `Impact score: ${impactScoreFormatted.value}`
+})
+
+const impactBadgeLinkLabel = computed(() => {
+  if (te('product.hero.impactBadge.learnMore')) {
+    return t('product.hero.impactBadge.learnMore')
+  }
+
+  if (te('common.actions.learnMore')) {
+    return t('common.actions.learnMore')
+  }
+
+  if (te('common.learnMore')) {
+    return t('common.learnMore')
+  }
+
+  return 'Learn more'
+})
+
+const verticalHomeSegment = computed(() => {
+  const fullSlug = props.product.fullSlug?.toString().trim() ?? ''
+  const slug = props.product.slug?.toString().trim() ?? ''
+
+  if (fullSlug && slug && fullSlug.endsWith(slug)) {
+    const base = fullSlug.slice(0, fullSlug.length - slug.length).replace(/\/$/, '')
+    const normalized = base.replace(/^\/+/, '')
+    return normalized.length ? normalized : null
+  }
+
+  if (fullSlug) {
+    const segments = fullSlug.split('/').filter(Boolean)
+    segments.pop()
+    if (!segments.length) {
+      return null
+    }
+
+    return segments.join('/')
+  }
+
+  if (slug.includes('/')) {
+    const segments = slug.split('/').filter(Boolean)
+    segments.pop()
+    if (!segments.length) {
+      return null
+    }
+
+    return segments.join('/')
+  }
+
+  return null
+})
+
+const impactScoreLearnMoreLink = computed(() => {
+  const base = verticalHomeSegment.value
+  if (!base) {
+    return null
+  }
+
+  const normalized = base.replace(/\/$/, '')
+  return `/${normalized}/ecoscore`
+})
 </script>
 
 <style scoped>
@@ -385,7 +488,8 @@ const impactScore = computed(() => {
 
 .product-hero__brand-line {
   font-size: 1.05rem;
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
   margin: 0;
 }
 
@@ -414,8 +518,8 @@ const impactScore = computed(() => {
 }
 
 .product-hero__attribute-label {
-  font-weight: 600;
-  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 500;
+  color: rgba(var(--v-theme-text-neutral-strong), 0.9);
 }
 
 .product-hero__attribute-separator {
@@ -426,8 +530,27 @@ const impactScore = computed(() => {
   color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
 }
 
-.product-hero__impact {
-  display: inline-flex;
+.product-hero__meta-group {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: clamp(0.75rem, 2vh, 1.25rem);
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.product-hero__meta-top,
+.product-hero__meta-bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.product-hero__meta-middle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 }
 
 .product-hero__origin {
@@ -446,8 +569,71 @@ const impactScore = computed(() => {
   object-fit: cover;
 }
 
-.product-hero__spacer {
-  flex: 1 1 auto;
+.product-hero__impact-card {
+  width: 100%;
+  border-radius: 24px;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-surface-primary-050), 0.95),
+    rgba(var(--v-theme-surface-glass), 0.92)
+  );
+  box-shadow: 0 24px 54px rgba(15, 23, 42, 0.12);
+  padding: clamp(1.25rem, 2vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.product-hero__impact-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-hero__impact-score {
+  display: flex;
+  justify-content: center;
+}
+
+.product-hero__impact-link {
+  align-self: flex-end;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.product-hero__impact-link:hover,
+.product-hero__impact-link:focus-visible {
+  color: rgb(var(--v-theme-accent-primary-highlight));
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+.product-hero__meta-bottom {
+  justify-content: flex-end;
+}
+
+@media (max-width: 1280px) {
+  .product-hero__impact-card {
+    padding: clamp(1.1rem, 2.4vw, 1.5rem);
+  }
+}
+
+@media (max-width: 960px) {
+  .product-hero__impact-card {
+    padding: 1.1rem;
+  }
+
+  .product-hero__impact-title {
+    font-size: 0.95rem;
+  }
+
+  .product-hero__impact-link {
+    font-size: 0.85rem;
+  }
 }
 
 .product-hero__compare-button {

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -787,15 +787,17 @@ onBeforeUnmount(() => {
 .product-gallery-wrapper {
   border-radius: 24px;
   position: relative;
-  min-height: 420px;
+  min-height: clamp(360px, 32vw, 420px);
   background: rgba(15, 23, 42, 0.02);
+  display: flex;
 }
 
 .product-gallery {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
   height: 100%;
+  flex: 1 1 auto;
 }
 
 .product-gallery__stage {
@@ -807,7 +809,9 @@ onBeforeUnmount(() => {
   width: 100%;
   background: rgba(15, 23, 42, 0.04);
   cursor: zoom-in;
-  min-height: 360px;
+  flex: 1 1 auto;
+  min-height: clamp(260px, 26vw, 360px);
+  max-height: clamp(300px, 32vw, 400px);
   aspect-ratio: 4 / 3;
 }
 
@@ -840,9 +844,10 @@ onBeforeUnmount(() => {
 .product-gallery__thumbnails {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   width: 100%;
   justify-content: center;
+  margin-top: auto;
 }
 
 .product-gallery__thumbnails--nav {
@@ -859,7 +864,7 @@ onBeforeUnmount(() => {
 .product-gallery__thumbnails-list {
   list-style: none;
   display: flex;
-  gap: 0.75rem;
+  gap: 0.6rem;
   padding: 0;
   margin: 0;
 }
@@ -997,18 +1002,28 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 1280px) {
+  .product-gallery-wrapper {
+    min-height: clamp(320px, 40vw, 360px);
+  }
+
   .product-gallery__stage {
-    min-height: 320px;
+    min-height: clamp(220px, 30vw, 320px);
+    max-height: clamp(260px, 34vw, 340px);
   }
 }
 
 @media (max-width: 960px) {
   .product-gallery-wrapper {
-    min-height: 280px;
+    min-height: 260px;
   }
 
   .product-gallery__stage {
-    min-height: 240px;
+    min-height: 200px;
+    max-height: 260px;
+  }
+
+  .product-gallery__thumbnails {
+    gap: 0.5rem;
   }
 
   .product-gallery__thumbnails-arrow {
@@ -1017,8 +1032,8 @@ onBeforeUnmount(() => {
   }
 
   .product-gallery__thumbnail-image {
-    width: 68px;
-    height: 68px;
+    width: 64px;
+    height: 64px;
   }
 }
 </style>

--- a/frontend/app/components/product/ProductHeroPricing.spec.ts
+++ b/frontend/app/components/product/ProductHeroPricing.spec.ts
@@ -137,6 +137,11 @@ describe('ProductHeroPricing', () => {
     expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
     expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Merchant U')
 
+    const trendChip = wrapper.get('.product-hero__price-trend')
+    expect(trendChip.classes()).toContain('product-hero__price-trend--increase')
+    expect(trendChip.find('.v-icon-stub').text()).toBe('mdi-trending-up')
+    expect(trendChip.text()).toContain('Price increase of €5.00')
+
     await chips[1]?.trigger('click')
     await wrapper.vm.$nextTick()
 
@@ -144,6 +149,11 @@ describe('ProductHeroPricing', () => {
     expect(wrapper.get('.product-hero__price-value').text()).toBe('799')
     expect(wrapper.get('.product-hero__price-currency').text()).toBe('€')
     expect(wrapper.get('.product-hero__price-merchant-link').text()).toContain('Shop')
+
+    const updatedTrendChip = wrapper.get('.product-hero__price-trend')
+    expect(updatedTrendChip.classes()).toContain('product-hero__price-trend--decrease')
+    expect(updatedTrendChip.find('.v-icon-stub').text()).toBe('mdi-trending-down')
+    expect(updatedTrendChip.text()).toContain('Price drop of €10.00')
 
     await wrapper.unmount()
   })

--- a/frontend/app/components/product/ProductHeroPricing.vue
+++ b/frontend/app/components/product/ProductHeroPricing.vue
@@ -27,9 +27,22 @@
         {{ option.label }}
       </button>
     </div>
-    <h2 class="product-hero__pricing-title">
-      {{ $t('product.hero.bestPriceTitle') }}
-    </h2>
+    <div class="product-hero__pricing-header">
+      <button
+        v-if="priceTrendLabel"
+        type="button"
+        class="product-hero__price-trend"
+        :class="priceTrendToneClass"
+        @click="scrollToSelector('#price-history')"
+      >
+        <v-icon :icon="priceTrendIcon" size="18" class="product-hero__price-trend-icon" />
+        <span>{{ priceTrendLabel }}</span>
+      </button>
+
+      <h2 class="product-hero__pricing-title">
+        {{ $t('product.hero.bestPriceTitle') }}
+      </h2>
+    </div>
     <div class="product-hero__price">
       <span class="product-hero__price-value" itemprop="lowPrice">
         {{ bestPriceLabel }}
@@ -107,15 +120,6 @@
         </div>
       </div>
 
-      <button
-        v-if="priceTrendLabel"
-        type="button"
-        class="product-hero__price-trend"
-        @click="scrollToSelector('#price-history')"
-      >
-        <v-icon icon="mdi-chart-line" size="18" class="product-hero__price-trend-icon" />
-        <span>{{ priceTrendLabel }}</span>
-      </button>
     </div>
     <div class="product-hero__price-actions">
       <v-btn color="primary" variant="flat" @click="scrollToSelector('#offers-list', 136)">
@@ -298,13 +302,18 @@ const bestPriceMerchant = computed(() => {
   }
 })
 
-const priceTrendLabel = computed(() => {
+const priceTrend = computed(() => {
   const offers = props.product.offers
   if (!offers) {
     return null
   }
 
   const trend = activeCondition.value === 'occasion' ? offers.occasionTrend : offers.newTrend
+  return trend ?? null
+})
+
+const priceTrendLabel = computed(() => {
+  const trend = priceTrend.value
   if (!trend) {
     return null
   }
@@ -333,6 +342,32 @@ const priceTrendLabel = computed(() => {
 
   return t('product.price.trend.stable')
 })
+
+const priceTrendTone = computed<'decrease' | 'increase' | 'stable'>(() => {
+  const trendType = priceTrend.value?.trend
+  if (trendType === 'PRICE_DECREASE') {
+    return 'decrease'
+  }
+
+  if (trendType === 'PRICE_INCREASE') {
+    return 'increase'
+  }
+
+  return 'stable'
+})
+
+const priceTrendIcon = computed(() => {
+  switch (priceTrendTone.value) {
+    case 'decrease':
+      return 'mdi-trending-down'
+    case 'increase':
+      return 'mdi-trending-up'
+    default:
+      return 'mdi-trending-neutral'
+  }
+})
+
+const priceTrendToneClass = computed(() => `product-hero__price-trend--${priceTrendTone.value}`)
 
 const scrollToSelector = (selector: string, offset = 120) => {
   if (!import.meta.client) {
@@ -396,6 +431,14 @@ const scrollToSelector = (selector: string, offset = 120) => {
 .product-hero__price-chip:disabled {
   cursor: default;
   box-shadow: none;
+}
+
+.product-hero__pricing-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .product-hero__pricing-title {
@@ -468,25 +511,67 @@ const scrollToSelector = (selector: string, offset = 120) => {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.4rem 0.5rem;
+  padding: 0.4rem 0.6rem;
   border: none;
   border-radius: 999px;
-  background: rgba(var(--v-theme-surface-primary-080), 0.6);
-  color: rgb(var(--v-theme-text-neutral-secondary));
   font-weight: 600;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  background: transparent;
+  color: rgb(var(--v-theme-text-neutral-secondary));
 }
 
 .product-hero__price-trend:hover,
 .product-hero__price-trend:focus-visible {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
+}
+
+.product-hero__price-trend-icon {
+  transition: color 0.2s ease;
+}
+
+.product-hero__price-trend--stable {
+  background: rgba(var(--v-theme-surface-primary-080), 0.6);
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.product-hero__price-trend--stable .product-hero__price-trend-icon {
+  color: rgb(var(--v-theme-accent-primary-highlight));
+}
+
+.product-hero__price-trend--stable:hover,
+.product-hero__price-trend--stable:focus-visible {
   background: rgba(var(--v-theme-surface-primary-100), 0.85);
   color: rgb(var(--v-theme-text-neutral-strong));
 }
 
-.product-hero__price-trend-icon {
-  color: rgb(var(--v-theme-accent-primary-highlight));
+.product-hero__price-trend--decrease {
+  background: rgba(var(--v-theme-primary), 0.14);
+  color: rgb(var(--v-theme-primary));
+}
+
+.product-hero__price-trend--decrease .product-hero__price-trend-icon {
+  color: rgb(var(--v-theme-primary));
+}
+
+.product-hero__price-trend--decrease:hover,
+.product-hero__price-trend--decrease:focus-visible {
+  background: rgba(var(--v-theme-primary), 0.22);
+}
+
+.product-hero__price-trend--increase {
+  background: rgba(var(--v-theme-error), 0.18);
+  color: rgb(var(--v-theme-error));
+}
+
+.product-hero__price-trend--increase .product-hero__price-trend-icon {
+  color: rgb(var(--v-theme-error));
+}
+
+.product-hero__price-trend--increase:hover,
+.product-hero__price-trend--increase:focus-visible {
+  background: rgba(var(--v-theme-error), 0.26);
 }
 
 .product-hero__price-actions {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1400,6 +1400,10 @@
       "openGalleryFallback": "Open product media gallery",
       "openGalleryImage": "View image \"{label}\" in fullscreen",
       "openGalleryVideo": "Play video \"{label}\"",
+      "impactBadge": {
+        "title": "Impact score: {score}",
+        "learnMore": "Learn more"
+      },
       "priceMerchantPrefix": "At",
       "thumbnailLabel": "Select {type} {index} of {total}: {label}",
       "videoBadge": "Video",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1400,6 +1400,10 @@
       "openGalleryFallback": "Ouvrir la galerie média du produit",
       "openGalleryImage": "Afficher l’image « {label} » en plein écran",
       "openGalleryVideo": "Lire la vidéo « {label} »",
+      "impactBadge": {
+        "title": "Score d'impact : {score}",
+        "learnMore": "En savoir plus"
+      },
       "priceMerchantPrefix": "Chez",
       "thumbnailLabel": "Sélectionner {type} {index} sur {total} : {label}",
       "videoBadge": "Vidéo",


### PR DESCRIPTION
## Summary
- redesign the product hero metadata column with a dedicated impact badge, repositioned GTIN origin, and refreshed typography
- tighten the gallery layout and update the pricing trend chip iconography and colors to reflect price movement
- extend product hero unit tests and localisations for the new badge behaviour

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690473f336c08333811d136212ee8528