### PR TITLE
Adjust product hero layout and copy

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -380,7 +380,7 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     const impactCard = wrapper.get('.product-hero__impact-card')
-    expect(impactCard.get('.product-hero__impact-title').text()).toBe('Impact score: 3.5')
+    expect(impactCard.get('.product-hero__impact-title').text()).toBe('Impact score')
 
     const learnMoreLink = impactCard.get('.product-hero__impact-link')
     expect(learnMoreLink.attributes('href')).toBe('/appliances/ecoscore')

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -345,35 +345,20 @@ const impactScore = computed(() => {
   return typeof relative === 'number' ? relative : null
 })
 
-const impactScoreFormatted = computed(() => {
-  if (impactScore.value === null) {
-    return null
-  }
-
-  const value = impactScore.value
-  const hasFraction = Math.abs(value % 1) > 0.001
-
-  return n(value, {
-    style: 'decimal',
-    minimumFractionDigits: hasFraction ? 1 : 0,
-    maximumFractionDigits: hasFraction ? 1 : 0,
-  })
-})
-
 const impactBadgeTitle = computed(() => {
-  if (impactScoreFormatted.value === null) {
+  if (impactScore.value === null) {
     return ''
   }
 
   if (te('product.hero.impactBadge.title')) {
-    return t('product.hero.impactBadge.title', { score: impactScoreFormatted.value })
+    return t('product.hero.impactBadge.title')
   }
 
   if (te('product.hero.impactScoreLabel')) {
-    return `${t('product.hero.impactScoreLabel')}: ${impactScoreFormatted.value}`
+    return t('product.hero.impactScoreLabel')
   }
 
-  return `Impact score: ${impactScoreFormatted.value}`
+  return 'Impact score'
 })
 
 const impactBadgeLinkLabel = computed(() => {
@@ -589,6 +574,7 @@ const impactScoreLearnMoreLink = computed(() => {
   font-size: 1rem;
   font-weight: 700;
   color: rgb(var(--v-theme-text-neutral-strong));
+  text-align: center;
 }
 
 .product-hero__impact-score {

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -787,7 +787,7 @@ onBeforeUnmount(() => {
 .product-gallery-wrapper {
   border-radius: 24px;
   position: relative;
-  min-height: clamp(360px, 32vw, 420px);
+  min-height: clamp(240px, 22vw, 300px);
   background: rgba(15, 23, 42, 0.02);
   display: flex;
 }
@@ -810,8 +810,8 @@ onBeforeUnmount(() => {
   background: rgba(15, 23, 42, 0.04);
   cursor: zoom-in;
   flex: 1 1 auto;
-  min-height: clamp(260px, 26vw, 360px);
-  max-height: clamp(300px, 32vw, 400px);
+  min-height: clamp(175px, 18vw, 240px);
+  max-height: clamp(200px, 21vw, 268px);
   aspect-ratio: 4 / 3;
 }
 
@@ -1003,23 +1003,23 @@ onBeforeUnmount(() => {
 
 @media (max-width: 1280px) {
   .product-gallery-wrapper {
-    min-height: clamp(320px, 40vw, 360px);
+    min-height: clamp(214px, 27vw, 240px);
   }
 
   .product-gallery__stage {
-    min-height: clamp(220px, 30vw, 320px);
-    max-height: clamp(260px, 34vw, 340px);
+    min-height: clamp(150px, 20vw, 214px);
+    max-height: clamp(174px, 23vw, 227px);
   }
 }
 
 @media (max-width: 960px) {
   .product-gallery-wrapper {
-    min-height: 260px;
+    min-height: 180px;
   }
 
   .product-gallery__stage {
-    min-height: 200px;
-    max-height: 260px;
+    min-height: 140px;
+    max-height: 180px;
   }
 
   .product-gallery__thumbnails {

--- a/frontend/app/components/product/ProductHeroPricing.vue
+++ b/frontend/app/components/product/ProductHeroPricing.vue
@@ -445,6 +445,7 @@ const scrollToSelector = (selector: string, offset = 120) => {
   margin: 0;
   font-size: 1.2rem;
   font-weight: 700;
+  flex: 1 1 100%;
 }
 
 .product-hero__price {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1395,7 +1395,7 @@
       "openGalleryImage": "View image \"{label}\" in fullscreen",
       "openGalleryVideo": "Play video \"{label}\"",
       "impactBadge": {
-        "title": "Impact score: {score}",
+        "title": "Impact score",
         "learnMore": "Learn more"
       },
       "priceMerchantPrefix": "At",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1395,7 +1395,7 @@
       "openGalleryImage": "Afficher l’image « {label} » en plein écran",
       "openGalleryVideo": "Lire la vidéo « {label} »",
       "impactBadge": {
-        "title": "Score d'impact : {score}",
+        "title": "Score d'impact",
         "learnMore": "En savoir plus"
       },
       "priceMerchantPrefix": "Chez",


### PR DESCRIPTION
## Summary
- shrink the product hero gallery stage to 2/3 height so it occupies less space on large and medium breakpoints
- center the impact score title, drop the duplicated numeric suffix, and update translations plus the related unit test
- force the best price heading to wrap beneath the trend chip for clearer hierarchy

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_69047e4a6df48333806b6179eddca997