### PR TITLE
Fix ProductAlternatives to handle paginated search response

### DIFF
--- a/frontend/app/components/product/impact/ProductAlternatives.vue
+++ b/frontend/app/components/product/impact/ProductAlternatives.vue
@@ -482,7 +482,8 @@ const fetchAlternatives = async () => {
       return
     }
 
-    const products = (response.products ?? []).filter((candidate) => candidate.gtin !== props.product?.gtin)
+    const pageData = Array.isArray(response.products?.data) ? response.products.data : []
+    const products = pageData.filter((candidate) => candidate.gtin !== props.product?.gtin)
     alternatives.value = products.slice(0, props.maxResults)
   } catch (error) {
     if (currentToken !== requestToken) {


### PR DESCRIPTION
## Summary
- ensure ProductAlternatives reads paginated search results from the `data` array before filtering the current product out

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6904837aa8788333a209154ff367fd78