### PR TITLE
Refine category numeric filters and align chart styling

### DIFF
--- a/frontend/app/components/category/CategoryActiveFilters.spec.ts
+++ b/frontend/app/components/category/CategoryActiveFilters.spec.ts
@@ -9,6 +9,8 @@ import type { FieldMetadataDto, FilterRequestDto } from '~~/shared/api-client'
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
+    n: (value: number, options?: Intl.NumberFormatOptions) =>
+      new Intl.NumberFormat('en', options).format(value),
   }),
 }))
 
@@ -168,5 +170,27 @@ describe('CategoryActiveFilters', () => {
     const wrapper = mountComponent({ filters: {}, subsetClauses: [] })
 
     expect(wrapper.html()).toBe('<!--v-if-->')
+  })
+
+  it('formats range filters with one decimal place in chip labels', () => {
+    const wrapper = mountComponent({
+      filters: {
+        filters: [
+          {
+            field: 'weight',
+            operator: 'range',
+            min: 1.234,
+            max: 5.678,
+          },
+        ],
+      },
+      subsetClauses: [],
+      fieldMetadata: {
+        weight: { mapping: 'weight', title: 'Weight' } as FieldMetadataDto,
+      },
+    })
+
+    const chipTexts = wrapper.findAll('.v-chip-stub').map((chip) => chip.text())
+    expect(chipTexts).toContain('Weight: 1.2 → 5.7')
   })
 })

--- a/frontend/app/components/category/CategoryActiveFilters.vue
+++ b/frontend/app/components/category/CategoryActiveFilters.vue
@@ -55,6 +55,8 @@ import type {
 
 import type { CategorySubsetClause } from '~/types/category-subset'
 import { resolveFilterFieldTitle } from '~/utils/_field-localization'
+import { formatNumericRangeValue } from '~/utils/_number-formatting'
+import { isPriceField } from './filters/price-scale'
 
 type ManualFilterChip = {
   kind: 'manual'
@@ -86,11 +88,15 @@ const emit = defineEmits<{
   'clear-all': []
 }>()
 
-const { t } = useI18n()
+const { t, n } = useI18n()
 
 const activeFilters = computed(() => props.filters?.filters ?? [])
 const subsetClauses = computed(() => props.subsetClauses ?? [])
 const metadata = computed(() => props.fieldMetadata ?? {})
+
+const formatChipBoundary = (value: number | string | null | undefined, isPrice: boolean) => {
+  return formatNumericRangeValue(value, n, { isPrice })
+}
 
 const createManualLabel = (filter: Filter) => {
   const mapping = filter.field ?? ''
@@ -101,8 +107,9 @@ const createManualLabel = (filter: Filter) => {
     return term ? `${fieldLabel}: ${term}` : fieldLabel
   }
 
-  const minLabel = filter.min ?? '–'
-  const maxLabel = filter.max ?? '–'
+  const priceField = isPriceField(mapping)
+  const minLabel = formatChipBoundary(filter.min ?? null, priceField)
+  const maxLabel = formatChipBoundary(filter.max ?? null, priceField)
   return `${fieldLabel}: ${minLabel} → ${maxLabel}`
 }
 

--- a/frontend/app/components/category/filters/CategoryFilterNumeric.spec.ts
+++ b/frontend/app/components/category/filters/CategoryFilterNumeric.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import type { PropType } from 'vue'
+import type { AggregationResponseDto, FieldMetadataDto, Filter } from '~~/shared/api-client'
+
+import CategoryFilterNumeric from './CategoryFilterNumeric.vue'
+
+vi.mock('~/composables/usePluralizedTranslation', () => ({
+  usePluralizedTranslation: () => ({
+    translatePlural: () => '',
+  }),
+}))
+
+const createI18nPlugin = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: { 'category.filters.rangeAriaSuffix': 'range' } },
+  })
+
+const RangeSliderStub = defineComponent({
+  name: 'RangeSliderStub',
+  props: {
+    modelValue: { type: Array as PropType<[number, number]>, default: () => [0, 0] },
+  },
+  emits: ['update:modelValue', 'end'],
+  setup(props, { slots }) {
+    return () =>
+      h('div', { class: 'v-range-slider-stub' }, [
+        slots['thumb-label']?.({ modelValue: props.modelValue }),
+      ])
+  },
+})
+
+const mountComponent = (filter: Filter) => {
+  const aggregation: AggregationResponseDto = {
+    min: 0,
+    max: 10,
+    buckets: [],
+  }
+
+  const field: FieldMetadataDto = {
+    mapping: 'weight',
+    title: 'Weight',
+  }
+
+  const i18n = createI18nPlugin()
+
+  return mount(CategoryFilterNumeric, {
+    props: {
+      field,
+      aggregation,
+      modelValue: filter,
+    },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        ClientOnly: defineComponent({
+          name: 'ClientOnlyStub',
+          setup(_, { slots }) {
+            return () => slots.default?.()
+          },
+        }),
+        VueECharts: defineComponent({
+          name: 'VueEChartsStub',
+          setup() {
+            return () => h('div', { class: 'echarts-stub' })
+          },
+        }),
+        'v-range-slider': RangeSliderStub,
+      },
+    },
+  })
+}
+
+describe('CategoryFilterNumeric', () => {
+  it('displays the range label with at most one decimal', () => {
+    const filter: Filter = {
+      field: 'weight',
+      operator: 'range',
+      min: 1.234,
+      max: 5.678,
+    }
+
+    const wrapper = mountComponent(filter)
+    expect(wrapper.find('.category-filter-numeric__range').text()).toBe('1.2 → 5.7')
+  })
+})

--- a/frontend/app/utils/_number-formatting.ts
+++ b/frontend/app/utils/_number-formatting.ts
@@ -1,0 +1,29 @@
+export type NumberFormatter = (value: number, options?: Intl.NumberFormatOptions) => string
+
+type FormatNumericRangeValueOptions = {
+  isPrice?: boolean
+  fallback?: string
+}
+
+const DEFAULT_FALLBACK = '–'
+
+export const formatNumericRangeValue = (
+  value: number | string | null | undefined,
+  formatter: NumberFormatter,
+  { isPrice = false, fallback = DEFAULT_FALLBACK }: FormatNumericRangeValueOptions = {},
+): string => {
+  if (value == null || value === '') {
+    return fallback
+  }
+
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) {
+    return typeof value === 'string' ? value : fallback
+  }
+
+  const formatOptions: Intl.NumberFormatOptions = isPrice
+    ? { maximumFractionDigits: 0, minimumFractionDigits: 0 }
+    : { maximumFractionDigits: 1, minimumFractionDigits: 0 }
+
+  return formatter(numeric, formatOptions)
+}


### PR DESCRIPTION
## Summary
- move the category numeric range slider beneath the chart, reuse a shared formatter to cap displayed decimals, and ensure the chips share the same formatting logic
- align the category histogram colours and hover behaviour with the product impact chart, including axis-shadow tooltip highlighting
- cover the new behaviour with focused component tests for both the numeric filter and the active filter chips

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm vitest run app/components/category/CategoryActiveFilters.spec.ts app/components/category/filters/CategoryFilterNumeric.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6905c8c223cc8333b1f79fbe50f3e15b