### PR TITLE
feat: reposition product alternatives and impact visuals

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -17,8 +17,8 @@ describe('ProductImpactDetailsTable', () => {
             tableHeaders: {
               score: 'Indicator',
               value: 'Value',
-              ranking: 'Rank',
             },
+            noDetailsAvailable: 'No details available',
           },
         },
       },
@@ -30,7 +30,7 @@ describe('ProductImpactDetailsTable', () => {
     { id: 'CO2', label: 'CO2', relativeValue: 3.1, ranking: 12 },
   ]
 
-  it('renders a table without the percentile column', () => {
+  it('renders details without the ranking column and hides ecoscore', () => {
     const wrapper = mount(ProductImpactDetailsTable, {
       props: { scores },
       global: {
@@ -49,7 +49,30 @@ describe('ProductImpactDetailsTable', () => {
     const headers = wrapper.findAll('th').map((node) => node.text())
     expect(headers).toContain('Indicator')
     expect(headers).toContain('Value')
-    expect(headers).toContain('Rank')
-    expect(headers).not.toContain('Percentile')
+    expect(headers).not.toContain('Rank')
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.text()).toContain('CO2')
+    expect(wrapper.text()).not.toContain('Eco')
+  })
+
+  it('shows a fallback message when no rows remain', () => {
+    const wrapper = mount(ProductImpactDetailsTable, {
+      props: { scores: [{ id: 'ECOSCORE', label: 'Eco', relativeValue: 4.2 }] },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          'v-table': defineComponent({
+            name: 'VTableStub',
+            setup(_, { slots }) {
+              return () => h('table', { class: 'v-table-stub' }, slots.default?.())
+            },
+          }),
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('No details available')
   })
 })

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -1,22 +1,21 @@
 <template>
   <article class="impact-details">
     <h3 class="impact-details__title">{{ $t('product.impact.detailsTitle') }}</h3>
-    <v-table density="compact" class="impact-details__table">
+    <v-table v-if="displayScores.length" density="compact" class="impact-details__table">
       <thead>
         <tr>
           <th scope="col">{{ $t('product.impact.tableHeaders.score') }}</th>
           <th scope="col">{{ $t('product.impact.tableHeaders.value') }}</th>
-          <th scope="col">{{ $t('product.impact.tableHeaders.ranking') }}</th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="score in scores" :key="`${score.id}-details`">
+        <tr v-for="score in displayScores" :key="`${score.id}-details`">
           <th scope="row">{{ score.label }}</th>
           <td>{{ formatScore(score.relativeValue) }} / 5</td>
-          <td>{{ score.ranking ?? '—' }}</td>
         </tr>
       </tbody>
     </v-table>
+    <p v-else class="impact-details__empty">{{ $t('product.impact.noDetailsAvailable') }}</p>
   </article>
 </template>
 
@@ -28,7 +27,7 @@ const props = defineProps<{
   scores: ScoreView[]
 }>()
 
-const scores = computed(() => props.scores)
+const displayScores = computed(() => props.scores.filter((score) => score.id !== 'ECOSCORE'))
 
 const formatScore = (value: number | null) => {
   if (value == null || Number.isNaN(value)) {
@@ -59,5 +58,11 @@ const formatScore = (value: number | null) => {
 
 .impact-details__table :deep(tbody th) {
   font-weight: 500;
+}
+
+.impact-details__empty {
+  margin: 0;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+  font-size: 0.95rem;
 }
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1434,6 +1434,7 @@
       "absoluteValue": "Absolute value",
       "detailsTitle": "Assessment details",
       "noPrimaryScore": "Impact score unavailable",
+      "noDetailsAvailable": "No details are available for this assessment yet.",
       "percentile": "Percentile",
       "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
@@ -1456,6 +1457,7 @@
       "impact": "Environmental impact",
       "label": "Product detail navigation",
       "overview": "Overview",
+      "alternatives": "Alternatives",
       "price": "Pricing"
     },
     "price": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1434,6 +1434,7 @@
       "absoluteValue": "Valeur absolue",
       "detailsTitle": "Détails de l'évaluation",
       "noPrimaryScore": "Score indisponible",
+      "noDetailsAvailable": "Les détails de cette évaluation ne sont pas disponibles.",
       "percentile": "Percentile",
       "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
@@ -1456,6 +1457,7 @@
       "impact": "Impact écologique",
       "label": "Navigation de la fiche produit",
       "overview": "Aperçu",
+      "alternatives": "Alternatives",
       "price": "Prix"
     },
     "price": {


### PR DESCRIPTION
## Summary
- move the product alternatives module into its own section after pricing and expose it in the sticky navigation
- filter the eco-score out of radar/details views while hiding the radar when fewer than three indicators remain
- streamline the impact details table UX with a fallback message, updated locale strings, and refreshed unit tests

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6905d16ee9e88333925aa9c473177635