### PR TITLE
feat: add specialized impact subscore cards

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
@@ -1,74 +1,62 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { createI18n } from 'vue-i18n'
 import { defineComponent, h } from 'vue'
 import ProductImpactSubscoreCard from './ProductImpactSubscoreCard.vue'
 import type { ScoreView } from './impact-types'
 
-vi.mock('vue-echarts', () => ({
+vi.mock('./ProductImpactSubscoreGenericCard.vue', () => ({
   default: defineComponent({
-    name: 'VueEChartsStub',
-    props: ['option'],
-    setup() {
-      return () => h('div', { class: 'echart-stub' })
+    name: 'GenericCardStub',
+    setup(_, { attrs }) {
+      return () => h('div', { class: 'generic-card-stub' }, attrs['data-testid'] ?? 'generic-card')
     },
   }),
 }))
 
-describe('ProductImpactSubscoreCard', () => {
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en-US',
-    messages: {
-      'en-US': {
-        product: {
-          impact: {
-            absoluteValue: 'Absolute value',
-          },
-        },
-      },
+vi.mock('./subscores/ProductImpactSubscoreDataQualityCard.vue', () => ({
+  default: defineComponent({
+    name: 'DataQualityCardStub',
+    setup() {
+      return () => h('div', { class: 'data-quality-stub' }, 'data-quality')
     },
-  })
+  }),
+}))
 
-  const score: ScoreView = {
-    id: 'CO2',
-    label: 'CO2 emissions',
-    description: 'Lower is better',
-    relativeValue: 3.6,
-    absoluteValue: 42.5,
-    energyLetter: 'A',
-    distribution: [
-      { label: '1', value: 5 },
-      { label: '2', value: 10 },
-    ],
-  }
+const baseScore: ScoreView = {
+  id: 'UNKNOWN',
+  label: 'Label',
+  description: null,
+  relativeValue: 0,
+  absoluteValue: null,
+  percent: null,
+  ranking: null,
+  letter: null,
+  on20: null,
+  distribution: [],
+  energyLetter: null,
+  metadatas: null,
+}
 
-  it('renders score information and energy badge', () => {
+describe('ProductImpactSubscoreCard', () => {
+  it('falls back to the generic card for unknown ids', () => {
     const wrapper = mount(ProductImpactSubscoreCard, {
-      props: { score, productName: 'Demo Product' },
-      global: {
-        plugins: [i18n],
-        stubs: {
-          ImpactScore: defineComponent({
-            name: 'ImpactScoreStub',
-            props: ['score'],
-            setup(props) {
-              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
-            },
-          }),
-          ClientOnly: defineComponent({
-            name: 'ClientOnlyStub',
-            setup(_, { slots }) {
-              return () => slots.default?.()
-            },
-          }),
-        },
+      props: {
+        score: baseScore,
+        productName: 'Demo',
       },
     })
 
-    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Absolute value')
-    expect(wrapper.text()).toContain('42.5')
-    expect(wrapper.text()).toContain('A')
+    expect(wrapper.find('.generic-card-stub').exists()).toBe(true)
+  })
+
+  it('renders the specialized card when available', () => {
+    const wrapper = mount(ProductImpactSubscoreCard, {
+      props: {
+        score: { ...baseScore, id: 'DATA_QUALITY' },
+        productName: 'Demo',
+      },
+    })
+
+    expect(wrapper.find('.data-quality-stub').exists()).toBe(true)
   })
 })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
@@ -1,238 +1,35 @@
 <template>
-  <article class="impact-subscore">
-    <header class="impact-subscore__header">
-      <div>
-        <h4 class="impact-subscore__title">{{ score.label }}</h4>
-        <p v-if="score.description" class="impact-subscore__description">{{ score.description }}</p>
-      </div>
-      <span v-if="score.letter" class="impact-subscore__letter">{{ score.letter }}</span>
-    </header>
-
-    <div class="impact-subscore__score">
-      <ImpactScore :score="relativeScore" :max="5" show-value size="medium" />
-    </div>
-
-    <div v-if="absoluteValue" class="impact-subscore__absolute">
-      <span class="impact-subscore__absolute-label">{{ $t('product.impact.absoluteValue') }}</span>
-      <span class="impact-subscore__absolute-value">{{ absoluteValue }}</span>
-    </div>
-
-    <div v-if="score.energyLetter" class="impact-subscore__badge">
-      <span class="impact-subscore__energy">{{ score.energyLetter }}</span>
-    </div>
-
-    <div v-if="hasDistribution" class="impact-subscore__chart">
-      <ClientOnly>
-        <VueECharts
-          v-if="histogramOption"
-          :option="histogramOption"
-          :autoresize="true"
-          class="impact-subscore__echart"
-        />
-        <template #fallback>
-          <div class="impact-subscore__chart-placeholder" />
-        </template>
-      </ClientOnly>
-    </div>
-  </article>
+  <component :is="resolvedComponent" :score="score" :product-name="productName" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import VueECharts from 'vue-echarts'
-import type { EChartsOption } from 'echarts'
-import { useI18n } from 'vue-i18n'
-import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
-import type { DistributionBucket, ScoreView } from './impact-types'
-import { ensureImpactECharts } from './echarts-setup'
+import type { Component } from 'vue'
+import type { ScoreView } from './impact-types'
+import ProductImpactSubscoreGenericCard from './ProductImpactSubscoreGenericCard.vue'
+import ProductImpactSubscorePowerConsumptionTypicalCard from './subscores/ProductImpactSubscorePowerConsumptionTypicalCard.vue'
+import ProductImpactSubscoreRepairabilityIndexCard from './subscores/ProductImpactSubscoreRepairabilityIndexCard.vue'
+import ProductImpactSubscorePowerConsumptionOffCard from './subscores/ProductImpactSubscorePowerConsumptionOffCard.vue'
+import ProductImpactSubscoreClasseEnergyCard from './subscores/ProductImpactSubscoreClasseEnergyCard.vue'
+import ProductImpactSubscoreBrandSustainabilityCard from './subscores/ProductImpactSubscoreBrandSustainabilityCard.vue'
+import ProductImpactSubscoreDataQualityCard from './subscores/ProductImpactSubscoreDataQualityCard.vue'
 
 const props = defineProps<{
   score: ScoreView
   productName: string
 }>()
 
-ensureImpactECharts()
+const specializationMap: Record<string, Component> = {
+  POWER_CONSUMPTION_TYPICAL: ProductImpactSubscorePowerConsumptionTypicalCard,
+  POWER_CONSUMPTION_OFF: ProductImpactSubscorePowerConsumptionOffCard,
+  REPAIRABILITY_INDEX: ProductImpactSubscoreRepairabilityIndexCard,
+  CLASSE_ENERGY: ProductImpactSubscoreClasseEnergyCard,
+  BRAND_SUSTAINABILITY: ProductImpactSubscoreBrandSustainabilityCard,
+  DATA_QUALITY: ProductImpactSubscoreDataQualityCard,
+}
 
-const { n } = useI18n()
-
-const relativeScore = computed(() => (props.score.relativeValue ?? 0) || 0)
-
-const absoluteValue = computed(() => {
-  const value = props.score.absoluteValue
-  if (value == null || value === '') {
-    return null
-  }
-
-  if (typeof value === 'number') {
-    return n(value, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
-  }
-
-  return String(value)
-})
-
-const hasDistribution = computed(() => Boolean(props.score.distribution?.length))
-
-const histogramOption = computed<EChartsOption | null>(() => {
-  const distribution = props.score.distribution ?? []
-  if (!distribution.length) {
-    return null
-  }
-
-  const markPointLabel = (() => {
-    const relativeValue = props.score.relativeValue
-    if (relativeValue == null) {
-      return null
-    }
-
-    const closest = distribution.reduce<DistributionBucket | null>((candidate, bucket) => {
-      const labelNumber = Number(bucket.label)
-      if (!Number.isFinite(labelNumber)) {
-        return candidate
-      }
-
-      if (!candidate) {
-        return bucket
-      }
-
-      const candidateDistance = Math.abs(labelNumber - relativeValue)
-      const currentDistance = Math.abs(Number(candidate.label) - relativeValue)
-
-      return candidateDistance < currentDistance ? bucket : candidate
-    }, null)
-
-    return closest?.label ?? null
-  })()
-
-  return {
-    grid: { top: 20, left: 40, right: 20, bottom: 40 },
-    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
-    xAxis: {
-      type: 'category',
-      data: distribution.map((bucket) => bucket.label),
-      axisLabel: { rotate: 35 },
-    },
-    yAxis: { type: 'value' },
-    series: [
-      {
-        type: 'bar',
-        name: props.score.label,
-        data: distribution.map((bucket) => bucket.value),
-        itemStyle: {
-          color: 'rgba(33, 150, 243, 0.75)',
-        },
-        markLine:
-          props.score.relativeValue != null && markPointLabel
-            ? {
-                symbol: 'none',
-                label: {
-                  formatter: props.productName,
-                  color: '#1f2937',
-                },
-                data: [
-                  {
-                    xAxis: markPointLabel,
-                  },
-                ],
-              }
-            : undefined,
-      },
-    ],
-  }
+const resolvedComponent = computed(() => {
+  const normalizedId = (props.score.id ?? '').toUpperCase()
+  return specializationMap[normalizedId] ?? ProductImpactSubscoreGenericCard
 })
 </script>
-
-<style scoped>
-.impact-subscore {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.5rem;
-  border-radius: 22px;
-  background: rgba(var(--v-theme-surface-glass-strong), 0.94);
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
-  min-height: 100%;
-}
-
-.impact-subscore__header {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  align-items: flex-start;
-}
-
-.impact-subscore__title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 600;
-}
-
-.impact-subscore__description {
-  margin: 0.35rem 0 0;
-  font-size: 0.95rem;
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
-}
-
-.impact-subscore__letter {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: rgb(var(--v-theme-accent-supporting));
-}
-
-.impact-subscore__score {
-  display: flex;
-  justify-content: flex-start;
-}
-
-.impact-subscore__absolute {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  background: rgba(var(--v-theme-surface-glass), 0.9);
-  border-radius: 16px;
-  padding: 0.6rem 1rem;
-}
-
-.impact-subscore__absolute-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
-}
-
-.impact-subscore__absolute-value {
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.impact-subscore__badge {
-  display: flex;
-}
-
-.impact-subscore__energy {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 48px;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  background: linear-gradient(135deg, #22c55e, #f97316);
-  color: #ffffff;
-  text-transform: uppercase;
-}
-
-.impact-subscore__chart {
-  margin-top: auto;
-}
-
-.impact-subscore__echart {
-  height: 220px;
-}
-
-.impact-subscore__chart-placeholder {
-  height: 220px;
-  border-radius: 18px;
-  background: rgba(148, 163, 184, 0.15);
-}
-</style>

--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
@@ -1,0 +1,118 @@
+<template>
+  <div v-if="hasData" class="impact-subscore-chart">
+    <ClientOnly>
+      <VueECharts
+        v-if="chartOption"
+        :option="chartOption"
+        :autoresize="true"
+        class="impact-subscore-chart__echart"
+      />
+      <template #fallback>
+        <div class="impact-subscore-chart__placeholder" />
+      </template>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import VueECharts from 'vue-echarts'
+import type { EChartsOption } from 'echarts'
+import type { DistributionBucket } from './impact-types'
+import { ensureImpactECharts } from './echarts-setup'
+
+const props = defineProps<{
+  distribution: DistributionBucket[]
+  label: string
+  relativeValue: number | null
+  productName: string
+}>()
+
+ensureImpactECharts()
+
+const hasData = computed(() => props.distribution.length > 0)
+
+const chartOption = computed<EChartsOption | null>(() => {
+  if (!hasData.value) {
+    return null
+  }
+
+  const markPointLabel = (() => {
+    if (props.relativeValue == null) {
+      return null
+    }
+
+    const relativeValue = props.relativeValue
+
+    const closest = props.distribution.reduce<DistributionBucket | null>((candidate, bucket) => {
+      const labelNumber = Number(bucket.label)
+      if (!Number.isFinite(labelNumber)) {
+        return candidate
+      }
+
+      if (!candidate) {
+        return bucket
+      }
+
+      const candidateDistance = Math.abs(Number(candidate.label) - relativeValue)
+      const currentDistance = Math.abs(labelNumber - relativeValue)
+
+      return candidateDistance < currentDistance ? bucket : candidate
+    }, null)
+
+    return closest?.label ?? null
+  })()
+
+  return {
+    grid: { top: 20, left: 40, right: 20, bottom: 40 },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    xAxis: {
+      type: 'category',
+      data: props.distribution.map((bucket) => bucket.label),
+      axisLabel: { rotate: 35 },
+    },
+    yAxis: { type: 'value' },
+    series: [
+      {
+        type: 'bar',
+        name: props.label,
+        data: props.distribution.map((bucket) => bucket.value),
+        itemStyle: {
+          color: 'rgba(33, 150, 243, 0.75)',
+        },
+        markLine:
+          props.relativeValue != null && markPointLabel
+            ? {
+                symbol: 'none',
+                label: {
+                  formatter: props.productName,
+                  color: '#1f2937',
+                },
+                data: [
+                  {
+                    xAxis: markPointLabel,
+                  },
+                ],
+              }
+            : undefined,
+      },
+    ],
+  }
+})
+</script>
+
+<style scoped>
+.impact-subscore-chart {
+  margin-top: auto;
+}
+
+.impact-subscore-chart__echart {
+  height: 220px;
+}
+
+.impact-subscore-chart__placeholder {
+  height: 220px;
+  border-radius: 18px;
+  background: rgba(148, 163, 184, 0.15);
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
@@ -1,0 +1,151 @@
+<template>
+  <section v-if="hasContent" class="impact-subscore-explanation">
+    <h5 class="impact-subscore-explanation__title">{{ $t('product.impact.explanationTitle') }}</h5>
+    <p v-if="score.description" class="impact-subscore-explanation__description">{{ score.description }}</p>
+
+    <dl v-if="infoItems.length" class="impact-subscore-explanation__list">
+      <div v-for="item in infoItems" :key="item.label" class="impact-subscore-explanation__row">
+        <dt class="impact-subscore-explanation__term">{{ item.label }}</dt>
+        <dd class="impact-subscore-explanation__value">{{ item.value }}</dd>
+      </div>
+    </dl>
+
+    <dl v-if="metadataItems.length" class="impact-subscore-explanation__list impact-subscore-explanation__list--metadata">
+      <div v-for="item in metadataItems" :key="item.label" class="impact-subscore-explanation__row">
+        <dt class="impact-subscore-explanation__term">{{ item.label }}</dt>
+        <dd class="impact-subscore-explanation__value">{{ item.value }}</dd>
+      </div>
+    </dl>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { ScoreView } from './impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  absoluteValue: string | null
+}>()
+
+const { n, t } = useI18n()
+
+const infoItems = computed(() => {
+  const items: Array<{ label: string; value: string }> = []
+
+  if (props.absoluteValue) {
+    items.push({
+      label: t('product.impact.absoluteValue'),
+      value: props.absoluteValue,
+    })
+  }
+
+  if (props.score.percent != null && Number.isFinite(props.score.percent)) {
+    items.push({
+      label: t('product.impact.percentile'),
+      value: `${n(props.score.percent, { maximumFractionDigits: 0, minimumFractionDigits: 0 })}%`,
+    })
+  }
+
+  if (props.score.ranking != null && Number.isFinite(Number(props.score.ranking))) {
+    items.push({
+      label: t('product.impact.tableHeaders.ranking'),
+      value: n(Number(props.score.ranking), { maximumFractionDigits: 0, minimumFractionDigits: 0 }),
+    })
+  }
+
+  return items
+})
+
+const metadataItems = computed(() => {
+  const entries = Object.entries(props.score.metadatas ?? {})
+    .map(([key, value]) => ({ key, value }))
+    .filter((entry) => entry.value != null && String(entry.value).trim().length > 0)
+
+  return entries.map(({ key, value }) => ({
+    label: formatMetadataLabel(key),
+    value: String(value),
+  }))
+})
+
+const hasContent = computed(
+  () => Boolean(props.score.description) || infoItems.value.length > 0 || metadataItems.value.length > 0,
+)
+
+function formatMetadataLabel(rawKey: string): string {
+  const humanized = rawKey
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  return humanized
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+</script>
+
+<style scoped>
+.impact-subscore-explanation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
+}
+
+.impact-subscore-explanation__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-subscore-explanation__description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.impact-subscore-explanation__list {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.impact-subscore-explanation__list--metadata {
+  border-top: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12);
+  padding-top: 0.75rem;
+}
+
+.impact-subscore-explanation__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.impact-subscore-explanation__term {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.impact-subscore-explanation__value {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+@media (max-width: 640px) {
+  .impact-subscore-explanation__row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -1,0 +1,96 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductImpactSubscoreGenericCard from './ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from './impact-types'
+
+vi.mock('vue-echarts', () => ({
+  default: defineComponent({
+    name: 'VueEChartsStub',
+    props: ['option'],
+    setup() {
+      return () => h('div', { class: 'echart-stub' })
+    },
+  }),
+}))
+
+describe('ProductImpactSubscoreGenericCard', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          impact: {
+            absoluteValue: 'Absolute value',
+            explanationTitle: 'Explanation',
+            percentile: 'Percentile',
+            weightChip: 'Counts for {value}% of the total score',
+            subscoreEyebrow: 'Impact indicator',
+            tableHeaders: {
+              ranking: 'Rank',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const score: ScoreView = {
+    id: 'CO2',
+    label: 'CO2 emissions',
+    description: 'Lower is better',
+    relativeValue: 3.6,
+    absoluteValue: 42.5,
+    energyLetter: 'A',
+    distribution: [
+      { label: '1', value: 5 },
+      { label: '2', value: 10 },
+    ],
+    percent: 88,
+    ranking: 3,
+    on20: 17.3,
+    metadatas: {
+      coverage: 'High',
+    },
+  }
+
+  it('renders the header, score, chart and explanation details', () => {
+    const wrapper = mount(ProductImpactSubscoreGenericCard, {
+      props: { score, productName: 'Demo Product' },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ImpactScore: defineComponent({
+            name: 'ImpactScoreStub',
+            props: ['score'],
+            setup(props) {
+              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
+            },
+          }),
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => slots.default?.()
+            },
+          }),
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Impact indicator')
+    expect(wrapper.text()).toContain('Counts for 88% of the total score')
+    expect(wrapper.text()).toContain('17.3')
+    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Absolute value')
+    expect(wrapper.text()).toContain('42.5')
+    expect(wrapper.text()).toContain('Explanation')
+    expect(wrapper.text()).toContain('Lower is better')
+    expect(wrapper.text()).toContain('Percentile')
+    expect(wrapper.text()).toContain('88%')
+    expect(wrapper.text()).toContain('Rank')
+    expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('High')
+  })
+})

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -1,0 +1,124 @@
+<template>
+  <article class="impact-subscore">
+    <ProductImpactSubscoreHeader
+      :title="score.label"
+      :subtitle="score.description ?? undefined"
+      :on20="score.on20"
+      :percent="score.percent"
+    />
+
+    <div class="impact-subscore__score">
+      <ImpactScore :score="relativeScore" :max="5" show-value size="medium" />
+    </div>
+
+    <div v-if="absoluteValue" class="impact-subscore__absolute">
+      <span class="impact-subscore__absolute-label">{{ $t('product.impact.absoluteValue') }}</span>
+      <span class="impact-subscore__absolute-value">{{ absoluteValue }}</span>
+    </div>
+
+    <div v-if="score.energyLetter" class="impact-subscore__badge">
+      <span class="impact-subscore__energy">{{ score.energyLetter }}</span>
+    </div>
+
+    <ProductImpactSubscoreChart
+      v-if="hasDistribution"
+      :distribution="score.distribution ?? []"
+      :label="score.label"
+      :relative-value="score.relativeValue"
+      :product-name="productName"
+    />
+
+    <ProductImpactSubscoreExplanation :score="score" :absolute-value="absoluteValue" />
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import ProductImpactSubscoreHeader from './ProductImpactSubscoreHeader.vue'
+import ProductImpactSubscoreChart from './ProductImpactSubscoreChart.vue'
+import ProductImpactSubscoreExplanation from './ProductImpactSubscoreExplanation.vue'
+import type { ScoreView } from './impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+
+const { n } = useI18n()
+
+const relativeScore = computed(() => (props.score.relativeValue ?? 0) || 0)
+
+const absoluteValue = computed(() => {
+  const value = props.score.absoluteValue
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (typeof value === 'number') {
+    return n(value, { maximumFractionDigits: 2, minimumFractionDigits: 0 })
+  }
+
+  return String(value)
+})
+
+const hasDistribution = computed(() => Boolean(props.score.distribution?.length))
+</script>
+
+<style scoped>
+.impact-subscore {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem 1.5rem;
+  border-radius: 22px;
+  background: rgba(var(--v-theme-surface-glass-strong), 0.94);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
+  min-height: 100%;
+}
+
+.impact-subscore__score {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.impact-subscore__absolute {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border-radius: 16px;
+  padding: 0.6rem 1rem;
+}
+
+.impact-subscore__absolute-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
+}
+
+.impact-subscore__absolute-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.impact-subscore__badge {
+  display: flex;
+}
+
+.impact-subscore__energy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  background: linear-gradient(135deg, #22c55e, #f97316);
+  color: #ffffff;
+  text-transform: uppercase;
+}
+</style>

--- a/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
@@ -1,0 +1,123 @@
+<template>
+  <header class="impact-subscore-header">
+    <div class="impact-subscore-header__info">
+      <p class="impact-subscore-header__eyebrow">{{ $t('product.impact.subscoreEyebrow') }}</p>
+      <h4 class="impact-subscore-header__title">{{ title }}</h4>
+      <p v-if="subtitle" class="impact-subscore-header__subtitle">{{ subtitle }}</p>
+      <span v-if="weightText" class="impact-subscore-header__weight">{{ weightText }}</span>
+    </div>
+
+    <div v-if="on20Value" class="impact-subscore-header__score" aria-hidden="true">
+      <span class="impact-subscore-header__score-value">{{ on20Value }}</span>
+      <span class="impact-subscore-header__score-scale">/20</span>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps<{
+  title: string
+  subtitle?: string
+  on20?: number | null
+  percent?: number | null
+}>()
+
+const { n, t } = useI18n()
+
+const on20Value = computed(() => {
+  if (typeof props.on20 !== 'number' || Number.isNaN(props.on20)) {
+    return null
+  }
+
+  return n(props.on20, { maximumFractionDigits: 1, minimumFractionDigits: 0 })
+})
+
+const weightText = computed(() => {
+  if (typeof props.percent !== 'number' || Number.isNaN(props.percent)) {
+    return null
+  }
+
+  return t('product.impact.weightChip', {
+    value: n(props.percent, { maximumFractionDigits: 0, minimumFractionDigits: 0 }),
+  })
+})
+</script>
+
+<style scoped>
+.impact-subscore-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.impact-subscore-header__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.impact-subscore-header__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.75);
+}
+
+.impact-subscore-header__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-subscore-header__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.impact-subscore-header__weight {
+  align-self: flex-start;
+  padding: 0.2rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-surface-primary-080), 0.8);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.impact-subscore-header__score {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.25rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-accent-supporting));
+}
+
+.impact-subscore-header__score-value {
+  font-size: clamp(1.8rem, 3.5vw, 2.2rem);
+  line-height: 1;
+}
+
+.impact-subscore-header__score-scale {
+  font-size: 1rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.75);
+}
+
+@media (max-width: 600px) {
+  .impact-subscore-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .impact-subscore-header__score {
+    margin-top: 0.5rem;
+  }
+}
+</style>

--- a/frontend/app/components/product/impact/impact-types.ts
+++ b/frontend/app/components/product/impact/impact-types.ts
@@ -12,8 +12,10 @@ export type ScoreView = {
   percent?: number | null
   ranking?: number | string | null
   letter?: string | null
+  on20?: number | null
   distribution?: DistributionBucket[]
   energyLetter?: string | null
+  metadatas?: Record<string, string> | null
 }
 
 export type RankingInfo = {

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreBrandSustainabilityCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreBrandSustainabilityCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreClasseEnergyCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreClasseEnergyCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreDataQualityCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreDataQualityCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionOffCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionOffCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionTypicalCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionTypicalCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <ProductImpactSubscoreGenericCard v-bind="props" />
+</template>
+
+<script setup lang="ts">
+import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
+import type { ScoreView } from '../impact-types'
+
+const props = defineProps<{
+  score: ScoreView
+  productName: string
+}>()
+</script>

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -403,8 +403,10 @@ const impactScores = computed(() => {
         percent: score.percent ?? null,
         ranking: score.ranking ?? null,
         letter: score.letter ?? null,
+        on20: score.on20 ?? null,
         distribution,
         energyLetter: score.id === 'CLASSE_ENERGY' && score.letter ? score.letter : null,
+        metadatas: score.metadatas ?? null,
       }
     })
 })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1432,10 +1432,13 @@
         }
       },
       "absoluteValue": "Absolute value",
+      "explanationTitle": "How to interpret this indicator",
       "detailsTitle": "Assessment details",
       "noPrimaryScore": "Impact score unavailable",
       "noDetailsAvailable": "No details are available for this assessment yet.",
       "percentile": "Percentile",
+      "weightChip": "Counts for {value}% of the total score",
+      "subscoreEyebrow": "Impact indicator",
       "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
       "scoreRanking": "Factor ranking",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1432,10 +1432,13 @@
         }
       },
       "absoluteValue": "Valeur absolue",
+      "explanationTitle": "Comment lire cet indicateur",
       "detailsTitle": "Détails de l'évaluation",
       "noPrimaryScore": "Score indisponible",
       "noDetailsAvailable": "Les détails de cette évaluation ne sont pas disponibles.",
       "percentile": "Percentile",
+      "weightChip": "Compte pour {value}% de la note totale",
+      "subscoreEyebrow": "Indicateur d'impact",
       "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
       "scoreRanking": "Classement du facteur",


### PR DESCRIPTION
## Summary
- introduce a dynamic ProductImpactSubscoreCard that resolves dedicated components for known subscores and falls back to the generic view
- extract reusable header, chart, and explanation building blocks so subscores now display on20 values, weighting chips, and contextual details
- extend score data mapping and i18n resources to support the new UI and cover the behaviour with component tests

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6905d939f20c83338acc68c7160d5a91