### PR TITLE
Improve product page SEO metadata and navigation semantics

### DIFF
--- a/frontend/app/components/product/ProductSummaryNavigation.vue
+++ b/frontend/app/components/product/ProductSummaryNavigation.vue
@@ -14,6 +14,8 @@
           type="button"
           class="product-summary-navigation__link"
           :class="{ 'product-summary-navigation__link--active': section.id === activeSection }"
+          :aria-current="section.id === activeSection ? 'true' : undefined"
+          :aria-controls="section.id"
           @click="onNavigate(section.id)"
         >
           <v-icon


### PR DESCRIPTION
## Summary
- normalise the product page canonical URL and emit product-specific Open Graph tags sourced from gallery media
- stop serialising empty offer arrays in JSON-LD and attach the resolved product image to the structured data payload
- add aria-current semantics to the product summary navigation buttons so screen readers announce the active section

## Testing
- pnpm lint
- pnpm exec vitest run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6906330ed1648333a91f0a9e90c13085