### PR TITLE
feat: highlight impact subscore position indicator

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.spec.ts
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import type { BarSeriesOption, EChartsOption, MarkLineComponentOption } from 'echarts'
+import ProductImpactSubscoreChart from './ProductImpactSubscoreChart.vue'
+
+vi.mock('vue-echarts', () => ({
+  default: defineComponent({
+    name: 'VueEChartsStub',
+    props: {
+      option: { type: Object, required: false },
+    },
+    setup(props) {
+      return () => h('div', { class: 'echart-stub', 'data-option': JSON.stringify(props.option ?? {}) })
+    },
+  }),
+}))
+
+describe('ProductImpactSubscoreChart', () => {
+  const clientOnlyStub = defineComponent({
+    name: 'ClientOnlyStub',
+    setup(_, { slots }) {
+      return () => slots.default?.()
+    },
+  })
+
+  it('does not render the chart when no distribution is provided', () => {
+    const wrapper = mount(ProductImpactSubscoreChart, {
+      props: {
+        distribution: [],
+        label: 'CO2 emissions',
+        relativeValue: null,
+        productName: 'Demo product',
+      },
+      global: {
+        stubs: {
+          ClientOnly: clientOnlyStub,
+        },
+      },
+    })
+
+    expect(wrapper.find('.impact-subscore-chart__echart').exists()).toBe(false)
+  })
+
+  it('renders an indicator aligned with the closest bucket and colors it based on the percent value', async () => {
+    const wrapper = mount(ProductImpactSubscoreChart, {
+      props: {
+        distribution: [
+          { label: '1', value: 5 },
+          { label: '2', value: 10 },
+          { label: '3', value: 2 },
+        ],
+        label: 'CO2 emissions',
+        relativeValue: 1.3,
+        productName: 'Demo product',
+        percent: 50,
+      },
+      global: {
+        stubs: {
+          ClientOnly: clientOnlyStub,
+        },
+      },
+    })
+
+    await nextTick()
+
+    const echartStub = wrapper.findComponent({ name: 'VueEChartsStub' })
+    expect(echartStub.exists()).toBe(true)
+
+    const option = echartStub.props('option') as EChartsOption
+    const grid = Array.isArray(option.grid) ? option.grid[0] : option.grid
+    expect(grid?.top).toBe(52)
+
+    const yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
+    expect(yAxis?.max).toBeCloseTo(11.2)
+
+    const seriesOption = (Array.isArray(option.series) ? option.series[0] : option.series) as BarSeriesOption
+    const markLine = seriesOption.markLine as MarkLineComponentOption
+    expect(markLine?.symbol).toEqual(['none', 'path://M12 24L24 8H16V0H8V8H0L12 24Z'])
+
+    const markLineData = Array.isArray(markLine?.data) ? markLine?.data[0] : undefined
+    expect(markLine?.lineStyle?.color).toBe('hsl(60.00, 75%, 45%)')
+    expect(markLineData && 'xAxis' in markLineData ? markLineData.xAxis : undefined).toBe('1')
+    expect(markLineData && 'yAxis' in markLineData ? markLineData.yAxis : undefined).toBeCloseTo(11.2)
+  })
+
+  it('falls back to a default accent color when percent is not provided', async () => {
+    const wrapper = mount(ProductImpactSubscoreChart, {
+      props: {
+        distribution: [
+          { label: '10', value: 4 },
+          { label: '20', value: 6 },
+        ],
+        label: 'CO2 emissions',
+        relativeValue: 18,
+        productName: 'Demo product',
+        percent: null,
+      },
+      global: {
+        stubs: {
+          ClientOnly: clientOnlyStub,
+        },
+      },
+    })
+
+    await nextTick()
+
+    const option = wrapper.findComponent({ name: 'VueEChartsStub' }).props('option') as EChartsOption
+    const seriesOption = (Array.isArray(option.series) ? option.series[0] : option.series) as BarSeriesOption
+    const markLine = seriesOption.markLine as MarkLineComponentOption
+    expect(markLine?.lineStyle?.color).toBe('#2563eb')
+  })
+})

--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.spec.ts
@@ -69,7 +69,7 @@ describe('ProductImpactSubscoreChart', () => {
 
     const option = echartStub.props('option') as EChartsOption
     const grid = Array.isArray(option.grid) ? option.grid[0] : option.grid
-    expect(grid?.top).toBe(52)
+    expect(grid?.top).toBe(32)
 
     const yAxis = Array.isArray(option.yAxis) ? option.yAxis[0] : option.yAxis
     expect(yAxis?.max).toBeCloseTo(11.2)
@@ -109,5 +109,35 @@ describe('ProductImpactSubscoreChart', () => {
     const seriesOption = (Array.isArray(option.series) ? option.series[0] : option.series) as BarSeriesOption
     const markLine = seriesOption.markLine as MarkLineComponentOption
     expect(markLine?.lineStyle?.color).toBe('#2563eb')
+  })
+
+  it('still aligns the indicator when bucket labels use comma separators', async () => {
+    const wrapper = mount(ProductImpactSubscoreChart, {
+      props: {
+        distribution: [
+          { label: '0,5', value: 12 },
+          { label: '1,5', value: 8 },
+          { label: '2,5', value: 4 },
+        ],
+        label: 'CO2 emissions',
+        relativeValue: 1.4,
+        productName: 'Demo product',
+        percent: 75,
+      },
+      global: {
+        stubs: {
+          ClientOnly: clientOnlyStub,
+        },
+      },
+    })
+
+    await nextTick()
+
+    const option = wrapper.findComponent({ name: 'VueEChartsStub' }).props('option') as EChartsOption
+    const seriesOption = (Array.isArray(option.series) ? option.series[0] : option.series) as BarSeriesOption
+    const markLine = seriesOption.markLine as MarkLineComponentOption
+    const markLineData = Array.isArray(markLine?.data) ? markLine?.data[0] : undefined
+
+    expect(markLineData && 'xAxis' in markLineData ? markLineData.xAxis : undefined).toBe('1,5')
   })
 })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
@@ -26,11 +26,28 @@ const props = defineProps<{
   label: string
   relativeValue: number | null
   productName: string
+  percent?: number | null
 }>()
+
+const ARROW_SYMBOL = 'path://M12 24L24 8H16V0H8V8H0L12 24Z'
+
+const computeIndicatorColor = (percent?: number | null): string => {
+  if (percent == null || Number.isNaN(percent)) {
+    return '#2563eb'
+  }
+
+  const clamped = Math.min(100, Math.max(0, percent))
+  const hue = (clamped / 100) * 120
+  return `hsl(${hue.toFixed(2)}, 75%, 45%)`
+}
 
 ensureImpactECharts()
 
 const hasData = computed(() => props.distribution.length > 0)
+
+const maxBucketValue = computed(() =>
+  props.distribution.reduce((max, bucket) => Math.max(max, bucket.value), 0)
+)
 
 const chartOption = computed<EChartsOption | null>(() => {
   if (!hasData.value) {
@@ -57,21 +74,26 @@ const chartOption = computed<EChartsOption | null>(() => {
       const candidateDistance = Math.abs(Number(candidate.label) - relativeValue)
       const currentDistance = Math.abs(labelNumber - relativeValue)
 
-      return candidateDistance < currentDistance ? bucket : candidate
+      return candidateDistance <= currentDistance ? candidate : bucket
     }, null)
 
     return closest?.label ?? null
   })()
 
+  const indicatorColor = computeIndicatorColor(props.percent ?? null)
+
+  const yAxisMax = maxBucketValue.value > 0 ? maxBucketValue.value * 1.12 : undefined
+  const indicatorYAxis = yAxisMax ?? maxBucketValue.value
+
   return {
-    grid: { top: 20, left: 40, right: 20, bottom: 40 },
+    grid: { top: 52, left: 40, right: 20, bottom: 40 },
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
     xAxis: {
       type: 'category',
       data: props.distribution.map((bucket) => bucket.label),
       axisLabel: { rotate: 35 },
     },
-    yAxis: { type: 'value' },
+    yAxis: { type: 'value', max: yAxisMax },
     series: [
       {
         type: 'bar',
@@ -83,14 +105,28 @@ const chartOption = computed<EChartsOption | null>(() => {
         markLine:
           props.relativeValue != null && markPointLabel
             ? {
-                symbol: 'none',
+                symbol: ['none', ARROW_SYMBOL],
+                symbolSize: [24, 24],
+                symbolOffset: [0, -12],
+                lineStyle: {
+                  color: indicatorColor,
+                  width: 2,
+                  type: 'dashed',
+                },
                 label: {
                   formatter: props.productName,
-                  color: '#1f2937',
+                  color: indicatorColor,
+                  fontWeight: 600,
+                  distance: 18,
+                  position: 'end',
+                  backgroundColor: 'rgba(255, 255, 255, 0.92)',
+                  padding: [4, 10],
+                  borderRadius: 12,
                 },
                 data: [
                   {
                     xAxis: markPointLabel,
+                    yAxis: indicatorYAxis,
                   },
                 ],
               }

--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
@@ -31,6 +31,16 @@ const props = defineProps<{
 
 const ARROW_SYMBOL = 'path://M12 24L24 8H16V0H8V8H0L12 24Z'
 
+const parseBucketLabel = (label: string): number | null => {
+  const normalised = label.replace(',', '.').trim()
+  if (!normalised) {
+    return null
+  }
+
+  const numericValue = Number(normalised)
+  return Number.isFinite(numericValue) ? numericValue : null
+}
+
 const computeIndicatorColor = (percent?: number | null): string => {
   if (percent == null || Number.isNaN(percent)) {
     return '#2563eb'
@@ -61,23 +71,23 @@ const chartOption = computed<EChartsOption | null>(() => {
 
     const relativeValue = props.relativeValue
 
-    const closest = props.distribution.reduce<DistributionBucket | null>((candidate, bucket) => {
-      const labelNumber = Number(bucket.label)
-      if (!Number.isFinite(labelNumber)) {
-        return candidate
+    let closestBucket: DistributionBucket | null = null
+    let smallestDistance = Number.POSITIVE_INFINITY
+
+    for (const bucket of props.distribution) {
+      const labelValue = parseBucketLabel(bucket.label)
+      if (labelValue == null) {
+        continue
       }
 
-      if (!candidate) {
-        return bucket
+      const distance = Math.abs(labelValue - relativeValue)
+      if (distance < smallestDistance) {
+        smallestDistance = distance
+        closestBucket = bucket
       }
+    }
 
-      const candidateDistance = Math.abs(Number(candidate.label) - relativeValue)
-      const currentDistance = Math.abs(labelNumber - relativeValue)
-
-      return candidateDistance <= currentDistance ? candidate : bucket
-    }, null)
-
-    return closest?.label ?? null
+    return closestBucket?.label ?? null
   })()
 
   const indicatorColor = computeIndicatorColor(props.percent ?? null)
@@ -86,7 +96,7 @@ const chartOption = computed<EChartsOption | null>(() => {
   const indicatorYAxis = yAxisMax ?? maxBucketValue.value
 
   return {
-    grid: { top: 52, left: 40, right: 20, bottom: 40 },
+    grid: { top: 32, left: 40, right: 20, bottom: 40 },
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
     xAxis: {
       type: 'category',

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -26,6 +26,7 @@
       :label="score.label"
       :relative-value="score.relativeValue"
       :product-name="productName"
+      :percent="score.percent ?? null"
     />
 
     <ProductImpactSubscoreExplanation :score="score" :absolute-value="absoluteValue" />


### PR DESCRIPTION
## Summary
- add a color-coded arrow indicator to the impact subscore chart and leave space for the marker label
- ensure the closest bucket is selected for the product marker and surface the score percent to the chart component
- cover the new behaviour with a dedicated chart unit test suite

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate


------
https://chatgpt.com/codex/tasks/task_e_690717f937e0833388ff01dc33560f69