### PR TITLE
Implement global search endpoint

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
@@ -80,7 +79,6 @@ public class SearchController {
                             })
             }
     )
-    @SecurityRequirement(name = "basicAuth")
     public ResponseEntity<GlobalSearchResponseDto> globalSearch(
             @RequestParam(name = "query") String query,
             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
@@ -103,7 +101,6 @@ public class SearchController {
     }
 
     private GlobalSearchResultDto toDto(GlobalSearchHit hit) {
-        return new GlobalSearchResultDto(hit.gtin(), hit.verticalId(), hit.title(), hit.brand(), hit.model(),
-                hit.offersCount(), hit.score());
+        return new GlobalSearchResultDto(hit.product(), hit.score());
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
@@ -1,0 +1,109 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.util.List;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.search.GlobalSearchResponseDto;
+import org.open4goods.nudgerfrontapi.dto.search.GlobalSearchResultDto;
+import org.open4goods.nudgerfrontapi.dto.search.GlobalSearchVerticalGroupDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.SearchService;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchHit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing the global search endpoint. The controller delegates the
+ * two-pass search logic to {@link SearchService} and ensures the response is fully documented
+ * in the OpenAPI contract.
+ */
+@RestController
+@RequestMapping("/search")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Search", description = "Global product search with boosted relevance")
+public class SearchController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchController.class);
+
+    private final SearchService searchService;
+
+    public SearchController(SearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    /**
+     * Execute a global search using the two-pass relevance strategy.
+     *
+     * @param query          free-text query provided by the caller
+     * @param domainLanguage requested localisation hint
+     * @return grouped search results respecting the configured boosting rules
+     */
+    @GetMapping("/global")
+    @Operation(
+            summary = "Execute a global search",
+            description = "Runs a two-pass search. Results are first grouped by vertical when matches exist, "
+                    + "otherwise a fallback search on non verticalised products is executed.",
+            parameters = {
+                    @Parameter(name = "query", in = ParameterIn.QUERY, required = true,
+                            description = "Free-text query used to search across products",
+                            schema = @Schema(type = "string", example = "Fairphone 4")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language hint used to resolve locale specific data.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Search executed successfully",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = GlobalSearchResponseDto.class)),
+                            headers = {
+                                    @Header(name = "X-Locale", description = "Resolved locale for the response",
+                                            schema = @Schema(type = "string", example = "fr"))
+                            })
+            }
+    )
+    @SecurityRequirement(name = "basicAuth")
+    public ResponseEntity<GlobalSearchResponseDto> globalSearch(
+            @RequestParam(name = "query") String query,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Entering globalSearch(query='{}', domainLanguage={})", query, domainLanguage);
+        SearchService.GlobalSearchResult result = searchService.globalSearch(query, domainLanguage);
+
+        List<GlobalSearchVerticalGroupDto> groups = result.verticalGroups().stream()
+                .map(group -> new GlobalSearchVerticalGroupDto(group.verticalId(),
+                        group.results().stream().map(this::toDto).toList()))
+                .toList();
+        List<GlobalSearchResultDto> fallback = result.fallbackResults().stream()
+                .map(this::toDto)
+                .toList();
+
+        GlobalSearchResponseDto body = new GlobalSearchResponseDto(groups, fallback, result.fallbackTriggered());
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIVE_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(body);
+    }
+
+    private GlobalSearchResultDto toDto(GlobalSearchHit hit) {
+        return new GlobalSearchResultDto(hit.gtin(), hit.verticalId(), hit.title(), hit.brand(), hit.model(),
+                hit.offersCount(), hit.score());
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResponseDto.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response payload returned by the global search endpoint.
+ */
+public record GlobalSearchResponseDto(
+        @Schema(description = "Vertical groups produced by the primary search pass")
+        List<GlobalSearchVerticalGroupDto> verticalGroups,
+        @Schema(description = "Fallback results when no vertical match is found")
+        List<GlobalSearchResultDto> fallbackResults,
+        @Schema(description = "Flag indicating whether the fallback pass has been executed", example = "false")
+        boolean fallbackTriggered) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResultDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResultDto.java
@@ -1,23 +1,14 @@
 package org.open4goods.nudgerfrontapi.dto.search;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 
 /**
  * Represents a single product hit returned by the global search endpoint.
  */
 public record GlobalSearchResultDto(
-        @Schema(description = "Product GTIN uniquely identifying the hit", example = "7612345678901")
-        Long gtin,
-        @Schema(description = "Identifier of the vertical attached to the product, when available", example = "smartphones", nullable = true)
-        String verticalId,
-        @Schema(description = "Display title resolved for the product", example = "Fairphone 4 128 Go")
-        String title,
-        @Schema(description = "Brand extracted from referential attributes", example = "Fairphone", nullable = true)
-        String brand,
-        @Schema(description = "Model extracted from referential attributes", example = "Fairphone 4", nullable = true)
-        String model,
-        @Schema(description = "Number of active offers for the product", example = "12", nullable = true)
-        Integer offersCount,
+        @Schema(description = "Full product payload returned by the search result")
+        ProductDto product,
         @Schema(description = "Pertinence score returned by Elasticsearch", example = "7.42")
         double score) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResultDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResultDto.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Represents a single product hit returned by the global search endpoint.
+ */
+public record GlobalSearchResultDto(
+        @Schema(description = "Product GTIN uniquely identifying the hit", example = "7612345678901")
+        Long gtin,
+        @Schema(description = "Identifier of the vertical attached to the product, when available", example = "smartphones", nullable = true)
+        String verticalId,
+        @Schema(description = "Display title resolved for the product", example = "Fairphone 4 128 Go")
+        String title,
+        @Schema(description = "Brand extracted from referential attributes", example = "Fairphone", nullable = true)
+        String brand,
+        @Schema(description = "Model extracted from referential attributes", example = "Fairphone 4", nullable = true)
+        String model,
+        @Schema(description = "Number of active offers for the product", example = "12", nullable = true)
+        Integer offersCount,
+        @Schema(description = "Pertinence score returned by Elasticsearch", example = "7.42")
+        double score) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchVerticalGroupDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchVerticalGroupDto.java
@@ -1,0 +1,15 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Container DTO grouping global search hits by vertical.
+ */
+public record GlobalSearchVerticalGroupDto(
+        @Schema(description = "Identifier of the vertical associated with the group", example = "smartphones")
+        String verticalId,
+        @Schema(description = "Ordered results belonging to the vertical")
+        List<GlobalSearchResultDto> results) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
@@ -1,15 +1,22 @@
 package org.open4goods.nudgerfrontapi.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.open4goods.model.attribute.ReferentielKey;
 import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.model.product.Product;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationBucketDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.Agg;
@@ -25,9 +32,12 @@ import org.open4goods.verticals.VerticalsConfigService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQueryBuilder;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
@@ -35,6 +45,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.Script;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.aggregations.HistogramAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.HistogramBucket;
@@ -44,6 +59,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.MissingAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.StatsAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.json.JsonData;
 
 /**
  * Dedicated search service tailored for the frontend API.
@@ -63,6 +79,26 @@ public class SearchService {
     private static final String MISSING_BUCKET = "ES-UNKNOWN";
     private static final int DEFAULT_BUCKET_COUNT = 10;
     private static final int DEFAULT_TERMS_SIZE = 50;
+    private static final int GLOBAL_SEARCH_LIMIT = 100;
+    private static final String OFFER_NAMES_DENSITY_SCRIPT = """
+            if (params.tokens == null || params.tokens.isEmpty()) { return _score; }
+            def offers = params['_source'].offerNames;
+            if (offers == null) { return _score; }
+            double matched = 0;
+            for (token in params.tokens) {
+                if (token == null) { continue; }
+                for (offer in offers) {
+                    if (offer == null) { continue; }
+                    if (offer.toLowerCase().contains(token)) {
+                        matched += 1;
+                        break;
+                    }
+                }
+            }
+            double density = matched / params.tokens.size();
+            if (density <= 0) { return _score; }
+            return _score * (1.0 + density);
+            """;
 
     private final ProductRepository repository;
     private final VerticalsConfigService verticalsConfigService;
@@ -134,6 +170,33 @@ public class SearchService {
 		}
         List<AggregationResponseDto> aggregations = extractAggregationResults(hits, descriptors);
         return new SearchResult(hits, List.copyOf(aggregations));
+    }
+
+    /**
+     * Execute the two-pass global search strategy described in the functional specification.
+     *
+     * @param query          raw user query
+     * @param domainLanguage localisation hint (currently unused but kept for future enhancements)
+     * @return grouped search results and fallback hits when necessary
+     */
+    public GlobalSearchResult globalSearch(String query, DomainLanguage domainLanguage) {
+        Criteria criteria = repository.getRecentPriceQuery();
+        criteria = criteria.and(new Criteria("excluded").is(false));
+
+        String sanitizedQuery = sanitize(query);
+        if (!StringUtils.hasText(sanitizedQuery)) {
+            return new GlobalSearchResult(List.of(), List.of(), false);
+        }
+
+        SearchHits<Product> firstPassHits = executeGlobalSearch(sanitizedQuery, true, false);
+        if (firstPassHits != null && !firstPassHits.isEmpty()) {
+            List<GlobalSearchVerticalGroup> groups = groupByVertical(firstPassHits);
+            return new GlobalSearchResult(groups, List.of(), false);
+        }
+
+        SearchHits<Product> fallbackHits = executeGlobalSearch(sanitizedQuery, false, true);
+        List<GlobalSearchHit> fallback = mapHits(fallbackHits);
+        return new GlobalSearchResult(List.of(), fallback, true);
     }
 
     private boolean isValidAggregation(Agg agg) {
@@ -322,6 +385,142 @@ public class SearchService {
         return responses;
     }
 
+    private SearchHits<Product> executeGlobalSearch(String sanitizedQuery, boolean requireVertical, boolean missingVertical) {
+        List<String> tokens = Arrays.stream(sanitizedQuery.toLowerCase(Locale.ROOT).split("\\s+"))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .map(token -> token.toLowerCase(Locale.ROOT))
+                .distinct()
+                .toList();
+
+        Query query = buildGlobalSearchQuery(sanitizedQuery, requireVertical, missingVertical, tokens);
+        NativeQueryBuilder builder = new NativeQueryBuilder()
+                .withQuery(query)
+                .withPageable(PageRequest.of(0, GLOBAL_SEARCH_LIMIT));
+
+        try {
+            return repository.search(builder.build(), ProductRepository.MAIN_INDEX_NAME);
+        } catch (Exception e) {
+            elasticLog(e);
+            throw e;
+        }
+    }
+
+    private Query buildGlobalSearchQuery(String sanitizedQuery, boolean requireVertical, boolean missingVertical,
+            List<String> tokens) {
+        long expiration = repository.expirationClause();
+
+        return Query.of(q -> q.functionScore(fs -> {
+            fs.scoreMode(FunctionScoreMode.Multiply);
+            fs.boostMode(FunctionBoostMode.Multiply);
+            fs.query(inner -> inner.bool(b -> {
+                b.filter(f -> f.range(r -> r.number(n -> n
+                        .field("lastChange")
+                        .gt((double) expiration)
+                )));
+                b.filter(f -> f.range(r -> r.number(n -> n
+                        .field("offersCount")
+                        .gt(0.0)
+                )));
+                b.filter(f -> f.term(t -> t.field("excluded").value(false)));
+                if (requireVertical) {
+                    b.filter(f -> f.exists(e -> e.field("vertical")));
+                }
+                if (missingVertical) {
+                    b.mustNot(m -> m.exists(e -> e.field("vertical")));
+                }
+                b.should(s -> s.match(m -> m.field("attributes.referentielAttributes.MODEL")
+                        .query(sanitizedQuery)
+                        .boost(8f)));
+                b.should(s -> s.match(m -> m.field("offerNames")
+                        .query(sanitizedQuery)
+                        .operator(Operator.And)
+                        .boost(4f)));
+                b.should(s -> s.match(m -> m.field("attributes.referentielAttributes.BRAND")
+                        .query(sanitizedQuery)
+                        .boost(2f)));
+                b.minimumShouldMatch("1");
+                return b;
+            }));
+            if (!tokens.isEmpty()) {
+                fs.functions(func -> func.scriptScore(ss -> ss.script(Script.of(s -> s
+                        .lang("painless")
+                        .source(OFFER_NAMES_DENSITY_SCRIPT)
+                        .params(Map.of("tokens", JsonData.of(tokens)))))));
+            }
+            return fs;
+        }));
+    }
+
+    private List<GlobalSearchVerticalGroup> groupByVertical(SearchHits<Product> hits) {
+        if (hits == null || hits.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, List<GlobalSearchHit>> grouped = new LinkedHashMap<>();
+        for (SearchHit<Product> hit : hits.getSearchHits()) {
+            GlobalSearchHit mapped = mapHit(hit);
+            if (mapped == null) {
+                continue;
+            }
+            grouped.computeIfAbsent(mapped.verticalId(), key -> new ArrayList<>()).add(mapped);
+        }
+
+        return grouped.entrySet().stream()
+                .map(entry -> new GlobalSearchVerticalGroup(entry.getKey(), entry.getValue().stream()
+                        .sorted(Comparator.comparing(GlobalSearchHit::score).reversed())
+                        .toList()))
+                .sorted(Comparator.comparing((GlobalSearchVerticalGroup group) -> group.results().isEmpty() ? Double.NEGATIVE_INFINITY
+                        : group.results().get(0).score()).reversed())
+                .toList();
+    }
+
+    private List<GlobalSearchHit> mapHits(SearchHits<Product> hits) {
+        if (hits == null || hits.isEmpty()) {
+            return List.of();
+        }
+        return hits.getSearchHits().stream()
+                .map(this::mapHit)
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(GlobalSearchHit::score).reversed())
+                .toList();
+    }
+
+    private GlobalSearchHit mapHit(SearchHit<Product> hit) {
+        if (hit == null || hit.getContent() == null) {
+            return null;
+        }
+        Product product = hit.getContent();
+        String brand = resolveReferential(product, ReferentielKey.BRAND);
+        String model = resolveReferential(product, ReferentielKey.MODEL);
+        String title = resolveTitle(product, brand, model);
+        double score = hit.getScore();
+        return new GlobalSearchHit(product.getId(), product.getVertical(), title, brand, model, product.getOffersCount(), score);
+    }
+
+    private String resolveReferential(Product product, ReferentielKey key) {
+        if (product.getAttributes() == null || product.getAttributes().getReferentielAttributes() == null) {
+            return null;
+        }
+        return product.getAttributes().getReferentielAttributes().get(key);
+    }
+
+    private String resolveTitle(Product product, String brand, String model) {
+        if (product.getOfferNames() != null && !product.getOfferNames().isEmpty()) {
+            return product.getOfferNames().iterator().next();
+        }
+        if (StringUtils.hasText(brand) && StringUtils.hasText(model)) {
+            return brand + " " + model;
+        }
+        if (StringUtils.hasText(model)) {
+            return model;
+        }
+        if (StringUtils.hasText(brand)) {
+            return brand;
+        }
+        return null;
+    }
+
     private AggregationResponseDto extractTermsAggregation(ElasticsearchAggregations aggregations, AggregationDescriptor descriptor) {
         var aggregation = aggregations.get(descriptor.histogramName);
         if (aggregation == null) {
@@ -386,6 +585,35 @@ public class SearchService {
         String sanitized = value.replaceAll("[^\\p{IsAlphabetic}\\p{IsDigit}\\s]", " ");
         sanitized = sanitized.replaceAll("\\s+", " ").trim();
         return sanitized;
+    }
+
+    /**
+     * Global search result including grouped hits and optional fallback.
+     */
+    public record GlobalSearchResult(List<GlobalSearchVerticalGroup> verticalGroups,
+            List<GlobalSearchHit> fallbackResults, boolean fallbackTriggered) {
+
+        public GlobalSearchResult {
+            verticalGroups = List.copyOf(verticalGroups);
+            fallbackResults = List.copyOf(fallbackResults);
+        }
+    }
+
+    /**
+     * Group of hits belonging to the same vertical.
+     */
+    public record GlobalSearchVerticalGroup(String verticalId, List<GlobalSearchHit> results) {
+
+        public GlobalSearchVerticalGroup {
+            results = List.copyOf(results);
+        }
+    }
+
+    /**
+     * Lightweight representation of a product hit used by the controller layer.
+     */
+    public record GlobalSearchHit(Long gtin, String verticalId, String title, String brand, String model,
+            Integer offersCount, double score) {
     }
 
     /**

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
@@ -1,0 +1,71 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.SearchService;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchHit;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchResult;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchVerticalGroup;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Unit tests for {@link SearchController}.
+ */
+class SearchControllerTest {
+
+    private SearchService searchService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        searchService = mock(SearchService.class);
+        mockMvc = MockMvcBuilders.standaloneSetup(new SearchController(searchService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    void globalSearchReturnsGroupedPayload() throws Exception {
+        GlobalSearchHit hit = new GlobalSearchHit(1L, "phones", "Fairphone 4", "Fairphone", "Fairphone 4", 5, 7.2d);
+        GlobalSearchVerticalGroup group = new GlobalSearchVerticalGroup("phones", List.of(hit));
+        GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(group), List.of(), false);
+        when(searchService.globalSearch("fairphone", DomainLanguage.fr)).thenReturn(serviceResult);
+
+        mockMvc.perform(get("/search/global")
+                        .param("query", "fairphone")
+                        .param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$.verticalGroups[0].verticalId").value("phones"))
+                .andExpect(jsonPath("$.verticalGroups[0].results[0].gtin").value(1))
+                .andExpect(jsonPath("$.fallbackTriggered").value(false));
+    }
+
+    @Test
+    void globalSearchIncludesFallbackResults() throws Exception {
+        GlobalSearchHit fallbackHit = new GlobalSearchHit(2L, null, "Universal Charger", null, null, 2, 3.5d);
+        GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(), List.of(fallbackHit), true);
+        when(searchService.globalSearch("chargeur", DomainLanguage.en)).thenReturn(serviceResult);
+
+        mockMvc.perform(get("/search/global")
+                        .param("query", "chargeur")
+                        .param("domainLanguage", "en"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "en"))
+                .andExpect(jsonPath("$.verticalGroups").isEmpty())
+                .andExpect(jsonPath("$.fallbackResults[0].title").value("Universal Charger"))
+                .andExpect(jsonPath("$.fallbackTriggered").value(true));
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.nudgerfrontapi.service.SearchService;
 import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchHit;
@@ -38,7 +39,8 @@ class SearchControllerTest {
 
     @Test
     void globalSearchReturnsGroupedPayload() throws Exception {
-        GlobalSearchHit hit = new GlobalSearchHit(1L, "phones", "Fairphone 4", "Fairphone", "Fairphone 4", 5, 7.2d);
+        ProductDto phone = new ProductDto(1L, null, null, null, null, null, null, null, null, null, null, null);
+        GlobalSearchHit hit = new GlobalSearchHit("phones", phone, 7.2d);
         GlobalSearchVerticalGroup group = new GlobalSearchVerticalGroup("phones", List.of(hit));
         GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(group), List.of(), false);
         when(searchService.globalSearch("fairphone", DomainLanguage.fr)).thenReturn(serviceResult);
@@ -49,13 +51,14 @@ class SearchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string("X-Locale", "fr"))
                 .andExpect(jsonPath("$.verticalGroups[0].verticalId").value("phones"))
-                .andExpect(jsonPath("$.verticalGroups[0].results[0].gtin").value(1))
+                .andExpect(jsonPath("$.verticalGroups[0].results[0].product.gtin").value(1))
                 .andExpect(jsonPath("$.fallbackTriggered").value(false));
     }
 
     @Test
     void globalSearchIncludesFallbackResults() throws Exception {
-        GlobalSearchHit fallbackHit = new GlobalSearchHit(2L, null, "Universal Charger", null, null, 2, 3.5d);
+        ProductDto accessory = new ProductDto(2L, "universal-charger", null, null, null, null, null, null, null, null, null, null);
+        GlobalSearchHit fallbackHit = new GlobalSearchHit(null, accessory, 3.5d);
         GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(), List.of(fallbackHit), true);
         when(searchService.globalSearch("chargeur", DomainLanguage.en)).thenReturn(serviceResult);
 
@@ -65,7 +68,7 @@ class SearchControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string("X-Locale", "en"))
                 .andExpect(jsonPath("$.verticalGroups").isEmpty())
-                .andExpect(jsonPath("$.fallbackResults[0].title").value("Universal Charger"))
+                .andExpect(jsonPath("$.fallbackResults[0].product.slug").value("universal-charger"))
                 .andExpect(jsonPath("$.fallbackTriggered").value(true));
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `/search/global` controller that exposes the two-pass global search endpoint and returns the documented response contract【F:front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java†L33-L108】
- define response DTOs for grouped vertical hits and fallback results with OpenAPI metadata for the new endpoint【F:front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResponseDto.java†L7-L16】【F:front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchVerticalGroupDto.java†L7-L14】【F:front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchResultDto.java†L5-L22】
- implement the `globalSearch` two-pass logic in `SearchService` with boosting, script scoring, vertical grouping, and fallback handling together with focused unit tests for the service and controller【F:front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java†L82-L616】【F:front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java†L112-L175】【F:front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java†L26-L70】

## Testing
- mvn --offline -pl front-api -am test【9c3513†L1-L40】

------
https://chatgpt.com/codex/tasks/task_e_6907131ba81c833380863e8285b79b5c