### PR TITLE
Fix cached lookup when bulk fetching products

### DIFF
--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -665,11 +665,11 @@ public class ProductRepository {
 //		});
 //
 		// Getting the one we don't have in redis from elastic
-		Set<String> missingIds = ids.stream().filter(e -> !ret.containsKey(e)).map(e-> String.valueOf(e)) .collect(Collectors.toSet());
+                Set<String> missingIds = computeMissingIds(ids, ret);
 		logger.info("returned hits : {}, missing : {}",ret.size(), missingIds.size());
 
 
-		if (missingIds.size() != 0) {
+                if (missingIds.size() != 0) {
 
 
 			NativeQuery query = new NativeQueryBuilder().withIds(missingIds).build();
@@ -709,6 +709,13 @@ public class ProductRepository {
         public Long countMainIndexHavingRecentPrices() {
                 CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery());
                 return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
+        static Set<String> computeMissingIds(Collection<Long> ids, Map<String, ?> existingResults) {
+                return ids.stream()
+                                .map(String::valueOf)
+                                .filter(id -> !existingResults.containsKey(id))
+                                .collect(Collectors.toSet());
         }
 
         @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)

--- a/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
+++ b/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
@@ -1,0 +1,26 @@
+package org.open4goods.services.productrepository.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.product.Product;
+
+class ProductRepositoryTest {
+
+    @Test
+    void computeMissingIdsUsesStringKeysFromExistingResults() {
+        Map<String, Product> cachedResults = new HashMap<>();
+        Product cachedProduct = new Product();
+        cachedProduct.setId(123L);
+        cachedResults.put("123", cachedProduct);
+
+        Set<String> missingIds = ProductRepository.computeMissingIds(List.of(123L, 456L), cachedResults);
+
+        assertThat(missingIds).containsExactlyInAnyOrder("456");
+    }
+}


### PR DESCRIPTION
## Summary
- correct the cache hit detection in ProductRepository#multiGetById so IDs already loaded are skipped
- add a unit test that covers the helper ensuring cached GTINs are honoured

## Testing
- mvn -pl services/product-repository -am test

------
https://chatgpt.com/codex/tasks/task_e_69077d5f3514832295beef792b70470c