### PR TITLE
feat(search): refresh hero and fix localisation

### DIFF
--- a/frontend/app/components/search/SearchResultGroup.spec.ts
+++ b/frontend/app/components/search/SearchResultGroup.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import type { Component } from 'vue'
+
+import SearchResultGroup from './SearchResultGroup.vue'
+
+const createStub = (tag: string): Component => ({
+  inheritAttrs: false,
+  setup(_props, { attrs, slots }) {
+    return () => h(tag, attrs, slots.default?.())
+  },
+})
+
+const NuxtLinkStub: Component = {
+  inheritAttrs: false,
+  props: {
+    to: {
+      type: [String, Object],
+      default: '#',
+    },
+    ariaLabel: {
+      type: String,
+      default: undefined,
+    },
+  },
+  setup(props, { slots, attrs }) {
+    const href = typeof props.to === 'string' ? props.to : '#'
+
+    return () =>
+      h(
+        'a',
+        {
+          ...attrs,
+          href,
+          'aria-label': props.ariaLabel,
+        },
+        slots.default?.(),
+      )
+  },
+}
+
+type SearchResultGroupProps = InstanceType<typeof SearchResultGroup>['$props']
+
+const emptyProducts: SearchResultGroupProps['products'] = []
+
+const mountGroup = (props: SearchResultGroupProps) =>
+  mount(SearchResultGroup, {
+    props,
+    global: {
+      stubs: {
+        CategoryProductCardGrid: createStub('div'),
+        NuxtLink: NuxtLinkStub,
+        VIcon: createStub('span'),
+      },
+    },
+  })
+
+describe('SearchResultGroup', () => {
+  it('renders the title, count and navigation link', () => {
+    const wrapper = mountGroup({
+      title: 'Coffee makers',
+      products: emptyProducts,
+      countLabel: '4 produits',
+      verticalHomeUrl: '/cafetieres',
+      categoryLinkLabel: 'Accéder à la catégorie',
+      categoryLinkAria: 'Accéder à la catégorie Cafetières',
+    })
+
+    expect(wrapper.find('h2').text()).toBe('Coffee makers')
+    expect(wrapper.find('.search-result-group__count').text()).toBe('4 produits')
+
+    const link = wrapper.get('[data-test="search-result-group-link"]')
+    expect(link.attributes('href')).toBe('/cafetieres')
+    expect(link.attributes('aria-label')).toBe('Accéder à la catégorie Cafetières')
+    expect(link.text()).toContain('Accéder à la catégorie')
+  })
+
+  it('does not render the link when no category URL is provided', () => {
+    const wrapper = mountGroup({
+      title: 'Mixers',
+      products: emptyProducts,
+      countLabel: '2 produits',
+      verticalHomeUrl: null,
+      categoryLinkLabel: 'Voir la catégorie',
+    })
+
+    expect(wrapper.find('[data-test="search-result-group-link"]').exists()).toBe(false)
+  })
+
+  it('omits the count block when no label is provided', () => {
+    const wrapper = mountGroup({
+      title: 'Grinders',
+      products: emptyProducts,
+      verticalHomeUrl: '/grinders',
+      categoryLinkLabel: 'Browse this category',
+    })
+
+    expect(wrapper.find('.search-result-group__count').exists()).toBe(false)
+  })
+})

--- a/frontend/app/components/search/SearchResultGroup.vue
+++ b/frontend/app/components/search/SearchResultGroup.vue
@@ -2,8 +2,17 @@
   <section class="search-result-group">
     <header class="search-result-group__header">
       <div class="search-result-group__headline">
-        <p v-if="eyebrow" class="search-result-group__eyebrow">{{ eyebrow }}</p>
         <h2 class="search-result-group__title">{{ title }}</h2>
+        <NuxtLink
+          v-if="verticalHomeUrl"
+          :to="verticalHomeUrl"
+          class="search-result-group__link"
+          :aria-label="categoryLinkAria || undefined"
+          data-test="search-result-group-link"
+        >
+          <span>{{ categoryLinkLabel }}</span>
+          <v-icon icon="mdi-arrow-right" size="small" aria-hidden="true" />
+        </NuxtLink>
       </div>
       <p v-if="countLabel" class="search-result-group__count">{{ countLabel }}</p>
     </header>
@@ -27,12 +36,16 @@ withDefaults(
     products: ProductDto[]
     countLabel?: string | null
     popularAttributes?: AttributeConfigDto[]
-    eyebrow?: string | null
+    verticalHomeUrl?: string | null
+    categoryLinkLabel?: string | null
+    categoryLinkAria?: string | null
   }>(),
   {
     countLabel: null,
     popularAttributes: () => [],
-    eyebrow: null,
+    verticalHomeUrl: null,
+    categoryLinkLabel: '',
+    categoryLinkAria: null,
   },
 )
 </script>
@@ -61,20 +74,31 @@ withDefaults(
   &__headline
     display: flex
     flex-direction: column
-    gap: 0.25rem
-
-  &__eyebrow
-    margin: 0
-    font-size: 0.875rem
-    letter-spacing: 0.08em
-    text-transform: uppercase
-    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+    gap: 0.5rem
 
   &__title
     margin: 0
     font-size: clamp(1.5rem, 1.1rem + 0.9vw, 2rem)
     font-weight: 600
     color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__link
+    display: inline-flex
+    align-items: center
+    gap: 0.4rem
+    align-self: flex-start
+    padding: 0.25rem 0.6rem 0.25rem 0
+    border-radius: 999px
+    font-size: 0.95rem
+    font-weight: 500
+    color: rgba(var(--v-theme-accent-primary-highlight), 0.95)
+    text-decoration: none
+    transition: color 0.2s ease, transform 0.2s ease
+
+    &:hover,
+    &:focus-visible
+      color: rgb(var(--v-theme-primary))
+      transform: translateX(2px)
 
   &__count
     margin: 0

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1278,14 +1278,23 @@
       }
     },
     "results": {
-      "summary": "Displaying {count, plural, one {# result} other {# results}} for \u201c{query}\u201d"
+      "summary": "Displaying {countLabel} for \u201c{query}\u201d",
+      "count": {
+        "one": "{count} result",
+        "other": "{count} results"
+      }
     },
     "notice": {
       "fallback": "We could not match a specific category, so we are showing the most relevant products overall."
     },
     "groups": {
-      "count": "{count, plural, one {# product} other {# products}}",
-      "unknownTitle": "Other products"
+      "count": {
+        "one": "{count} product",
+        "other": "{count} products"
+      },
+      "unknownTitle": "Other products",
+      "viewCategory": "Browse this category",
+      "viewCategoryAria": "Browse the {title} category"
     },
     "seo": {
       "title": "Product search",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1278,14 +1278,23 @@
       }
     },
     "results": {
-      "summary": "Affichage de {count, plural, one {# résultat} other {# résultats}} pour \u00ab {query} \u00bb"
+      "summary": "Affichage de {countLabel} pour \u00ab {query} \u00bb",
+      "count": {
+        "one": "{count} résultat",
+        "other": "{count} résultats"
+      }
     },
     "notice": {
       "fallback": "Nous n'avons pas identifié de verticale précise, voici les produits les plus pertinents globalement."
     },
     "groups": {
-      "count": "{count, plural, one {# produit} other {# produits}}",
-      "unknownTitle": "Autres produits"
+      "count": {
+        "one": "{count} produit",
+        "other": "{count} produits"
+      },
+      "unknownTitle": "Autres produits",
+      "viewCategory": "Accéder à la catégorie",
+      "viewCategoryAria": "Accéder à la catégorie {title}"
     },
     "seo": {
       "title": "Recherche de produits",

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -4,11 +4,11 @@ import { DEFAULT_NUXT_LOCALE } from './domain-language'
 const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
 
 export type LocalizedRouteName =
-   'compare'
-   | 'partners'
-   | 'team'
-   | 'search'
-   | LocalizedWikiRouteName
+  | 'compare'
+  | 'partners'
+  | 'team'
+  | 'search'
+  | LocalizedWikiRouteName
 
 export type LocalizedRoutePath = `/${string}`
 export type LocalizedRoutePaths = Record<LocalizedRouteName, Record<NuxtLocale, LocalizedRoutePath>>


### PR DESCRIPTION
## Summary
- restyle the search hero to mirror the blog layout and refine the search form experience
- ensure result and group counts use pluralised translations and expose a category link for each vertical
- add coverage for the search result group link rendering behaviour

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690864762b988322962b6bd42ca04fc5