### PR TITLE
Add search suggestion endpoint for the front API

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestCategoryDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestCategoryDto.java
@@ -1,0 +1,22 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO describing a category suggestion returned by the search suggest endpoint.
+ */
+public record SearchSuggestCategoryDto(
+        @Schema(description = "Identifier of the matched vertical.", example = "tv")
+        String verticalId,
+
+        @Schema(description = "Absolute URL to the small vertical illustration used in suggestion cards.",
+                example = "https://cdn.nudger.fr/images/verticals/tv-100.webp")
+        String imageSmall,
+
+        @Schema(description = "Localised title of the vertical home page.", example = "Téléviseurs")
+        String verticalHomeTitle,
+
+        @Schema(description = "Localised URL slug leading to the vertical home page.", example = "televiseurs")
+        String verticalHomeUrl
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestProductDto.java
@@ -1,0 +1,31 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing the lightweight information for a product suggestion.
+ */
+public record SearchSuggestProductDto(
+        @Schema(description = "Model extracted from referential attributes.", example = "QE55QN90A")
+        String model,
+
+        @Schema(description = "Brand extracted from referential attributes.", example = "Samsung")
+        String brand,
+
+        @Schema(description = "GTIN associated with the product when available.", example = "8806092074061")
+        String gtin,
+
+        @Schema(description = "Absolute path to the cover image of the product if any.",
+                example = "https://cdn.nudger.fr/images/products/8806092074061.webp")
+        String coverImagePath,
+
+        @Schema(description = "Identifier of the vertical owning the product.", example = "tv")
+        String verticalId,
+
+        @Schema(description = "Eco-score value computed for the product when available.", example = "72.5")
+        Double ecoscoreValue,
+
+        @Schema(description = "Native Elasticsearch score associated with the hit.", example = "1.85")
+        Double score
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestResponseDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.search;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response payload combining category and product matches for the suggest endpoint.
+ */
+public record SearchSuggestResponseDto(
+        @ArraySchema(schema = @Schema(implementation = SearchSuggestCategoryDto.class),
+                arraySchema = @Schema(description = "Category matches resolved from the in-memory vertical index."))
+        List<SearchSuggestCategoryDto> categoryMatches,
+
+        @ArraySchema(schema = @Schema(implementation = SearchSuggestProductDto.class),
+                arraySchema = @Schema(description = "Product matches obtained from the classical Elasticsearch search."))
+        List<SearchSuggestProductDto> productMatches
+) {
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -3,6 +3,7 @@ package org.open4goods.nudgerfrontapi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.open4goods.model.product.Product;
 import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.AggregationRequestDto.Agg;
@@ -65,11 +67,15 @@ class SearchServiceTest {
     @Mock
     private ProductMappingService productMappingService;
 
+    @Mock
+    private ApiProperties apiProperties;
+
     private SearchService searchService;
 
     @BeforeEach
     void setUp() {
-        searchService = new SearchService(repository, verticalsConfigService, productMappingService);
+        lenient().when(apiProperties.getResourceRootPath()).thenReturn("https://assets.nudger.test");
+        searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- expose a documented /search/suggest endpoint returning category and product suggestions
- implement in-memory vertical matching and limited-field Elasticsearch queries to build suggestions
- add dedicated DTOs and adjust the search service test for the new dependency

## Testing
- `mvn -pl front-api -am test`


------
https://chatgpt.com/codex/tasks/task_e_69087ad23408833398b7efacf1a38ca8