### PR TITLE
Fix search suggestion service API invocation

### DIFF
--- a/frontend/shared/api-client/services/search.services.ts
+++ b/frontend/shared/api-client/services/search.services.ts
@@ -48,7 +48,7 @@ export const useSearchService = (domainLanguage: DomainLanguage) => {
     }
 
     try {
-      return await resolveApi().searchSuggest({
+      return await resolveApi().suggest({
         query: normalizedQuery,
         domainLanguage,
       })


### PR DESCRIPTION
## Summary
- update the server-side search service to call the generated `suggest` method instead of the nonexistent `searchSuggest`

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6908bf7ab7bc8322bf9581af6bf34475