### PR TITLE
Refine product attribute section layout

### DIFF
--- a/frontend/app/components/product/ProductAttributesSection.spec.ts
+++ b/frontend/app/components/product/ProductAttributesSection.spec.ts
@@ -81,6 +81,25 @@ const VTextFieldStub = defineComponent({
   },
 })
 
+const VRowStub = defineComponent({
+  name: 'VRowStub',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-row-stub' }, slots.default?.())
+  },
+})
+
+const VColStub = defineComponent({
+  name: 'VColStub',
+  props: {
+    cols: { type: [Number, String], default: 12 },
+    sm: { type: [Number, String], default: undefined },
+    lg: { type: [Number, String], default: undefined },
+  },
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-col-stub' }, slots.default?.())
+  },
+})
+
 const buildProduct = (): ProductDto => ({
   gtin: 1234567890123,
   base: {
@@ -96,7 +115,7 @@ const buildProduct = (): ProductDto => ({
   },
   attributes: {
     indexedAttributes: {
-      weight: { name: 'Weight', value: '2 kg' },
+      weight: { name: 'Weight', value: '<strong>2 kg</strong>' },
       depth: { name: 'Depth', numericValue: 45 },
       wireless: { name: 'Wireless', booleanValue: true },
     },
@@ -105,7 +124,7 @@ const buildProduct = (): ProductDto => ({
         name: 'Performance',
         features: [{ name: 'Battery life', value: '10 h' }],
         unFeatures: [{ name: 'Noise level', value: 'High' }],
-        attributes: [{ name: 'Power', value: '200 W' }],
+        attributes: [{ name: 'Power', value: '<em>200 W</em>' }],
       },
       {
         name: 'Dimensions',
@@ -127,8 +146,6 @@ const i18n = createI18n({
           title: 'Technical specifications',
           subtitle: 'Browse every specification and filter with keywords.',
           searchPlaceholder: 'Search a specification',
-          features: 'Highlights',
-          unfeatures: 'Watchouts',
           main: {
             title: 'Key specifications',
             identity: {
@@ -145,7 +162,6 @@ const i18n = createI18n({
               empty: 'Identity information is not yet available for this product.',
             },
             attributes: {
-              title: 'Indexed attributes',
               empty: 'Indexed attributes will appear here when available.',
             },
           },
@@ -183,6 +199,8 @@ const mountComponent = async (product: ProductDto) => {
         VChip: VChipStub,
         VImg: VImgStub,
         VTextField: VTextFieldStub,
+        VRow: VRowStub,
+        VCol: VColStub,
       },
     },
   })
@@ -229,6 +247,10 @@ describe('ProductAttributesSection', () => {
     expect(mainText).toContain('45')
     expect(mainText).toContain('Wireless')
     expect(mainText).toContain('Yes')
+
+    const richValue = wrapper.find('.product-attributes__table-value')
+    expect(richValue.exists()).toBe(true)
+    expect(richValue.html()).toContain('<strong>2 kg</strong>')
   })
 
   it('filters detailed groups with the search input', async () => {

--- a/frontend/app/components/product/attributes/ProductAttributesDetailCard.vue
+++ b/frontend/app/components/product/attributes/ProductAttributesDetailCard.vue
@@ -1,0 +1,157 @@
+<template>
+  <v-col cols="12" sm="6" lg="4" class="product-attributes-detail-card__col">
+    <v-card class="product-attributes__detail-card" variant="flat">
+      <header class="product-attributes__detail-header">
+        <h4 class="product-attributes__detail-title">{{ group.name }}</h4>
+        <v-chip size="small" variant="tonal" color="primary">
+          {{ group.totalCount }}
+        </v-chip>
+      </header>
+
+      <div v-if="group.features.length" class="product-attributes__chip-list product-attributes__chip-list--positive">
+        <ul>
+          <li v-for="feature in group.features" :key="feature.key">
+            <v-icon icon="mdi-check-circle" size="18" class="product-attributes__chip-icon product-attributes__chip-icon--positive" />
+            <span class="product-attributes__chip-label">{{ feature.name }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <div v-if="group.unFeatures.length" class="product-attributes__chip-list product-attributes__chip-list--negative">
+        <ul>
+          <li v-for="feature in group.unFeatures" :key="feature.key">
+            <v-icon icon="mdi-alert-circle" size="18" class="product-attributes__chip-icon product-attributes__chip-icon--negative" />
+            <span class="product-attributes__chip-label">{{ feature.name }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <v-table v-if="group.attributes.length" density="comfortable" class="product-attributes__table">
+        <tbody>
+          <tr v-for="attribute in group.attributes" :key="attribute.key">
+            <th scope="row">{{ attribute.name }}</th>
+            <td>
+              <!-- eslint-disable-next-line vue/no-v-html -->
+              <span class="product-attributes__table-value" v-html="attribute.value" />
+            </td>
+          </tr>
+        </tbody>
+      </v-table>
+    </v-card>
+  </v-col>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue'
+import type { PropType } from 'vue'
+import type { DetailGroupView } from '~/components/product/ProductAttributesSection.vue'
+
+const props = defineProps({
+  group: {
+    type: Object as PropType<DetailGroupView>,
+    required: true,
+  },
+})
+
+const { group } = toRefs(props)
+</script>
+
+<style scoped>
+.product-attributes-detail-card__col {
+  padding: 0.75rem;
+}
+
+.product-attributes__detail-card {
+  border-radius: 20px;
+  background: rgba(var(--v-theme-surface-glass-strong), 0.96);
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6);
+  box-shadow: 0 10px 25px -12px rgba(15, 23, 42, 0.15);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: 100%;
+}
+
+.product-attributes__detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.product-attributes__detail-title {
+  font-size: clamp(1rem, 1.4vw, 1.2rem);
+  font-weight: 600;
+  margin: 0;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-attributes__chip-list {
+  padding: 0.5rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(var(--v-theme-surface-primary-080), 0.75);
+}
+
+.product-attributes__chip-list--positive {
+  border-left: 4px solid rgba(var(--v-theme-success), 0.75);
+}
+
+.product-attributes__chip-list--negative {
+  border-left: 4px solid rgba(var(--v-theme-error), 0.75);
+  background: rgba(var(--v-theme-surface-primary-050), 0.7);
+}
+
+.product-attributes__chip-list ul {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.product-attributes__chip-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.product-attributes__chip-icon {
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.product-attributes__chip-icon--positive {
+  color: rgb(var(--v-theme-success));
+}
+
+.product-attributes__chip-icon--negative {
+  color: rgb(var(--v-theme-error));
+}
+
+.product-attributes__chip-label {
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-attributes__table {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.product-attributes__table tbody tr:nth-child(odd) {
+  background: rgba(var(--v-theme-surface-primary-050), 0.7);
+}
+
+.product-attributes__table th {
+  text-align: left;
+  font-weight: 600;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95);
+  padding: 0.6rem 0.75rem;
+}
+
+.product-attributes__table td {
+  padding: 0.6rem 0.75rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1412,8 +1412,6 @@
       "title": "Technical specifications",
       "subtitle": "Browse every specification and filter with keywords.",
       "searchPlaceholder": "Search a specification",
-      "features": "Highlights",
-      "unfeatures": "Watchouts",
       "main": {
         "title": "Key specifications",
         "identity": {
@@ -1430,7 +1428,6 @@
           "empty": "Identity information is not yet available for this product."
         },
         "attributes": {
-          "title": "Indexed attributes",
           "empty": "Indexed attributes will appear here when available."
         }
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1412,8 +1412,6 @@
       "title": "Caractéristiques techniques",
       "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
       "searchPlaceholder": "Rechercher une caractéristique",
-      "features": "Points forts",
-      "unfeatures": "Points à surveiller",
       "main": {
         "title": "Caractéristiques principales",
         "identity": {
@@ -1430,7 +1428,6 @@
           "empty": "Les informations d'identité ne sont pas encore disponibles pour ce produit."
         },
         "attributes": {
-          "title": "Attributs indexés",
           "empty": "Les attributs indexés apparaîtront ici dès qu'ils seront disponibles."
         }
       },


### PR DESCRIPTION
## Summary
- restructure the product attribute detail grid to use a dedicated card component with responsive columns, iconised highlights and HTML-friendly values
- surface alternative brand/model names beneath the model row, shrink the GTIN image footprint, and render attribute values with HTML content support
- drop the unused feature section translations and extend the existing unit tests to cover the new layout and HTML handling

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_6908e352d57483229107afbd0a6035e0