### PR TITLE
feat(frontend): craft modern home page experience

### DIFF
--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -1,0 +1,276 @@
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+const messages: Record<string, string> = {
+  'home.hero.search.label': 'Search for a product',
+  'home.hero.search.placeholder': 'Search a product',
+  'home.hero.search.ariaLabel': 'Search input',
+  'home.hero.search.cta': 'Compare',
+  'home.hero.search.helper': '50M references',
+  'home.hero.eyebrow': 'Responsible shopping',
+  'home.hero.title': 'Responsible choices are not a luxury',
+  'home.hero.subtitle': 'Save time, stay true to your values.',
+  'home.hero.imageAlt': 'Hero illustration',
+  'home.problems.title': 'Too many labels, not enough clarity?',
+  'home.problems.items.labelsOverload': 'Lost in the jungle of labels? Hard to truly compare.',
+  'home.problems.items.budgetVsEcology': 'Ecology versus budget? Tired of choosing between the two.',
+  'home.problems.items.tooManyTabs': 'Eight tabs open? One place is enough.',
+  'home.solution.title': 'Responsible shopping, minus the headache',
+  'home.solution.description': 'Nudger combines environmental, technical and pricing insights to simplify every decision.',
+  'home.solution.benefits.time': 'Save time — we analyse the data for you.',
+  'home.solution.benefits.savings': 'Save money — price comparison built in.',
+  'home.solution.benefits.planet': 'Shop better — spot the most responsible products.',
+  'home.solution.benefits.trust': 'Trustworthy — open data, independent recommendations.',
+  'home.features.title': 'Key features',
+  'home.features.subtitle': 'See what Nudger puts at your fingertips.',
+  'home.features.cards.impactScore.title': 'AI Impact Score',
+  'home.features.cards.impactScore.description': 'A clear ecological score (5 criteria, AI used with restraint).',
+  'home.features.cards.priceComparison.title': 'Price comparison + history',
+  'home.features.cards.priceComparison.description': 'Pay the right price at the right time.',
+  'home.features.cards.openIndependent.title': 'Open & independent',
+  'home.features.cards.openIndependent.description': 'Open source, open data, no brand influence.',
+  'home.features.cards.noTracking.title': 'Zero tracking',
+  'home.features.cards.noTracking.description': 'We track products, not you. Cookies are for eating.',
+  'home.features.cards.massiveBase.title': 'Massive dataset',
+  'home.features.cards.massiveBase.description': 'The largest open-data catalogue on the market: 50 million references.',
+  'home.categories.title': 'Browse categories',
+  'home.categories.subtitle': 'Start with our most popular universes and refine in one click.',
+  'home.categories.cta': 'Browse products',
+  'home.categories.items.electronics.title': 'Electronics',
+  'home.categories.items.electronics.description': 'Smartphones, TVs, audio…',
+  'home.categories.items.appliances.title': 'Appliances',
+  'home.categories.items.appliances.description': 'Washing machines, dishwashers, fridges…',
+  'home.trust.title': 'Proof & trust',
+  'home.trust.subtitle': 'Demanding partners and open data keep us accountable.',
+  'home.trust.logos.ademe': 'ADEME logo',
+  'home.trust.stats.references': '50,000,000+ open-data references',
+  'home.trust.stats.updates': 'Updated on a regular basis',
+  'home.blog.title': 'From the blog',
+  'home.blog.cta': 'Browse all articles',
+  'home.blog.readMore': 'Read article',
+  'home.blog.items.first.title': 'How we keep our AI frugal',
+  'home.blog.items.first.date': '15 Jan 2025',
+  'home.blog.items.first.excerpt': 'The technical choices that keep Nudger’s computations low-carbon.',
+  'home.blog.items.second.title': 'Prioritising durability and repairability',
+  'home.blog.items.second.date': '8 Jan 2025',
+  'home.blog.items.second.excerpt': 'Why repairability weighs more in the Impact Score.',
+  'home.blog.items.third.title': 'Balancing price and impact, step by step',
+  'home.blog.items.third.date': '20 Dec 2024',
+  'home.blog.items.third.excerpt': 'Nudger’s method to align ecology and budget.',
+  'home.objections.title': 'Straight questions, clear answers',
+  'home.objections.subtitle': 'The topics we hear about the most.',
+  'home.objections.items.aiEnergy.question': 'Does AI burn too much energy?',
+  'home.objections.items.aiEnergy.answer': 'Frugal AI, optimised computations, net positive impact.',
+  'home.objections.items.reuse.question': 'Is true frugality all about reuse?',
+  'home.objections.items.reuse.answer': 'We promote using less first, then better.',
+  'home.objections.items.independence.question': 'Are you independent?',
+  'home.objections.items.independence.answer': 'Yes. Results stay neutral, code is open.',
+  'home.faq.title': 'FAQ',
+  'home.faq.subtitle': 'Quick answers to the most common questions.',
+  'home.faq.items.free.question': 'Is Nudger free?',
+  'home.faq.items.free.answer': 'Yes, searching is free to use.',
+  'home.faq.items.account.question': 'Do I need an account?',
+  'home.faq.items.account.answer': 'No for searching; an account is optional.',
+  'home.faq.items.categories.question': 'Which categories are covered?',
+  'home.faq.items.categories.answer': 'Electronics & Appliances today, more to come.',
+  'home.faq.items.impactScore.question': 'How do you calculate the Impact Score?',
+  'home.faq.items.impactScore.answer': 'Five weighted criteria + lean AI, fully open methodology.',
+  'home.faq.items.dataFreshness.question': 'Are the data kept up to date?',
+  'home.faq.items.dataFreshness.answer': 'Yes, refreshed regularly with quality checks.',
+  'home.faq.items.suggestProduct.question': 'How can I suggest a product?',
+  'home.faq.items.suggestProduct.answer': 'Use our dedicated contact form.',
+  'home.cta.title': 'Ready to buy better without overspending?',
+  'home.cta.subtitle': 'Restart a search or explore the analysed offers.',
+  'home.cta.button': 'Start a search',
+  'home.cta.altLink': 'Open the search page',
+  'home.seo.title': 'Nudger – Responsible shopping made easy',
+  'home.seo.description': 'Compare the environmental impact and prices of over 50 million products with Nudger.',
+  'home.seo.imageAlt': 'Illustration of the Nudger dashboard',
+  'siteIdentity.siteName': 'Nudger'
+}
+
+const translate = (key: string) => messages[key] ?? key
+
+const localeRef = ref('fr-FR')
+const headSpy = vi.fn()
+const routerPush = vi.fn()
+const routerReplace = vi.fn()
+const localePathMock = vi.fn((to: unknown) => {
+  if (typeof to === 'string') {
+    return `/localized/${to}`
+  }
+
+  if (to && typeof to === 'object' && 'name' in to) {
+    const name = String(to.name)
+    const query = 'query' in to && to.query && typeof to.query === 'object' && 'q' in to.query
+      ? `?q=${String((to.query as Record<string, unknown>).q ?? '')}`
+      : ''
+    return `/localized/${name}${query}`
+  }
+
+  return '/localized'
+})
+
+function useLocalePathMock() {
+  return (to: unknown) => localePathMock(to)
+}
+
+mockNuxtImport('useI18n', () => () => ({
+  t: (key: string) => translate(key),
+  locale: localeRef,
+  availableLocales: ['fr-FR', 'en-US'],
+}))
+
+mockNuxtImport('useRouter', () => () => ({
+  push: routerPush,
+  replace: routerReplace,
+}))
+
+mockNuxtImport('useLocalePath', () => useLocalePathMock)
+mockNuxtImport('useRequestURL', () => () => new URL('https://nudger.test/fr/'))
+mockNuxtImport('useSeoMeta', () => vi.fn())
+mockNuxtImport('useHead', () => (input: unknown) => {
+  const value = typeof input === 'function' ? input() : input
+  headSpy(value)
+  return value
+})
+
+const simpleStub = (tag: string) =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_props, { slots, attrs }) {
+      return () => h(tag, attrs, slots.default?.())
+    },
+  })
+
+const VTextFieldStub = defineComponent({
+  name: 'VTextFieldStub',
+  props: {
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit, attrs }) {
+    const onInput = (event: Event) => {
+      const target = event.target as HTMLInputElement
+      emit('update:modelValue', target.value)
+    }
+
+    return () => h('input', { ...attrs, value: props.modelValue, onInput })
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  props: {
+    type: { type: String, default: 'button' },
+  },
+  setup(props, { slots, attrs }) {
+    return () => h('button', { ...attrs, type: props.type }, slots.default?.())
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIconStub',
+  props: {
+    icon: { type: String, default: '' },
+  },
+  setup(props, { attrs }) {
+    return () => h('span', { ...attrs, 'data-icon': props.icon }, props.icon)
+  },
+})
+
+const VImgStub = defineComponent({
+  name: 'VImgStub',
+  props: {
+    src: { type: String, default: '' },
+    alt: { type: String, default: '' },
+  },
+  setup(props, { attrs }) {
+    return () => h('img', { ...attrs, src: props.src, alt: props.alt })
+  },
+})
+
+const NuxtLinkStub = defineComponent({
+  name: 'NuxtLinkStub',
+  props: {
+    to: { type: [String, Object], default: '' },
+  },
+  setup(props, { slots, attrs }) {
+    const href = typeof props.to === 'string' ? props.to : JSON.stringify(props.to)
+    return () => h('a', { ...attrs, href }, slots.default?.())
+  },
+})
+
+const mountHomePage = async () => {
+  const component = (await import('./index.vue')).default
+  return mountSuspended(component, {
+    global: {
+      stubs: {
+        VContainer: simpleStub('div'),
+        VRow: simpleStub('div'),
+        VCol: simpleStub('div'),
+        VCard: simpleStub('div'),
+        VSheet: simpleStub('div'),
+        VIcon: VIconStub,
+        VBtn: VBtnStub,
+        VTextField: VTextFieldStub,
+        VImg: VImgStub,
+        VDivider: simpleStub('hr'),
+        VExpansionPanels: simpleStub('div'),
+        VExpansionPanel: simpleStub('div'),
+        VExpansionPanelTitle: simpleStub('div'),
+        VExpansionPanelText: simpleStub('div'),
+        NuxtLink: NuxtLinkStub,
+      },
+    },
+  })
+}
+
+describe('Home page', () => {
+  beforeEach(() => {
+    routerPush.mockReset()
+    routerReplace.mockReset()
+    localePathMock.mockClear()
+    headSpy.mockReset()
+  })
+
+  it('submits the search query using the localized search route', async () => {
+    const wrapper = await mountHomePage()
+
+    const searchForm = wrapper.find('section.home-hero form[role="search"]')
+    const searchInput = searchForm.find('input')
+
+    await searchInput.setValue('smart tv')
+    await searchForm.trigger('submit.prevent')
+
+    expect(localePathMock).toHaveBeenCalledWith({ name: 'search', query: { q: 'smart tv' } })
+    expect(routerPush).toHaveBeenCalledWith('/localized/search?q=smart tv')
+  })
+
+  it('registers FAQ structured data in head tags', async () => {
+    await mountHomePage()
+
+    const headEntries = headSpy.mock.calls.map(([value]) => value)
+    const scriptEntry = headEntries
+      .flatMap((entry) => (entry && typeof entry === 'object' && 'script' in entry ? (entry.script as unknown[]) : []))
+      .find((entry) => entry && typeof entry === 'object' && 'key' in entry && (entry as { key: string }).key === 'home-faq-jsonld') as
+      | { children?: string }
+      | undefined
+
+    expect(scriptEntry).toBeTruthy()
+
+    const json = scriptEntry?.children ? JSON.parse(scriptEntry.children) : null
+
+    expect(json).toBeTruthy()
+    expect(json).toMatchObject({
+      '@type': 'FAQPage',
+    })
+    expect(Array.isArray(json?.mainEntity)).toBe(true)
+    expect(json?.mainEntity).toHaveLength(6)
+    expect(json?.mainEntity[0]).toMatchObject({
+      '@type': 'Question',
+      acceptedAnswer: { '@type': 'Answer' },
+    })
+  })
+})

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -482,9 +482,7 @@ useHead(() => ({
 
 .home-hero
   padding-block: clamp(4rem, 10vw, 7rem)
-  background: radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-start), 0.28), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(var(--v-theme-hero-gradient-end), 0.25), transparent 60%),
-    rgb(var(--v-theme-surface-default))
+  background: radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-start), 0.28), transparent 55%), radial-gradient(circle at bottom right, rgba(var(--v-theme-hero-gradient-end), 0.25), transparent 60%), rgb(var(--v-theme-surface-default))
 
 .home-hero__container
   display: flex

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -1,20 +1,862 @@
 <script setup lang="ts">
-const drawerStore = useState("mobileDrawer", () => false);
+import { computed, ref } from 'vue'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
-const toggleDrawer = () => {
-  drawerStore.value = !drawerStore.value;
-};
+definePageMeta({
+  ssr: true,
+})
+
+const { t, locale, availableLocales } = useI18n()
+const router = useRouter()
+const localePath = useLocalePath()
+const requestURL = useRequestURL()
+
+const searchQuery = ref('')
+
+const heroImageSrc = '/images/home/hero-placeholder.svg'
+
+const problemItems = computed(() => [
+  {
+    icon: 'mdi-sign-direction',
+    text: String(t('home.problems.items.labelsOverload')),
+  },
+  {
+    icon: 'mdi-scale-balance',
+    text: String(t('home.problems.items.budgetVsEcology')),
+  },
+  {
+    icon: 'mdi-tab-multiple',
+    text: String(t('home.problems.items.tooManyTabs')),
+  },
+])
+
+const solutionBenefits = computed(() => [
+  {
+    emoji: '⏱️',
+    label: String(t('home.solution.benefits.time')),
+  },
+  {
+    emoji: '💰',
+    label: String(t('home.solution.benefits.savings')),
+  },
+  {
+    emoji: '🌍',
+    label: String(t('home.solution.benefits.planet')),
+  },
+  {
+    emoji: '🛡️',
+    label: String(t('home.solution.benefits.trust')),
+  },
+])
+
+const featureCards = computed(() => [
+  {
+    icon: 'mdi-leaf-circle',
+    title: String(t('home.features.cards.impactScore.title')),
+    description: String(t('home.features.cards.impactScore.description')),
+  },
+  {
+    icon: 'mdi-chart-line',
+    title: String(t('home.features.cards.priceComparison.title')),
+    description: String(t('home.features.cards.priceComparison.description')),
+  },
+  {
+    icon: 'mdi-source-branch',
+    title: String(t('home.features.cards.openIndependent.title')),
+    description: String(t('home.features.cards.openIndependent.description')),
+  },
+  {
+    icon: 'mdi-shield-off-outline',
+    title: String(t('home.features.cards.noTracking.title')),
+    description: String(t('home.features.cards.noTracking.description')),
+  },
+  {
+    icon: 'mdi-database',
+    title: String(t('home.features.cards.massiveBase.title')),
+    description: String(t('home.features.cards.massiveBase.description')),
+  },
+])
+
+const categoryCards = computed(() => [
+  {
+    icon: 'mdi-cellphone',
+    title: String(t('home.categories.items.electronics.title')),
+    description: String(t('home.categories.items.electronics.description')),
+    href: localePath({ name: 'search', query: { q: 'smartphone' } }),
+  },
+  {
+    icon: 'mdi-fridge',
+    title: String(t('home.categories.items.appliances.title')),
+    description: String(t('home.categories.items.appliances.description')),
+    href: localePath({ name: 'search', query: { q: 'lave-linge' } }),
+  },
+])
+
+const blogEntries = computed(() => [
+  {
+    title: String(t('home.blog.items.first.title')),
+    date: String(t('home.blog.items.first.date')),
+    excerpt: String(t('home.blog.items.first.excerpt')),
+    href: '#',
+  },
+  {
+    title: String(t('home.blog.items.second.title')),
+    date: String(t('home.blog.items.second.date')),
+    excerpt: String(t('home.blog.items.second.excerpt')),
+    href: '#',
+  },
+  {
+    title: String(t('home.blog.items.third.title')),
+    date: String(t('home.blog.items.third.date')),
+    excerpt: String(t('home.blog.items.third.excerpt')),
+    href: '#',
+  },
+])
+
+const objectionItems = computed(() => [
+  {
+    icon: 'mdi-lightning-bolt',
+    question: String(t('home.objections.items.aiEnergy.question')),
+    answer: String(t('home.objections.items.aiEnergy.answer')),
+  },
+  {
+    icon: 'mdi-recycle',
+    question: String(t('home.objections.items.reuse.question')),
+    answer: String(t('home.objections.items.reuse.answer')),
+  },
+  {
+    icon: 'mdi-scale-balance',
+    question: String(t('home.objections.items.independence.question')),
+    answer: String(t('home.objections.items.independence.answer')),
+  },
+])
+
+const faqItems = computed(() => [
+  {
+    question: String(t('home.faq.items.free.question')),
+    answer: String(t('home.faq.items.free.answer')),
+  },
+  {
+    question: String(t('home.faq.items.account.question')),
+    answer: String(t('home.faq.items.account.answer')),
+  },
+  {
+    question: String(t('home.faq.items.categories.question')),
+    answer: String(t('home.faq.items.categories.answer')),
+  },
+  {
+    question: String(t('home.faq.items.impactScore.question')),
+    answer: String(t('home.faq.items.impactScore.answer')),
+  },
+  {
+    question: String(t('home.faq.items.dataFreshness.question')),
+    answer: String(t('home.faq.items.dataFreshness.answer')),
+  },
+  {
+    question: String(t('home.faq.items.suggestProduct.question')),
+    answer: String(t('home.faq.items.suggestProduct.answer')),
+  },
+])
+
+const faqJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.value.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answer,
+    },
+  })),
+}))
+
+const canonicalUrl = computed(
+  () => new URL(resolveLocalizedRoutePath('index', locale.value), requestURL.origin).toString(),
+)
+
+const alternateLinks = computed(() =>
+  availableLocales.map((availableLocale) => ({
+    rel: 'alternate' as const,
+    hreflang: availableLocale,
+    href: new URL(resolveLocalizedRoutePath('index', availableLocale), requestURL.origin).toString(),
+  })),
+)
+
+const searchLandingUrl = computed(() => localePath({ name: 'search' }))
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+
+const handleSearchSubmit = () => {
+  const trimmedQuery = searchQuery.value.trim()
+  const target = localePath({
+    name: 'search',
+    query: trimmedQuery.length > 0 ? { q: trimmedQuery } : undefined,
+  })
+
+  router.push(target)
+}
+
+useSeoMeta({
+  title: () => String(t('home.seo.title')),
+  description: () => String(t('home.seo.description')),
+  ogTitle: () => String(t('home.seo.title')),
+  ogDescription: () => String(t('home.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+  ogSiteName: () => String(t('siteIdentity.siteName')),
+  ogLocale: () => locale.value.replace('-', '_'),
+  ogImageAlt: () => String(t('home.seo.imageAlt')),
+})
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+    ...alternateLinks.value,
+  ],
+  script: [
+    {
+      key: 'home-faq-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(faqJsonLd.value),
+    },
+  ],
+}))
 </script>
 
 <template>
-  <div class="full-height">
-    <Hero-section @toggle-drawer="toggleDrawer" />
+  <div class="home-page">
+    <section class="home-hero" aria-labelledby="home-hero-title">
+      <v-container class="home-hero__container" max-width="lg">
+        <div class="home-hero__layout">
+          <div class="home-hero__content">
+            <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+            <h1 id="home-hero-title" class="home-hero__title">
+              {{ t('home.hero.title') }}
+            </h1>
+            <p class="home-hero__subtitle">{{ t('home.hero.subtitle') }}</p>
 
-    <The-section-items-slide />
+            <form class="home-hero__search" role="search" @submit.prevent="handleSearchSubmit">
+              <v-text-field
+                v-model="searchQuery"
+                class="home-hero__search-input"
+                variant="outlined"
+                density="comfortable"
+                :label="t('home.hero.search.label')"
+                :placeholder="t('home.hero.search.placeholder')"
+                :aria-label="t('home.hero.search.ariaLabel')"
+                prepend-inner-icon="mdi-magnify"
+                hide-details="auto"
+              />
+              <v-btn class="home-hero__search-button" type="submit" size="large" color="primary" elevation="2">
+                {{ t('home.hero.search.cta') }}
+              </v-btn>
+            </form>
 
-    <Bloc3Hz />
+            <p class="home-hero__helper">
+              <span aria-hidden="true">⚡</span>
+              {{ t('home.hero.search.helper') }}
+            </p>
+          </div>
 
+          <div class="home-hero__media" aria-hidden="true">
+            <v-sheet rounded="xl" elevation="6" class="home-hero__media-sheet">
+              <v-img :src="heroImageSrc" :alt="t('home.hero.imageAlt')" cover class="home-hero__image" />
+            </v-sheet>
+          </div>
+        </div>
+      </v-container>
+    </section>
+
+    <section class="home-section home-problems" aria-labelledby="home-problems-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-problems-title">{{ t('home.problems.title') }}</h2>
+        </header>
+        <v-row class="home-problems__grid" dense>
+          <v-col v-for="item in problemItems" :key="item.text" cols="12" md="4">
+            <v-card class="home-problems__card" variant="tonal">
+              <v-icon class="home-problems__icon" :icon="item.icon" size="32" />
+              <p class="home-problems__text">{{ item.text }}</p>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </section>
+
+    <section class="home-section home-solution" aria-labelledby="home-solution-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-solution-title">{{ t('home.solution.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.solution.description') }}</p>
+        </header>
+        <ul class="home-solution__list">
+          <li v-for="item in solutionBenefits" :key="item.label" class="home-solution__item">
+            <span class="home-solution__emoji" aria-hidden="true">{{ item.emoji }}</span>
+            <span class="home-solution__label">{{ item.label }}</span>
+          </li>
+        </ul>
+      </v-container>
+    </section>
+
+    <section class="home-section home-features" aria-labelledby="home-features-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-features-title">{{ t('home.features.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.features.subtitle') }}</p>
+        </header>
+        <v-row class="home-features__grid" dense>
+          <v-col v-for="card in featureCards" :key="card.title" cols="12" sm="6" md="4">
+            <v-card class="home-features__card" variant="outlined">
+              <v-icon class="home-features__icon" :icon="card.icon" size="32" />
+              <h3 class="home-features__card-title">{{ card.title }}</h3>
+              <p class="home-features__card-description">{{ card.description }}</p>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </section>
+
+    <section class="home-section home-categories" aria-labelledby="home-categories-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-categories-title">{{ t('home.categories.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.categories.subtitle') }}</p>
+        </header>
+        <v-row class="home-categories__grid" dense>
+          <v-col v-for="card in categoryCards" :key="card.title" cols="12" sm="6">
+            <NuxtLink :to="card.href" class="home-categories__link">
+              <v-card class="home-categories__card" variant="outlined">
+                <div class="home-categories__card-header">
+                  <v-icon class="home-categories__icon" :icon="card.icon" size="32" />
+                  <h3 class="home-categories__card-title">{{ card.title }}</h3>
+                </div>
+                <p class="home-categories__card-description">{{ card.description }}</p>
+                <span class="home-categories__cta">{{ t('home.categories.cta') }}</span>
+              </v-card>
+            </NuxtLink>
+          </v-col>
+        </v-row>
+      </v-container>
+    </section>
+
+    <section class="home-section home-trust" aria-labelledby="home-trust-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-trust-title">{{ t('home.trust.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.trust.subtitle') }}</p>
+        </header>
+
+        <div class="home-trust__logos" role="list">
+          <div class="home-trust__logo" role="listitem">
+            <v-img src="/images/ecosystem/ademe.png" :alt="t('home.trust.logos.ademe')" />
+          </div>
+        </div>
+
+        <div class="home-trust__stats">
+          <p class="home-trust__stat">{{ t('home.trust.stats.references') }}</p>
+          <v-divider class="home-trust__divider" vertical />
+          <p class="home-trust__stat">{{ t('home.trust.stats.updates') }}</p>
+        </div>
+
+        <div class="home-trust__blog">
+          <div class="home-trust__blog-header">
+            <h3 class="home-trust__blog-title">{{ t('home.blog.title') }}</h3>
+            <NuxtLink class="home-trust__blog-link" :to="localePath('blog')">
+              {{ t('home.blog.cta') }}
+            </NuxtLink>
+          </div>
+          <v-row class="home-trust__blog-grid" dense>
+            <v-col v-for="entry in blogEntries" :key="entry.title" cols="12" md="4">
+              <v-card class="home-trust__blog-card" variant="tonal">
+                <p class="home-trust__blog-date">{{ entry.date }}</p>
+                <h4 class="home-trust__blog-card-title">{{ entry.title }}</h4>
+                <p class="home-trust__blog-excerpt">{{ entry.excerpt }}</p>
+                <NuxtLink class="home-trust__blog-read" :to="entry.href">
+                  {{ t('home.blog.readMore') }}
+                </NuxtLink>
+              </v-card>
+            </v-col>
+          </v-row>
+        </div>
+      </v-container>
+    </section>
+
+    <section class="home-section home-objections" aria-labelledby="home-objections-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-objections-title">{{ t('home.objections.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.objections.subtitle') }}</p>
+        </header>
+        <v-row class="home-objections__grid" dense>
+          <v-col v-for="item in objectionItems" :key="item.question" cols="12" md="4">
+            <v-card class="home-objections__card" variant="outlined">
+              <div class="home-objections__card-header">
+                <v-icon class="home-objections__icon" :icon="item.icon" size="28" />
+                <h3 class="home-objections__question">{{ item.question }}</h3>
+              </div>
+              <p class="home-objections__answer">{{ item.answer }}</p>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-container>
+    </section>
+
+    <section class="home-section home-faq" aria-labelledby="home-faq-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-faq-title">{{ t('home.faq.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.faq.subtitle') }}</p>
+        </header>
+        <v-expansion-panels class="home-faq__panels" multiple variant="accordion">
+          <v-expansion-panel v-for="item in faqItems" :key="item.question">
+            <v-expansion-panel-title class="home-faq__panel-title">
+              {{ item.question }}
+            </v-expansion-panel-title>
+            <v-expansion-panel-text class="home-faq__panel-text">
+              {{ item.answer }}
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-container>
+    </section>
+
+    <section class="home-cta" aria-labelledby="home-cta-title">
+      <v-container class="home-cta__container" max-width="lg">
+        <div class="home-cta__content">
+          <h2 id="home-cta-title" class="home-cta__title">{{ t('home.cta.title') }}</h2>
+          <p class="home-cta__subtitle">{{ t('home.cta.subtitle') }}</p>
+          <div class="home-cta__actions">
+            <form class="home-cta__form" role="search" @submit.prevent="handleSearchSubmit">
+              <v-text-field
+                v-model="searchQuery"
+                class="home-cta__search-input"
+                variant="outlined"
+                density="comfortable"
+                :label="t('home.hero.search.label')"
+                :placeholder="t('home.hero.search.placeholder')"
+                :aria-label="t('home.hero.search.ariaLabel')"
+                prepend-inner-icon="mdi-magnify"
+                hide-details="auto"
+              />
+              <v-btn class="home-cta__button" type="submit" size="large" color="primary" elevation="2">
+                {{ t('home.cta.button') }}
+              </v-btn>
+            </form>
+            <NuxtLink class="home-cta__link" :to="searchLandingUrl">
+              {{ t('home.cta.altLink') }}
+            </NuxtLink>
+          </div>
+        </div>
+      </v-container>
+    </section>
   </div>
 </template>
 
-<style lang="sass" scoped></style>
+<style scoped lang="sass">
+.home-page
+  display: flex
+  flex-direction: column
+
+.home-section
+  padding-block: clamp(3rem, 6vw, 6rem)
+  background: rgb(var(--v-theme-surface-default))
+
+.home-section:nth-of-type(even)
+  background: rgba(var(--v-theme-surface-muted), 0.6)
+
+.home-section__container
+  display: flex
+  flex-direction: column
+  gap: clamp(2rem, 5vw, 3.5rem)
+
+.home-section__header
+  max-width: 720px
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-section__subtitle
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  margin: 0
+
+.home-hero
+  padding-block: clamp(4rem, 10vw, 7rem)
+  background: radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-start), 0.28), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(var(--v-theme-hero-gradient-end), 0.25), transparent 60%),
+    rgb(var(--v-theme-surface-default))
+
+.home-hero__container
+  display: flex
+  flex-direction: column
+  gap: clamp(2rem, 5vw, 3rem)
+
+.home-hero__layout
+  display: grid
+  gap: clamp(2rem, 5vw, 3rem)
+
+.home-hero__content
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+.home-hero__eyebrow
+  font-weight: 600
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
+  margin: 0
+
+.home-hero__title
+  font-size: clamp(2rem, 5vw, 3.5rem)
+  line-height: 1.1
+  margin: 0
+
+.home-hero__subtitle
+  font-size: clamp(1.05rem, 2.5vw, 1.35rem)
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  margin: 0
+
+.home-hero__search
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-hero__search-input :deep(.v-field)
+  border-radius: 999px
+
+.home-hero__search-input :deep(input)
+  font-size: 1.05rem
+
+.home-hero__search-button
+  align-self: flex-start
+  border-radius: 999px
+  padding-inline: clamp(1.5rem, 4vw, 2.5rem)
+
+.home-hero__helper
+  display: flex
+  align-items: center
+  gap: 0.5rem
+  font-size: 0.95rem
+  color: rgb(var(--v-theme-text-neutral-soft))
+  margin: 0
+
+.home-hero__media
+  display: flex
+  justify-content: center
+
+.home-hero__media-sheet
+  padding: clamp(1rem, 3vw, 2rem)
+  background: rgba(var(--v-theme-surface-glass-strong), 0.7)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25)
+
+.home-hero__image
+  max-height: 320px
+  border-radius: 1rem
+
+.home-problems__grid
+  row-gap: 1.5rem
+
+.home-problems__card
+  padding: 1.5rem
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  height: 100%
+  background: rgba(var(--v-theme-surface-primary-080), 0.6)
+
+.home-problems__icon
+  color: rgba(var(--v-theme-accent-primary-highlight), 0.9)
+
+.home-problems__text
+  margin: 0
+  font-size: 1.05rem
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.home-solution__list
+  list-style: none
+  display: grid
+  gap: 1rem
+  padding: 0
+  margin: 0
+
+.home-solution__item
+  display: flex
+  align-items: flex-start
+  gap: 0.75rem
+  padding: 1rem 1.25rem
+  border-radius: 1rem
+  background: rgba(var(--v-theme-surface-glass), 0.7)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
+
+.home-solution__emoji
+  font-size: 1.5rem
+
+.home-solution__label
+  font-size: 1.05rem
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.home-features__grid
+  row-gap: 1.5rem
+
+.home-features__card
+  padding: 1.75rem
+  height: 100%
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  border-radius: 1.25rem
+  background: rgba(var(--v-theme-surface-glass-strong), 0.75)
+
+.home-features__icon
+  color: rgba(var(--v-theme-hero-gradient-start), 0.9)
+
+.home-features__card-title
+  font-size: 1.2rem
+  margin: 0
+
+.home-features__card-description
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-categories
+  background: rgba(var(--v-theme-surface-primary-050), 0.8)
+
+.home-categories__grid
+  row-gap: 1.5rem
+
+.home-categories__link
+  text-decoration: none
+
+.home-categories__card
+  padding: 1.75rem
+  height: 100%
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  border-radius: 1.5rem
+  transition: transform 0.25s ease, box-shadow 0.25s ease
+
+.home-categories__card:hover
+  transform: translateY(-4px)
+  box-shadow: 0 12px 24px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
+.home-categories__card-header
+  display: flex
+  align-items: center
+  gap: 0.75rem
+
+.home-categories__cta
+  font-weight: 600
+  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
+
+.home-trust__logos
+  display: flex
+  flex-wrap: wrap
+  gap: 1.5rem
+  align-items: center
+
+.home-trust__logo
+  padding: 0.75rem 1.5rem
+  border-radius: 999px
+  background: rgba(var(--v-theme-surface-glass-strong), 0.8)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
+  :deep(img)
+    max-height: 48px
+    width: auto
+    display: block
+
+.home-trust__stats
+  display: flex
+  flex-wrap: wrap
+  align-items: center
+  gap: 1rem
+  padding: 1.5rem
+  border-radius: 1.25rem
+  background: rgba(var(--v-theme-surface-glass), 0.7)
+  margin-top: 2rem
+
+.home-trust__stat
+  margin: 0
+  font-weight: 600
+
+.home-trust__divider
+  height: 32px
+
+.home-trust__blog
+  margin-top: clamp(2rem, 5vw, 3rem)
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+
+.home-trust__blog-header
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+
+.home-trust__blog-title
+  margin: 0
+
+.home-trust__blog-link
+  font-weight: 600
+  color: rgba(var(--v-theme-hero-gradient-start), 0.9)
+  text-decoration: none
+
+.home-trust__blog-grid
+  row-gap: 1.5rem
+
+.home-trust__blog-card
+  padding: 1.5rem
+  height: 100%
+  border-radius: 1.25rem
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-trust__blog-date
+  margin: 0
+  font-size: 0.95rem
+  color: rgb(var(--v-theme-text-neutral-soft))
+
+.home-trust__blog-card-title
+  margin: 0
+  font-size: 1.1rem
+
+.home-trust__blog-excerpt
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  flex-grow: 1
+
+.home-trust__blog-read
+  font-weight: 600
+  text-decoration: none
+  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
+
+.home-objections__grid
+  row-gap: 1.5rem
+
+.home-objections__card
+  padding: 1.5rem
+  height: 100%
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  border-radius: 1.25rem
+  background: rgba(var(--v-theme-surface-glass-strong), 0.8)
+
+.home-objections__card-header
+  display: flex
+  gap: 0.75rem
+  align-items: center
+
+.home-objections__question
+  margin: 0
+  font-size: 1.05rem
+
+.home-objections__answer
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-faq__panels
+  border-radius: 1.25rem
+  background: rgba(var(--v-theme-surface-glass-strong), 0.7)
+  padding: 0.5rem
+
+.home-faq__panel-title
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.home-faq__panel-text
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-cta
+  padding-block: clamp(3rem, 8vw, 5rem)
+  background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.16), rgba(var(--v-theme-hero-gradient-end), 0.18))
+
+.home-cta__container
+  display: flex
+  justify-content: center
+
+.home-cta__content
+  background: rgba(var(--v-theme-surface-default), 0.9)
+  border-radius: clamp(1.5rem, 4vw, 2rem)
+  padding: clamp(2rem, 5vw, 3rem)
+  box-shadow: 0 24px 40px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  display: flex
+  flex-direction: column
+  gap: 1.5rem
+  max-width: 720px
+  width: 100%
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
+
+.home-cta__title
+  margin: 0
+  text-align: center
+  font-size: clamp(1.8rem, 4vw, 2.5rem)
+
+.home-cta__subtitle
+  margin: 0
+  text-align: center
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-cta__actions
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  align-items: center
+
+.home-cta__form
+  width: 100%
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-cta__search-input :deep(.v-field)
+  border-radius: 999px
+
+.home-cta__button
+  border-radius: 999px
+  align-self: center
+  padding-inline: clamp(1.75rem, 5vw, 2.5rem)
+
+.home-cta__link
+  text-decoration: none
+  font-weight: 600
+  color: rgba(var(--v-theme-hero-gradient-start), 0.9)
+
+@media (min-width: 960px)
+  .home-hero__layout
+    grid-template-columns: repeat(2, minmax(0, 1fr))
+    align-items: center
+
+  .home-hero__search
+    flex-direction: row
+    align-items: center
+
+  .home-hero__search-button
+    margin-inline-start: 0.5rem
+
+  .home-hero__helper
+    font-size: 1rem
+
+  .home-solution__list
+    grid-template-columns: repeat(2, minmax(0, 1fr))
+
+  .home-trust__blog-header
+    flex-direction: row
+    justify-content: space-between
+    align-items: baseline
+
+  .home-cta__actions
+    flex-direction: row
+    justify-content: center
+    gap: 1.5rem
+
+  .home-cta__form
+    flex-direction: row
+    align-items: center
+    max-width: 500px
+
+  .home-cta__button
+    margin: 0
+</style>

--- a/frontend/app/public/images/home/hero-placeholder.svg
+++ b/frontend/app/public/images/home/hero-placeholder.svg
@@ -1,0 +1,50 @@
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Illustration d'un tableau de bord de consommation responsable</title>
+  <desc id="desc">Une composition abstraite représentant des cartes de produits, un graphique d'impact environnemental et un comparateur de prix.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#E3F2FD" />
+      <stop offset="50%" stop-color="#E8F5E9" />
+      <stop offset="100%" stop-color="#F3E5F5" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#F1F5F9" stop-opacity="0.9" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1976D2" />
+      <stop offset="100%" stop-color="#43A047" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" rx="48" fill="url(#bg)" />
+  <g transform="translate(80 80)">
+    <rect width="280" height="180" rx="20" fill="url(#card)" />
+    <rect x="24" y="36" width="100" height="16" rx="8" fill="#1976D2" opacity="0.85" />
+    <rect x="24" y="64" width="160" height="16" rx="8" fill="#43A047" opacity="0.75" />
+    <rect x="24" y="100" width="220" height="16" rx="8" fill="#101828" opacity="0.12" />
+    <rect x="24" y="132" width="160" height="16" rx="8" fill="#101828" opacity="0.12" />
+    <circle cx="240" cy="48" r="32" fill="#FFFFFF" opacity="0.9" />
+  </g>
+  <g transform="translate(380 140)">
+    <rect width="320" height="260" rx="28" fill="url(#card)" />
+    <rect x="32" y="40" width="160" height="20" rx="10" fill="#101828" opacity="0.12" />
+    <rect x="32" y="72" width="200" height="20" rx="10" fill="#101828" opacity="0.12" />
+    <g transform="translate(32 120)">
+      <polyline points="0,80 60,32 120,64 180,16" fill="none" stroke="url(#accent)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" />
+      <circle cx="0" cy="80" r="8" fill="#1976D2" />
+      <circle cx="60" cy="32" r="8" fill="#2196F3" />
+      <circle cx="120" cy="64" r="8" fill="#43A047" />
+      <circle cx="180" cy="16" r="8" fill="#4CAF50" />
+    </g>
+    <rect x="32" y="196" width="256" height="24" rx="12" fill="#1976D2" opacity="0.85" />
+  </g>
+  <g transform="translate(120 320)">
+    <rect width="240" height="180" rx="24" fill="url(#card)" />
+    <rect x="24" y="40" width="120" height="16" rx="8" fill="#101828" opacity="0.12" />
+    <rect x="24" y="72" width="80" height="16" rx="8" fill="#43A047" opacity="0.7" />
+    <rect x="24" y="112" width="160" height="16" rx="8" fill="#1976D2" opacity="0.7" />
+  </g>
+  <circle cx="660" cy="420" r="90" fill="url(#accent)" opacity="0.16" />
+  <circle cx="620" cy="160" r="36" fill="#1976D2" opacity="0.2" />
+  <circle cx="200" cy="520" r="28" fill="#43A047" opacity="0.18" />
+</svg>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -34,6 +34,172 @@
       "tagTitle": "{tag} articles – Nudger Blog"
     }
   },
+  "home": {
+    "seo": {
+      "title": "Nudger – Responsible shopping made easy",
+      "description": "Compare the environmental impact and prices of over 50 million products with Nudger.",
+      "imageAlt": "Illustration of the Nudger dashboard showing impact scores and price comparisons."
+    },
+    "hero": {
+      "eyebrow": "Responsible shopping",
+      "title": "Responsible choices aren’t a luxury",
+      "subtitle": "Save time, stay true to your values. Compare effortlessly, choose freely.",
+      "imageAlt": "Illustration of the Nudger comparison experience with product cards and impact charts.",
+      "search": {
+        "label": "Search for a product",
+        "placeholder": "Search a product (e.g. television, smartphone…)",
+        "ariaLabel": "Search for a responsible product",
+        "cta": "Compare",
+        "helper": "Already 50M+ references in open data."
+      }
+    },
+    "problems": {
+      "title": "Too many labels, not enough clarity?",
+      "items": {
+        "labelsOverload": "Lost in the jungle of labels? Hard to truly compare.",
+        "budgetVsEcology": "Ecology versus budget? Tired of choosing between the two.",
+        "tooManyTabs": "Eight tabs open? One place is enough."
+      }
+    },
+    "solution": {
+      "title": "Responsible shopping, minus the headache",
+      "description": "Nudger combines environmental, technical and pricing insights to simplify every decision.",
+      "benefits": {
+        "time": "Save time — we analyse the data for you.",
+        "savings": "Save money — price comparison built in.",
+        "planet": "Shop better — spot the most responsible products.",
+        "trust": "Trustworthy — open data, independent recommendations."
+      }
+    },
+    "features": {
+      "title": "Key features",
+      "subtitle": "See what Nudger puts at your fingertips.",
+      "cards": {
+        "impactScore": {
+          "title": "AI Impact Score",
+          "description": "A clear ecological score (5 criteria, AI used with restraint)."
+        },
+        "priceComparison": {
+          "title": "Price comparison + history",
+          "description": "Pay the right price at the right time."
+        },
+        "openIndependent": {
+          "title": "Open & independent",
+          "description": "Open source, open data, no brand influence."
+        },
+        "noTracking": {
+          "title": "Zero tracking",
+          "description": "We track products, not you. Cookies are for eating 🍪."
+        },
+        "massiveBase": {
+          "title": "Massive dataset",
+          "description": "The largest open-data catalogue on the market: 50 million references."
+        }
+      }
+    },
+    "categories": {
+      "title": "Browse categories",
+      "subtitle": "Start with our most popular universes and refine in one click.",
+      "cta": "Browse products",
+      "items": {
+        "electronics": {
+          "title": "Electronics",
+          "description": "Smartphones, TVs, audio… stay connected without compromising your values."
+        },
+        "appliances": {
+          "title": "Appliances",
+          "description": "Washing machines, dishwashers, fridges… optimise your energy use."
+        }
+      }
+    },
+    "trust": {
+      "title": "Proof & trust",
+      "subtitle": "Demanding partners and open data keep us accountable.",
+      "logos": {
+        "ademe": "ADEME – French Agency for Ecological Transition"
+      },
+      "stats": {
+        "references": "50,000,000+ open-data references",
+        "updates": "Updated on a regular basis"
+      }
+    },
+    "blog": {
+      "title": "From the blog",
+      "cta": "Browse all articles",
+      "readMore": "Read article",
+      "items": {
+        "first": {
+          "title": "How we keep our AI frugal",
+          "date": "15 Jan 2025",
+          "excerpt": "The technical choices that keep Nudger’s computations low-carbon."
+        },
+        "second": {
+          "title": "Prioritising durability and repairability",
+          "date": "8 Jan 2025",
+          "excerpt": "Why repairability weighs more in the Impact Score."
+        },
+        "third": {
+          "title": "Balancing price and impact, step by step",
+          "date": "20 Dec 2024",
+          "excerpt": "Nudger’s method to align ecology and budget without compromise."
+        }
+      }
+    },
+    "objections": {
+      "title": "Straight questions, clear answers",
+      "subtitle": "The topics we hear about the most.",
+      "items": {
+        "aiEnergy": {
+          "question": "Does AI burn too much energy?",
+          "answer": "Frugal AI, optimised computations, net positive impact."
+        },
+        "reuse": {
+          "question": "Is true frugality all about reuse?",
+          "answer": "We promote using less first, then better; durability and refurb when available."
+        },
+        "independence": {
+          "question": "Are you independent?",
+          "answer": "Yes. Results stay neutral, code is open, funding never affects rankings."
+        }
+      }
+    },
+    "faq": {
+      "title": "FAQ",
+      "subtitle": "Quick answers to the most common questions.",
+      "items": {
+        "free": {
+          "question": "Is Nudger free?",
+          "answer": "Yes, searching is free to use."
+        },
+        "account": {
+          "question": "Do I need an account?",
+          "answer": "No for searching; an account is optional if you want lists or alerts."
+        },
+        "categories": {
+          "question": "Which categories are covered?",
+          "answer": "Electronics & Appliances today, more to come."
+        },
+        "impactScore": {
+          "question": "How do you calculate the Impact Score?",
+          "answer": "Five weighted criteria + lean AI, fully open methodology."
+        },
+        "dataFreshness": {
+          "question": "Are the data kept up to date?",
+          "answer": "Yes, refreshed regularly with quality checks."
+        },
+        "suggestProduct": {
+          "question": "How can I suggest a product?",
+          "answer": "Use our dedicated contact form."
+        }
+      }
+    },
+    "cta": {
+      "title": "Ready to buy better without overspending?",
+      "subtitle": "Restart a search or explore the analysed offers.",
+      "button": "Start a search",
+      "altLink": "Open the search page"
+    }
+  },
   "categories": {
     "navigation": {
       "error": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -34,6 +34,172 @@
       "tagTitle": "Articles {tag} – Blog Nudger"
     }
   },
+  "home": {
+    "seo": {
+      "title": "Nudger – Consommer responsable n’est pas un luxe",
+      "description": "Comparez l’impact environnemental et les prix de plus de 50 millions de produits grâce à Nudger.",
+      "imageAlt": "Illustration du tableau de bord Nudger présentant des scores d’impact et des prix."
+    },
+    "hero": {
+      "eyebrow": "Consommation responsable",
+      "title": "Consommer responsable n’est pas un luxe",
+      "subtitle": "Gagne du temps, garde tes valeurs. Compare simplement, choisis librement.",
+      "imageAlt": "Illustration d’un comparateur Nudger affichant des cartes produits et des graphiques d’impact.",
+      "search": {
+        "label": "Rechercher un produit",
+        "placeholder": "Recherchez un produit (ex. téléviseur, smartphone…)",
+        "ariaLabel": "Rechercher un produit responsable",
+        "cta": "Comparer",
+        "helper": "Déjà +50 millions de références en open data."
+      }
+    },
+    "problems": {
+      "title": "Trop de labels, pas assez de clarté ?",
+      "items": {
+        "labelsOverload": "Perdu dans la jungle des labels ? Difficile de comparer vraiment.",
+        "budgetVsEcology": "Écologie vs pouvoir d’achat ? Marre de choisir entre les deux.",
+        "tooManyTabs": "8 sites ouverts ? Un seul endroit suffit."
+      }
+    },
+    "solution": {
+      "title": "Acheter responsable, sans prise de tête",
+      "description": "Nudger analyse les données écologiques, techniques et de prix pour simplifier chaque décision.",
+      "benefits": {
+        "time": "Gagnez du temps — on analyse pour vous.",
+        "savings": "Économisez — comparateur de prix intégré.",
+        "planet": "Consommez mieux — repérez les produits les plus responsables.",
+        "trust": "Confiance — données ouvertes, recommandations indépendantes."
+      }
+    },
+    "features": {
+      "title": "Fonctionnalités clés",
+      "subtitle": "Découvrez ce que Nudger met à votre service.",
+      "cards": {
+        "impactScore": {
+          "title": "Impact Score IA",
+          "description": "Un score écologique clair (5 critères, IA utilisée avec sobriété)."
+        },
+        "priceComparison": {
+          "title": "Comparateur de prix + historique",
+          "description": "Payer le juste prix, au bon moment."
+        },
+        "openIndependent": {
+          "title": "Ouvert & indépendant",
+          "description": "Open source, open data, aucune influence de marque."
+        },
+        "noTracking": {
+          "title": "Zéro tracking",
+          "description": "On suit les produits, pas vous. Les cookies, on les mange 🍪."
+        },
+        "massiveBase": {
+          "title": "Base massive",
+          "description": "La plus grande base open data du marché : 50 millions de références."
+        }
+      }
+    },
+    "categories": {
+      "title": "Parcourir les catégories",
+      "subtitle": "Commencez par nos univers les plus demandés et filtrez en un clic.",
+      "cta": "Voir les produits",
+      "items": {
+        "electronics": {
+          "title": "Électronique",
+          "description": "Smartphones, TV, audio… restez connecté sans renoncer à vos valeurs."
+        },
+        "appliances": {
+          "title": "Électroménager",
+          "description": "Lave-linge, lave-vaisselle, frigos… optimisez vos consommations d’énergie."
+        }
+      }
+    },
+    "trust": {
+      "title": "Preuves & confiance",
+      "subtitle": "Des partenaires exigeants et des données ouvertes pour garder le cap.",
+      "logos": {
+        "ademe": "ADEME – Agence de la transition écologique"
+      },
+      "stats": {
+        "references": "50 000 000+ références open data",
+        "updates": "Mises à jour régulières"
+      }
+    },
+    "blog": {
+      "title": "Du blog",
+      "cta": "Voir tous les articles",
+      "readMore": "Lire l’article",
+      "items": {
+        "first": {
+          "title": "Comment nous gardons une IA frugale",
+          "date": "15 janv. 2025",
+          "excerpt": "Nos choix techniques pour limiter l’empreinte carbone des calculs Nudger."
+        },
+        "second": {
+          "title": "Prioriser durabilité et réparabilité",
+          "date": "8 janv. 2025",
+          "excerpt": "Pourquoi les critères de réparabilité ont plus de poids dans l’Impact Score."
+        },
+        "third": {
+          "title": "Comparer prix et impact, mode d’emploi",
+          "date": "20 déc. 2024",
+          "excerpt": "La méthode Nudger pour confronter écologie et budget sans compromis."
+        }
+      }
+    },
+    "objections": {
+      "title": "Questions directes, réponses transparentes",
+      "subtitle": "Les sujets qui reviennent le plus souvent.",
+      "items": {
+        "aiEnergy": {
+          "question": "L’IA consomme beaucoup d’énergie ?",
+          "answer": "IA frugale, calculs optimisés, valeur nette positive."
+        },
+        "reuse": {
+          "question": "La vraie frugalité c’est le réemploi ?",
+          "answer": "On encourage d’abord consommer moins, puis mieux ; durabilité et reconditionné quand disponibles."
+        },
+        "independence": {
+          "question": "Êtes-vous indépendants ?",
+          "answer": "Oui. Résultats neutres, code ouvert, financements sans influence sur le classement."
+        }
+      }
+    },
+    "faq": {
+      "title": "FAQ",
+      "subtitle": "Les réponses rapides aux questions fréquentes.",
+      "items": {
+        "free": {
+          "question": "Nudger est-il gratuit ?",
+          "answer": "Oui, la recherche est libre d’accès."
+        },
+        "account": {
+          "question": "Besoin d’un compte ?",
+          "answer": "Non pour rechercher ; compte optionnel si vous souhaitez listes ou alertes."
+        },
+        "categories": {
+          "question": "Quelles catégories ?",
+          "answer": "Électronique & Électroménager aujourd’hui, extensions à venir."
+        },
+        "impactScore": {
+          "question": "Comment calculez-vous l’Impact Score ?",
+          "answer": "5 critères pondérés + IA sobre, méthode ouverte et auditée."
+        },
+        "dataFreshness": {
+          "question": "Les données sont-elles à jour ?",
+          "answer": "Oui, mises à jour régulières avec contrôles qualité."
+        },
+        "suggestProduct": {
+          "question": "Comment suggérer un produit ?",
+          "answer": "Via notre formulaire de contact dédié."
+        }
+      }
+    },
+    "cta": {
+      "title": "Prêt à acheter mieux sans vous ruiner ?",
+      "subtitle": "Relancez une recherche ou découvrez les offres analysées.",
+      "button": "Lancer une recherche",
+      "altLink": "Explorer la recherche"
+    }
+  },
   "categories": {
     "navigation": {
       "error": {


### PR DESCRIPTION
## Summary
- redesign the home page with a modern hero, solution, features, categories, trust, FAQ, and CTA flow
- add localized copy for the new sections and ship a dedicated hero illustration asset
- cover the search flow and FAQ structured data with a focused Vitest suite

## Testing
- pnpm exec vitest run --reporter=dot app/pages/index.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_690a20781b4c83229908384cf786150d