### PR TITLE
feat: enhance home hero search and media

### DIFF
--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -6,7 +6,7 @@ const messages: Record<string, string> = {
   'home.hero.search.label': 'Search for a product',
   'home.hero.search.placeholder': 'Search a product',
   'home.hero.search.ariaLabel': 'Search input',
-  'home.hero.search.cta': 'Compare',
+  'home.hero.search.cta': 'NUDGER',
   'home.hero.search.helper': '50M references',
   'home.hero.eyebrow': 'Responsible shopping',
   'home.hero.title': 'Responsible choices are not a luxury',
@@ -160,6 +160,34 @@ const VTextFieldStub = defineComponent({
   },
 })
 
+const SearchSuggestFieldStub = defineComponent({
+  name: 'SearchSuggestFieldStub',
+  props: {
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue', 'clear', 'select-category', 'select-product', 'submit'],
+  setup(props, { emit, attrs }) {
+    const onInput = (event: Event) => {
+      const target = event.target as HTMLInputElement
+      emit('update:modelValue', target.value)
+    }
+
+    const onKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && !event.isComposing) {
+        emit('submit')
+      }
+    }
+
+    return () =>
+      h('input', {
+        ...attrs,
+        value: props.modelValue,
+        onInput,
+        onKeydown,
+      })
+  },
+})
+
 const VBtnStub = defineComponent({
   name: 'VBtnStub',
   props: {
@@ -215,6 +243,7 @@ const mountHomePage = async () => {
         VIcon: VIconStub,
         VBtn: VBtnStub,
         VTextField: VTextFieldStub,
+        SearchSuggestField: SearchSuggestFieldStub,
         VImg: VImgStub,
         VDivider: simpleStub('hr'),
         VExpansionPanels: simpleStub('div'),

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -49,7 +49,7 @@
         "label": "Search for a product",
         "placeholder": "Search a product (e.g. television, smartphone…)",
         "ariaLabel": "Search for a responsible product",
-        "cta": "Compare",
+        "cta": "NUDGER",
         "helper": "Already 50M+ references in open data."
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -49,7 +49,7 @@
         "label": "Rechercher un produit",
         "placeholder": "Recherchez un produit (ex. téléviseur, smartphone…)",
         "ariaLabel": "Rechercher un produit responsable",
-        "cta": "Comparer",
+        "cta": "NUDGER",
         "helper": "Déjà +50 millions de références en open data."
       }
     },


### PR DESCRIPTION
## Summary
- replace the home hero text field with the existing SearchSuggestField component to surface category and product suggestions and route selections appropriately
- embed the existing hero demo video in the home hero media panel with new styling and keep the search state consistent across the page
- rename the home hero CTA label to "NUDGER" in both locales and adjust the home page test stubs to cover the suggest field

## Testing
- pnpm lint
- pnpm vitest run pages/index.spec.ts components/search/SearchSuggestField.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690c616fca188333b5dadf91ae4da2b9