### PR TITLE
Enhance impact score layout and add category carousel

### DIFF
--- a/frontend/app/components/shared/ui/ResponsiveCarousel.vue
+++ b/frontend/app/components/shared/ui/ResponsiveCarousel.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="responsive-carousel">
+    <v-carousel
+      v-model="currentSlide"
+      class="responsive-carousel__container"
+      :aria-label="ariaLabel"
+      :show-arrows="showControls"
+      :cycle="showControls"
+      :hide-delimiters="slides.length <= 1"
+      :hide-delimiter-background="true"
+      :touch="showControls"
+      height="auto"
+      role="region"
+    >
+      <v-carousel-item v-for="(slideItems, index) in slides" :key="`carousel-slide-${index}`">
+        <div class="responsive-carousel__slide" role="list">
+          <div
+            v-for="(item, itemIndex) in slideItems"
+            :key="itemKey(item, itemIndex)"
+            class="responsive-carousel__item"
+            role="listitem"
+          >
+            <slot name="item" :item="item" :index="itemIndex" />
+          </div>
+        </div>
+      </v-carousel-item>
+    </v-carousel>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useDisplay } from 'vuetify'
+
+type BreakpointKey = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+const props = withDefaults(
+  defineProps<{
+    items: unknown[]
+    ariaLabel: string
+    breakpoints?: Partial<Record<BreakpointKey, number>>
+    itemKey?: (item: unknown, index: number) => string | number
+  }>(),
+  {
+    breakpoints: () => ({ xs: 1, sm: 1, md: 2, lg: 3, xl: 3 }),
+    itemKey: (_item: unknown, index: number) => index,
+  },
+)
+
+const display = useDisplay()
+
+const currentSlide = ref(0)
+
+const itemsPerSlide = computed(() => {
+  const config = props.breakpoints ?? {}
+
+  if (display.xl.value) {
+    return Math.max(1, config.xl ?? config.lg ?? config.md ?? config.sm ?? config.xs ?? 1)
+  }
+
+  if (display.lg.value) {
+    return Math.max(1, config.lg ?? config.md ?? config.sm ?? config.xs ?? 1)
+  }
+
+  if (display.md.value) {
+    return Math.max(1, config.md ?? config.sm ?? config.xs ?? 1)
+  }
+
+  if (display.sm.value) {
+    return Math.max(1, config.sm ?? config.xs ?? 1)
+  }
+
+  return Math.max(1, config.xs ?? 1)
+})
+
+const slides = computed(() => {
+  const chunkSize = itemsPerSlide.value
+  const groups: unknown[][] = []
+
+  props.items.forEach((item, index) => {
+    const groupIndex = Math.floor(index / chunkSize)
+    if (!groups[groupIndex]) {
+      groups[groupIndex] = []
+    }
+    groups[groupIndex]?.push(item)
+  })
+
+  return groups
+})
+
+const showControls = computed(() => slides.value.length > 1)
+
+watch(
+  () => slides.value.length,
+  (length) => {
+    if (currentSlide.value >= length) {
+      currentSlide.value = 0
+    }
+  },
+)
+
+watch(
+  () => props.items.length,
+  () => {
+    currentSlide.value = 0
+  },
+)
+
+watch(
+  () => props.items,
+  () => {
+    currentSlide.value = 0
+  },
+  { deep: false },
+)
+</script>
+
+<style scoped>
+.responsive-carousel__container {
+  background: transparent;
+}
+
+.responsive-carousel__slide {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0 0.5rem 0.5rem;
+}
+
+.responsive-carousel__item {
+  height: 100%;
+  display: flex;
+}
+
+.responsive-carousel__item > :deep(*) {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 600px) {
+  .responsive-carousel__slide {
+    gap: 1.25rem;
+    padding-inline: 0;
+  }
+}
+</style>
+

--- a/frontend/app/pages/impact-score/index.vue
+++ b/frontend/app/pages/impact-score/index.vue
@@ -54,13 +54,13 @@
               </header>
 
               <v-row class="impact-score-section__row impact-score-section__row--balanced" align="stretch">
-                <v-col cols="12" lg="7">
+                <v-col cols="12" md="6" lg="7">
                   <div class="impact-score-section__body">
                     <TextContent bloc-id="ECOSCORE:2:" />
                   </div>
                 </v-col>
 
-                <v-col cols="12" lg="5" class="impact-score-section__rating">
+                <v-col cols="12" md="6" lg="5" class="impact-score-section__rating">
                   <v-card
                     variant="flat"
                     class="impact-score-example"
@@ -112,7 +112,7 @@
                 </h2>
               </header>
 
-              <v-row class="impact-score-section__row impact-score-section__row--media" align="center">
+              <v-row class="impact-score-section__row impact-score-section__row--media" align="stretch">
                 <v-col cols="12" md="5" lg="4" class="impact-score-section__media">
                   <figure class="impact-score-media" role="presentation">
                     <v-img
@@ -152,41 +152,38 @@
                 <p>{{ t('impactScorePage.sections.methodology.intro') }}</p>
               </div>
 
-              <div v-if="verticalCards.length" class="impact-score-verticals" role="list">
-                <v-row class="impact-score-verticals__row" align="stretch" justify="start">
-                  <v-col
-                    v-for="vertical in verticalCards"
-                    :key="vertical.id"
-                    cols="12"
-                    sm="6"
-                    md="4"
-                    role="listitem"
+              <ResponsiveCarousel
+                v-if="verticalCards.length"
+                class="impact-score-verticals"
+                :items="verticalCards"
+                :breakpoints="{ xs: 1, sm: 1, md: 2, lg: 3 }"
+                :aria-label="t('impactScorePage.sections.methodology.verticalCarouselAria')"
+              >
+                <template #item="{ item }">
+                  <NuxtLink
+                    :to="item.href"
+                    class="impact-score-vertical-card"
+                    :aria-label="t('impactScorePage.sections.methodology.verticalCardAria', { vertical: item.displayName })"
                   >
-                    <NuxtLink
-                      :to="vertical.href"
-                      class="impact-score-vertical-card"
-                      :aria-label="t('impactScorePage.sections.methodology.verticalCardAria', { vertical: vertical.displayName })"
-                    >
-                      <v-img
-                        v-if="vertical.image"
-                        :src="vertical.image"
-                        :alt="t('impactScorePage.sections.methodology.verticalImageAlt', { vertical: vertical.displayName })"
-                        class="impact-score-vertical-card__image"
-                        cover
-                      />
-                      <div class="impact-score-vertical-card__content">
-                        <span class="impact-score-vertical-card__eyebrow">
-                          {{ t('impactScorePage.sections.methodology.verticalLabel') }}
-                        </span>
-                        <strong class="impact-score-vertical-card__title">{{ vertical.displayName }}</strong>
-                        <span class="impact-score-vertical-card__cta">
-                          {{ t('impactScorePage.sections.methodology.verticalCta') }}
-                        </span>
-                      </div>
-                    </NuxtLink>
-                  </v-col>
-                </v-row>
-              </div>
+                    <v-img
+                      v-if="item.image"
+                      :src="item.image"
+                      :alt="t('impactScorePage.sections.methodology.verticalImageAlt', { vertical: item.displayName })"
+                      class="impact-score-vertical-card__image"
+                      cover
+                    />
+                    <div class="impact-score-vertical-card__content">
+                      <span class="impact-score-vertical-card__eyebrow">
+                        {{ t('impactScorePage.sections.methodology.verticalLabel') }}
+                      </span>
+                      <strong class="impact-score-vertical-card__title">{{ item.displayName }}</strong>
+                      <span class="impact-score-vertical-card__cta">
+                        {{ t('impactScorePage.sections.methodology.verticalCta') }}
+                      </span>
+                    </div>
+                  </NuxtLink>
+                </template>
+              </ResponsiveCarousel>
               <v-alert
                 v-else
                 type="info"
@@ -270,6 +267,7 @@ import { useDisplay } from 'vuetify'
 import { useI18n } from 'vue-i18n'
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import ResponsiveCarousel from '~/components/shared/ui/ResponsiveCarousel.vue'
 import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
 
 const props = defineProps({
@@ -524,13 +522,16 @@ function formatCoeff(n: number | null | undefined) {
 }
 
 .impact-score-page__content {
-  margin-top: -72px;
+  margin-top: 0;
+  padding-top: clamp(2.5rem, 4vw, 4rem);
+  max-width: min(1320px, 96vw);
 }
 
 .impact-score-page__layout {
   display: grid;
-  grid-template-columns: minmax(240px, 280px) minmax(0, 1fr);
-  gap: 2.5rem;
+  grid-template-columns: minmax(200px, 240px) minmax(0, 1fr);
+  gap: clamp(2rem, 3vw, 3rem);
+  align-items: start;
 }
 
 .impact-score-page__nav {
@@ -600,7 +601,7 @@ function formatCoeff(n: number | null | undefined) {
 }
 
 .impact-score-section__row--media {
-  align-items: center;
+  align-items: flex-start;
 }
 
 .impact-score-section__body :deep(p + p) {
@@ -610,12 +611,13 @@ function formatCoeff(n: number | null | undefined) {
 .impact-score-section__media {
   display: flex;
   justify-content: center;
+  align-items: flex-start;
 }
 
 .impact-score-media,
 .impact-score-insight__media {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   background: rgba(var(--v-theme-surface-primary-100), 0.85);
   border-radius: 24px;
@@ -635,7 +637,7 @@ function formatCoeff(n: number | null | undefined) {
 
 .impact-score-section__rating {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
 }
 
@@ -679,11 +681,19 @@ function formatCoeff(n: number | null | undefined) {
 }
 
 .impact-score-verticals {
-  margin: 1.75rem 0;
+  margin: 1.75rem 0 0;
 }
 
-.impact-score-verticals__row {
-  row-gap: 1.5rem;
+.impact-score-verticals :deep(.responsive-carousel__container) {
+  box-shadow: none;
+}
+
+.impact-score-verticals :deep(.responsive-carousel__slide) {
+  padding-block: 0.25rem 0.5rem;
+}
+
+.impact-score-verticals :deep(.responsive-carousel__item) {
+  display: flex;
 }
 
 .impact-score-vertical-card {
@@ -781,7 +791,11 @@ function formatCoeff(n: number | null | undefined) {
   margin-top: 1rem;
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1200px) {
+  .impact-score-page__content {
+    padding-top: 3rem;
+  }
+
   .impact-score-page__layout {
     grid-template-columns: 1fr;
   }
@@ -809,7 +823,7 @@ function formatCoeff(n: number | null | undefined) {
 
 @media (max-width: 960px) {
   .impact-score-page__content {
-    margin-top: -36px;
+    padding-top: 2rem;
   }
 
   .impact-score-section__surface {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -840,6 +840,7 @@
         "eyebrow": "Methodology",
         "intro": "The ecoscore calculation rules are detailed on every product (see the “environmental balance” section). Each product category has its own criteria and weights. These categories are currently covered:",
         "title": "How is the Impact Score calculated?",
+        "verticalCarouselAria": "Browse the ecoscore categories carousel",
         "verticalCardAria": "Open the ecoscore details for the {vertical} category",
         "verticalCta": "Open the ecoscore details",
         "verticalImageAlt": "Illustration for the {vertical} category",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -840,6 +840,7 @@
         "eyebrow": "Méthodologie",
         "intro": "Les règles de calcul de l’ecoscore sont détaillées sur chaque produit (section « bilan écologique »). Chaque catégorie de produit possède ses propres critères et pondérations. Voici les catégories couvertes :",
         "title": "Comment est calculé l'Impact Score ?",
+        "verticalCarouselAria": "Parcourir le carrousel des catégories ecoscore",
         "verticalCardAria": "Accéder à l’Impact Score détaillé de la catégorie {vertical}",
         "verticalCta": "Découvrir l’impact détaillé",
         "verticalImageAlt": "Illustration de la catégorie {vertical}",


### PR DESCRIPTION
## Summary
- relax the hero overlap by expanding the main grid width and spacing on the impact score page
- realign the approach section media/text and surface the sample card sooner on medium screens
- introduce a reusable responsive carousel component and reuse it for the category examples with updated i18n copy

## Testing
- pnpm --offline lint
- pnpm --offline test --run
- pnpm --offline generate

------
https://chatgpt.com/codex/tasks/task_e_690c6b3db3a8832297effef2e98cfff8