### PR TITLE
Revamp home hero layout and add carousel components

### DIFF
--- a/frontend/app/components/home/HomeBlogCarousel.vue
+++ b/frontend/app/components/home/HomeBlogCarousel.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
+import type { BlogPostDto } from '~~/shared/api-client'
+
+type EnrichedBlogSlide = BlogPostDto & {
+  formattedDate?: string
+  link?: string
+  isExternal?: boolean
+}
+
+const props = defineProps<{
+  items: EnrichedBlogSlide[]
+  loading?: boolean
+}>()
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+const display = useDisplay()
+
+const slidesPerView = computed(() => {
+  if (display.lgAndUp.value) {
+    return 3
+  }
+
+  if (display.mdAndUp.value) {
+    return 2
+  }
+
+  return 1
+})
+
+const chunkItems = <T,>(input: readonly T[], size: number) => {
+  if (size <= 0) {
+    return [input.slice()]
+  }
+
+  const chunks: T[][] = []
+  for (let index = 0; index < input.length; index += size) {
+    chunks.push(input.slice(index, index + size))
+  }
+
+  return chunks
+}
+
+const resolveArticleLink = (article: BlogPostDto) => {
+  const rawUrl = article.url?.trim()
+
+  if (!rawUrl) {
+    return localePath('blog')
+  }
+
+  if (/^https?:\/\//i.test(rawUrl)) {
+    try {
+      const parsedUrl = new URL(rawUrl)
+      const slug = parsedUrl.pathname.split('/').filter(Boolean).pop()
+      if (slug) {
+        return localePath({ name: 'blog-slug', params: { slug } })
+      }
+    } catch (error) {
+      console.warn('Failed to parse blog article URL', rawUrl, error)
+    }
+
+    return rawUrl
+  }
+
+  if (rawUrl.startsWith('/')) {
+    return rawUrl
+  }
+
+  return localePath({ name: 'blog-slug', params: { slug: rawUrl } })
+}
+
+const enrichedItems = computed(() =>
+  props.items.map((item) => {
+    const link = resolveArticleLink(item)
+    const isExternal = /^https?:\/\//i.test(link)
+    return {
+      ...item,
+      link,
+      isExternal,
+    }
+  }),
+)
+
+const chunkedItems = computed(() => chunkItems(enrichedItems.value, slidesPerView.value))
+const shouldShowArrows = computed(() => chunkedItems.value.length > 1)
+const shouldCycle = computed(() => enrichedItems.value.length > slidesPerView.value)
+</script>
+
+<template>
+  <div class="home-blog-carousel">
+    <v-skeleton-loader
+      v-if="loading"
+      type="heading, image, paragraph"
+      class="home-blog-carousel__skeleton"
+    />
+    <v-alert
+      v-else-if="!items.length"
+      type="info"
+      variant="tonal"
+      class="home-blog-carousel__empty"
+      border="start"
+    >
+      {{ t('home.blog.emptyState') }}
+    </v-alert>
+    <v-carousel
+      v-else
+      class="home-blog-carousel__carousel"
+      :show-arrows="shouldShowArrows"
+      :cycle="shouldCycle"
+      :interval="7500"
+      hide-delimiter-background
+      height="auto"
+      :aria-label="t('home.blog.carouselAriaLabel')"
+    >
+      <v-carousel-item
+        v-for="(slide, index) in chunkedItems"
+        :key="`blog-slide-${index}`"
+      >
+        <v-row class="home-blog-carousel__row" no-gutters>
+          <v-col
+            v-for="article in slide"
+            :key="article.url ?? article.title ?? index"
+            cols="12"
+            md="6"
+            lg="4"
+          >
+            <component
+              :is="article.isExternal ? 'a' : NuxtLink"
+              :to="!article.isExternal ? article.link : undefined"
+              :href="article.isExternal ? article.link : undefined"
+              class="home-blog-carousel__link"
+              :target="article.isExternal ? '_blank' : undefined"
+              :rel="article.isExternal ? 'noopener' : undefined"
+            >
+              <v-card
+                class="home-blog-carousel__card"
+                variant="elevated"
+                elevation="6"
+              >
+                <div class="home-blog-carousel__media">
+                  <v-img
+                    v-if="article.image"
+                    :src="article.image"
+                    :alt="article.title ?? ''"
+                    cover
+                    height="160"
+                    class="home-blog-carousel__image"
+                  />
+                  <div v-else class="home-blog-carousel__icon" aria-hidden="true">
+                    <v-icon icon="mdi-post-outline" size="52" />
+                  </div>
+                </div>
+                <div class="home-blog-carousel__content">
+                  <p class="home-blog-carousel__date">
+                    {{ article.formattedDate ?? '' }}
+                  </p>
+                  <h3 class="home-blog-carousel__title">{{ article.title }}</h3>
+                  <p class="home-blog-carousel__summary">{{ article.summary }}</p>
+                  <span class="home-blog-carousel__cta">{{ t('home.blog.readMore') }}</span>
+                </div>
+              </v-card>
+            </component>
+          </v-col>
+        </v-row>
+      </v-carousel-item>
+    </v-carousel>
+  </div>
+</template>
+
+<style scoped lang="sass">
+.home-blog-carousel
+  position: relative
+
+  &__skeleton
+    border-radius: 1.5rem
+    overflow: hidden
+
+  &__empty
+    border-radius: 1.5rem
+
+  &__carousel
+    border-radius: clamp(1.5rem, 4vw, 2rem)
+    overflow: hidden
+    background: transparent
+
+  &__row
+    gap: 1.5rem
+    padding: clamp(1.5rem, 4vw, 2rem)
+
+  &__link
+    text-decoration: none
+    display: block
+    height: 100%
+    color: inherit
+
+  &__card
+    height: 100%
+    display: flex
+    flex-direction: column
+    border-radius: clamp(1.25rem, 3vw, 1.75rem)
+    background: rgba(var(--v-theme-surface-default), 0.92)
+    transition: transform 0.25s ease, box-shadow 0.25s ease
+
+    &:hover
+      transform: translateY(-6px)
+      box-shadow: 0 24px 36px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
+  &__media
+    position: relative
+    overflow: hidden
+    border-radius: clamp(1.25rem, 3vw, 1.75rem) clamp(1.25rem, 3vw, 1.75rem) 0 0
+
+  &__image
+    object-fit: cover
+
+  &__icon
+    display: flex
+    align-items: center
+    justify-content: center
+    height: 160px
+    background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.18), rgba(var(--v-theme-hero-gradient-end), 0.18))
+    color: rgba(var(--v-theme-hero-gradient-start), 0.95)
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    padding: clamp(1.25rem, 3vw, 1.75rem)
+
+  &__date
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-soft))
+    font-size: 0.95rem
+
+  &__title
+    margin: 0
+    font-size: clamp(1.15rem, 2vw, 1.35rem)
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__summary
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    flex-grow: 1
+
+  &__cta
+    font-weight: 600
+    color: rgba(var(--v-theme-hero-gradient-end), 0.95)
+</style>

--- a/frontend/app/components/home/HomeCategoryCarousel.vue
+++ b/frontend/app/components/home/HomeCategoryCarousel.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
+
+interface CategorySlideItem {
+  id: string
+  title: string
+  description: string
+  href: string
+  image?: string | null
+}
+
+const props = defineProps<{
+  items: CategorySlideItem[]
+  loading?: boolean
+}>()
+
+const { t } = useI18n()
+const display = useDisplay()
+
+const slidesPerView = computed(() => {
+  if (display.lgAndUp.value) {
+    return 3
+  }
+
+  if (display.mdAndUp.value) {
+    return 2
+  }
+
+  return 1
+})
+
+const chunkItems = <T,>(input: readonly T[], size: number) => {
+  if (size <= 0) {
+    return [input.slice()]
+  }
+
+  const chunks: T[][] = []
+  for (let index = 0; index < input.length; index += size) {
+    chunks.push(input.slice(index, index + size))
+  }
+
+  return chunks
+}
+
+const chunkedItems = computed(() => chunkItems(props.items, slidesPerView.value))
+
+const shouldShowArrows = computed(() => chunkedItems.value.length > 1)
+const shouldCycle = computed(() => props.items.length > slidesPerView.value)
+</script>
+
+<template>
+  <div class="home-category-carousel">
+    <v-skeleton-loader
+      v-if="loading"
+      type="heading, image, paragraph"
+      class="home-category-carousel__skeleton"
+    />
+    <v-alert
+      v-else-if="!items.length"
+      type="info"
+      variant="tonal"
+      class="home-category-carousel__empty"
+      border="start"
+    >
+      {{ t('home.categories.emptyState') }}
+    </v-alert>
+    <v-carousel
+      v-else
+      class="home-category-carousel__carousel"
+      :show-arrows="shouldShowArrows"
+      :cycle="shouldCycle"
+      :interval="7000"
+      hide-delimiter-background
+      height="auto"
+      :aria-label="t('home.categories.carouselAriaLabel')"
+    >
+      <v-carousel-item
+        v-for="(slide, index) in chunkedItems"
+        :key="`category-slide-${index}`"
+      >
+        <v-row class="home-category-carousel__row" no-gutters>
+          <v-col
+            v-for="category in slide"
+            :key="category.id"
+            cols="12"
+            md="6"
+            lg="4"
+          >
+            <NuxtLink :to="category.href" class="home-category-carousel__link">
+              <v-card
+                class="home-category-carousel__card"
+                variant="elevated"
+                elevation="6"
+              >
+                <div class="home-category-carousel__media">
+                  <v-img
+                    v-if="category.image"
+                    :src="category.image"
+                    :alt="category.title"
+                    cover
+                    height="160"
+                    class="home-category-carousel__image"
+                  />
+                  <div v-else class="home-category-carousel__icon" aria-hidden="true">
+                    <v-icon icon="mdi-shape-outline" size="56" />
+                  </div>
+                </div>
+                <div class="home-category-carousel__content">
+                  <h3 class="home-category-carousel__title">{{ category.title }}</h3>
+                  <p class="home-category-carousel__description">
+                    {{ category.description }}
+                  </p>
+                  <span class="home-category-carousel__cta">
+                    {{ t('home.categories.cta') }}
+                  </span>
+                </div>
+              </v-card>
+            </NuxtLink>
+          </v-col>
+        </v-row>
+      </v-carousel-item>
+    </v-carousel>
+  </div>
+</template>
+
+<style scoped lang="sass">
+.home-category-carousel
+  position: relative
+
+  &__skeleton
+    border-radius: 1.5rem
+    overflow: hidden
+
+  &__empty
+    border-radius: 1.5rem
+
+  &__carousel
+    border-radius: clamp(1.5rem, 4vw, 2rem)
+    overflow: hidden
+    background: transparent
+
+  &__row
+    gap: 1.5rem
+    padding: clamp(1.5rem, 4vw, 2rem)
+
+  &__link
+    text-decoration: none
+    display: block
+    height: 100%
+
+  &__card
+    height: 100%
+    display: flex
+    flex-direction: column
+    border-radius: clamp(1.25rem, 3vw, 1.75rem)
+    background: rgba(var(--v-theme-surface-default), 0.92)
+    transition: transform 0.25s ease, box-shadow 0.25s ease
+
+    &:hover
+      transform: translateY(-6px)
+      box-shadow: 0 24px 36px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
+  &__media
+    position: relative
+    overflow: hidden
+    border-radius: clamp(1.25rem, 3vw, 1.75rem) clamp(1.25rem, 3vw, 1.75rem) 0 0
+
+  &__image
+    object-fit: cover
+
+  &__icon
+    display: flex
+    align-items: center
+    justify-content: center
+    height: 160px
+    background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.18), rgba(var(--v-theme-hero-gradient-end), 0.18))
+    color: rgba(var(--v-theme-hero-gradient-start), 0.95)
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    padding: clamp(1.25rem, 3vw, 1.75rem)
+
+  &__title
+    margin: 0
+    font-size: clamp(1.2rem, 2vw, 1.4rem)
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__description
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__cta
+    margin-top: auto
+    font-weight: 600
+    color: rgba(var(--v-theme-hero-gradient-end), 0.95)
+</style>

--- a/frontend/app/components/search/SearchSuggestField.vue
+++ b/frontend/app/components/search/SearchSuggestField.vue
@@ -21,6 +21,9 @@
     @click:clear="handleClear"
     @keydown.enter="handleEnterKey"
   >
+    <template v-if="$slots['append-inner']" #append-inner>
+      <slot name="append-inner" />
+    </template>
     <template #item="{ item, props: itemProps, index }">
       <div class="search-suggest-field__entry" :data-section="item.raw.type">
         <p

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -101,6 +101,10 @@
       "title": "Browse categories",
       "subtitle": "Start with our most popular universes and refine in one click.",
       "cta": "Browse products",
+      "fallbackTitle": "Category",
+      "fallbackDescription": "Explore responsible products in this universe.",
+      "carouselAriaLabel": "Popular categories carousel",
+      "emptyState": "Categories will appear here as soon as they're available.",
       "items": {
         "electronics": {
           "title": "Electronics",
@@ -124,9 +128,12 @@
       }
     },
     "blog": {
-      "title": "From the blog",
+      "title": "Live from the blog",
+      "subtitle": "The latest analyses from our editorial team.",
       "cta": "Browse all articles",
       "readMore": "Read article",
+      "emptyState": "New blog posts will land here shortly.",
+      "carouselAriaLabel": "Featured blog posts carousel",
       "items": {
         "first": {
           "title": "How we keep our AI frugal",
@@ -197,7 +204,9 @@
       "title": "Ready to buy better without overspending?",
       "subtitle": "Restart a search or explore the analysed offers.",
       "button": "Start a search",
-      "altLink": "Open the search page"
+      "altLink": "Open the search page",
+      "searchSubmit": "Launch search",
+      "browseTaxonomy": "Explore categories"
     }
   },
   "categories": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -101,6 +101,10 @@
       "title": "Parcourir les catégories",
       "subtitle": "Commencez par nos univers les plus demandés et filtrez en un clic.",
       "cta": "Voir les produits",
+      "fallbackTitle": "Catégorie",
+      "fallbackDescription": "Parcourez des produits responsables dans cet univers.",
+      "carouselAriaLabel": "Carrousel des catégories populaires",
+      "emptyState": "Les catégories apparaîtront ici dès qu’elles seront disponibles.",
       "items": {
         "electronics": {
           "title": "Électronique",
@@ -124,9 +128,12 @@
       }
     },
     "blog": {
-      "title": "Du blog",
+      "title": "En direct du blog",
+      "subtitle": "Les derniers éclairages de notre rédaction.",
       "cta": "Voir tous les articles",
       "readMore": "Lire l’article",
+      "emptyState": "Les nouveaux articles seront affichés ici très bientôt.",
+      "carouselAriaLabel": "Carrousel des articles du blog",
       "items": {
         "first": {
           "title": "Comment nous gardons une IA frugale",
@@ -197,7 +204,9 @@
       "title": "Prêt à acheter mieux sans vous ruiner ?",
       "subtitle": "Relancez une recherche ou découvrez les offres analysées.",
       "button": "Lancer une recherche",
-      "altLink": "Explorer la recherche"
+      "altLink": "Explorer la recherche",
+      "searchSubmit": "Lancer la recherche",
+      "browseTaxonomy": "Explorer les catégories"
     }
   },
   "categories": {


### PR DESCRIPTION
## Summary
- refresh the home hero and CTA sections with embedded search actions and more generous spacing across feature/problem grids
- introduce HomeCategoryCarousel and HomeBlogCarousel components to surface popular categories and latest blog posts in airier sliders
- extend shared content components and tests (SearchSuggestField, TextContent, home page spec) plus update EN/FR translations for the new UI

## Testing
- pnpm lint
- pnpm test -- --runInBand --watch=false
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690c696fba7c83338d4e3955ace9e5df