### PR TITLE
Refresh home page layout and blog integration

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -202,8 +202,8 @@ public class ApiConfig {
 	}
 
 	@Bean
-	EprelCompletionService eprelCompletionService(ProductRepository productRepository, VerticalsConfigService verticalConfigService, DataSourceConfigService dataSourceConfigService, AggregationFacadeService aggregationFacade, EprelSearchService eprelSearchService ) throws TechnicalException {
-		return new EprelCompletionService(verticalConfigService, productRepository, apiProperties, eprelSearchService );
+	EprelCompletionService eprelCompletionService(ProductRepository productRepository, VerticalsConfigService verticalConfigService, DataSourceConfigService dataSourceConfigService, AggregationFacadeService aggregationFacade, EprelSearchService eprelSearchService) throws TechnicalException {
+		return new EprelCompletionService(verticalConfigService, productRepository, apiProperties, eprelSearchService,aggregationFacade );
 	}
 
 

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -137,6 +138,11 @@ public class AttributeRealtimeAggregationService extends AbstractAggregationServ
 						}
 					} else {
 						 indexedAttr = new IndexedAttribute(attrConfig.getKey(), cleanedValue);
+
+						 // Todo : force value through referenced datasources order
+						 // TO
+
+
 					}
 
 					indexedAttr.getSource().addAll(attr.getSource());
@@ -284,7 +290,7 @@ public class AttributeRealtimeAggregationService extends AbstractAggregationServ
 				data.getExcludedCauses().add("missing_attr_" + e);
 			});
 
-			dedicatedLogger.info("Excluded because attributes are missing : {}", data );
+			dedicatedLogger.info("Excluded because required attributes are missing : {}", data );
 			ret =  true;
 
 		}

--- a/commons/src/main/java/org/open4goods/commons/model/SourcedString.java
+++ b/commons/src/main/java/org/open4goods/commons/model/SourcedString.java
@@ -23,40 +23,40 @@ public class SourcedString {
 	 */
 	@Field(index = true, store = false, type = FieldType.Keyword)
 	private String bestValue;
-	
+
 	/**
 	 * History, by datasource name
 	 */
-	
+
 	@Field(index = false, store = false, type = FieldType.Object)
 	private Map<String,List<SourcedStringHistory>> history = new HashMap<>();
 
-	
+
 	@Override
 	public String toString() {
 		return history.size() + " : "+ bestValue ;
 	}
-	
-	
+
+
 	/**
 	 * Shortcut to a unique source
 	 * @return
 	 */
 	public String source() {
-		return history.keySet().stream().findFirst().orElse(null);  
+		return history.keySet().stream().findFirst().orElse(null);
 	}
-	
+
 	/**
 	 * Add a value, with historisation, datasource ventilation and best value computing
 	 * @param value
 	 * @param datasourceName
 	 * @param timestamp
-	 * @return 
+	 * @return
 	 */
 	public void addValue(String value, String datasourceName, Long timestamp) {
 		// Adding to history
 		doVersion(value, datasourceName, timestamp);
-		
+
 		// compute the best attribute
 		doBestValueElection();
 	}
@@ -64,14 +64,14 @@ public class SourcedString {
 
 	private void doVersion(String value, String datasourceName, Long timestamp) {
 		List<SourcedStringHistory> historyItem = history.get(datasourceName);
-		
+
 		// Existing item
 		if (null != historyItem) {
-			
+
 			// Finding history last value
-			Optional<SourcedStringHistory> last = historyItem.stream().findFirst();			
+			Optional<SourcedStringHistory> last = historyItem.stream().findFirst();
 			// update history
-			if (last.isPresent()) {				
+			if (last.isPresent()) {
 				// Not equal to the previous version
 				if (!last.get().getValue().equals(value)) {
 						// Adding a version
@@ -86,50 +86,56 @@ public class SourcedString {
 		}
 
 		// First time wee see this item
-		else {			
+		else {
 			history.get(datasourceName).add(new SourcedStringHistory(value,timestamp));
 		}
 	}
-	
-	
+
+
 	/**
 	 * Determine the best value, terms frequency based
 	 */
-	public void doBestValueElection( ) {		
+	public void doBestValueElection( ) {
 		String bValue = null;
 		int freq = 0;
+		// TODO : Design concern. Export to a dedicated election service
+
+
+
+
+
 		for (SourcedStringHistory value : history.values().stream().findFirst().get() ) {
-			int count = Collections.frequency(new ArrayList<String>(getAsValueMap().values()), value);			
+			int count = Collections.frequency(new ArrayList<String>(getAsValueMap().values()), value);
 			if (count > freq) {
 				freq = count;
 				bValue = value.getValue();
 			}
-		}		
-		this.bestValue = bValue;		
+		}
+		this.bestValue = bValue;
 	}
-	
-	
+
+
 	/**
 	 * Return the last attribute value for a given datasource
 	 * @param datasourceNAme
 	 * @return
 	 */
 	public String getValue(String datasourceName ) {
-		Optional<SourcedStringHistory> item = history.get(datasourceName).stream().findFirst();		
+		Optional<SourcedStringHistory> item = history.get(datasourceName).stream().findFirst();
 		if (item.isEmpty()) {
 			return null;
 		} else {
 			return history.get(datasourceName).stream().findFirst().get().getValue();
-		}		
+		}
 	}
 
 	/**
 	 * Return the versionned implementation to an handy datasource / value vap
-	 * @return 
+	 * @return
 	 */
 	public Map<String, String> getAsValueMap( ) {
 		Map<String,String> byIds = new HashMap<>();
-		
+
 		for (Entry<String, List<SourcedStringHistory>> provider : history.entrySet()) {
 			String val = getValue(provider.getKey());
 			byIds.put(provider.getKey() , val);
@@ -146,6 +152,6 @@ public class SourcedString {
 	public void setBestValue(String bestValue) {
 		this.bestValue = bestValue;
 	}
-	
-	
+
+
 }

--- a/frontend/app/components/home/HomeCategoryCarousel.vue
+++ b/frontend/app/components/home/HomeCategoryCarousel.vue
@@ -99,7 +99,7 @@ const shouldCycle = computed(() => props.items.length > slidesPerView.value)
                     :src="category.image"
                     :alt="category.title"
                     cover
-                    height="160"
+                    height="140"
                     class="home-category-carousel__image"
                   />
                   <div v-else class="home-category-carousel__icon" aria-hidden="true">
@@ -173,7 +173,7 @@ const shouldCycle = computed(() => props.items.length > slidesPerView.value)
     display: flex
     align-items: center
     justify-content: center
-    height: 160px
+    height: 140px
     background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.18), rgba(var(--v-theme-hero-gradient-end), 0.18))
     color: rgba(var(--v-theme-hero-gradient-start), 0.95)
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -7,7 +7,6 @@ import SearchSuggestField, {
   type ProductSuggestionItem,
 } from '~/components/search/SearchSuggestField.vue'
 import HomeCategoryCarousel from '~/components/home/HomeCategoryCarousel.vue'
-import HomeBlogCarousel from '~/components/home/HomeBlogCarousel.vue'
 import TextContent from '~/components/domains/content/TextContent.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useBlog } from '~/composables/blog/useBlog'
@@ -28,20 +27,23 @@ const heroVideoSrc = '/videos/video-concept1.mp4'
 const heroVideoPoster = '/images/home/hero-placeholder.svg'
 
 type HomeBlogItem = BlogPostDto & { formattedDate?: string }
+type EnrichedBlogItem = HomeBlogItem & { link: string; isExternal: boolean }
 
 const { categories: rawCategories, fetchCategories, loading: categoriesLoading } = useCategories()
 const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
 
+const BLOG_ARTICLES_LIMIT = 10
+
 if (import.meta.server) {
   await fetchCategories(true)
-  await fetchArticles(1, 6, null)
+  await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
 } else {
   if (rawCategories.value.length === 0) {
     await fetchCategories(true)
   }
 
   if (paginatedArticles.value.length === 0) {
-    await fetchArticles(1, 6, null)
+    await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
   }
 }
 
@@ -279,8 +281,8 @@ const fallbackBlogEntries = computed<HomeBlogItem[]>(() => [
   },
 ])
 
-const blogCarouselItems = computed<HomeBlogItem[]>(() => {
-  const articles = paginatedArticles.value.slice(0, 6)
+const blogListItems = computed<HomeBlogItem[]>(() => {
+  const articles = paginatedArticles.value.slice(0, BLOG_ARTICLES_LIMIT)
 
   if (!articles.length) {
     return fallbackBlogEntries.value
@@ -294,6 +296,50 @@ const blogCarouselItems = computed<HomeBlogItem[]>(() => {
       : '',
   }))
 })
+
+const resolveBlogArticleLink = (article: BlogPostDto) => {
+  const rawUrl = article.url?.trim()
+
+  if (!rawUrl) {
+    return localePath('blog')
+  }
+
+  if (/^https?:\/\//i.test(rawUrl)) {
+    try {
+      const parsedUrl = new URL(rawUrl)
+      const slug = parsedUrl.pathname.split('/').filter(Boolean).pop()
+      if (slug) {
+        return localePath({ name: 'blog-slug', params: { slug } })
+      }
+    } catch (error) {
+      console.warn('Failed to parse blog article URL', rawUrl, error)
+    }
+
+    return rawUrl
+  }
+
+  if (rawUrl.startsWith('/')) {
+    return rawUrl
+  }
+
+  return localePath({ name: 'blog-slug', params: { slug: rawUrl } })
+}
+
+const enrichedBlogItems = computed<EnrichedBlogItem[]>(() =>
+  blogListItems.value.map((item) => {
+    const link = resolveBlogArticleLink(item)
+    const isExternal = /^https?:\/\//i.test(link)
+
+    return {
+      ...item,
+      link,
+      isExternal,
+    }
+  }),
+)
+
+const featuredBlogItem = computed(() => enrichedBlogItems.value[0] ?? null)
+const secondaryBlogItems = computed(() => enrichedBlogItems.value.slice(1))
 
 const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
 
@@ -379,8 +425,9 @@ useHead(() => ({
 <template>
   <div class="home-page">
     <section class="home-hero" aria-labelledby="home-hero-title">
-      <v-container class="home-hero__container" max-width="lg">
-        <div class="home-hero__layout">
+      <v-container class="home-hero__container" fluid>
+        <div class="home-hero__inner">
+          <div class="home-hero__layout">
           <div class="home-hero__content">
             <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
             <h1 id="home-hero-title" class="home-hero__title">
@@ -438,7 +485,18 @@ useHead(() => ({
               </div>
             </v-sheet>
           </div>
+          </div>
         </div>
+      </v-container>
+    </section>
+
+    <section class="home-section home-categories" aria-labelledby="home-categories-title">
+      <v-container class="home-section__container" max-width="lg">
+        <header class="home-section__header">
+          <h2 id="home-categories-title">{{ t('home.categories.title') }}</h2>
+          <p class="home-section__subtitle">{{ t('home.categories.subtitle') }}</p>
+        </header>
+        <HomeCategoryCarousel :items="categoryCarouselItems" :loading="categoriesLoading" />
       </v-container>
     </section>
 
@@ -447,43 +505,45 @@ useHead(() => ({
         <header class="home-section__header">
           <h2 id="home-problems-title">{{ t('home.problems.title') }}</h2>
         </header>
-        <ul class="home-problems__list">
-          <li
+        <div class="home-problems__grid">
+          <article
             v-for="(item, index) in problemItems"
             :key="item.text"
-            class="home-problems__item"
-            :class="{ 'home-problems__item--reverse': index % 2 === 1 }"
+            class="home-problems__card"
+            :class="{ 'home-problems__card--reverse': index % 2 === 1 }"
           >
-            <v-card class="home-problems__card" variant="tonal">
+            <div class="home-problems__card-inner">
               <div class="home-problems__icon-wrapper" aria-hidden="true">
-                <v-icon class="home-problems__icon" :icon="item.icon" size="48" />
+                <v-icon class="home-problems__icon" :icon="item.icon" size="56" />
               </div>
               <p class="home-problems__text">{{ item.text }}</p>
-            </v-card>
-          </li>
-        </ul>
+            </div>
+          </article>
+        </div>
       </v-container>
     </section>
 
     <section class="home-section home-solution" aria-labelledby="home-solution-title">
-      <v-container class="home-section__container" max-width="lg">
-        <header class="home-section__header">
-          <h2 id="home-solution-title">{{ t('home.solution.title') }}</h2>
-          <p class="home-section__subtitle">{{ t('home.solution.description') }}</p>
-        </header>
-        <v-row class="home-solution__grid" align="stretch" no-gutters>
-          <v-col
-            v-for="item in solutionBenefits"
-            :key="item.label"
-            cols="12"
-            sm="6"
-          >
-            <v-card class="home-solution__card" variant="outlined">
-              <span class="home-solution__emoji" aria-hidden="true">{{ item.emoji }}</span>
-              <p class="home-solution__label">{{ item.label }}</p>
-            </v-card>
-          </v-col>
-        </v-row>
+      <v-container class="home-section__container home-solution__container" fluid>
+        <div class="home-section__inner">
+          <header class="home-section__header">
+            <h2 id="home-solution-title">{{ t('home.solution.title') }}</h2>
+            <p class="home-section__subtitle">{{ t('home.solution.description') }}</p>
+          </header>
+          <ul class="home-solution__list">
+            <li
+              v-for="(item, index) in solutionBenefits"
+              :key="item.label"
+              class="home-solution__item"
+              :class="{ 'home-solution__item--reverse': index % 2 === 1 }"
+            >
+              <v-card class="home-solution__card" variant="outlined">
+                <span class="home-solution__emoji" aria-hidden="true">{{ item.emoji }}</span>
+                <p class="home-solution__label">{{ item.label }}</p>
+              </v-card>
+            </li>
+          </ul>
+        </div>
       </v-container>
     </section>
 
@@ -505,23 +565,91 @@ useHead(() => ({
       </v-container>
     </section>
 
-    <section class="home-section home-categories" aria-labelledby="home-categories-title">
-      <v-container class="home-section__container" max-width="lg">
-        <header class="home-section__header">
-          <h2 id="home-categories-title">{{ t('home.categories.title') }}</h2>
-          <p class="home-section__subtitle">{{ t('home.categories.subtitle') }}</p>
-        </header>
-        <HomeCategoryCarousel :items="categoryCarouselItems" :loading="categoriesLoading" />
-      </v-container>
-    </section>
-
     <section class="home-section home-blog" aria-labelledby="home-blog-title">
       <v-container class="home-section__container" max-width="lg">
         <header class="home-section__header">
           <h2 id="home-blog-title">{{ t('home.blog.title') }}</h2>
           <p class="home-section__subtitle">{{ t('home.blog.subtitle') }}</p>
         </header>
-        <HomeBlogCarousel :items="blogCarouselItems" :loading="blogLoading" />
+        <div v-if="blogLoading" class="home-blog__skeletons" aria-hidden="true">
+          <v-skeleton-loader
+            v-for="index in 4"
+            :key="`blog-skeleton-${index}`"
+            type="image, list-item"
+            class="home-blog__skeleton"
+          />
+        </div>
+        <div v-else-if="featuredBlogItem || secondaryBlogItems.length" class="home-blog__grid">
+          <component
+            :is="featuredBlogItem?.isExternal ? 'a' : NuxtLink"
+            v-if="featuredBlogItem"
+            :key="'featured-article'"
+            class="home-blog__item home-blog__item--featured"
+            :href="featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
+            :to="!featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
+            :target="featuredBlogItem.isExternal ? '_blank' : undefined"
+            :rel="featuredBlogItem.isExternal ? 'noopener' : undefined"
+          >
+            <article class="home-blog__card">
+              <div class="home-blog__media" aria-hidden="true">
+                <v-img
+                  v-if="featuredBlogItem.image"
+                  :src="featuredBlogItem.image"
+                  :alt="featuredBlogItem.title ?? ''"
+                  cover
+                />
+                <div v-else class="home-blog__placeholder">
+                  <v-icon icon="mdi-post-outline" size="68" />
+                </div>
+              </div>
+              <div class="home-blog__content">
+                <p class="home-blog__date">{{ featuredBlogItem.formattedDate }}</p>
+                <h3 class="home-blog__title">{{ featuredBlogItem.title }}</h3>
+                <p class="home-blog__summary">{{ featuredBlogItem.summary }}</p>
+                <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
+              </div>
+            </article>
+          </component>
+          <component
+            :is="article.isExternal ? 'a' : NuxtLink"
+            v-for="article in secondaryBlogItems"
+            :key="article.url ?? article.title ?? article.link"
+            class="home-blog__item"
+            :href="article.isExternal ? article.link : undefined"
+            :to="!article.isExternal ? article.link : undefined"
+            :target="article.isExternal ? '_blank' : undefined"
+            :rel="article.isExternal ? 'noopener' : undefined"
+          >
+            <article class="home-blog__card">
+              <div class="home-blog__media" aria-hidden="true">
+                <v-img
+                  v-if="article.image"
+                  :src="article.image"
+                  :alt="article.title ?? ''"
+                  cover
+                />
+                <div v-else class="home-blog__placeholder">
+                  <v-icon icon="mdi-post-outline" size="48" />
+                </div>
+              </div>
+              <div class="home-blog__content">
+                <p class="home-blog__date">{{ article.formattedDate }}</p>
+                <h3 class="home-blog__title">{{ article.title }}</h3>
+                <p class="home-blog__summary">{{ article.summary }}</p>
+                <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
+              </div>
+            </article>
+          </component>
+        </div>
+        <v-alert
+          v-else
+          type="info"
+          variant="tonal"
+          border="start"
+          class="home-blog__empty"
+        >
+          {{ t('home.blog.emptyState') }}
+        </v-alert>
         <div class="home-blog__actions">
           <v-btn
             class="home-blog__cta"
@@ -648,6 +776,14 @@ useHead(() => ({
   display: flex
   flex-direction: column
   gap: clamp(2rem, 5vw, 3.5rem)
+  padding-inline: clamp(1.5rem, 4vw, 3rem)
+
+.home-section__inner
+  max-width: 1120px
+  margin: 0 auto
+  display: flex
+  flex-direction: column
+  gap: clamp(2rem, 5vw, 3.5rem)
 
 .home-section__header
   max-width: 720px
@@ -664,6 +800,11 @@ useHead(() => ({
   background: radial-gradient(circle at top left, rgba(var(--v-theme-hero-gradient-start), 0.28), transparent 55%), radial-gradient(circle at bottom right, rgba(var(--v-theme-hero-gradient-end), 0.25), transparent 60%), rgb(var(--v-theme-surface-default))
 
 .home-hero__container
+  padding-inline: clamp(1.5rem, 4vw, 4rem)
+
+.home-hero__inner
+  max-width: 1120px
+  margin: 0 auto
   display: flex
   flex-direction: column
   gap: clamp(2rem, 5vw, 3rem)
@@ -763,72 +904,125 @@ useHead(() => ({
   border-radius: inherit
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
 
-.home-problems__list
-  list-style: none
-  display: flex
-  flex-direction: column
-  gap: 1.5rem
-  padding: 0
-  margin: 0
+.home-problems__grid
+  display: grid
+  gap: clamp(1.5rem, 4vw, 2.5rem)
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr))
 
-.home-problems__item
-  display: flex
-  justify-content: flex-start
+@media (min-width: 960px)
+  .home-problems__grid
+    grid-template-columns: repeat(2, minmax(0, 1fr))
 
-.home-problems__item--reverse
-  justify-content: flex-end
+  .home-problems__card
+    max-width: 520px
+
+  .home-problems__card:not(.home-problems__card--reverse)
+    margin-inline-end: auto
+
+  .home-problems__card--reverse
+    margin-inline-start: auto
 
 .home-problems__card
-  max-width: 560px
-  width: 100%
-  padding: clamp(1.5rem, 4vw, 2rem)
+  position: relative
+  transition: transform 0.25s ease, box-shadow 0.25s ease
+
+.home-problems__card::before
+  content: ''
+  position: absolute
+  inset: 0
+  border-radius: clamp(1.5rem, 4vw, 2.25rem)
+  background: rgba(var(--v-theme-surface-primary-080), 0.52)
+  transform: translate(12px, 12px)
+  z-index: 0
+
+.home-problems__card--reverse::before
+  transform: translate(-12px, 12px)
+
+.home-problems__card-inner
+  position: relative
+  z-index: 1
   display: flex
   align-items: center
-  gap: 1.25rem
-  border-radius: clamp(1.25rem, 3vw, 1.75rem)
-  background: rgba(var(--v-theme-surface-primary-080), 0.65)
-  backdrop-filter: blur(12px)
-  box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  gap: 1.5rem
+  padding: clamp(1.75rem, 4vw, 2.5rem)
+  border-radius: clamp(1.5rem, 4vw, 2.25rem)
+  background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.18), rgba(var(--v-theme-hero-gradient-end), 0.16))
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
+  box-shadow: 0 20px 36px rgba(var(--v-theme-shadow-primary-600), 0.16)
+
+.home-problems__card:hover
+  transform: translateY(-6px)
+  box-shadow: 0 26px 40px rgba(var(--v-theme-shadow-primary-600), 0.18)
 
 .home-problems__icon-wrapper
   display: flex
   align-items: center
   justify-content: center
-  width: 72px
-  height: 72px
-  border-radius: 24px
-  background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.25), rgba(var(--v-theme-hero-gradient-end), 0.25))
+  width: clamp(72px, 12vw, 88px)
+  height: clamp(72px, 12vw, 88px)
+  border-radius: 28px
+  background: radial-gradient(circle at top, rgba(var(--v-theme-hero-gradient-start), 0.38), rgba(var(--v-theme-hero-gradient-end), 0.22))
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.4)
 
 .home-problems__icon
   color: rgba(var(--v-theme-hero-gradient-start), 0.95)
 
 .home-problems__text
   margin: 0
-  font-size: 1.1rem
-  line-height: 1.5
+  font-size: clamp(1.05rem, 2.4vw, 1.3rem)
+  line-height: 1.45
   color: rgb(var(--v-theme-text-neutral-strong))
 
-.home-solution__grid
-  gap: 1.5rem
+.home-solution__list
+  list-style: none
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr))
+  gap: clamp(1.5rem, 4vw, 2.5rem)
+  margin: 0
+  padding: 0
+
+.home-solution__item
+  position: relative
+
+.home-solution__item::before
+  content: ''
+  position: absolute
+  inset: 10px 16px 0
+  border-radius: clamp(1.5rem, 4vw, 2.25rem)
+  background: rgba(var(--v-theme-surface-primary-050), 0.6)
+  z-index: 0
+
+.home-solution__item--reverse::before
+  inset-inline: 16px 10px
+
+@media (max-width: 599px)
+  .home-solution__item::before
+    display: none
 
 .home-solution__card
+  position: relative
+  z-index: 1
   height: 100%
-  padding: clamp(1.5rem, 4vw, 2rem)
-  border-radius: clamp(1.25rem, 3vw, 1.75rem)
   display: flex
   flex-direction: column
-  gap: 0.75rem
-  align-items: flex-start
-  background: rgba(var(--v-theme-surface-glass-strong), 0.85)
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
-  box-shadow: 0 12px 24px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  gap: 1rem
+  padding: clamp(1.75rem, 4vw, 2.5rem)
+  border-radius: clamp(1.5rem, 4vw, 2.25rem)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.32)
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.92), rgba(var(--v-theme-surface-default), 0.96))
+  box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.14)
+
+.home-solution__item--reverse .home-solution__card
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-default), 0.96), rgba(var(--v-theme-surface-primary-080), 0.92))
 
 .home-solution__emoji
-  font-size: 2rem
+  font-size: clamp(2.5rem, 7vw, 3.6rem)
+  line-height: 1
 
 .home-solution__label
   margin: 0
-  font-size: 1.1rem
+  font-size: clamp(1.1rem, 2.6vw, 1.45rem)
+  font-weight: 600
   color: rgb(var(--v-theme-text-neutral-strong))
 
 .home-features__grid
@@ -863,16 +1057,106 @@ useHead(() => ({
 .home-categories :deep(.home-category-carousel__carousel)
   margin-top: 1.5rem
 
+
 .home-blog
   background: rgba(var(--v-theme-surface-default), 0.92)
 
-.home-blog :deep(.home-blog-carousel__carousel)
-  margin-top: 1.5rem
+.home-blog__skeletons
+  display: grid
+  gap: 1.5rem
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))
+  margin-top: clamp(1rem, 3vw, 1.5rem)
+
+.home-blog__skeleton
+  border-radius: clamp(1.25rem, 3vw, 1.75rem)
+
+.home-blog__grid
+  display: grid
+  gap: clamp(1.5rem, 4vw, 2.5rem)
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr))
+  margin-top: clamp(1rem, 3vw, 1.75rem)
+
+.home-blog__item
+  text-decoration: none
+  color: inherit
+
+.home-blog__empty
+  border-radius: clamp(1.25rem, 3vw, 1.75rem)
+  margin-top: clamp(1rem, 3vw, 1.5rem)
+
+@media (min-width: 960px)
+  .home-blog__item--featured
+    grid-column: span 2
+    grid-row: span 2
+
+.home-blog__card
+  height: 100%
+  display: flex
+  flex-direction: column
+  border-radius: clamp(1.25rem, 3vw, 1.85rem)
+  overflow: hidden
+  background: rgba(var(--v-theme-surface-default), 0.96)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.28)
+  box-shadow: 0 18px 28px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  transition: transform 0.25s ease, box-shadow 0.25s ease
+
+.home-blog__card:hover
+  transform: translateY(-6px)
+  box-shadow: 0 26px 40px rgba(var(--v-theme-shadow-primary-600), 0.16)
+
+.home-blog__media
+  position: relative
+  aspect-ratio: 16 / 10
+  background: rgba(var(--v-theme-surface-primary-050), 0.8)
+
+.home-blog__media :deep(.v-img)
+  width: 100%
+  height: 100%
+
+.home-blog__media :deep(img)
+  object-fit: cover
+
+.home-blog__placeholder
+  display: flex
+  align-items: center
+  justify-content: center
+  height: 100%
+  color: rgba(var(--v-theme-hero-gradient-start), 0.85)
+
+.home-blog__content
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+  padding: clamp(1.5rem, 4vw, 2.25rem)
+
+.home-blog__date
+  margin: 0
+  font-size: 0.9rem
+  letter-spacing: 0.04em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+
+.home-blog__title
+  margin: 0
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem)
+  color: rgb(var(--v-theme-text-neutral-strong))
+  font-weight: 600
+
+.home-blog__summary
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-size: clamp(0.95rem, 2.2vw, 1.05rem)
+  line-height: 1.6
+
+.home-blog__link-label
+  margin-top: auto
+  font-weight: 600
+  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
 
 .home-blog__actions
   display: flex
   justify-content: center
-  margin-top: clamp(1.5rem, 4vw, 2.5rem)
+  margin-top: clamp(1.75rem, 4vw, 2.75rem)
 
 .home-blog__cta
   border-radius: 999px

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -48,7 +48,15 @@ const toSafeString = (value: unknown) => {
 
 const toTrimmedString = (value: unknown) => toSafeString(value).trim()
 
-const stripHtmlComments = (value: string) => value.replace(/<!--[\s\S]*?-->/g, '')
+const stripHtmlComments = (value: string) => {
+  let previous;
+  let input = value;
+  do {
+    previous = input;
+    input = input.replace(/<!--[\s\S]*?-->/g, '');
+  } while (input !== previous);
+  return input;
+};
 
 const sanitizeBlogSummary = (value: unknown) => stripHtmlComments(toSafeString(value)).trim()
 

--- a/model/src/main/java/org/open4goods/model/vertical/AttributesConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AttributesConfig.java
@@ -49,10 +49,16 @@ public class AttributesConfig {
 	private Map<String, String> valueKeyMap = new HashMap<String, String>();
 
 	/**
-	 * Attributes config by feature groups
+	 * icecat Attributes config by feature groups
 	 */
 	private Map<String, AttributeConfig> byIcecatFeatureGroup = new HashMap<String, AttributeConfig>();
-	
+
+
+	/**
+	 * eprel attributes  config by feature name
+	 */
+	private Map<String, AttributeConfig> byEprelFeatureGroup = new HashMap<String, AttributeConfig>();
+
 
 	public AttributesConfig(List<AttributeConfig> configs) {
 		this.configs = configs;
@@ -65,22 +71,22 @@ public class AttributesConfig {
 
 
 	/**
-	 * Return the attribute config key name for an attribute name 
+	 * Return the attribute config key name for an attribute name
 	 * @param value
 	 * @return
 	 */
 	public String getKeyForValue(final String value) {
-		
+
 		if (cacheHashedSynonyms == null) {
 			synonyms();
 		}
         return valueKeyMap.get(value);
     }
-	
-	
-	
-	
-	
+
+
+
+
+
 	/**
 	 * Get all configs synonyms by provider
 	 *
@@ -91,20 +97,24 @@ public class AttributesConfig {
 	public Map<String, Map<String, String>> synonyms() {
 
 		if (cacheHashedSynonyms == null) {
-			
+
 			final Map<String, Map<String, String>> hashedSynonyms = new HashMap<>();
-	
+
 			if (null != configs) {
 				for (final AttributeConfig ac : configs) {
-					
+
 					for (String id : ac.getIcecatFeaturesIds()) {
 						byIcecatFeatureGroup.put(id, ac);
 					}
-					
+
+					for (String id : ac.getEprelFeatureNames()) {
+						byEprelFeatureGroup.put(id, ac);
+					}
+
 					for (final Entry<String, Set<String>> entry : ac.getSynonyms().entrySet()) {
 						if (!hashedSynonyms.containsKey(entry.getKey())) {
 							hashedSynonyms.put(entry.getKey(), new HashMap<>());
-							
+
 						}
 						valueKeyMap.put(ac.getKey(), ac.getKey());
 						for (final String val : entry.getValue()) {
@@ -114,7 +124,7 @@ public class AttributesConfig {
 						}
 					}
 				}
-				
+
 			}
 			cacheHashedSynonyms = hashedSynonyms;
 		}
@@ -123,28 +133,40 @@ public class AttributesConfig {
 
 
 	/**
-	 * Resolve a product attribute against icecat taxonomy or faalback on attributes config 
+	 * Resolve a product attribute against icecat taxonomy or faalback on attributes config
 	 * @param attr
 	 * @return
 	 */
 	public AttributeConfig resolveFromProductAttribute(ProductAttribute attr) {
-	
+
 		AttributeConfig ret = null;
-		
-		
-		// 1 - Checking from icecat forced taxonomy
+
+
+		// 1 - Checking from epred taxonomy
 		for (SourcedAttribute source : attr.getSource()) {
 
 			if (null != source.getIcecatTaxonomyId()) {
-				ret = byIcecatFeatureGroup.get(String.valueOf(source.getIcecatTaxonomyId()));				
+				ret = byIcecatFeatureGroup.get(String.valueOf(source.getIcecatTaxonomyId()));
 			}
-			
+
 			if (null != ret) {
 				break;
 			}
 		}
-		
-		
+
+		// 2 - Checking from icecat forced taxonomy
+		for (SourcedAttribute source : attr.getSource()) {
+
+			if (null != source.getIcecatTaxonomyId()) {
+				ret = byIcecatFeatureGroup.get(String.valueOf(source.getIcecatTaxonomyId()));
+			}
+
+			if (null != ret) {
+				break;
+			}
+		}
+
+
 		// 2 - Looking by specific datasource name
 		if (null == ret) {
 			for (SourcedAttribute source : attr.getSource()) {
@@ -167,13 +189,13 @@ public class AttributesConfig {
 					ret =  getAttributeConfigByKey(specSynonyms.get(attr.getName()));
 				}
 		}
-		
+
 		return ret;
-		
-		
+
+
 	}
-	
-	
+
+
 
 	/**
 	 * Gets an attribute config by it's id
@@ -197,7 +219,7 @@ public class AttributesConfig {
 	}
 
 	private void singletonHashAttrs() {
-		
+
 		// Caching if needed
 		if (null == hashedAttributesByKey) {
 			hashedAttributesByKey = new HashMap<>();
@@ -242,6 +264,16 @@ public class AttributesConfig {
 
 	public void setExclusions(Set<String> exclusions) {
 		this.exclusions = exclusions;
+	}
+
+
+	public Map<String, AttributeConfig> getByEprelFeatureGroup() {
+		return byEprelFeatureGroup;
+	}
+
+
+	public void setByEprelFeatureGroup(Map<String, AttributeConfig> byEprelFeatureGroup) {
+		this.byEprelFeatureGroup = byEprelFeatureGroup;
 	}
 
 

--- a/services/eprel-service/.classpath
+++ b/services/eprel-service/.classpath
@@ -39,17 +39,11 @@
 	<classpathentry kind="src" path="target/generated-sources/annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
 		<attributes>
 			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
-			<attribute name="m2e-apt" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/services/eprel-service/.project
+++ b/services/eprel-service/.project
@@ -11,12 +11,12 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.springframework.ide.eclipse.boot.validation.springbootbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.springframework.ide.eclipse.boot.validation.springbootbuilder</name>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/services/eprel-service/src/main/java/org/open4goods/services/eprelservice/service/EprelSearchService.java
+++ b/services/eprel-service/src/main/java/org/open4goods/services/eprelservice/service/EprelSearchService.java
@@ -22,7 +22,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 
 /**
  * Provides read access to the EPREL Elasticsearch index.
- * TODO : PErf : restict search on product defined eprelMapping if any
+ * TODO : PErf : restict search on product defined vertical (against eprel associated categorie)if any
  */
 @Service
 public class EprelSearchService
@@ -140,7 +140,10 @@ public class EprelSearchService
                 LOGGER.info("Found {} result by exact model : {}", results.size(), model);
                 return results;
             }
+        }
 
+        for (String model : candidates)
+        {
             LOGGER.info("Searching by model prefix : {}", model);
             results = searchByModelPrefix(model);
             if (!results.isEmpty())
@@ -148,7 +151,10 @@ public class EprelSearchService
                 LOGGER.info("Found {} result by model prefix : {}", results.size(), model);
                 return results;
             }
+        }
 
+        for (String model : candidates)
+        {
             LOGGER.info("Searching by model best match : {}", model);
             results = searchByModelBestMatch(model);
             if (!results.isEmpty())

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -390,12 +390,10 @@ attributesConfig:
     synonyms:
       all:
       - "CLASSE ÉNERGÉTIQUE"
-      - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
       - "CLASSE ECO"
       - "CLASSE ENERGÉTIQUE"
       - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE"
       - "CLASSE D'EFFICACITE ENERGETIQUE"
-      - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
       - "ENERGY EFFICIENCY CLASS"
       - "CLASSE_ENERGY"
 #      - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
@@ -490,6 +488,7 @@ attributesConfig:
       - "ANNÉE DE MODÈLE"
       - "ANNEE DE LANCEMENT"
       - "YEAR"
+      - "ONMARKETSTARTDATETS"
       
     parser:
       normalize: true
@@ -686,6 +685,7 @@ attributesConfig:
            - "CONSOMMATION ELECTRIQUE (ARRET)"
            - "CONSOMMATION D'ENERGIE (MODE VEILLE)"
            - "POWER_CONSUMPTION_OFF"
+           - "POWERSTANDBY"
              
     parser:
          normalize: true

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -409,7 +409,7 @@ attributesConfig:
   ##################################################################################################################      
 
      ##################################
-     # DIAGONALE
+     # MINAVAILABILITYSPAREPARTSYEARS
      ##################################
      - key: "MINAVAILABILITYSPAREPARTSYEARS"
        betterIs: "GREATER"
@@ -509,45 +509,44 @@ attributesConfig:
            
            
            
-             ################################################################################
-             #                         CONSOMMATION ELECTRIQUE (ARRET / VEILLE)
-             ################################################################################
-             # Generated on 10/12/2024 21:22, coverage was 2% (63/2389) . 
-             # TOP attributes values are :
-           #     - 0.3 (34 items)
-           #     - 0.5 (24 items)
-           #     - 0 (2 items)
-           #     - 0, 3 W (2 items)
-           #   
-             ##################################
+     ################################################################################
+     #                         CONSOMMATION ELECTRIQUE (ARRET / VEILLE / RESEAU)
+     ################################################################################
+     # Generated on 10/12/2024 21:22, coverage was 2% (63/2389) . 
+     # TOP attributes values are :
+   #     - 0.3 (34 items)
+   #     - 0.5 (24 items)
+   #     - 0 (2 items)
+   #     - 0, 3 W (2 items)
+   #   
+     ##################################
              
      - key: "POWER_CONSUMPTION_STANDBY_NETWORKD"
-           betterIs: "LOWER"
-           filteringType: "NUMERIC"
-           asScore: true
-           reverseScore: true    
-           faIcon: "mdi-power-plug-off"
-         
-           icecatFeaturesIds:      
-# TODO : Icecat features id
+       betterIs: "LOWER"
+       filteringType: "NUMERIC"
+       asScore: true
+       reverseScore: true    
+       faIcon: "mdi-power-plug-off"
+     
+       icecatFeaturesIds:      
 
-             
-           name:
-                default: "Power consumption (off)"
-                fr: "Consommation électrique (arrêt/veille)"
-             
-           synonyms:
-                all:
-                  - "POWERSTANDBYNETWORKED"
-                    
-           parser:
-                normalize: true
-                trim: true
-                lowerCase: false
-                upperCase: true
-                removeParenthesis: false
-                deleteTokens:
-                 - "W"
+         
+       name:
+            default: "Power consumption (off)"
+            fr: "Consommation électrique (arrêt/veille)"
+         
+       synonyms:
+            all:
+              - "POWERSTANDBYNETWORKED"
+                
+       parser:
+            normalize: true
+            trim: true
+            lowerCase: false
+            upperCase: true
+            removeParenthesis: false
+            deleteTokens:
+             - "W"
 
          ################################################################################
          #                         CONSOMMATION ELECTRIQUE SDR
@@ -563,32 +562,31 @@ attributesConfig:
              
 
      - key: "POWER_CONSUMPTION_SDR"
-           betterIs: "LOWER"
-           filteringType: "NUMERIC"
-           asScore: true
-           reverseScore: true    
-           faIcon: "mdi-power-plug-off"
-         
-           icecatFeaturesIds:      
-# TODO : Icecat features id
+       betterIs: "LOWER"
+       filteringType: "NUMERIC"
+       asScore: true
+       reverseScore: true    
+       faIcon: "mdi-power-plug-off"
+     
+       icecatFeaturesIds:      
 
-             
-           name:
-                default: "Power consumption (SDR)"
-                fr: "Consommation électrique (Basse définition)"
-             
-           synonyms:
-                all:
-                  - "POWERONMODESDR"
-                    
-           parser:
-                normalize: true
-                trim: true
-                lowerCase: false
-                upperCase: true
-                removeParenthesis: false
-                deleteTokens:
-                 - "W"
+         
+       name:
+            default: "Power consumption (SDR)"
+            fr: "Consommation électrique (Basse définition)"
+         
+       synonyms:
+            all:
+              - "POWERONMODESDR"
+                
+       parser:
+            normalize: true
+            trim: true
+            lowerCase: false
+            upperCase: true
+            removeParenthesis: false
+            deleteTokens:
+             - "W"
  ################################################################################
  #                         CONSOMMATION ELECTRIQUE HDR
  ################################################################################
@@ -603,53 +601,54 @@ attributesConfig:
              
 
      - key: "POWER_CONSUMPTION_HDR"
-           betterIs: "LOWER"
-           filteringType: "NUMERIC"
-           asScore: true
-           reverseScore: true    
-           faIcon: "mdi-power-plug-off"
-         
-           icecatFeaturesIds:      
-# TODO : Icecat features id
+       betterIs: "LOWER"
+       filteringType: "NUMERIC"
+       asScore: true
+       reverseScore: true    
+       faIcon: "mdi-power-plug-off"
+     
+       icecatFeaturesIds:      
 
-             
-           name:
-                default: "Power consumption (HDR)"
-                fr: "Consommation électrique (Hauté définition)"
-             
-           synonyms:
-                all:
-                  - "POWERONMODEHDR"
-                    
-           parser:
-                normalize: true
-                trim: true
-                lowerCase: false
-                upperCase: true
-                removeParenthesis: false
-                deleteTokens:
-                 - "W"
+         
+       name:
+            default: "Power consumption (HDR)"
+            fr: "Consommation électrique (Hauté définition)"
+         
+       synonyms:
+            all:
+              - "POWERONMODEHDR"
+                
+       parser:
+            normalize: true
+            trim: true
+            lowerCase: false
+            upperCase: true
+            removeParenthesis: false
+            deleteTokens:
+             - "W"
+
+
 
  ################################################################################
  #                         CLASS ENERGY HDR
  ################################################################################
  
      - key: "CLASSE_ENERGY_HDR"
-        betterIs: "GREATER"
-        faIcon: "mdi-flash"
-        name:
-          default: "Energy class HDR"
-          fr: "Classe énergétique (haute résolution)"
-        filteringType: "TEXT"
-        asScore: true
+       betterIs: "GREATER"
+       faIcon: "mdi-flash"
+       name:
+         default: "Energy class HDR"
+         fr: "Classe énergétique (haute résolution)"
+       filteringType: "TEXT"
+       asScore: true
     
-        attributeValuesOrdering: "MAPPED"
-        synonyms:
+       attributeValuesOrdering: "MAPPED"
+       synonyms:
           all:
           - "ENERGYCLASSHDR"
           - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
           
-        parser:
+       parser:
           normalize: true
           trim: true
           lowerCase: false
@@ -659,7 +658,7 @@ attributesConfig:
           - "CLASSE"
           - "(ÉCHELLE A++ À E)"
           - "NOT AVAILABLE"
-        numericMapping:
+       numericMapping:
           A+++: 18.0    
           A++: 18.0
           A+: 17.0
@@ -681,13 +680,11 @@ attributesConfig:
           F: 1.0
           G: 0.0      
 
-
-
  ################################################################################
  #                         CLASSE ELECTRIQUE SDR
  ################################################################################
  
-     - key: "CLASSE_ENERGY_SDR"
+     -  key: "CLASSE_ENERGY_SDR"
         betterIs: "GREATER"
         faIcon: "mdi-flash"
         name:
@@ -695,7 +692,7 @@ attributesConfig:
           fr: "Classe énergétique (haute résolution)"
         filteringType: "TEXT"
         asScore: true
-    
+        
         attributeValuesOrdering: "MAPPED"
         synonyms:
           all:

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -407,6 +407,40 @@ attributesConfig:
   # ATTRIBUTES DEFINITIONS
   # Those attributes will be availlable for all products if one is found.
   ##################################################################################################################      
+
+     ##################################
+     # DIAGONALE
+     ##################################
+     - key: "MINAVAILABILITYSPAREPARTSYEARS"
+       betterIs: "GREATER"
+       icecatFeaturesIds:
+       
+       eprelFeatureNames:
+        - diagonalInch
+       faIcon: "mdi-arrow-top-right-bottom-left"
+       name:
+         default: "Screen size"
+         fr: "Diagonale (en pouces)"
+       suffix:
+         default: "\""
+         fr: "\""
+       filteringType: "NUMERIC"
+   
+       asScore: false
+       synonyms:
+         all:
+           - "minAvailabilitySparePartsYears" 
+
+   
+       parser:
+         normalize: true
+         trim: false
+         lowerCase: false
+         upperCase: true
+         removeParenthesis: false
+   #      deleteTokens:
+
+
   
      ##################################
      # DIAGONALE
@@ -416,7 +450,7 @@ attributesConfig:
        icecatFeaturesIds:
          - 944       
        eprelFeatureNames:
-        - 
+        - diagonalInch
        faIcon: "mdi-arrow-top-right-bottom-left"
        name:
          default: "Screen size"
@@ -430,6 +464,7 @@ attributesConfig:
        synonyms:
          all:
            - "DIAGONALE_POUCES" 
+           - "DIAGONALINCH"
          rakuten.com:      
            - "DIAGONALE"
    
@@ -459,6 +494,7 @@ attributesConfig:
        synonyms:
           all:
             - "DISPLAY_TECHNOLOGY" 
+            - "PANELTECHNOLOGY"
           rakuten.com:      
             - "TYPE DE PRODUIT"
          
@@ -473,8 +509,234 @@ attributesConfig:
            
            
            
-           
+             ################################################################################
+             #                         CONSOMMATION ELECTRIQUE (ARRET / VEILLE)
+             ################################################################################
+             # Generated on 10/12/2024 21:22, coverage was 2% (63/2389) . 
+             # TOP attributes values are :
+           #     - 0.3 (34 items)
+           #     - 0.5 (24 items)
+           #     - 0 (2 items)
+           #     - 0, 3 W (2 items)
+           #   
+             ##################################
+             
+     - key: "POWER_CONSUMPTION_STANDBY_NETWORKD"
+           betterIs: "LOWER"
+           filteringType: "NUMERIC"
+           asScore: true
+           reverseScore: true    
+           faIcon: "mdi-power-plug-off"
+         
+           icecatFeaturesIds:      
+# TODO : Icecat features id
 
+             
+           name:
+                default: "Power consumption (off)"
+                fr: "Consommation électrique (arrêt/veille)"
+             
+           synonyms:
+                all:
+                  - "POWERSTANDBYNETWORKED"
+                    
+           parser:
+                normalize: true
+                trim: true
+                lowerCase: false
+                upperCase: true
+                removeParenthesis: false
+                deleteTokens:
+                 - "W"
+
+         ################################################################################
+         #                         CONSOMMATION ELECTRIQUE SDR
+         ################################################################################
+         # Generated on 10/12/2024 21:22, coverage was 2% (63/2389) . 
+         # TOP attributes values are :
+       #     - 0.3 (34 items)
+       #     - 0.5 (24 items)
+       #     - 0 (2 items)
+       #     - 0, 3 W (2 items)
+       #   
+         ##################################
+             
+
+     - key: "POWER_CONSUMPTION_SDR"
+           betterIs: "LOWER"
+           filteringType: "NUMERIC"
+           asScore: true
+           reverseScore: true    
+           faIcon: "mdi-power-plug-off"
+         
+           icecatFeaturesIds:      
+# TODO : Icecat features id
+
+             
+           name:
+                default: "Power consumption (SDR)"
+                fr: "Consommation électrique (Basse définition)"
+             
+           synonyms:
+                all:
+                  - "POWERONMODESDR"
+                    
+           parser:
+                normalize: true
+                trim: true
+                lowerCase: false
+                upperCase: true
+                removeParenthesis: false
+                deleteTokens:
+                 - "W"
+ ################################################################################
+ #                         CONSOMMATION ELECTRIQUE HDR
+ ################################################################################
+         # Generated on 10/12/2024 21:22, coverage was 2% (63/2389) . 
+         # TOP attributes values are :
+       #     - 0.3 (34 items)
+       #     - 0.5 (24 items)
+       #     - 0 (2 items)
+       #     - 0, 3 W (2 items)
+       #   
+         ##################################
+             
+
+     - key: "POWER_CONSUMPTION_HDR"
+           betterIs: "LOWER"
+           filteringType: "NUMERIC"
+           asScore: true
+           reverseScore: true    
+           faIcon: "mdi-power-plug-off"
+         
+           icecatFeaturesIds:      
+# TODO : Icecat features id
+
+             
+           name:
+                default: "Power consumption (HDR)"
+                fr: "Consommation électrique (Hauté définition)"
+             
+           synonyms:
+                all:
+                  - "POWERONMODEHDR"
+                    
+           parser:
+                normalize: true
+                trim: true
+                lowerCase: false
+                upperCase: true
+                removeParenthesis: false
+                deleteTokens:
+                 - "W"
+
+ ################################################################################
+ #                         CLASS ENERGY HDR
+ ################################################################################
+ 
+     - key: "CLASSE_ENERGY_HDR"
+        betterIs: "GREATER"
+        faIcon: "mdi-flash"
+        name:
+          default: "Energy class HDR"
+          fr: "Classe énergétique (haute résolution)"
+        filteringType: "TEXT"
+        asScore: true
+    
+        attributeValuesOrdering: "MAPPED"
+        synonyms:
+          all:
+          - "ENERGYCLASSHDR"
+          - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
+          
+        parser:
+          normalize: true
+          trim: true
+          lowerCase: false
+          upperCase: true
+          removeParenthesis: false
+          deleteTokens:
+          - "CLASSE"
+          - "(ÉCHELLE A++ À E)"
+          - "NOT AVAILABLE"
+        numericMapping:
+          A+++: 18.0    
+          A++: 18.0
+          A+: 17.0
+          A: 16.0
+          B++: 15.0
+          B+: 14.0
+          B: 13.0
+          C++: 12.0
+          C+: 11.0
+          C: 10.0
+          D++: 9.0
+          D+: 8.0
+          D: 7.0
+          E++: 6.0
+          E+: 5.0
+          E: 4.0
+          F++: 3.0
+          F+: 2.0
+          F: 1.0
+          G: 0.0      
+
+
+
+ ################################################################################
+ #                         CLASSE ELECTRIQUE SDR
+ ################################################################################
+ 
+     - key: "CLASSE_ENERGY_SDR"
+        betterIs: "GREATER"
+        faIcon: "mdi-flash"
+        name:
+          default: "Energy class HDR"
+          fr: "Classe énergétique (haute résolution)"
+        filteringType: "TEXT"
+        asScore: true
+    
+        attributeValuesOrdering: "MAPPED"
+        synonyms:
+          all:
+          - "ENERGYCLASSHDR"
+          - "CLASSE D'EFFICACITÉ ÉNERGÉTIQUE (HDR)"
+          
+        parser:
+          normalize: true
+          trim: true
+          lowerCase: false
+          upperCase: true
+          removeParenthesis: false
+          deleteTokens:
+          - "CLASSE"
+          - "(ÉCHELLE A++ À E)"
+          - "NOT AVAILABLE"
+        numericMapping:
+          A+++: 18.0    
+          A++: 18.0
+          A+: 17.0
+          A: 16.0
+          B++: 15.0
+          B+: 14.0
+          B: 13.0
+          C++: 12.0
+          C+: 11.0
+          C: 10.0
+          D++: 9.0
+          D+: 8.0
+          D: 7.0
+          E++: 6.0
+          E+: 5.0
+          E: 4.0
+          F++: 3.0
+          F+: 2.0
+          F: 1.0
+          G: 0.0      
+
+
+
+      
 ##############################################################################
 # Product classification from categories
 ##############################################################################


### PR DESCRIPTION
## Summary
- make the hero and solution sections use fluid containers while reordering the category browser directly under the hero
- restyle the “Trop de labels” and solution highlights with alternating cards and reduce category gallery thumbnail sizes
- replace the blog carousel with a 10-article API-driven grid, including improved loading, empty states, and richer metadata

## Testing
- pnpm lint
- pnpm vitest run pages/index.spec.ts
- pnpm generate

------
https://chatgpt.com/codex/tasks/task_e_690caa97071883338e5543a3aaa41cc2