### PR TITLE
refactor: adopt vuetify grids on home page and shared widgets

### DIFF
--- a/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
@@ -1,35 +1,30 @@
 <template>
-  <nav
-    v-if="visibleItems.length"
+  <v-breadcrumbs
+    v-if="breadcrumbItems.length"
     class="category-navigation-breadcrumbs"
     :aria-label="ariaLabel"
+    :items="breadcrumbItems"
+    divider="/"
+    tag="nav"
   >
-    <ol class="category-navigation-breadcrumbs__list">
-      <li
-        v-for="(item, index) in visibleItems"
-        :key="`${item.title}-${index}`"
+    <template #item="{ item }">
+      <v-breadcrumbs-item
+        :disabled="item.disabled"
+        :href="item.href"
+        :to="item.to"
         class="category-navigation-breadcrumbs__item"
       >
-        <span v-if="!item.link" class="category-navigation-breadcrumbs__current">
-          {{ item.title }}
-        </span>
-        <NuxtLink
-          v-else
-          :to="item.link"
-          class="category-navigation-breadcrumbs__link"
-        >
-          {{ item.title }}
-        </NuxtLink>
         <span
-          v-if="index < visibleItems.length - 1"
-          aria-hidden="true"
-          class="category-navigation-breadcrumbs__separator"
+          :class="[
+            'category-navigation-breadcrumbs__label',
+            item.disabled ? 'category-navigation-breadcrumbs__label--current' : 'category-navigation-breadcrumbs__label--link',
+          ]"
         >
-          /
+          {{ item.title }}
         </span>
-      </li>
-    </ol>
-  </nav>
+      </v-breadcrumbs-item>
+    </template>
+  </v-breadcrumbs>
 </template>
 
 <script setup lang="ts">
@@ -45,28 +40,47 @@ const props = defineProps<{
   ariaLabel: string
 }>()
 
-const visibleItems = computed(() =>
-  props.items.filter((item) => item.title?.trim().length),
-)
+const visibleItems = computed(() => props.items.filter((item) => item.title?.trim().length))
+
+const breadcrumbItems = computed(() => {
+  const items = visibleItems.value
+
+  return items.map((item, index) => {
+    const rawLink = item.link?.trim()
+    const isLast = index === items.length - 1
+
+    if (!rawLink || isLast) {
+      return {
+        title: item.title,
+        disabled: true,
+      }
+    }
+
+    if (/^https?:\/\//i.test(rawLink)) {
+      return {
+        title: item.title,
+        href: rawLink,
+        disabled: false,
+      }
+    }
+
+    return {
+      title: item.title,
+      to: rawLink,
+      disabled: false,
+    }
+  })
+})
 </script>
 
 <style scoped>
 .category-navigation-breadcrumbs {
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.5rem;
   font-size: 0.875rem;
   color: rgb(var(--v-theme-text-neutral-secondary));
-}
-
-.category-navigation-breadcrumbs__list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  list-style: none;
-  padding: 0;
-  margin: 0;
 }
 
 .category-navigation-breadcrumbs__item {
@@ -75,24 +89,27 @@ const visibleItems = computed(() =>
   gap: 0.25rem;
 }
 
-.category-navigation-breadcrumbs__link {
-  color: inherit;
-  text-decoration: none;
+.category-navigation-breadcrumbs__label {
   transition: color 0.2s ease;
 }
 
-.category-navigation-breadcrumbs__link:hover,
-.category-navigation-breadcrumbs__link:focus-visible {
+.category-navigation-breadcrumbs__label--link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.category-navigation-breadcrumbs__label--link:hover,
+.category-navigation-breadcrumbs__label--link:focus-visible {
   color: rgb(var(--v-theme-primary));
   text-decoration: underline;
 }
 
-.category-navigation-breadcrumbs__separator {
-  opacity: 0.6;
-}
-
-.category-navigation-breadcrumbs__current {
+.category-navigation-breadcrumbs__label--current {
   font-weight: 600;
   color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.category-navigation-breadcrumbs :deep(.v-breadcrumbs-item__divider) {
+  opacity: 0.6;
 }
 </style>

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -9,22 +9,18 @@
         tabindex="0"
         role="img"
       >
-        <div class="impact-score__stars" :style="starStyle">
-          <div class="impact-score__stars-track" aria-hidden="true">
-            <v-icon
-              v-for="index in length"
-              :key="`track-${index}`"
-              icon="mdi-star"
-            />
-          </div>
-          <div class="impact-score__stars-fill" :style="{ width: fillWidth }" aria-hidden="true">
-            <v-icon
-              v-for="index in length"
-              :key="`fill-${index}`"
-              icon="mdi-star"
-            />
-          </div>
-        </div>
+        <v-rating
+          class="impact-score__rating"
+          :model-value="normalizedScore"
+          :length="length"
+          :size="ratingSize"
+          color="accent-supporting"
+          :bg-color="inactiveColor"
+          density="comfortable"
+          half-increments
+          readonly
+          aria-hidden="true"
+        />
         <span v-if="showValue" class="impact-score__value">{{ formattedScore }}</span>
       </div>
     </template>
@@ -68,7 +64,7 @@ const formattedScore = computed(() =>
   `${n(normalizedScore.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 })} / ${length.value}`,
 )
 
-const starSize = computed(() => {
+const ratingSize = computed(() => {
   switch (props.size) {
     case 'small':
       return 18
@@ -79,23 +75,7 @@ const starSize = computed(() => {
   }
 })
 
-const starGap = computed(() => {
-  switch (props.size) {
-    case 'small':
-      return 4
-    case 'large':
-      return 8
-    default:
-      return 6
-  }
-})
-
-const fillWidth = computed(() => `${(normalizedScore.value / length.value) * 100}%`)
-
-const starStyle = computed(() => ({
-  '--impact-score-star-size': `${starSize.value}px`,
-  '--impact-score-star-gap': `${starGap.value}px`,
-}))
+const inactiveColor = computed(() => 'rgba(var(--v-theme-text-neutral-soft), 0.35)')
 
 const tooltipLabel = computed(() =>
   t('components.impactScore.tooltip', {
@@ -129,33 +109,24 @@ const showValue = computed(() => props.showValue)
   font-size: 1.05rem;
 }
 
-.impact-score__stars {
-  position: relative;
-  display: inline-flex;
+.impact-score__rating :deep(.v-rating__wrapper) {
+  gap: 0.375rem;
 }
 
-.impact-score__stars-track,
-.impact-score__stars-fill {
-  display: inline-flex;
-  gap: var(--impact-score-star-gap);
+.impact-score--small .impact-score__rating :deep(.v-rating__wrapper) {
+  gap: 0.25rem;
 }
 
-.impact-score__stars-track {
+.impact-score--large .impact-score__rating :deep(.v-rating__wrapper) {
+  gap: 0.5rem;
+}
+
+.impact-score__rating :deep(.v-icon) {
   color: rgba(var(--v-theme-text-neutral-soft), 0.35);
 }
 
-.impact-score__stars-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  display: inline-flex;
-  overflow: hidden;
+.impact-score__rating :deep(.v-rating__item--active .v-icon),
+.impact-score__rating :deep(.v-rating__item--hover .v-icon) {
   color: rgb(var(--v-theme-accent-supporting));
-  gap: var(--impact-score-star-gap);
-}
-
-.impact-score__stars-track :deep(.v-icon),
-.impact-score__stars-fill :deep(.v-icon) {
-  font-size: var(--impact-score-star-size);
-  line-height: 1;
 }
 </style>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -485,8 +485,8 @@ useHead(() => ({
     <section class="home-hero" aria-labelledby="home-hero-title">
       <v-container class="home-hero__container" fluid>
         <div class="home-hero__inner">
-          <div class="home-hero__layout">
-          <div class="home-hero__content">
+          <v-row class="home-hero__layout" align="stretch" justify="center">
+            <v-col cols="12" lg="6" class="home-hero__content">
             <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
             <h1 id="home-hero-title" class="home-hero__title">
               {{ t('home.hero.title') }}
@@ -523,27 +523,27 @@ useHead(() => ({
               <span aria-hidden="true">⚡</span>
               {{ t('home.hero.search.helper') }}
             </p>
-          </div>
+            </v-col>
 
-          <div class="home-hero__media" aria-hidden="true">
-            <v-sheet rounded="xl" elevation="6" class="home-hero__media-sheet">
-              <div class="home-hero__video-wrapper">
-                <video
-                  class="home-hero__video"
-                  :poster="heroVideoPoster"
-                  autoplay
-                  muted
-                  loop
-                  playsinline
-                  preload="metadata"
-                >
-                  <source :src="heroVideoSrc" type="video/mp4" />
-                </video>
-                <div class="home-hero__video-overlay" />
-              </div>
-            </v-sheet>
-          </div>
-          </div>
+            <v-col cols="12" lg="6" class="home-hero__media" aria-hidden="true">
+              <v-sheet rounded="xl" elevation="6" class="home-hero__media-sheet">
+                <div class="home-hero__video-wrapper">
+                  <video
+                    class="home-hero__video"
+                    :poster="heroVideoPoster"
+                    autoplay
+                    muted
+                    loop
+                    playsinline
+                    preload="metadata"
+                  >
+                    <source :src="heroVideoSrc" type="video/mp4" />
+                  </video>
+                  <div class="home-hero__video-overlay" />
+                </div>
+              </v-sheet>
+            </v-col>
+          </v-row>
         </div>
       </v-container>
     </section>
@@ -563,21 +563,28 @@ useHead(() => ({
         <header class="home-section__header">
           <h2 id="home-problems-title">{{ t('home.problems.title') }}</h2>
         </header>
-        <div class="home-problems__grid">
-          <article
+        <v-row class="home-problems__grid" align="stretch">
+          <v-col
             v-for="(item, index) in problemItems"
             :key="item.text"
-            class="home-problems__card"
-            :class="{ 'home-problems__card--reverse': index % 2 === 1 }"
+            cols="12"
+            md="6"
+            lg="4"
+            class="home-problems__col"
           >
-            <div class="home-problems__card-inner">
-              <div class="home-problems__icon-wrapper" aria-hidden="true">
-                <v-icon class="home-problems__icon" :icon="item.icon" size="56" />
+            <article
+              class="home-problems__card"
+              :class="{ 'home-problems__card--reverse': index % 2 === 1 }"
+            >
+              <div class="home-problems__card-inner">
+                <div class="home-problems__icon-wrapper" aria-hidden="true">
+                  <v-icon class="home-problems__icon" :icon="item.icon" size="56" />
+                </div>
+                <p class="home-problems__text">{{ item.text }}</p>
               </div>
-              <p class="home-problems__text">{{ item.text }}</p>
-            </div>
-          </article>
-        </div>
+            </article>
+          </v-col>
+        </v-row>
       </v-container>
     </section>
 
@@ -588,19 +595,22 @@ useHead(() => ({
             <h2 id="home-solution-title">{{ t('home.solution.title') }}</h2>
             <p class="home-section__subtitle">{{ t('home.solution.description') }}</p>
           </header>
-          <ul class="home-solution__list">
-            <li
-              v-for="(item, index) in solutionBenefits"
+          <v-row class="home-solution__list" tag="ul" align="stretch" justify="center">
+            <v-col
+              v-for="item in solutionBenefits"
               :key="item.label"
+              cols="12"
+              sm="6"
+              md="3"
               class="home-solution__item"
-              :class="{ 'home-solution__item--reverse': index % 2 === 1 }"
+              tag="li"
             >
               <v-card class="home-solution__card" variant="outlined">
                 <span class="home-solution__emoji" aria-hidden="true">{{ item.emoji }}</span>
                 <p class="home-solution__label">{{ item.label }}</p>
               </v-card>
-            </li>
-          </ul>
+            </v-col>
+          </v-row>
         </div>
       </v-container>
     </section>
@@ -637,68 +647,87 @@ useHead(() => ({
             class="home-blog__skeleton"
           />
         </div>
-        <div v-else-if="featuredBlogItem || secondaryBlogItems.length" class="home-blog__grid">
-          <component
-            :is="featuredBlogItem?.isExternal ? 'a' : 'NuxtLink'"
+        <v-row
+          v-else-if="featuredBlogItem || secondaryBlogItems.length"
+          class="home-blog__grid"
+          align="stretch"
+        >
+          <v-col
             v-if="featuredBlogItem"
-            :key="'featured-article'"
-            class="home-blog__item home-blog__item--featured"
-            :href="featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
-            :to="!featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
-            :target="featuredBlogItem.isExternal ? '_blank' : undefined"
-            :rel="featuredBlogItem.isExternal ? 'noopener' : undefined"
+            key="featured-article"
+            cols="12"
+            md="7"
+            lg="8"
+            class="home-blog__col home-blog__col--featured"
           >
-            <article class="home-blog__card">
-              <div class="home-blog__media" aria-hidden="true">
-                <v-img
-                  v-if="hasRenderableImage(featuredBlogItem.image)"
-                  :src="featuredBlogItem.image"
-                  :alt="featuredBlogItem.title ?? ''"
-                  cover
-                />
-                <div v-else class="home-blog__placeholder">
-                  <v-icon icon="mdi-post-outline" size="68" />
+            <component
+              :is="featuredBlogItem.isExternal ? 'a' : 'NuxtLink'"
+              class="home-blog__item home-blog__item--featured"
+              :href="featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
+              :to="!featuredBlogItem.isExternal ? featuredBlogItem.link : undefined"
+              :target="featuredBlogItem.isExternal ? '_blank' : undefined"
+              :rel="featuredBlogItem.isExternal ? 'noopener' : undefined"
+            >
+              <article class="home-blog__card">
+                <div class="home-blog__media" aria-hidden="true">
+                  <v-img
+                    v-if="hasRenderableImage(featuredBlogItem.image)"
+                    :src="featuredBlogItem.image"
+                    :alt="featuredBlogItem.title ?? ''"
+                    cover
+                  />
+                  <div v-else class="home-blog__placeholder">
+                    <v-icon icon="mdi-post-outline" size="68" />
+                  </div>
                 </div>
-              </div>
-              <div class="home-blog__content">
-                <p class="home-blog__date">{{ featuredBlogItem.formattedDate }}</p>
-                <h3 class="home-blog__title">{{ featuredBlogItem.title }}</h3>
-                <p class="home-blog__summary">{{ featuredBlogItem.summary }}</p>
-                <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
-              </div>
-            </article>
-          </component>
-          <component
-            :is="article.isExternal ? 'a' : 'NuxtLink'"
+                <div class="home-blog__content">
+                  <p class="home-blog__date">{{ featuredBlogItem.formattedDate }}</p>
+                  <h3 class="home-blog__title">{{ featuredBlogItem.title }}</h3>
+                  <p class="home-blog__summary">{{ featuredBlogItem.summary }}</p>
+                  <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
+                </div>
+              </article>
+            </component>
+          </v-col>
+          <v-col
             v-for="article in secondaryBlogItems"
             :key="article.url ?? article.title ?? article.link"
-            class="home-blog__item"
-            :href="article.isExternal ? article.link : undefined"
-            :to="!article.isExternal ? article.link : undefined"
-            :target="article.isExternal ? '_blank' : undefined"
-            :rel="article.isExternal ? 'noopener' : undefined"
+            cols="12"
+            sm="6"
+            md="5"
+            lg="4"
+            class="home-blog__col"
           >
-            <article class="home-blog__card">
-              <div class="home-blog__media" aria-hidden="true">
-                <v-img
-                  v-if="hasRenderableImage(article.image)"
-                  :src="article.image"
-                  :alt="article.title ?? ''"
-                  cover
-                />
-                <div v-else class="home-blog__placeholder">
-                  <v-icon icon="mdi-post-outline" size="48" />
+            <component
+              :is="article.isExternal ? 'a' : 'NuxtLink'"
+              class="home-blog__item"
+              :href="article.isExternal ? article.link : undefined"
+              :to="!article.isExternal ? article.link : undefined"
+              :target="article.isExternal ? '_blank' : undefined"
+              :rel="article.isExternal ? 'noopener' : undefined"
+            >
+              <article class="home-blog__card">
+                <div class="home-blog__media" aria-hidden="true">
+                  <v-img
+                    v-if="hasRenderableImage(article.image)"
+                    :src="article.image"
+                    :alt="article.title ?? ''"
+                    cover
+                  />
+                  <div v-else class="home-blog__placeholder">
+                    <v-icon icon="mdi-post-outline" size="48" />
+                  </div>
                 </div>
-              </div>
-              <div class="home-blog__content">
-                <p class="home-blog__date">{{ article.formattedDate }}</p>
-                <h3 class="home-blog__title">{{ article.title }}</h3>
-                <p class="home-blog__summary">{{ article.summary }}</p>
-                <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
-              </div>
-            </article>
-          </component>
-        </div>
+                <div class="home-blog__content">
+                  <p class="home-blog__date">{{ article.formattedDate }}</p>
+                  <h3 class="home-blog__title">{{ article.title }}</h3>
+                  <p class="home-blog__summary">{{ article.summary }}</p>
+                  <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
+                </div>
+              </article>
+            </component>
+          </v-col>
+        </v-row>
         <v-alert
           v-else
           type="info"
@@ -868,8 +897,8 @@ useHead(() => ({
   gap: clamp(2rem, 5vw, 3rem)
 
 .home-hero__layout
-  display: grid
-  gap: clamp(2rem, 5vw, 3rem)
+  --v-gutter-x: clamp(2rem, 5vw, 3.5rem)
+  --v-gutter-y: clamp(2rem, 5vw, 3.5rem)
 
 .home-hero__content
   display: flex
@@ -963,25 +992,28 @@ useHead(() => ({
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
 
 .home-problems__grid
-  display: grid
-  gap: clamp(1.5rem, 4vw, 2.5rem)
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr))
+  --v-gutter-x: clamp(1.5rem, 4vw, 2.5rem)
+  --v-gutter-y: clamp(1.5rem, 4vw, 2.5rem)
+
+.home-problems__col
+  display: flex
 
 @media (min-width: 960px)
-  .home-problems__grid
-    grid-template-columns: repeat(2, minmax(0, 1fr))
-
   .home-problems__card
     max-width: 520px
+    margin-inline: auto
 
   .home-problems__card:not(.home-problems__card--reverse)
     margin-inline-end: auto
+    margin-inline-start: 0
 
   .home-problems__card--reverse
     margin-inline-start: auto
+    margin-inline-end: 0
 
 .home-problems__card
   position: relative
+  width: 100%
   transition: transform 0.25s ease, box-shadow 0.25s ease
 
 .home-problems__card::before
@@ -1033,14 +1065,14 @@ useHead(() => ({
 
 .home-solution__list
   list-style: none
-  display: grid
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr))
-  gap: clamp(1.5rem, 4vw, 2.5rem)
   margin: 0
   padding: 0
+  --v-gutter-x: clamp(1.5rem, 4vw, 2.5rem)
+  --v-gutter-y: clamp(1.5rem, 4vw, 2.5rem)
 
 .home-solution__item
   position: relative
+  display: flex
 
 .home-solution__item::before
   content: ''
@@ -1050,9 +1082,6 @@ useHead(() => ({
   background: rgba(var(--v-theme-surface-primary-050), 0.6)
   z-index: 0
 
-.home-solution__item--reverse::before
-  inset-inline: 16px 10px
-
 @media (max-width: 599px)
   .home-solution__item::before
     display: none
@@ -1061,6 +1090,7 @@ useHead(() => ({
   position: relative
   z-index: 1
   height: 100%
+  width: 100%
   display: flex
   flex-direction: column
   gap: 1rem
@@ -1069,9 +1099,6 @@ useHead(() => ({
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.32)
   background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.92), rgba(var(--v-theme-surface-default), 0.96))
   box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.14)
-
-.home-solution__item--reverse .home-solution__card
-  background: linear-gradient(135deg, rgba(var(--v-theme-surface-default), 0.96), rgba(var(--v-theme-surface-primary-080), 0.92))
 
 .home-solution__emoji
   font-size: clamp(2.5rem, 7vw, 3.6rem)
@@ -1129,26 +1156,28 @@ useHead(() => ({
   border-radius: clamp(1.25rem, 3vw, 1.75rem)
 
 .home-blog__grid
-  display: grid
-  gap: clamp(1.5rem, 4vw, 2.5rem)
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr))
+  --v-gutter-x: clamp(1.5rem, 4vw, 2.5rem)
+  --v-gutter-y: clamp(1.5rem, 4vw, 2.5rem)
   margin-top: clamp(1rem, 3vw, 1.75rem)
+
+.home-blog__col
+  display: flex
 
 .home-blog__item
   text-decoration: none
   color: inherit
+  display: flex
+  flex: 1
 
 .home-blog__empty
   border-radius: clamp(1.25rem, 3vw, 1.75rem)
   margin-top: clamp(1rem, 3vw, 1.5rem)
 
-@media (min-width: 960px)
-  .home-blog__item--featured
-    grid-column: span 2
-    grid-row: span 2
+
 
 .home-blog__card
   height: 100%
+  flex: 1
   display: flex
   flex-direction: column
   border-radius: clamp(1.25rem, 3vw, 1.85rem)


### PR DESCRIPTION
## Summary
- replace the category breadcrumb implementation with `v-breadcrumbs`, keeping styling hooks while simplifying link handling
- rebuild the shared impact score widget around `v-rating` for better accessibility and theming control
- restructure the home page hero, problem, solution, and blog sections to use `v-row`/`v-col`, pruning custom grid CSS in favour of Vuetify gutters

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_690d1c7f05988333a3cc700a6b97a488