### PR TITLE
feat(front-api): expose EPREL facet and attribute sourcing details

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeDto.java
@@ -14,7 +14,7 @@ public record ProductAttributeDto(
         String value,
         @Schema(description = "Icecat taxonomy identifiers associated to the attribute")
         Set<Integer> icecatTaxonomyIds,
-        @Schema(description = "Attributes values contributed by datasources")
-        Set<ProductSourcedAttributeDto> sources
+        @Schema(description = "Sourcing metadata for this attribute, including contributing datasources")
+        ProductAttributeSourceDto sourcing
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeSourceDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductAttributeSourceDto.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Aggregated sourcing information for a product attribute.
+ * <p>
+ * This structure exposes the resolved best value alongside the list of
+ * datasource contributions and a conflict indicator so that the frontend can
+ * communicate data quality hints to end users.
+ * </p>
+ */
+public record ProductAttributeSourceDto(
+        @Schema(description = "Resolved best value for the attribute", example = "55")
+        String bestValue,
+        @Schema(description = "Datasource contributions used to compute the best value")
+        Set<ProductSourcedAttributeDto> sources,
+        @Schema(description = "Flag indicating whether conflicting datasource values exist")
+        boolean conflicts
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -34,7 +34,8 @@ public record ProductDto(
         ProductScoresDto scores,
         @Schema(description = "AI generated review resolved for the requested domain language")
         ProductAiReviewDto aiReview,
-
+        @Schema(description = "EPREL product information when available", implementation = ProductEprelDto.class)
+        ProductEprelDto eprel,
         @Schema(description = "Product offers and pricing information")
         ProductOffersDto offers
 ) {
@@ -52,6 +53,7 @@ public record ProductDto(
                 scores,
                 aiReview,
                 aiTexts,
+                eprel,
                 offers
         }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductEprelDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductEprelDto.java
@@ -1,0 +1,44 @@
+package org.open4goods.nudgerfrontapi.dto.product;
+
+import org.open4goods.model.eprel.EprelProduct;
+import org.springframework.beans.BeanUtils;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Sanitised copy of an {@link EprelProduct} tailored for transport through the
+ * frontend API.
+ * <p>
+ * The EPREL catalogue stores a very large and heterogeneous payload in the
+ * {@code categorySpecificAttributes} map which is not required by the
+ * frontend. Returning a clone avoids leaking this heavy structure while
+ * keeping the rest of the metadata available to consumers.
+ * </p>
+ */
+@Schema(name = "ProductEprelDto", description = "EPREL product metadata without category specific attributes")
+public class ProductEprelDto extends EprelProduct {
+
+    /**
+     * Create an empty DTO instance.
+     */
+    public ProductEprelDto() {
+        super();
+    }
+
+    /**
+     * Build a DTO from the provided {@link EprelProduct} while removing the
+     * {@code categorySpecificAttributes} section.
+     *
+     * @param source original EPREL entity coming from the repository
+     * @return cloned DTO instance or {@code null} when the source is {@code null}
+     */
+    public static ProductEprelDto from(EprelProduct source) {
+        if (source == null) {
+            return null;
+        }
+        ProductEprelDto target = new ProductEprelDto();
+        BeanUtils.copyProperties(source, target);
+        target.setCategorySpecificAttributes(null);
+        return target;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIndexedAttributeDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductIndexedAttributeDto.java
@@ -13,6 +13,8 @@ public record ProductIndexedAttributeDto(
         @Schema(description = "Numeric interpretation when available", nullable = true, example = "12.5")
         Double numericValue,
         @Schema(description = "Boolean interpretation when available", nullable = true)
-        Boolean booleanValue
+        Boolean booleanValue,
+        @Schema(description = "Sourcing metadata attached to the indexed attribute")
+        ProductAttributeSourceDto sourcing
 ) {
 }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/ProductControllerIT.java
@@ -96,7 +96,7 @@ class ProductControllerIT {
     void includeParameterFiltersFields() throws Exception {
         long gtin = 321L;
         given(service.getProduct(anyLong(), any(Locale.class), anySet(), any(DomainLanguage.class)))
-                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null));
+                .willReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null));
 
         mockMvc.perform(get("/products/{gtin}", gtin)
                         .param("include", "gtin")
@@ -123,7 +123,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointReturnsPage() throws Exception {
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -141,7 +141,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointParsesAggregationArraySyntax() throws Exception {
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -171,7 +171,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointParsesAggregationObjectSyntax() throws Exception {
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -245,7 +245,7 @@ class ProductControllerIT {
         VerticalConfig config = verticalConfigWithNumericAttribute("battery_life");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
 
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -266,7 +266,7 @@ class ProductControllerIT {
         config.setId("electronics");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
 
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -286,7 +286,7 @@ class ProductControllerIT {
         VerticalConfig config = verticalConfigWithNumericAttribute("battery_life");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
 
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -320,7 +320,7 @@ class ProductControllerIT {
         VerticalConfig config = verticalConfigWithNumericAttribute("battery_life");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
 
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), nullable(FilterRequestDto.class)))
@@ -354,7 +354,7 @@ class ProductControllerIT {
         VerticalConfig config = verticalConfigWithNumericAttribute("battery_life");
         given(verticalsConfigService.getConfigById("electronics")).willReturn(config);
 
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), any(FilterRequestDto.class)))
@@ -395,7 +395,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointParsesFilterArraySyntax() throws Exception {
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), any(FilterRequestDto.class)))
@@ -420,7 +420,7 @@ class ProductControllerIT {
 
     @Test
     void productsEndpointParsesFilterObjectSyntax() throws Exception {
-        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null);
+        var product = new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null);
         PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of(product));
         ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
         given(service.searchProducts(any(Pageable.class), any(Locale.class), anySet(), nullable(AggregationRequestDto.class), any(DomainLanguage.class), nullable(String.class), nullable(String.class), any(FilterRequestDto.class)))

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/SearchControllerTest.java
@@ -39,7 +39,7 @@ class SearchControllerTest {
 
     @Test
     void globalSearchReturnsGroupedPayload() throws Exception {
-        ProductDto phone = new ProductDto(1L, null, null, null, null, null, null, null, null, null, null, null);
+        ProductDto phone = new ProductDto(1L, null, null, null, null, null, null, null, null, null, null, null, null);
         GlobalSearchHit hit = new GlobalSearchHit("phones", phone, 7.2d);
         GlobalSearchVerticalGroup group = new GlobalSearchVerticalGroup("phones", List.of(hit));
         GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(group), List.of(), false);
@@ -57,7 +57,7 @@ class SearchControllerTest {
 
     @Test
     void globalSearchIncludesFallbackResults() throws Exception {
-        ProductDto accessory = new ProductDto(2L, "universal-charger", null, null, null, null, null, null, null, null, null, null);
+        ProductDto accessory = new ProductDto(2L, "universal-charger", null, null, null, null, null, null, null, null, null, null, null);
         GlobalSearchHit fallbackHit = new GlobalSearchHit(null, accessory, 3.5d);
         GlobalSearchResult serviceResult = new GlobalSearchResult(List.of(), List.of(fallbackHit), true);
         when(searchService.globalSearch("chargeur", DomainLanguage.en)).thenReturn(serviceResult);


### PR DESCRIPTION
## Summary
- add an EPREL facet to `ProductDto` and project sanitised catalogue data through a dedicated DTO
- expose sourcing metadata for indexed and aggregated attributes, including best values and conflicts
- update product controller tests to reflect the extended DTO signature

## Testing
- mvn --offline -pl front-api test

------
https://chatgpt.com/codex/tasks/task_e_690d27fb816883338e17f3312e4ade64