### PR TITLE
feat: add admin excluded filter on category page

### DIFF
--- a/frontend/app/components/category/CategoryAdminFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryAdminFiltersPanel.vue
@@ -1,0 +1,169 @@
+<template>
+  <section class="category-admin-panel" aria-labelledby="category-admin-panel-title">
+    <header class="category-admin-panel__header">
+      <p id="category-admin-panel-title" class="category-admin-panel__eyebrow">
+        {{ t('category.admin.title') }}
+      </p>
+      <p class="category-admin-panel__helper">
+        {{ t('category.admin.helper') }}
+      </p>
+      <p v-if="fieldHelper" class="category-admin-panel__field-helper">
+        {{ fieldHelper }}
+      </p>
+    </header>
+
+    <CategoryFilterList
+      v-if="fields.length"
+      :fields="fields"
+      :aggregations="aggregationMap"
+      :baseline-aggregations="baselineAggregationMap"
+      :active-filters="activeFilters"
+      class="category-admin-panel__filters"
+      @update-range="updateRangeFilter"
+      @update-terms="updateTermsFilter"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  AggregationResponseDto,
+  FieldMetadataDto,
+  Filter,
+  FilterRequestDto,
+} from '~~/shared/api-client'
+import CategoryFilterList from './filters/CategoryFilterList.vue'
+
+const props = withDefaults(
+  defineProps<{
+    fields: FieldMetadataDto[]
+    aggregations: AggregationResponseDto[]
+    baselineAggregations?: AggregationResponseDto[]
+    filters: FilterRequestDto | null
+  }>(),
+  {
+    baselineAggregations: () => [],
+  },
+)
+
+const emit = defineEmits<{ 'update:filters': [FilterRequestDto] }>()
+
+const { t } = useI18n()
+
+const activeFilters = computed(() => props.filters?.filters ?? [])
+
+const aggregationMap = computed<Record<string, AggregationResponseDto>>(() => {
+  return props.aggregations.reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
+    if (aggregation.field) {
+      accumulator[aggregation.field] = aggregation
+    }
+
+    return accumulator
+  }, {})
+})
+
+const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(() => {
+  return props.baselineAggregations.reduce<Record<string, AggregationResponseDto>>((accumulator, aggregation) => {
+    if (aggregation.field && !(aggregation.field in accumulator)) {
+      accumulator[aggregation.field] = aggregation
+    }
+
+    return accumulator
+  }, {})
+})
+
+const fieldHelper = computed(() => {
+  if (!props.fields.length) {
+    return ''
+  }
+
+  const helperKey = `category.admin.filters.${props.fields[0]?.mapping ?? ''}.helper`
+  const translated = t(helperKey)
+  return translated !== helperKey ? translated : ''
+})
+
+const emitFilters = (filters: Filter[]) => {
+  emit('update:filters', filters.length ? { filters } : {})
+}
+
+const updateRangeFilter = (field: string, range: { min?: number; max?: number }) => {
+  const current = activeFilters.value.filter((filter) => filter.field !== field)
+
+  if (range.min == null && range.max == null) {
+    emitFilters(current)
+    return
+  }
+
+  emitFilters([
+    ...current,
+    {
+      field,
+      operator: 'range',
+      min: range.min,
+      max: range.max,
+    },
+  ])
+}
+
+const updateTermsFilter = (field: string, terms: string[]) => {
+  const current = activeFilters.value.filter((filter) => filter.field !== field)
+
+  if (!terms.length) {
+    emitFilters(current)
+    return
+  }
+
+  emitFilters([
+    ...current,
+    {
+      field,
+      operator: 'term',
+      terms,
+    },
+  ])
+}
+</script>
+
+<style scoped lang="sass">
+.category-admin-panel
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  padding: 1.25rem
+  border-radius: 1rem
+  border: 1px solid rgba(var(--v-theme-error), 0.35)
+  background: rgba(var(--v-theme-error), 0.08)
+  box-shadow: 0 18px 32px -24px rgba(var(--v-theme-error), 0.3)
+
+  &__header
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+  &__eyebrow
+    margin: 0
+    font-size: 0.75rem
+    font-weight: 700
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgb(var(--v-theme-error))
+
+  &__helper
+    margin: 0
+    font-size: 0.88rem
+    color: rgba(var(--v-theme-error), 0.95)
+
+  &__field-helper
+    margin: 0
+    font-size: 0.8rem
+    color: rgba(var(--v-theme-error), 0.85)
+
+  &__filters
+    padding-top: 0.5rem
+
+@media (max-width: 959px)
+  .category-admin-panel
+    padding: 1rem
+</style>

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -12,6 +12,15 @@
       @update:technical-expanded="(value) => emit('update:technicalExpanded', value)"
     />
 
+    <CategoryAdminFiltersPanel
+      v-if="shouldShowAdminPanel"
+      :fields="adminFields"
+      :aggregations="props.aggregations"
+      :baseline-aggregations="props.baselineAggregations"
+      :filters="props.filters"
+      @update:filters="(value) => emit('update:filters', value)"
+    />
+
     <div v-if="showMobileActions" class="category-page__filters-actions">
       <v-btn block color="primary" class="mb-2" @click="emit('apply-mobile')">
         {{ t('category.filters.mobileApply') }}
@@ -45,6 +54,7 @@ import { useI18n } from 'vue-i18n'
 import type {
   AggregationResponseDto,
   BlogPostDto,
+  FieldMetadataDto,
   FilterRequestDto,
   ProductFieldOptionsResponse,
   WikiPageConfig,
@@ -53,6 +63,7 @@ import type {
 import CategoryFiltersPanel from './CategoryFiltersPanel.vue'
 import CategoryDocumentationRail from './CategoryDocumentationRail.vue'
 import CategoryEcoscoreCard from './CategoryEcoscoreCard.vue'
+import CategoryAdminFiltersPanel from './CategoryAdminFiltersPanel.vue'
 const props = withDefaults(
   defineProps<{
     filterOptions: ProductFieldOptionsResponse | null
@@ -66,10 +77,14 @@ const props = withDefaults(
     wikiPages: WikiPageConfig[]
     relatedPosts: BlogPostDto[]
     verticalHomeUrl?: string | null
+    showAdminPanel?: boolean
+    adminFilterFields?: FieldMetadataDto[]
   }>(),
   {
     baselineAggregations: () => [],
     verticalHomeUrl: null,
+    showAdminPanel: false,
+    adminFilterFields: () => [],
   },
 )
 
@@ -88,4 +103,8 @@ const relatedPosts = computed(() => props.relatedPosts ?? [])
 const hasDocumentation = computed(() => props.hasDocumentation)
 const showMobileActions = computed(() => props.showMobileActions)
 const ecoscoreLinkAvailable = computed(() => Boolean(props.verticalHomeUrl))
+const adminFields = computed(() => props.adminFilterFields ?? [])
+const shouldShowAdminPanel = computed(
+  () => props.showAdminPanel && adminFields.value.length > 0,
+)
 </script>

--- a/frontend/app/components/category/filters/CategoryFilterTerms.vue
+++ b/frontend/app/components/category/filters/CategoryFilterTerms.vue
@@ -221,7 +221,23 @@ const onCheckboxChange = (term: string | undefined, selected: boolean | null) =>
   )
 }
 
-const formatOptionLabel = (key?: string) => key ?? t('category.filters.missingLabel')
+const formatOptionLabel = (key?: string) => {
+  if (!key) {
+    return t('category.filters.missingLabel')
+  }
+
+  const mapping = props.field.mapping
+  if (mapping) {
+    const translationKey = `category.filters.options.${mapping}.${key}`
+    const translated = t(translationKey)
+
+    if (translated && translated !== translationKey) {
+      return translated
+    }
+  }
+
+  return key
+}
 </script>
 
 <style scoped lang="sass">

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -394,6 +394,12 @@
       "showMoreImpact": "Show more impact filters",
       "showMoreTechnical": "Show more technical filters",
       "technicalTitle": "Technical filters",
+      "options": {
+        "excluded": {
+          "true": "Excluded products",
+          "false": "Visible products"
+        }
+      },
       "toggle": {
         "hide": "Hide filters column",
         "show": "Show filters column"
@@ -403,6 +409,16 @@
         "description": "Understand how we evaluate each product's environmental footprint and the indicators we monitor.",
         "cta": "Explore the methodology",
         "ariaLabel": "Open the Eco-score guide"
+      }
+    },
+    "admin": {
+      "title": "Admin filters",
+      "helper": "Restricted tools for Nudger teammates. Inspect excluded catalog entries here.",
+      "filters": {
+        "excluded": {
+          "title": "Product visibility",
+          "helper": "Toggle results excluded from the public catalog."
+        }
       }
     },
     "hero": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -394,6 +394,12 @@
       "showMoreImpact": "Plus de filtres",
       "showMoreTechnical": "Plus de filtres",
       "technicalTitle": "Filtres techniques",
+      "options": {
+        "excluded": {
+          "true": "Produits exclus",
+          "false": "Produits visibles"
+        }
+      },
       "toggle": {
         "hide": "Masquer la colonne des filtres",
         "show": "Afficher la colonne des filtres"
@@ -403,6 +409,16 @@
         "description": "Comprenez comment nous évaluons l'empreinte environnementale de chaque produit et les indicateurs suivis.",
         "cta": "Explorer la méthodologie",
         "ariaLabel": "Ouvrir le guide Eco-score"
+      }
+    },
+    "admin": {
+      "title": "Filtres admin",
+      "helper": "Outils réservés aux coéquipiers Nudger connectés pour examiner les fiches exclues.",
+      "filters": {
+        "excluded": {
+          "title": "Visibilité des produits",
+          "helper": "Inclure ou non les produits retirés du catalogue public."
+        }
       }
     },
     "hero": {


### PR DESCRIPTION
## Summary
- add an admin-only filters card for the category sidebar to mirror the product page experience
- allow admins to filter products by the excluded flag with proper aggregation, sanitisation, and option labelling
- localise the new filter labels in English and French and translate term buckets for better readability

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da053d0f08322b5196607ab012eed)