### PR TITLE
fix(frontend): fallback GTIN redirect to slug without vertical

### DIFF
--- a/frontend/app/utils/_gtin-redirect.spec.ts
+++ b/frontend/app/utils/_gtin-redirect.spec.ts
@@ -63,9 +63,19 @@ describe('app/utils/_gtin-redirect', () => {
     })
   })
 
-  it('throws a 404 when the product does not expose a fullSlug', async () => {
+  it('falls back to the raw product slug when the fullSlug is missing', async () => {
     const dependencies = createDependencies({
-      fetchProduct: vi.fn().mockResolvedValue({ fullSlug: '' }),
+      fetchProduct: vi.fn().mockResolvedValue({ slug: '123456-example-product ' }),
+    })
+
+    const target = await resolveGtinRedirectTarget('123456', dependencies)
+
+    expect(target).toBe('/123456-example-product')
+  })
+
+  it('throws a 404 when the product does not expose a navigable slug', async () => {
+    const dependencies = createDependencies({
+      fetchProduct: vi.fn().mockResolvedValue({ fullSlug: '   ', slug: null }),
     })
 
     await expect(resolveGtinRedirectTarget('123456', dependencies)).rejects.toMatchObject({

--- a/frontend/app/utils/_gtin-redirect.ts
+++ b/frontend/app/utils/_gtin-redirect.ts
@@ -29,15 +29,17 @@ export const resolveGtinRedirectTarget = async (
   }
 
   const normalizedFullSlug = product.fullSlug?.trim()
+  const normalizedSlug = product.slug?.trim()
+  const canonicalSlug = normalizedFullSlug || normalizedSlug
 
-  if (!normalizedFullSlug) {
+  if (!canonicalSlug) {
     throw createError({
       statusCode: 404,
       statusMessage: 'Product not found',
     })
   }
 
-  const [maybeBareSlug] = normalizedFullSlug.split(/[?#]/, 1)
+  const [maybeBareSlug] = canonicalSlug.split(/[?#]/, 1)
   const bareFullSlug = (maybeBareSlug ?? '').trim()
 
   if (!bareFullSlug) {


### PR DESCRIPTION
## Summary
- allow the GTIN redirect helper to fall back to the product slug when no vertical-specific fullSlug exists
- add regression tests covering the slug fallback and the 404 scenario when no navigable slug is exposed

## Testing
- pnpm lint
- pnpm test --run *(fails: Vitest stays queued with 0 tests executed in this environment)*
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da30486dc8322b322bd0c4799df79)