### PR TITLE
Fix admin filter visibility for category pages

### DIFF
--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -373,6 +373,7 @@ import {
 } from '~/utils/_subset-to-filters'
 import type { CategorySubsetClause } from '~/types/category-subset'
 import { resolveFilterFieldTitle, resolveSortFieldTitle } from '~/utils/_field-localization'
+import { hasAdminAccess } from '~~/shared/utils/_roles'
 
 const route = useRoute()
 const router = useRouter()
@@ -380,7 +381,7 @@ const { locale, t } = useI18n()
 const requestURL = useRequestURL()
 const { isLoggedIn, roles } = useAuth()
 
-const isAdmin = computed(() => isLoggedIn.value && roles.value.includes('admin'))
+const isAdmin = computed(() => isLoggedIn.value && hasAdminAccess(roles.value))
 const ADMIN_EXCLUDED_FIELD = 'excluded'
 
 const adminFilterFields = computed<FieldMetadataDto[]>(() => {

--- a/frontend/shared/utils/_roles.spec.ts
+++ b/frontend/shared/utils/_roles.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasAdminAccess } from './_roles'
+
+describe('hasAdminAccess', () => {
+  it('returns false when roles are empty or undefined', () => {
+    expect(hasAdminAccess()).toBe(false)
+    expect(hasAdminAccess([])).toBe(false)
+  })
+
+  it('matches lowercase admin role', () => {
+    expect(hasAdminAccess(['admin'])).toBe(true)
+  })
+
+  it('matches uppercase admin role', () => {
+    expect(hasAdminAccess(['ADMIN'])).toBe(true)
+  })
+
+  it('matches prefixed admin role', () => {
+    expect(hasAdminAccess(['ROLE_ADMIN'])).toBe(true)
+  })
+
+  it('ignores roles without admin privileges', () => {
+    expect(hasAdminAccess(['user'])).toBe(false)
+    expect(hasAdminAccess(['domain'])).toBe(false)
+  })
+})

--- a/frontend/shared/utils/_roles.ts
+++ b/frontend/shared/utils/_roles.ts
@@ -1,0 +1,14 @@
+export const hasAdminAccess = (roles?: readonly (string | null | undefined)[] | null) => {
+  if (!roles || roles.length === 0) {
+    return false
+  }
+
+  return roles.some((role) => {
+    if (!role) {
+      return false
+    }
+
+    const normalized = role.trim().toLowerCase()
+    return normalized === 'admin' || normalized === 'role_admin'
+  })
+}


### PR DESCRIPTION
## Summary
- ensure the category page checks admin rights with the reusable `hasAdminAccess` helper so the excluded filter renders for all admin role encodings
- add a shared roles utility with unit coverage for mixed-case and prefixed admin roles

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dcc79e3908322856abece76ff338a)