### PR TITLE
Handle uncategorized product slugs

### DIFF
--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -20,6 +20,18 @@ describe('_product-route', () => {
       })
     })
 
+    it('supports routes without category segment', () => {
+      const match = matchProductRouteFromSegments([
+        '1234567890123-super-produit',
+      ])
+
+      expect(match).toEqual({
+        categorySlug: null,
+        gtin: '1234567890123',
+        slug: 'super-produit',
+      })
+    })
+
     it('normalises category slug casing', () => {
       const match = matchProductRouteFromSegments([
         'Beaute-Soins',
@@ -33,7 +45,7 @@ describe('_product-route', () => {
       })
     })
 
-    it('returns null when the route does not contain exactly two segments', () => {
+    it('returns null when the route is empty or contains more than two segments', () => {
       expect(matchProductRouteFromSegments([])).toBeNull()
       expect(matchProductRouteFromSegments(['only-one'])).toBeNull()
       expect(

--- a/frontend/shared/utils/_product-route.ts
+++ b/frontend/shared/utils/_product-route.ts
@@ -1,5 +1,5 @@
 export interface ProductRouteMatch {
-  categorySlug: string
+  categorySlug: string | null
   gtin: string
   slug: string
 }
@@ -8,17 +8,27 @@ const CATEGORY_SLUG_PATTERN = /^[a-z]+(?:-[a-z]+)*$/
 const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[a-z0-9-]+)$/i
 
 export const matchProductRouteFromSegments = (
-  segments: readonly string[]
+  segments: readonly string[],
 ): ProductRouteMatch | null => {
-  if (segments.length !== 2) {
+  if (segments.length === 0 || segments.length > 2) {
     return null
   }
 
-  const [rawCategorySlug, rawProductSegment] = segments
-  const categorySlug = rawCategorySlug?.trim().toLowerCase()
+  let rawCategorySlug: string | undefined
+  let rawProductSegment: string | undefined
 
-  if (!categorySlug || !CATEGORY_SLUG_PATTERN.test(categorySlug)) {
-    return null
+  if (segments.length === 1) {
+    ;[rawProductSegment] = segments
+  } else {
+    ;[rawCategorySlug, rawProductSegment] = segments
+  }
+
+  const categorySlug = rawCategorySlug?.trim().toLowerCase() ?? null
+
+  if (rawCategorySlug != null) {
+    if (!categorySlug || !CATEGORY_SLUG_PATTERN.test(categorySlug)) {
+      return null
+    }
   }
 
   const productMatch = rawProductSegment?.trim().match(PRODUCT_SEGMENT_PATTERN)


### PR DESCRIPTION
## Summary
- allow product route matching to accept uncategorized product slugs while preserving category validation
- update the product route unit tests to cover single-segment slugs and revised validation rules

## Testing
- pnpm lint
- pnpm vitest run shared/utils/_product-route.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dce0e49dc83229d2d2af774d09c3a)