### PR TITLE
fix: allow product routes without category prefix

### DIFF
--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -7,7 +7,7 @@ import {
 
 describe('_product-route', () => {
   describe('matchProductRouteFromSegments', () => {
-    it('returns route details when both segments are valid', () => {
+    it('returns route details when both segments are valid (category + combined)', () => {
       const match = matchProductRouteFromSegments([
         'electronique',
         '1234567890123-super-produit',
@@ -32,6 +32,33 @@ describe('_product-route', () => {
       })
     })
 
+    it('supports routes exposing GTIN and slug as separate segments', () => {
+      const match = matchProductRouteFromSegments([
+        '1234567890123',
+        'Super-Produit',
+      ])
+
+      expect(match).toEqual({
+        categorySlug: null,
+        gtin: '1234567890123',
+        slug: 'super-produit',
+      })
+    })
+
+    it('supports category-prefixed routes with split GTIN and slug segments', () => {
+      const match = matchProductRouteFromSegments([
+        'electronique',
+        '1234567890123',
+        'super-produit',
+      ])
+
+      expect(match).toEqual({
+        categorySlug: 'electronique',
+        gtin: '1234567890123',
+        slug: 'super-produit',
+      })
+    })
+
     it('normalises category slug casing', () => {
       const match = matchProductRouteFromSegments([
         'Beaute-Soins',
@@ -45,7 +72,7 @@ describe('_product-route', () => {
       })
     })
 
-    it('returns null when the route is empty or contains more than two segments', () => {
+    it('returns null when the route is empty or contains more than three segments', () => {
       expect(matchProductRouteFromSegments([])).toBeNull()
       expect(matchProductRouteFromSegments(['only-one'])).toBeNull()
       expect(
@@ -53,6 +80,7 @@ describe('_product-route', () => {
           'too',
           'many',
           'segments',
+          'here',
         ])
       ).toBeNull()
     })

--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -59,6 +59,28 @@ describe('_product-route', () => {
       })
     })
 
+    it('accepts unicode characters in the slug portion', () => {
+      expect(
+        matchProductRouteFromSegments(['1234567890123-Éco-Produit']),
+      ).toEqual({
+        categorySlug: null,
+        gtin: '1234567890123',
+        slug: 'éco-produit',
+      })
+
+      expect(
+        matchProductRouteFromSegments([
+          'maison-jardin',
+          '1234567890123',
+          'Produit-Éco',
+        ]),
+      ).toEqual({
+        categorySlug: 'maison-jardin',
+        gtin: '1234567890123',
+        slug: 'produit-éco',
+      })
+    })
+
     it('normalises category slug casing', () => {
       const match = matchProductRouteFromSegments([
         'Beaute-Soins',

--- a/frontend/shared/utils/_product-route.ts
+++ b/frontend/shared/utils/_product-route.ts
@@ -6,51 +6,97 @@ export interface ProductRouteMatch {
 
 const CATEGORY_SLUG_PATTERN = /^[a-z]+(?:-[a-z]+)*$/
 const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[a-z0-9-]+)$/i
+const GTIN_ONLY_PATTERN = /^\d{6,}$/
+const SLUG_ONLY_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i
 
-export const matchProductRouteFromSegments = (
-  segments: readonly string[],
-): ProductRouteMatch | null => {
-  if (segments.length === 0 || segments.length > 2) {
+const normaliseCategorySlug = (value: string | undefined): string | null => {
+  if (value == null) {
     return null
   }
 
-  let rawCategorySlug: string | undefined
-  let rawProductSegment: string | undefined
+  const slug = value.trim().toLowerCase()
 
-  if (segments.length === 1) {
-    ;[rawProductSegment] = segments
-  } else {
-    ;[rawCategorySlug, rawProductSegment] = segments
-  }
-
-  const categorySlug = rawCategorySlug?.trim().toLowerCase() ?? null
-
-  if (rawCategorySlug != null) {
-    if (!categorySlug || !CATEGORY_SLUG_PATTERN.test(categorySlug)) {
-      return null
-    }
-  }
-
-  const productMatch = rawProductSegment?.trim().match(PRODUCT_SEGMENT_PATTERN)
-
-  if (!productMatch?.groups) {
+  if (!slug || !CATEGORY_SLUG_PATTERN.test(slug)) {
     return null
   }
 
-  const { gtin, slug: rawSlug } = productMatch.groups as {
-    gtin: string
-    slug: string
+  return slug
+}
+
+const matchProductSegment = (
+  productSegment: string | undefined,
+): { gtin: string; slug: string } | null => {
+  const match = productSegment?.trim().match(PRODUCT_SEGMENT_PATTERN)
+
+  if (!match?.groups) {
+    return null
   }
 
-  if (!gtin || gtin.length < 6 || !rawSlug) {
+  const { gtin, slug } = match.groups as { gtin: string; slug: string }
+
+  if (!gtin || gtin.length < 6 || !slug) {
+    return null
+  }
+
+  return { gtin, slug: slug.toLowerCase() }
+}
+
+const matchSplitProductSegments = (
+  gtinSegment: string | undefined,
+  slugSegment: string | undefined,
+): { gtin: string; slug: string } | null => {
+  const gtin = gtinSegment?.trim() ?? ''
+  const slug = slugSegment?.trim() ?? ''
+
+  if (!GTIN_ONLY_PATTERN.test(gtin) || !SLUG_ONLY_PATTERN.test(slug)) {
     return null
   }
 
   return {
-    categorySlug,
     gtin,
-    slug: rawSlug.toLowerCase(),
+    slug: slug.toLowerCase(),
   }
+}
+
+export const matchProductRouteFromSegments = (
+  segments: readonly string[],
+): ProductRouteMatch | null => {
+  if (segments.length === 0 || segments.length > 3) {
+    return null
+  }
+
+  if (segments.length === 1) {
+    const product = matchProductSegment(segments[0])
+
+    return product ? { categorySlug: null, ...product } : null
+  }
+
+  if (segments.length === 2) {
+    const [first, second] = segments
+
+    const categorySlug = normaliseCategorySlug(first)
+
+    if (categorySlug) {
+      const product = matchProductSegment(second)
+
+      return product ? { categorySlug, ...product } : null
+    }
+
+    const product = matchSplitProductSegments(first, second)
+
+    return product ? { categorySlug: null, ...product } : null
+  }
+
+  const [maybeCategory, maybeGtin, maybeSlug] = segments
+  const categorySlug = normaliseCategorySlug(maybeCategory)
+
+  if (!categorySlug) {
+    return null
+  }
+
+  const product = matchSplitProductSegments(maybeGtin, maybeSlug)
+
+  return product ? { categorySlug, ...product } : null
 }
 
 export const isBackendNotFoundError = (error: unknown): boolean => {

--- a/frontend/shared/utils/_product-route.ts
+++ b/frontend/shared/utils/_product-route.ts
@@ -5,9 +5,9 @@ export interface ProductRouteMatch {
 }
 
 const CATEGORY_SLUG_PATTERN = /^[a-z]+(?:-[a-z]+)*$/
-const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[a-z0-9-]+)$/i
+const PRODUCT_SEGMENT_PATTERN = /^(?<gtin>\d{6,})-(?<slug>[\p{L}0-9-]+)$/u
 const GTIN_ONLY_PATTERN = /^\d{6,}$/
-const SLUG_ONLY_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/i
+const SLUG_ONLY_PATTERN = /^[\p{L}0-9]+(?:-[\p{L}0-9]+)*$/u
 
 const normaliseCategorySlug = (value: string | undefined): string | null => {
   if (value == null) {


### PR DESCRIPTION
## Summary
- extend the product route matcher to handle split GTIN and slug segments with or without a category prefix
- add helpers to normalise category slugs and reuse GTIN/slug validation logic
- cover the new routing shapes with additional unit tests

## Testing
- pnpm lint
- CI=1 pnpm vitest run shared/utils/_product-route.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690de993a2608322b28f2cc9b25cbff3)