### PR TITLE
Handle GTIN slugs when resolving redirects

### DIFF
--- a/frontend/shared/utils/_gtin.spec.ts
+++ b/frontend/shared/utils/_gtin.spec.ts
@@ -7,28 +7,33 @@ describe('shared/utils/_gtin', () => {
     it('accepts strings with at least six digits', () => {
       expect(isValidGtinParam('123456')).toBe(true)
       expect(isValidGtinParam('9876543210')).toBe(true)
+      expect(isValidGtinParam('123456-some-product')).toBe(true)
     })
 
     it('rejects non-strings and short values', () => {
       expect(isValidGtinParam(123456 as unknown as string)).toBe(false)
       expect(isValidGtinParam('12345')).toBe(false)
       expect(isValidGtinParam('12345a')).toBe(false)
+      expect(isValidGtinParam('123456a')).toBe(false)
     })
   })
 
   describe('extractGtinParam', () => {
     it('returns the GTIN from valid strings', () => {
       expect(extractGtinParam('123456')).toBe('123456')
+      expect(extractGtinParam('123456-some-product')).toBe('123456')
     })
 
     it('returns the first GTIN from arrays', () => {
       expect(extractGtinParam(['foo', '654321', '987654'])).toBe('654321')
+      expect(extractGtinParam(['foo', '654321-product'])).toBe('654321')
     })
 
     it('returns null for invalid inputs', () => {
       expect(extractGtinParam(undefined)).toBeNull()
       expect(extractGtinParam('123')).toBeNull()
       expect(extractGtinParam(['abc', '12345'])).toBeNull()
+      expect(extractGtinParam('123456a')).toBeNull()
     })
   })
 })

--- a/frontend/shared/utils/_gtin.ts
+++ b/frontend/shared/utils/_gtin.ts
@@ -1,19 +1,26 @@
-export const GTIN_PARAM_PATTERN = /^\d{6,}$/
+const GTIN_CAPTURE_PATTERN = /^(\d{6,})(?:$|[-_].*)$/
 
 export const isValidGtinParam = (value: unknown): value is string => {
-  return typeof value === 'string' && GTIN_PARAM_PATTERN.test(value)
+  return typeof value === 'string' && GTIN_CAPTURE_PATTERN.test(value)
 }
 
 export const extractGtinParam = (value: unknown): string | null => {
-  if (typeof value === 'string' && GTIN_PARAM_PATTERN.test(value)) {
-    return value
+  if (typeof value === 'string') {
+    const match = value.match(GTIN_CAPTURE_PATTERN)
+    return match ? match[1] : null
   }
 
   if (Array.isArray(value)) {
-    const match = value.find(
-      (item): item is string => typeof item === 'string' && GTIN_PARAM_PATTERN.test(item)
-    )
-    return match ?? null
+    for (const item of value) {
+      if (typeof item !== 'string') {
+        continue
+      }
+
+      const match = item.match(GTIN_CAPTURE_PATTERN)
+      if (match) {
+        return match[1]
+      }
+    }
   }
 
   return null


### PR DESCRIPTION
## Summary
- allow the GTIN redirect helper to accept hyphenated product slugs by parsing the numeric prefix
- cover slug and invalid suffix scenarios in the GTIN utility unit tests to guard regression

## Testing
- pnpm lint
- pnpm generate
- pnpm vitest run shared/utils/_gtin.spec.ts *(fails: Vitest Nuxt runner keeps the test file queued with 0 executed tests and never exits in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df3f14b708322a1d58584659d7bca)