### PR TITLE
feat(frontend): display product attribute sourcing details

### DIFF
--- a/frontend/app/components/product/ProductAttributesSection.spec.ts
+++ b/frontend/app/components/product/ProductAttributesSection.spec.ts
@@ -31,9 +31,23 @@ const VTableStub = defineComponent({
 
 const VIconStub = defineComponent({
   name: 'VIconStub',
-  props: { icon: { type: String, default: '' } },
+  props: {
+    icon: { type: String, default: '' },
+    color: { type: String, default: '' },
+    size: { type: [Number, String], default: 24 },
+  },
   setup(props) {
-    return () => h('i', { class: 'v-icon-stub' }, props.icon)
+    return () =>
+      h(
+        'i',
+        {
+          class: 'v-icon-stub',
+          'data-icon': props.icon,
+          'data-color': props.color,
+          'data-size': props.size,
+        },
+        props.icon,
+      )
   },
 })
 
@@ -41,6 +55,50 @@ const VChipStub = defineComponent({
   name: 'VChipStub',
   setup(_, { slots }) {
     return () => h('span', { class: 'v-chip-stub' }, slots.default?.())
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltipStub',
+  props: {
+    text: { type: String, default: '' },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub', 'data-text': props.text }, [
+        slots.activator?.({ props: {} }),
+        h('div', { class: 'v-tooltip-stub__content' }, slots.default?.()),
+      ])
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  props: {
+    icon: { type: Boolean, default: false },
+    density: { type: String, default: 'default' },
+    variant: { type: String, default: 'text' },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'button',
+        {
+          class: 'v-btn-stub',
+          'data-icon': props.icon,
+          'data-density': props.density,
+          'data-variant': props.variant,
+          type: 'button',
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VDividerStub = defineComponent({
+  name: 'VDividerStub',
+  setup() {
+    return () => h('hr', { class: 'v-divider-stub' })
   },
 })
 
@@ -115,22 +173,91 @@ const buildProduct = (): ProductDto => ({
   },
   attributes: {
     indexedAttributes: {
-      weight: { name: 'Weight', value: '<strong>2 kg</strong>' },
-      depth: { name: 'Depth', numericValue: 45 },
-      wireless: { name: 'Wireless', booleanValue: true },
+      weight: {
+        name: 'Weight',
+        value: '<strong>2 kg</strong>',
+        sourcing: {
+          bestValue: '2 kg',
+          conflicts: false,
+          sources: new Set([
+            {
+              datasourceName: 'datasource-a',
+              value: '2 kg',
+              language: 'fr',
+              icecatTaxonomyId: 1010,
+            },
+          ]),
+        },
+      },
+      depth: {
+        name: 'Depth',
+        numericValue: 45,
+        sourcing: {
+          bestValue: '45 cm',
+          conflicts: true,
+          sources: new Set([
+            {
+              datasourceName: 'datasource-a',
+              value: '45 cm',
+              language: 'fr',
+              icecatTaxonomyId: 2020,
+            },
+            {
+              datasourceName: 'datasource-b',
+              value: '44 cm',
+              language: 'en',
+              icecatTaxonomyId: 2020,
+            },
+          ]),
+        },
+      },
+      wireless: {
+        name: 'Wireless',
+        booleanValue: true,
+        sourcing: {
+          bestValue: 'Yes',
+          conflicts: false,
+          sources: new Set(),
+        },
+      },
     },
     classifiedAttributes: [
       {
         name: 'Performance',
         features: [{ name: 'Battery life', value: '10 h' }],
         unFeatures: [{ name: 'Noise level', value: 'High' }],
-        attributes: [{ name: 'Power', value: '<em>200 W</em>' }],
+        attributes: [
+          {
+            name: 'Power',
+            value: '<em>200 W</em>',
+            sourcing: {
+              bestValue: '200 W',
+              conflicts: false,
+              sources: new Set([
+                {
+                  datasourceName: 'datasource-a',
+                  value: '200 W',
+                },
+              ]),
+            },
+          },
+        ],
       },
       {
         name: 'Dimensions',
         features: [],
         unFeatures: [],
-        attributes: [{ name: 'Height', value: '120 cm' }],
+        attributes: [
+          {
+            name: 'Height',
+            value: '120 cm',
+            sourcing: {
+              bestValue: '120 cm',
+              conflicts: false,
+              sources: new Set(),
+            },
+          },
+        ],
       },
     ],
   },
@@ -172,6 +299,22 @@ const i18n = createI18n({
             empty: 'No detailed specifications are available for this product yet.',
             noResults: 'No specifications match your search.',
           },
+          sourcing: {
+            bestValue: 'Best value',
+            description: 'Details provided by our trusted data sources.',
+            columns: {
+              source: 'Source',
+              value: 'Value',
+              language: 'Lang',
+              taxonomy: 'Taxo.',
+            },
+            empty: 'No sourcing information available.',
+            status: {
+              conflicts: 'Conflicts detected',
+              noConflicts: 'No conflicts detected',
+            },
+            tooltipAriaLabel: 'Show sourcing details',
+          },
         },
       },
       common: {
@@ -197,6 +340,9 @@ const mountComponent = async (product: ProductDto) => {
         VTable: VTableStub,
         VIcon: VIconStub,
         VChip: VChipStub,
+        VTooltip: VTooltipStub,
+        VBtn: VBtnStub,
+        VDivider: VDividerStub,
         VImg: VImgStub,
         VTextField: VTextFieldStub,
         VRow: VRowStub,
@@ -244,13 +390,13 @@ describe('ProductAttributesSection', () => {
     expect(mainText).toContain('Weight')
     expect(mainText).toContain('2 kg')
     expect(mainText).toContain('Depth')
-    expect(mainText).toContain('45')
+    expect(mainText).toContain('45 cm')
     expect(mainText).toContain('Wireless')
     expect(mainText).toContain('Yes')
 
     const richValue = wrapper.find('.product-attributes__table-value')
     expect(richValue.exists()).toBe(true)
-    expect(richValue.html()).toContain('<strong>2 kg</strong>')
+    expect(richValue.text()).toContain('2 kg')
   })
 
   it('filters detailed groups with the search input', async () => {

--- a/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.spec.ts
+++ b/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.spec.ts
@@ -1,0 +1,162 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductAttributeSourcingLabel from './ProductAttributeSourcingLabel.vue'
+import type { ProductAttributeSourceDto } from '~~/shared/api-client'
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltipStub',
+  props: { text: { type: String, default: '' } },
+  setup(props, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub', 'data-text': props.text }, [
+        slots.activator?.({ props: {} }),
+        h('div', { class: 'v-tooltip-stub__content' }, slots.default?.()),
+      ])
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  props: {
+    icon: { type: Boolean, default: false },
+    density: { type: String, default: 'default' },
+    variant: { type: String, default: 'text' },
+    ariaLabel: { type: String, default: '' },
+  },
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'button',
+        {
+          class: 'v-btn-stub',
+          'data-icon': props.icon,
+          'data-density': props.density,
+          'data-variant': props.variant,
+          'aria-label': props.ariaLabel,
+          type: 'button',
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIconStub',
+  props: {
+    icon: { type: String, default: '' },
+    color: { type: String, default: '' },
+  },
+  setup(props) {
+    return () => h('i', { class: 'v-icon-stub', 'data-color': props.color }, props.icon)
+  },
+})
+
+const VCardStub = defineComponent({
+  name: 'VCardStub',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-card-stub' }, slots.default?.())
+  },
+})
+
+const VTableStub = defineComponent({
+  name: 'VTableStub',
+  setup(_, { slots }) {
+    return () => h('table', { class: 'v-table-stub' }, slots.default?.())
+  },
+})
+
+const VDividerStub = defineComponent({
+  name: 'VDividerStub',
+  setup() {
+    return () => h('hr', { class: 'v-divider-stub' })
+  },
+})
+
+const VChipStub = defineComponent({
+  name: 'VChipStub',
+  setup(_, { slots }) {
+    return () => h('span', { class: 'v-chip-stub' }, slots.default?.())
+  },
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      product: {
+        attributes: {
+          sourcing: {
+            bestValue: 'Best value',
+            description: 'More about this value.',
+            columns: {
+              source: 'Source',
+              value: 'Value',
+              language: 'Language',
+              taxonomy: 'Taxonomy',
+            },
+            empty: 'No sourcing information available.',
+            status: {
+              conflicts: 'Conflicts detected',
+              noConflicts: 'No conflicts detected',
+            },
+            tooltipAriaLabel: 'Show sourcing details',
+          },
+        },
+      },
+    },
+  },
+})
+
+describe('ProductAttributeSourcingLabel', () => {
+  const mountComponent = (sourcing?: ProductAttributeSourceDto | null, value = 'Fallback') =>
+    mount(ProductAttributeSourcingLabel, {
+      props: { sourcing, value },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          VTooltip: VTooltipStub,
+          VBtn: VBtnStub,
+          VIcon: VIconStub,
+          VCard: VCardStub,
+          VTable: VTableStub,
+          VDivider: VDividerStub,
+          VChip: VChipStub,
+        },
+      },
+    })
+
+  it('renders best value and conflict status', () => {
+    const sourcing: ProductAttributeSourceDto = {
+      bestValue: 'Argent',
+      conflicts: true,
+      sources: new Set([
+        {
+          datasourceName: 'fnac.com',
+          value: 'Argent',
+          language: 'fr',
+          icecatTaxonomyId: 46757,
+        },
+      ]),
+    }
+
+    const wrapper = mountComponent(sourcing, 'Original value')
+
+    expect(wrapper.text()).toContain('Argent')
+
+    const icon = wrapper.find('.v-icon-stub')
+    expect(icon.attributes('data-color')).toBe('warning')
+
+    const tableRows = wrapper.findAll('.v-table-stub tbody tr')
+    expect(tableRows).toHaveLength(1)
+    expect(tableRows[0].text()).toContain('fnac.com')
+  })
+
+  it('hides tooltip when sourcing is missing', () => {
+    const wrapper = mountComponent(null, 'Displayed value')
+    expect(wrapper.find('.v-btn-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Displayed value')
+  })
+})

--- a/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.vue
+++ b/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.vue
@@ -1,0 +1,319 @@
+<template>
+  <span class="product-attribute-sourcing">
+    <span class="product-attribute-sourcing__value">
+      <slot :display-value="displayValue">
+        <span class="product-attribute-sourcing__value-text">
+          {{ displayValue }}
+        </span>
+      </slot>
+    </span>
+
+    <v-tooltip
+      v-if="hasSourcingDetails"
+      location="top"
+      open-delay="150"
+      :close-delay="100"
+      :disabled="!hasSourcingDetails"
+    >
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          class="product-attribute-sourcing__info"
+          variant="text"
+          density="compact"
+          icon
+          :aria-label="tooltipAriaLabel"
+        >
+          <v-icon :icon="'mdi-information'" size="18" :color="iconColor" />
+        </v-btn>
+      </template>
+
+      <template #default>
+        <v-card class="product-attribute-sourcing__tooltip" elevation="8">
+          <header class="product-attribute-sourcing__tooltip-header">
+            <div class="product-attribute-sourcing__tooltip-legend">
+              <p class="product-attribute-sourcing__tooltip-title">
+                {{ t('product.attributes.sourcing.bestValue') }}
+              </p>
+              <p class="product-attribute-sourcing__tooltip-highlight">{{ displayValue }}</p>
+            </div>
+            <v-chip
+              size="small"
+              :color="chipColor"
+              variant="tonal"
+              class="product-attribute-sourcing__tooltip-chip"
+            >
+              {{ statusLabel }}
+            </v-chip>
+          </header>
+
+          <v-divider class="product-attribute-sourcing__tooltip-divider" />
+
+          <div class="product-attribute-sourcing__tooltip-body">
+            <p class="product-attribute-sourcing__tooltip-description">
+              {{ t('product.attributes.sourcing.description') }}
+            </p>
+
+            <v-table
+              v-if="normalizedSources.length"
+              density="compact"
+              class="product-attribute-sourcing__sources"
+            >
+              <thead>
+                <tr>
+                  <th scope="col">{{ t('product.attributes.sourcing.columns.source') }}</th>
+                  <th scope="col">{{ t('product.attributes.sourcing.columns.value') }}</th>
+                  <th scope="col">{{ t('product.attributes.sourcing.columns.language') }}</th>
+                  <th scope="col">{{ t('product.attributes.sourcing.columns.taxonomy') }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="source in normalizedSources" :key="sourceKey(source)">
+                  <td>{{ source.datasourceName ?? '—' }}</td>
+                  <td>{{ formatSourceValue(source.value) }}</td>
+                  <td>{{ formatLanguage(source.language) }}</td>
+                  <td>{{ formatTaxonomy(source.icecatTaxonomyId) }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+
+            <p v-else class="product-attribute-sourcing__tooltip-empty">
+              {{ t('product.attributes.sourcing.empty') }}
+            </p>
+          </div>
+        </v-card>
+      </template>
+    </v-tooltip>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  ProductAttributeSourceDto,
+  ProductSourcedAttributeDto,
+} from '~~/shared/api-client'
+
+const props = defineProps({
+  sourcing: {
+    type: Object as PropType<ProductAttributeSourceDto | null | undefined>,
+    default: null,
+  },
+  value: {
+    type: String,
+    default: '',
+  },
+})
+
+const { t } = useI18n()
+
+const bestValue = computed(() => {
+  const candidate = props.sourcing?.bestValue
+  if (typeof candidate !== 'string') {
+    return null
+  }
+
+  const trimmed = candidate.trim()
+  return trimmed.length ? trimmed : null
+})
+
+const displayValue = computed(() => bestValue.value ?? props.value)
+
+const hasSourcingDetails = computed(() => {
+  if (!props.sourcing) {
+    return false
+  }
+
+  if (bestValue.value) {
+    return true
+  }
+
+  const sources = props.sourcing.sources
+  if (sources instanceof Set) {
+    return sources.size > 0
+  }
+
+  if (Array.isArray(sources)) {
+    return sources.length > 0
+  }
+
+  return false
+})
+
+const normalizedSources = computed<ProductSourcedAttributeDto[]>(() => {
+  const sources = props.sourcing?.sources
+  if (!sources) {
+    return []
+  }
+
+  if (sources instanceof Set) {
+    return Array.from(sources)
+  }
+
+  if (Array.isArray(sources)) {
+    return sources
+  }
+
+  return []
+})
+
+const conflicts = computed(() => Boolean(props.sourcing?.conflicts))
+
+const iconColor = computed(() => (conflicts.value ? 'warning' : 'primary'))
+
+const chipColor = computed(() => (conflicts.value ? 'warning' : 'primary'))
+
+const statusLabel = computed(() =>
+  t(
+    conflicts.value
+      ? 'product.attributes.sourcing.status.conflicts'
+      : 'product.attributes.sourcing.status.noConflicts',
+  ),
+)
+
+const tooltipAriaLabel = computed(() =>
+  t('product.attributes.sourcing.tooltipAriaLabel'),
+)
+
+const formatLanguage = (language?: string | null) => {
+  if (!language) {
+    return '—'
+  }
+
+  return language.trim().toUpperCase()
+}
+
+const formatTaxonomy = (taxonomy?: number | null) => {
+  if (typeof taxonomy === 'number' && Number.isFinite(taxonomy)) {
+    return taxonomy.toString()
+  }
+
+  return '—'
+}
+
+const formatSourceValue = (value?: string | null) => {
+  if (typeof value !== 'string') {
+    return '—'
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : '—'
+}
+
+const sourceKey = (source: ProductSourcedAttributeDto) => {
+  return [
+    source.datasourceName ?? '',
+    source.value ?? '',
+    source.language ?? '',
+    source.icecatTaxonomyId ?? '',
+    source.name ?? '',
+  ]
+    .map((segment) => String(segment ?? ''))
+    .join('|')
+}
+</script>
+
+<style scoped>
+.product-attribute-sourcing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.product-attribute-sourcing__value-text {
+  color: inherit;
+}
+
+.product-attribute-sourcing__info {
+  --product-attribute-icon-bg: rgba(var(--v-theme-surface-primary-120), 0.8);
+  --product-attribute-icon-hover: rgba(var(--v-theme-surface-primary-100), 0.95);
+  border-radius: 999px;
+  padding: 0.15rem;
+  min-width: auto;
+}
+
+.product-attribute-sourcing__info:hover,
+.product-attribute-sourcing__info:focus-visible {
+  background: var(--product-attribute-icon-hover);
+}
+
+.product-attribute-sourcing__tooltip {
+  padding: 1rem 1.25rem;
+  max-width: min(420px, 80vw);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-attribute-sourcing__tooltip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.product-attribute-sourcing__tooltip-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.product-attribute-sourcing__tooltip-title {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+}
+
+.product-attribute-sourcing__tooltip-highlight {
+  margin: 0;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-attribute-sourcing__tooltip-chip {
+  flex-shrink: 0;
+}
+
+.product-attribute-sourcing__tooltip-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.product-attribute-sourcing__sources {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.product-attribute-sourcing__sources thead th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+  padding: 0.5rem 0.75rem;
+}
+
+.product-attribute-sourcing__sources tbody td {
+  padding: 0.45rem 0.75rem;
+  font-size: 0.85rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-attribute-sourcing__sources tbody tr:nth-child(odd) {
+  background: rgba(var(--v-theme-surface-primary-050), 0.65);
+}
+
+.product-attribute-sourcing__tooltip-empty {
+  margin: 0;
+  font-style: italic;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+@media (max-width: 600px) {
+  .product-attribute-sourcing__tooltip {
+    max-width: min(360px, 92vw);
+  }
+}
+</style>

--- a/frontend/app/components/product/attributes/ProductAttributesDetailCard.vue
+++ b/frontend/app/components/product/attributes/ProductAttributesDetailCard.vue
@@ -31,8 +31,11 @@
           <tr v-for="attribute in group.attributes" :key="attribute.key">
             <th scope="row">{{ attribute.name }}</th>
             <td>
-              <!-- eslint-disable-next-line vue/no-v-html -->
-              <span class="product-attributes__table-value" v-html="attribute.value" />
+              <ProductAttributeSourcingLabel
+                class="product-attributes__table-value"
+                :sourcing="attribute.sourcing"
+                :value="attribute.value"
+              />
             </td>
           </tr>
         </tbody>
@@ -44,6 +47,7 @@
 <script setup lang="ts">
 import { toRefs } from 'vue'
 import type { PropType } from 'vue'
+import ProductAttributeSourcingLabel from '~/components/product/attributes/ProductAttributeSourcingLabel.vue'
 import type { DetailGroupView } from '~/components/product/ProductAttributesSection.vue'
 
 const props = defineProps({

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1639,6 +1639,22 @@
         "untitledGroup": "Additional details",
         "empty": "No detailed specifications are available for this product yet.",
         "noResults": "No specifications match your search."
+      },
+      "sourcing": {
+        "bestValue": "Best value",
+        "description": "Details provided by our trusted data sources.",
+        "columns": {
+          "source": "Source",
+          "value": "Value",
+          "language": "Language",
+          "taxonomy": "Taxonomy"
+        },
+        "empty": "No sourcing information available yet.",
+        "status": {
+          "conflicts": "Conflicts detected",
+          "noConflicts": "No conflicts detected"
+        },
+        "tooltipAriaLabel": "View sourcing details"
       }
     },
     "docs": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1639,6 +1639,22 @@
         "untitledGroup": "Détails complémentaires",
         "empty": "Aucune caractéristique détaillée n'est disponible pour ce produit pour le moment.",
         "noResults": "Aucune caractéristique ne correspond à votre recherche."
+      },
+      "sourcing": {
+        "bestValue": "Valeur retenue",
+        "description": "Détails fournis par nos sources de données fiables.",
+        "columns": {
+          "source": "Source",
+          "value": "Valeur",
+          "language": "Langue",
+          "taxonomy": "Taxonomie"
+        },
+        "empty": "Aucune information de sourcing disponible pour le moment.",
+        "status": {
+          "conflicts": "Conflits détectés",
+          "noConflicts": "Aucun conflit détecté"
+        },
+        "tooltipAriaLabel": "Afficher les détails de sourcing"
       }
     },
     "docs": {


### PR DESCRIPTION
## Summary
- add a reusable `ProductAttributeSourcingLabel` that surfaces the best value, conflicts and datasource tooltip details for attributes
- replace raw attribute spans in the hero and specification tables with the sourcing label and adapt formatting to prefer sourced values
- localise sourcing vocabulary and cover the new component plus adjusted attributes section with tests

## Testing
- pnpm lint
- CI=1 pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e123063088322993aa5e8fdf6f82e)