### PR TITLE
feat(frontend): refresh product attribute sourcing tooltip

### DIFF
--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -47,6 +47,7 @@
                     class="product-hero__attribute-value-label"
                     :sourcing="attribute.sourcing"
                     :value="attribute.value"
+                    :enable-tooltip="attribute.enableTooltip !== false"
                   >
                     <template #default="{ displayValue }">
                       <span class="product-hero__attribute-value-content" v-bind="tooltipProps">
@@ -70,6 +71,7 @@
                 class="product-hero__attribute-value-label"
                 :sourcing="attribute.sourcing"
                 :value="attribute.value"
+                :enable-tooltip="attribute.enableTooltip !== false"
               >
                 <template #default="{ displayValue }">
                   <span class="product-hero__attribute-value-content">
@@ -201,6 +203,7 @@ type HeroAttribute = DisplayedAttribute & {
   flag?: string | null
   tooltip?: string
   sourcing?: ProductAttributeSourceDto | null
+  enableTooltip?: boolean
 }
 
 const popularAttributeConfigs = computed(() => props.popularAttributes ?? [])
@@ -238,6 +241,7 @@ const popularAttributes = computed<HeroAttribute[]>(() =>
         label: attribute.label,
         value,
         sourcing,
+        enableTooltip: false,
       }
     })
     .filter((attribute): attribute is HeroAttribute => attribute != null),

--- a/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.spec.ts
+++ b/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.spec.ts
@@ -90,12 +90,13 @@ const i18n = createI18n({
         attributes: {
           sourcing: {
             bestValue: 'Best value',
-            description: 'More about this value.',
+            sourceCount: {
+              one: '{count} source',
+              other: '{count} sources',
+            },
             columns: {
               source: 'Source',
               value: 'Value',
-              language: 'Language',
-              taxonomy: 'Taxonomy',
             },
             empty: 'No sourcing information available.',
             status: {
@@ -111,9 +112,13 @@ const i18n = createI18n({
 })
 
 describe('ProductAttributeSourcingLabel', () => {
-  const mountComponent = (sourcing?: ProductAttributeSourceDto | null, value = 'Fallback') =>
+  const mountComponent = (
+    sourcing?: ProductAttributeSourceDto | null,
+    value = 'Fallback',
+    extraProps: Record<string, unknown> = {},
+  ) =>
     mount(ProductAttributeSourcingLabel, {
-      props: { sourcing, value },
+      props: { sourcing, value, ...extraProps },
       global: {
         plugins: [i18n],
         stubs: {
@@ -152,11 +157,31 @@ describe('ProductAttributeSourcingLabel', () => {
     const tableRows = wrapper.findAll('.v-table-stub tbody tr')
     expect(tableRows).toHaveLength(1)
     expect(tableRows[0].text()).toContain('fnac.com')
+
+    const countLabel = wrapper.find('.product-attribute-sourcing__tooltip-count')
+    expect(countLabel.text()).toContain('1 source')
   })
 
   it('hides tooltip when sourcing is missing', () => {
     const wrapper = mountComponent(null, 'Displayed value')
     expect(wrapper.find('.v-btn-stub').exists()).toBe(false)
     expect(wrapper.text()).toContain('Displayed value')
+  })
+
+  it('can disable tooltip even when sourcing exists', () => {
+    const sourcing: ProductAttributeSourceDto = {
+      bestValue: 'Argent',
+      conflicts: false,
+      sources: [
+        {
+          datasourceName: 'fnac.com',
+          value: 'Argent',
+        },
+      ],
+    }
+
+    const wrapper = mountComponent(sourcing, 'Argent', { enableTooltip: false })
+    expect(wrapper.find('.v-btn-stub').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Argent')
   })
 })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1642,12 +1642,13 @@
       },
       "sourcing": {
         "bestValue": "Best value",
-        "description": "Details provided by our trusted data sources.",
+        "sourceCount": {
+          "one": "{count} source",
+          "other": "{count} sources"
+        },
         "columns": {
           "source": "Source",
-          "value": "Value",
-          "language": "Language",
-          "taxonomy": "Taxonomy"
+          "value": "Value"
         },
         "empty": "No sourcing information available yet.",
         "status": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1642,12 +1642,13 @@
       },
       "sourcing": {
         "bestValue": "Valeur retenue",
-        "description": "Détails fournis par nos sources de données fiables.",
+        "sourceCount": {
+          "one": "{count} source",
+          "other": "{count} sources"
+        },
         "columns": {
           "source": "Source",
-          "value": "Valeur",
-          "language": "Langue",
-          "taxonomy": "Taxonomie"
+          "value": "Valeur"
         },
         "empty": "Aucune information de sourcing disponible pour le moment.",
         "status": {


### PR DESCRIPTION
## Summary
- update the product attribute sourcing tooltip to show the number of sources and a simplified datasource/value table
- add the ability to disable sourcing tooltips for hero popular attributes and refresh locale strings
- extend the sourcing label unit tests to cover the new behaviour

## Testing
- pnpm lint
- pnpm test --run app/components/product/attributes/ProductAttributeSourcingLabel.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1a2bbbcc832295b4f1ed040d9c70)