### PR TITLE
Revamp home hero helpers and blog CTA layout

### DIFF
--- a/frontend/app/components/home/sections/HomeBlogSection.vue
+++ b/frontend/app/components/home/sections/HomeBlogSection.vue
@@ -33,6 +33,15 @@ const secondaryFallbackIconSize = 48
         <header class="home-section__header">
           <h2 id="home-blog-title">{{ t('home.blog.title') }}</h2>
           <p class="home-section__subtitle">{{ t('home.blog.subtitle') }}</p>
+          <v-btn
+            class="home-section__cta"
+            :to="localePath({ name: 'blog' })"
+            color="primary"
+            variant="tonal"
+            size="large"
+          >
+            {{ t('home.blog.cta') }}
+          </v-btn>
         </header>
 
         <div v-if="loading" class="home-blog__skeletons">
@@ -131,17 +140,6 @@ const secondaryFallbackIconSize = 48
           </v-alert>
         </template>
 
-        <div class="home-blog__actions">
-          <v-btn
-            class="home-blog__cta"
-            :to="localePath({ name: 'blog' })"
-            color="primary"
-            variant="tonal"
-            size="large"
-          >
-            {{ t('home.blog.cta') }}
-          </v-btn>
-        </div>
       </div>
     </v-container>
   </section>
@@ -167,6 +165,12 @@ const secondaryFallbackIconSize = 48
   display: flex
   flex-direction: column
   gap: 0.75rem
+
+.home-section__cta
+  align-self: flex-start
+  margin-top: 0.35rem
+  border-radius: 999px
+  font-weight: 600
 
 .home-section__subtitle
   margin: 0
@@ -279,13 +283,6 @@ const secondaryFallbackIconSize = 48
 .home-blog__empty
   border-radius: clamp(1.25rem, 3vw, 1.75rem)
 
-.home-blog__actions
-  display: flex
-  justify-content: center
-  padding-top: 0.5rem
-
-.home-blog__cta
-  min-width: 240px
 
 @media (max-width: 959px)
   .home-blog__featured-card

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -2,12 +2,18 @@ import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { defineComponent, h, ref, computed } from 'vue'
 
-const messages: Record<string, string> = {
+const messages: Record<string, unknown> = {
   'home.hero.search.label': 'Search for a product',
   'home.hero.search.placeholder': 'Search a product',
   'home.hero.search.ariaLabel': 'Search input',
   'home.hero.search.cta': 'NUDGER',
   'home.hero.search.helper': '50M references',
+  'home.hero.search.helpers': [
+    { icon: '🌿', label: 'A unique eco assessment' },
+    { icon: '🏷️', label: 'Best prices' },
+    { icon: '🛡️', label: 'Independent & open' },
+    { icon: '⚡', label: '50M references' },
+  ],
   'home.hero.eyebrow': 'Responsible shopping',
   'home.hero.title': 'Responsible choices are not a luxury',
   'home.hero.subtitle': 'Save time, stay true to your values.',
@@ -98,7 +104,10 @@ const messages: Record<string, string> = {
   'siteIdentity.siteName': 'Nudger'
 }
 
-const translate = (key: string) => messages[key] ?? key
+const translate = (key: string) => {
+  const value = messages[key]
+  return typeof value === 'string' ? value : key
+}
 
 const localeRef = ref('fr-FR')
 const headSpy = vi.fn()
@@ -195,6 +204,7 @@ const useBlogComposable = () => ({
 
 mockNuxtImport('useI18n', () => () => ({
   t: (key: string) => translate(key),
+  tm: (key: string) => messages[key],
   locale: localeRef,
   availableLocales: ['fr-FR', 'en-US'],
 }))

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -50,7 +50,25 @@
         "placeholder": "Search a product (e.g. television, smartphone…)",
         "ariaLabel": "Search for a responsible product",
         "cta": "NUDGER",
-        "helper": "Already 50M+ references in open data."
+        "helper": "Already 50M+ references in open data.",
+        "helpers": [
+          {
+            "icon": "🌿",
+            "label": "A unique ecological and environmental assessment"
+          },
+          {
+            "icon": "🏷️",
+            "label": "The best prices on the market"
+          },
+          {
+            "icon": "🛡️",
+            "label": "Independent comparator, open-source software and open data"
+          },
+          {
+            "icon": "⚡",
+            "label": "Already 50M+ references in open data"
+          }
+        ]
       }
     },
     "problems": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -50,7 +50,25 @@
         "placeholder": "Recherchez un produit (ex. téléviseur, smartphone…)",
         "ariaLabel": "Rechercher un produit responsable",
         "cta": "NUDGER",
-        "helper": "Déjà +50 millions de références en open data."
+        "helper": "Déjà +50 millions de références en open data.",
+        "helpers": [
+          {
+            "icon": "🌿",
+            "label": "Une évaluation écologique et environnementale unique"
+          },
+          {
+            "icon": "🏷️",
+            "label": "Les meilleurs prix du marché"
+          },
+          {
+            "icon": "🛡️",
+            "label": "Comparateur indépendant, logiciel libre et données ouvertes"
+          },
+          {
+            "icon": "⚡",
+            "label": "Déjà +50 millions de références en open data"
+          }
+        ]
       }
     },
     "problems": {


### PR DESCRIPTION
## Summary
- add reusable hero helper list with icons and tighten the overlapping category carousel sizing
- move the blog call-to-action under the section subtitle and make sure card links always point to /blog/<slug>
- update translations and tests to support the helper list structure

## Testing
- pnpm lint
- CI=1 pnpm vitest --run --reporter=basic app/pages/index.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910610d36f883228b4a96f2096f392b)