### PR TITLE
feat: collapse category filters by default

### DIFF
--- a/frontend/app/components/category/CategoryEcoscoreCard.vue
+++ b/frontend/app/components/category/CategoryEcoscoreCard.vue
@@ -18,7 +18,7 @@
         {{ t('category.filters.ecoscore.title') }}
       </p>
       <p class="category-ecoscore-card__description">
-        {{ t('category.filters.ecoscore.description') }}
+        {{ description }}
       </p>
       <span class="category-ecoscore-card__cta">
         {{ t('category.filters.ecoscore.cta') }}
@@ -31,9 +31,22 @@
 <script setup lang="ts">
 const props = defineProps<{
   verticalHomeUrl?: string | null
+  categoryName?: string | null
 }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
+
+const normalizedCategoryName = computed(() => {
+  if (!props.categoryName) {
+    return ''
+  }
+
+  return props.categoryName.toLocaleLowerCase(locale.value)
+})
+
+const description = computed(() =>
+  t('category.filters.ecoscore.description', { category: normalizedCategoryName.value }),
+)
 
 const ecoscoreUrl = computed(() => {
   if (!props.verticalHomeUrl) {
@@ -51,9 +64,10 @@ const ecoscoreUrl = computed(() => {
 <style scoped lang="sass">
 .category-ecoscore-card
   display: flex
-  align-items: center
+  align-items: flex-start
   gap: 1rem
-  padding: 1.25rem
+  padding: 1.5rem
+  min-height: 160px
   background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.95), rgba(var(--v-theme-surface-primary-120), 0.9))
   color: rgb(var(--v-theme-text-neutral-strong))
   text-decoration: none
@@ -82,6 +96,8 @@ const ecoscoreUrl = computed(() => {
     display: flex
     flex-direction: column
     gap: 0.35rem
+    flex: 1 1 auto
+    min-height: 0
 
   &__title
     font-size: 1rem
@@ -92,7 +108,7 @@ const ecoscoreUrl = computed(() => {
     margin: 0
     color: rgb(var(--v-theme-text-neutral-secondary))
     font-size: 0.875rem
-    line-height: 1.35
+    line-height: 1.5
 
   &__cta
     display: inline-flex

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -34,6 +34,7 @@
       v-if="ecoscoreLinkAvailable"
       class="category-page__ecoscore-entry mt-4"
       :vertical-home-url="props.verticalHomeUrl ?? undefined"
+      :category-name="props.categoryName ?? undefined"
     />
 
     <template v-if="hasDocumentation">
@@ -77,12 +78,14 @@ const props = withDefaults(
     wikiPages: WikiPageConfig[]
     relatedPosts: BlogPostDto[]
     verticalHomeUrl?: string | null
+    categoryName?: string | null
     showAdminPanel?: boolean
     adminFilterFields?: FieldMetadataDto[]
   }>(),
   {
     baselineAggregations: () => [],
     verticalHomeUrl: null,
+    categoryName: null,
     showAdminPanel: false,
     adminFilterFields: () => [],
   },

--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -85,6 +85,7 @@
               :wiki-pages="category?.wikiPages ?? []"
               :related-posts="category?.relatedPosts ?? []"
               :vertical-home-url="category?.verticalHomeUrl ?? null"
+              :category-name="categoryDisplayName"
               :show-admin-panel="showAdminFilters"
               :admin-filter-fields="adminFilterFields"
               @update:filters="onFiltersChange"
@@ -120,6 +121,7 @@
               :wiki-pages="category?.wikiPages ?? []"
               :related-posts="category?.relatedPosts ?? []"
               :vertical-home-url="category?.verticalHomeUrl ?? null"
+              :category-name="categoryDisplayName"
               :show-admin-panel="showAdminFilters"
               :admin-filter-fields="adminFilterFields"
               @update:filters="onFiltersChange"
@@ -151,7 +153,7 @@
           <meta itemprop="numberOfItems" :content="String(resultsCount)" />
 
           <div class="category-page__toolbar">
-            <div class="category-page__toolbar-left">
+            <div class="category-page__toolbar-section category-page__toolbar-section--left">
               <v-btn
                 v-if="!isDesktop"
                 color="primary"
@@ -163,25 +165,6 @@
               </v-btn>
 
               <CategoryResultsCount :count="resultsCount" />
-            </div>
-
-            <div class="category-page__toolbar-actions">
-              <div class="category-page__search">
-                <v-text-field
-                  v-model="searchTerm"
-                  :label="$t('category.products.searchPlaceholder')"
-                  prepend-inner-icon="mdi-magnify"
-                  clearable
-                  hide-details
-                  density="comfortable"
-                  class="category-page__search-input"
-                />
-                <v-tooltip
-                  activator="parent"
-                  :text="$t('category.products.tooltips.search')"
-                  location="bottom"
-                />
-              </div>
 
               <div class="category-page__sort">
                 <div class="category-page__sort-select">
@@ -220,7 +203,28 @@
                   </v-btn>
                 </v-btn-toggle>
               </div>
+            </div>
 
+            <div class="category-page__toolbar-section category-page__toolbar-section--center">
+              <div class="category-page__search">
+                <v-text-field
+                  v-model="searchTerm"
+                  :label="$t('category.products.searchPlaceholder')"
+                  prepend-inner-icon="mdi-magnify"
+                  clearable
+                  hide-details
+                  density="comfortable"
+                  class="category-page__search-input"
+                />
+                <v-tooltip
+                  activator="parent"
+                  :text="$t('category.products.tooltips.search')"
+                  location="bottom"
+                />
+              </div>
+            </div>
+
+            <div class="category-page__toolbar-section category-page__toolbar-section--right">
               <v-btn-toggle v-model="viewMode" mandatory class="category-page__view-toggle">
                 <v-btn value="cards" :aria-label="$t('category.products.viewCards')">
                   <v-icon icon="mdi-view-grid" />
@@ -490,6 +494,13 @@ const heroImage = computed(() => {
 })
 
 const siteName = computed(() => String(t('siteIdentity.siteName')))
+const categoryDisplayName = computed(
+  () =>
+    category.value?.verticalHomeTitle ??
+    category.value?.verticalMetaTitle ??
+    category.value?.verticalHomeDescription ??
+    siteName.value,
+)
 const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
 const seoTitle = computed(
   () => category.value?.verticalMetaTitle ?? category.value?.verticalHomeTitle ?? siteName.value,
@@ -657,7 +668,7 @@ const sortOptions = computed(() => sortOptionsData.value ?? null)
 
 const isDesktop = computed(() => (isHydrated.value ? display.lgAndUp.value : initialIsDesktop.value))
 const filtersDrawer = ref(false)
-const filtersCollapsed = ref(false)
+const filtersCollapsed = ref(true)
 const filtersToggleLabel = computed(() =>
   filtersCollapsed.value
     ? t('category.filters.toggle.show')
@@ -1780,18 +1791,21 @@ const clearAllFilters = () => {
     margin-bottom: 1.5rem
     width: 100%
 
-  &__toolbar-left
+  &__toolbar-section
     display: flex
     align-items: center
-    gap: 1rem
-    flex-wrap: wrap
-
-  &__toolbar-actions
-    display: flex
-    align-items: center
-    flex-wrap: wrap
     gap: 1rem
     width: 100%
+    flex-wrap: wrap
+
+  &__toolbar-section--left
+    justify-content: flex-start
+
+  &__toolbar-section--center
+    justify-content: center
+
+  &__toolbar-section--right
+    justify-content: flex-end
 
   &__fast-filters
     display: flex
@@ -1863,7 +1877,10 @@ const clearAllFilters = () => {
 
   &__search
     position: relative
-    min-width: 260px
+    min-width: min(260px, 100%)
+    width: 100%
+    max-width: 420px
+    flex: 1 1 100%
 
   &__search-input
     width: 100%
@@ -1883,7 +1900,6 @@ const clearAllFilters = () => {
 
   &__view-toggle
     border-radius: 999px
-    margin-left: auto
 
   &__results-count
     margin: 0
@@ -1998,18 +2014,25 @@ const clearAllFilters = () => {
 
 @media (min-width: 960px)
   .category-page__toolbar
-    flex-direction: row
+    display: grid
+    grid-template-columns: auto minmax(260px, 1fr) auto
     align-items: center
+    gap: 1.5rem
 
-  .category-page__toolbar-left
-    flex: 0 0 auto
+  .category-page__toolbar-section
+    flex-wrap: nowrap
 
-  .category-page__toolbar-actions
-    flex: 1 1 auto
-    width: auto
+  .category-page__toolbar-section--left
+    justify-content: flex-start
 
-  .category-page__view-toggle
-    margin-left: auto
+  .category-page__toolbar-section--center
+    justify-content: center
+
+  .category-page__toolbar-section--right
+    justify-content: flex-end
+
+  .category-page__search
+    flex: 0 1 420px
 
 @media (min-width: 1280px)
   .category-page__layout
@@ -2030,12 +2053,16 @@ const clearAllFilters = () => {
     flex-direction: column
     align-items: stretch
 
-  .category-page__toolbar-actions
-    justify-content: space-between
-
   .category-page__search
     flex: 1 1 100%
     min-width: 0
+    max-width: 100%
+
+  .category-page__toolbar-section--center
+    justify-content: center
+
+  .category-page__toolbar-section--right
+    justify-content: flex-end
 
   .category-page__sort
     width: 100%

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -423,8 +423,8 @@
         "show": "Show filters column"
       },
       "ecoscore": {
-        "title": "Discover the Eco-score",
-        "description": "Understand how we evaluate each product's environmental footprint and the indicators we monitor.",
+        "title": "Discover the Impact Score",
+        "description": "Understand how the eco-score is calculated for {category}",
         "cta": "Explore the methodology",
         "ariaLabel": "Open the Eco-score guide"
       }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -423,8 +423,8 @@
         "show": "Afficher la colonne des filtres"
       },
       "ecoscore": {
-        "title": "Découvrir l'Eco-score",
-        "description": "Comprenez comment nous évaluons l'empreinte environnementale de chaque produit et les indicateurs suivis.",
+        "title": "Découvrir l'Impact Score",
+        "description": "Comprendre comment est calculé l'écoscore des {category}",
         "cta": "Explorer la méthodologie",
         "ariaLabel": "Ouvrir le guide Eco-score"
       }


### PR DESCRIPTION
## Summary
- default the desktop filters column to collapsed on category pages
- realign category toolbar sections so sort sits near the counter, search is centered, and view toggles stay on the right
- refresh the ecoscore card copy/layout with dynamic category naming and taller content spacing, including updated i18n strings

## Testing
- pnpm lint
- pnpm test --run *(fails: existing ProductHero.spec expectation unrelated to these changes)*
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910780826f88322aac1589527702f8e)