### PR TITLE
feat: refresh product hero and impact surfaces

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -385,8 +385,10 @@ describe('ProductHero', () => {
     expect(impactOverview.text()).not.toContain('Impact score')
     expect(impactOverview.get('.impact-score-stub').text()).toBe('3.5')
 
+    const brandLine = wrapper.get('.product-hero__brand-line')
     const attributes = wrapper.get('.product-hero__attributes')
-    expect(attributes.element.previousElementSibling).toBe(impactOverview.element)
+    expect(impactOverview.element.nextElementSibling).toBe(brandLine.element)
+    expect(brandLine.element.nextElementSibling).toBe(attributes.element)
 
     await wrapper.unmount()
   })
@@ -433,8 +435,10 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     const breadcrumbLinks = wrapper.findAll('.breadcrumbs-stub__item')
-    expect(breadcrumbLinks).toHaveLength(2)
+    expect(breadcrumbLinks).toHaveLength(3)
     expect(breadcrumbLinks[1]?.attributes('href')).toBe('/appliances')
+    expect(breadcrumbLinks[2]?.text()).toBe('BrandCo - Model X')
+    expect(breadcrumbLinks[2]?.attributes('href')).toBe('#')
 
     const chips = wrapper.findAll('.product-hero__price-chip')
     expect(chips).toHaveLength(2)

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -10,7 +10,7 @@
     </header>
 
     <div class="product-impact__primary">
-      <ProductImpactEcoScoreCard :score="primaryScore" />
+      <ProductImpactEcoScoreCard :score="primaryScore" :vertical-home-url="verticalHomeUrl" />
     </div>
 
     <div class="product-impact__analysis">
@@ -75,10 +75,15 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  verticalHomeUrl: {
+    type: String,
+    default: '',
+  },
 })
 
 const radarValues = toRef(props, 'radarValues')
 const productName = toRef(props, 'productName')
+const verticalHomeUrl = toRef(props, 'verticalHomeUrl')
 
 const primaryScore = computed(() => props.scores[0] ?? null)
 const secondaryScores = computed(() => props.scores.slice(1))
@@ -122,7 +127,7 @@ const showRadar = computed(() => filteredRadarValues.value.length >= 3)
 
 .product-impact__analysis {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: 1fr;
   gap: 1.5rem;
   align-items: stretch;
 }
@@ -142,9 +147,9 @@ const showRadar = computed(() => filteredRadarValues.value.length >= 3)
   min-height: 320px;
 }
 
-@media (max-width: 1280px) {
+@media (min-width: 960px) {
   .product-impact__analysis {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
   }
 }
 

--- a/frontend/app/components/product/impact/ProductAlternativeCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductAlternativeCard.spec.ts
@@ -125,8 +125,8 @@ describe('ProductAlternativeCard', () => {
       },
     })
 
-    expect(wrapper.find('.product-alternative-card__title').text()).toBe('EcoCorp X')
-    expect(wrapper.find('.product-alternative-card__subtitle').text()).toContain('EcoCorp')
+    expect(wrapper.find('.product-alternative-card__title').text()).toBe('EcoCorp • X')
+    expect(wrapper.find('.product-alternative-card__attributes').exists()).toBe(false)
 
     const priceText = wrapper.find('.product-alternative-card__price').text()
     expect(priceText).toMatch(/299/)

--- a/frontend/app/components/product/impact/ProductAlternatives.spec.ts
+++ b/frontend/app/components/product/impact/ProductAlternatives.spec.ts
@@ -8,7 +8,7 @@ import { flushPromises } from '@vue/test-utils'
 vi.mock('./ProductAlternativeCard.vue', () => ({
   default: {
     name: 'ProductAlternativeCardStub',
-    props: { product: Object },
+    props: { product: Object, popularAttributes: Array },
     template: '<div class="product-alternative-card-stub"></div>',
   },
 }))
@@ -24,7 +24,7 @@ describe('ProductAlternatives', () => {
             alternatives: {
               title: 'Greener alternatives',
               subtitle: 'Discover better options.',
-              empty: 'No alternatives.',
+              bestProduct: 'Best product message.',
               error: 'Error loading alternatives.',
               retry: 'Retry',
               untitled: 'Untitled product',

--- a/frontend/app/components/product/impact/ProductAlternatives.vue
+++ b/frontend/app/components/product/impact/ProductAlternatives.vue
@@ -47,7 +47,11 @@
               :key="alternative.gtin ?? alternative.fullSlug ?? alternative.slug ?? JSON.stringify(alternative.identity)"
               class="product-alternatives__slide-item"
             >
-              <ProductAlternativeCard :product="alternative" class="product-alternatives__card" />
+              <ProductAlternativeCard
+                :product="alternative"
+                :popular-attributes="normalizedPopularAttributes"
+                class="product-alternatives__card"
+              />
             </v-slide-group-item>
           </v-slide-group>
         </div>
@@ -57,8 +61,9 @@
             {{ t('product.impact.alternatives.retry') }}
           </v-btn>
         </div>
-        <div v-else class="product-alternatives__empty">
-          <p>{{ t('product.impact.alternatives.empty') }}</p>
+        <div v-else class="product-alternatives__empty-card">
+          <v-icon icon="mdi-emoticon-happy-outline" size="56" class="product-alternatives__empty-icon" aria-hidden="true" />
+          <p class="product-alternatives__empty-message">{{ t('product.impact.alternatives.bestProduct') }}</p>
         </div>
       </template>
     </div>
@@ -598,27 +603,27 @@ const retryFetch = () => {
 .product-alternatives__scroller {
   position: relative;
   display: flex;
+  justify-content: center;
 }
 
 .product-alternatives__slide-group {
   width: 100%;
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 1rem;
+}
+
+.product-alternatives__slide-group :deep(.v-slide-group__content) {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0.25rem;
 }
 
 .product-alternatives__slide-item {
-  padding-inline: 0.75rem;
-}
-
-.product-alternatives__slide-item:first-child {
-  padding-left: 0.5rem;
-}
-
-.product-alternatives__slide-item:last-child {
-  padding-right: 0.5rem;
+  padding: 0;
 }
 
 .product-alternatives__card {
-  width: 220px;
+  width: 240px;
   max-width: 100%;
 }
 
@@ -641,13 +646,37 @@ const retryFetch = () => {
   color: rgb(var(--v-theme-error));
 }
 
+.product-alternatives__empty-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(var(--v-theme-surface-primary-080), 0.7);
+  color: rgb(var(--v-theme-primary));
+  font-weight: 600;
+  font-size: 1.05rem;
+  justify-content: center;
+  align-self: center;
+  max-width: 520px;
+}
+
+.product-alternatives__empty-icon {
+  color: rgba(var(--v-theme-primary), 0.85);
+}
+
+.product-alternatives__empty-message {
+  margin: 0;
+  color: rgb(var(--v-theme-primary));
+}
+
 @media (max-width: 960px) {
   .product-alternatives {
     padding: 1.25rem;
   }
 
   .product-alternatives__card {
-    width: 200px;
+    width: 220px;
   }
 }
 </style>

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -86,7 +86,7 @@ describe('ProductImpactDetailsTable', () => {
           }),
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
-            props: ['value'],
+            props: ['value', 'labelKey', 'labelParams', 'tooltipKey', 'tooltipParams'],
             setup(props) {
               return () => h('span', { class: 'coefficient-stub' }, `coefficient:${props.value}`)
             },
@@ -132,7 +132,7 @@ describe('ProductImpactDetailsTable', () => {
           }),
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
-            props: ['value'],
+            props: ['value', 'labelKey', 'labelParams', 'tooltipKey', 'tooltipParams'],
             setup(props) {
               return () => h('span', { class: 'coefficient-stub' }, `coefficient:${props.value}`)
             },

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -26,7 +26,11 @@
         </div>
       </template>
       <template #[`item.coefficient`]="{ item }">
-        <ImpactCoefficientBadge v-if="item.coefficient != null" :value="item.coefficient" />
+        <ImpactCoefficientBadge
+          v-if="item.coefficient != null"
+          :value="item.coefficient"
+          :tooltip-params="{ scoreName: item.label }"
+        />
         <span v-else class="impact-details__coefficient-empty">—</span>
       </template>
     </v-data-table>

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -34,6 +34,7 @@ import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
 const props = defineProps<{
   score: ScoreView | null
+  verticalHomeUrl?: string | null
 }>()
 
 const { locale } = useI18n()
@@ -48,9 +49,26 @@ const normalizedScore = computed(() => {
   return Math.max(0, Math.min(rawValue, 5))
 })
 
+const normalizedVerticalEcoscorePath = computed(() => {
+  const raw = props.verticalHomeUrl?.trim()
+  if (!raw) {
+    return null
+  }
+
+  const sanitized = raw.replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!sanitized.length) {
+    return null
+  }
+
+  return `/${sanitized}/ecoscore`
+})
+
 const methodologyHref = computed(() => {
-  const basePath = resolveLocalizedRoutePath('impact-score', locale.value)
-  return `${basePath}#calculation`
+  if (normalizedVerticalEcoscorePath.value) {
+    return normalizedVerticalEcoscorePath.value
+  }
+
+  return resolveLocalizedRoutePath('impact-score', locale.value)
 })
 </script>
 

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -71,7 +71,7 @@ describe('ProductImpactSubscoreGenericCard', () => {
           }),
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
-            props: ['value'],
+            props: ['value', 'labelKey', 'labelParams', 'tooltipKey', 'tooltipParams'],
             setup(props) {
               return () => h('span', { class: 'coefficient-stub' }, `coefficient:${props.value}`)
             },

--- a/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
@@ -3,7 +3,11 @@
     <div class="impact-subscore-header__info">
       <h4 class="impact-subscore-header__title">{{ title }}</h4>
       <p v-if="subtitle" class="impact-subscore-header__subtitle">{{ subtitle }}</p>
-      <ImpactCoefficientBadge v-if="coefficientValue != null" :value="coefficientValue" />
+      <ImpactCoefficientBadge
+        v-if="coefficientValue != null"
+        :value="coefficientValue"
+        :tooltip-params="{ scoreName: title }"
+      />
     </div>
 
     <div v-if="on20Value" class="impact-subscore-header__score" aria-hidden="true">

--- a/frontend/app/components/shared/ui/ImpactCoefficientBadge.vue
+++ b/frontend/app/components/shared/ui/ImpactCoefficientBadge.vue
@@ -1,6 +1,21 @@
 <template>
+  <v-tooltip v-if="badgeLabel && tooltipLabel" :text="tooltipLabel" location="top">
+    <template #activator="{ props: tooltipProps }">
+      <v-chip
+        class="impact-coefficient-badge"
+        density="comfortable"
+        rounded="pill"
+        variant="flat"
+        :data-coefficient-decimal="normalizedValue ?? undefined"
+        :data-coefficient-percent="percentValue ?? undefined"
+        v-bind="tooltipProps"
+      >
+        <span class="impact-coefficient-badge__label">{{ badgeLabel }}</span>
+      </v-chip>
+    </template>
+  </v-tooltip>
   <v-chip
-    v-if="badgeLabel"
+    v-else-if="badgeLabel"
     class="impact-coefficient-badge"
     density="comfortable"
     rounded="pill"
@@ -16,7 +31,13 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const props = defineProps<{ value?: number | null }>()
+const props = defineProps<{
+  value?: number | null
+  labelKey?: string
+  labelParams?: Record<string, unknown>
+  tooltipKey?: string
+  tooltipParams?: Record<string, unknown>
+}>()
 
 const { n, t } = useI18n()
 
@@ -42,17 +63,45 @@ const percentValue = computed<number | null>(() => {
   return normalizedValue.value * 100
 })
 
-const badgeLabel = computed<string | null>(() => {
+const percentLabel = computed<string | null>(() => {
   if (percentValue.value == null) {
     return null
   }
 
-  const formatted = n(percentValue.value, {
+  return n(percentValue.value, {
     maximumFractionDigits: 0,
     minimumFractionDigits: 0,
   })
+})
 
-  return t('product.impact.weightChip', { value: formatted })
+const badgeLabel = computed<string | null>(() => {
+  if (percentLabel.value == null) {
+    return null
+  }
+
+  const key = props.labelKey?.trim().length ? props.labelKey : 'product.impact.weightChip'
+  const params = {
+    value: percentLabel.value,
+    percent: percentLabel.value,
+    ...(props.labelParams ?? {}),
+  }
+
+  return t(key as string, params)
+})
+
+const tooltipLabel = computed<string | null>(() => {
+  if (percentLabel.value == null) {
+    return null
+  }
+
+  const key = props.tooltipKey?.trim().length ? props.tooltipKey : 'product.impact.weightTooltip'
+  const params = {
+    value: percentLabel.value,
+    percent: percentLabel.value,
+    ...(props.tooltipParams ?? {}),
+  }
+
+  return t(key as string, params)
 })
 </script>
 

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -42,7 +42,7 @@ const props = defineProps({
     default: 5,
   },
   size: {
-    type: String as PropType<'small' | 'medium' | 'large'>,
+    type: String as PropType<'small' | 'medium' | 'large' | 'xlarge'>,
     default: 'medium',
   },
   color: {
@@ -78,6 +78,8 @@ const ratingSize = computed(() => {
       return 18
     case 'large':
       return 32
+    case 'xlarge':
+      return 40
     default:
       return 24
   }
@@ -121,6 +123,12 @@ const showValue = computed(() => props.showValue)
   --impact-score-gap: 0.625rem;
   --impact-score-rating-gap: 0.5rem;
   --impact-score-value-font-size: 1.05rem;
+}
+
+.impact-score--xlarge {
+  --impact-score-gap: 0.75rem;
+  --impact-score-rating-gap: 0.6rem;
+  --impact-score-value-font-size: 1.2rem;
 }
 
 .impact-score__rating :deep(.v-rating__wrapper) {

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -49,6 +49,7 @@
             :radar-values="radarValues"
             :loading="loadingAggregations"
             :product-name="productTitle"
+            :vertical-home-url="verticalHomeUrl"
           />
         </section>
 
@@ -330,6 +331,7 @@ const productTitle = computed(() => {
 })
 
 const heroPopularAttributes = computed(() => categoryDetail.value?.popularAttributes ?? [])
+const verticalHomeUrl = computed(() => categoryDetail.value?.verticalHomeUrl?.trim() ?? '')
 
 const productBreadcrumbs = computed<ProductHeroBreadcrumb[]>(() => {
   const breadcrumbs = categoryDetail.value?.breadCrumb ?? []

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1707,7 +1707,6 @@
         "selected": "In comparison"
       },
       "gtin": "GTIN code",
-      "gtinCountryLabel": "GTIN registration country",
       "gtinTooltip": "Based on the product GTIN code, this does not necessarily indicate the manufacturing location.",
       "mediaType": {
         "image": "image",
@@ -1737,7 +1736,7 @@
       "alternatives": {
         "title": "Greener alternatives",
         "subtitle": "Discover similar products with a better impact score or price.",
-        "empty": "No alternatives match the selected filters yet.",
+        "bestProduct": "Voted best product for your criteria!",
         "error": "We couldn't load alternative products. Please try again.",
         "retry": "Retry",
         "untitled": "Unnamed product",
@@ -1762,7 +1761,8 @@
       "methodologyLink": "Access the methodology",
       "methodologyLinkAria": "Open the Impact Score methodology",
       "percentile": "Percentile",
-      "weightChip": "Counts for {value}% of the total score",
+      "weightChip": "{value}% of the total score",
+      "weightTooltip": "The {scoreName} score counts for {value}% of the total score",
       "subscoreDetailsToggle": "View indicator details",
       "subscoreEyebrow": "Impact indicator",
       "primaryScoreLabel": "Overall impact",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1707,7 +1707,6 @@
         "selected": "Comparé"
       },
       "gtin": "Code GTIN",
-      "gtinCountryLabel": "Pays d'enregistrement du GTIN",
       "gtinTooltip": "Basé sur le code GTIN du produit, cela n'indique pas nécessairement le lieu de fabrication.",
       "mediaType": {
         "image": "l’image",
@@ -1737,7 +1736,7 @@
       "alternatives": {
         "title": "Alternatives plus vertes",
         "subtitle": "Découvrez des produits similaires avec un meilleur score d'impact ou un prix plus accessible.",
-        "empty": "Aucune alternative ne correspond encore aux filtres sélectionnés.",
+        "bestProduct": "Élu meilleur produit par rapport à vos critères !",
         "error": "Impossible de charger les alternatives pour le moment. Réessayez.",
         "retry": "Réessayer",
         "untitled": "Produit sans nom",
@@ -1762,7 +1761,8 @@
       "methodologyLink": "Accéder à la méthodologie",
       "methodologyLinkAria": "Ouvrir la méthodologie de l'Impact Score",
       "percentile": "Percentile",
-      "weightChip": "Compte pour {value}% de la note totale",
+      "weightChip": "{value}% de la note totale",
+      "weightTooltip": "Le score {scoreName} compte pour {value}% de la note totale",
       "subscoreDetailsToggle": "Voir les détails de l'indicateur",
       "subscoreEyebrow": "Indicateur d'impact",
       "primaryScoreLabel": "Score global",


### PR DESCRIPTION
## Summary
- Product hero layout – Breadcrumbs now sit centered beneath the title with schema.org markup; the impact score moved above the meta block, uses the new `xlarge` size, and the GTIN country row hides its label.
- Breadcrumb microdata – Replaced the Vuetify breadcrumb with a custom `<nav>`/`<ol>` structure and accessible styling.
- Impact section – `ProductImpactSection` accepts `verticalHomeUrl`, passes it to `ProductImpactEcoScoreCard`, and the analysis grid shifts to a 1/3 (radar) vs. 2/3 (details) split on desktop.
- Eco-score card – Methodology CTA links to `/{verticalHomeUrl}/ecoscore` when provided.
- Impact coefficient badge – Added customizable label/tooltip props and tooltip support so tables and cards explain weights (“30 % de la note totale”).
- Impact score component – Added `xlarge` preset for hero usage.
- Product alternatives – Empty state now renders a centered happy-face card, slide-group spacing is increased/centered, and cards receive popular-attribute chips and reorganized layout (brand/model title, price below score, button pinned to footer).
- Page wiring – `app/pages/[...slug].vue` now passes the category `verticalHomeUrl` through to the impact section and appends the brand/model breadcrumb leaf.
- Locale updates – French and English strings now say “{value}% of the total score”, add a tooltip string, drop the unused GTIN country label, and add `product.impact.alternatives.bestProduct`.
- Breadcrumb semantics – Ensure the final crumb exposes `aria-current="page"` while keeping schema.org markup intact.

## Testing
- pnpm lint
- CI=1 pnpm test -- --run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910836e2ca48322b3bd39db2deb43d9)