### PR TITLE
Enhance product hero breadcrumbs and radar comparison toggles

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -219,7 +219,7 @@ describe('ProductHero', () => {
   const breadcrumbs = [
     { title: 'Home', link: '/' },
     { title: 'Appliances', link: '/appliances' },
-    { title: 'Demo Product', link: '/appliances/demo-product' },
+    { title: 'BrandCo', link: '/appliances#state-brandco' },
   ]
 
   const popularAttributes = [
@@ -365,7 +365,8 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     expect(wrapper.get('.product-hero__title').text()).toBe('Demo Product')
-    expect(wrapper.get('.product-hero__brand-line').text()).toBe('BrandCo - Model X')
+    expect(wrapper.get('.product-hero__brand-name').text()).toBe('BrandCo')
+    expect(wrapper.get('.product-hero__model-name').text()).toBe('Model X')
 
     const attributes = wrapper.findAll('.product-hero__attribute')
     expect(attributes).toHaveLength(2)
@@ -435,10 +436,12 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     const breadcrumbLinks = wrapper.findAll('.breadcrumbs-stub__item')
-    expect(breadcrumbLinks).toHaveLength(3)
+    expect(breadcrumbLinks).toHaveLength(4)
     expect(breadcrumbLinks[1]?.attributes('href')).toBe('/appliances')
-    expect(breadcrumbLinks[2]?.text()).toBe('BrandCo - Model X')
-    expect(breadcrumbLinks[2]?.attributes('href')).toBe('#')
+    expect(breadcrumbLinks[2]?.text()).toBe('BrandCo')
+    expect(breadcrumbLinks[2]?.attributes('href')).toBe('/appliances#state-brandco')
+    expect(breadcrumbLinks[3]?.text()).toBe('Model X')
+    expect(breadcrumbLinks[3]?.attributes('href')).toBe('#')
 
     const chips = wrapper.findAll('.product-hero__price-chip')
     expect(chips).toHaveLength(2)

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -14,12 +14,39 @@
     </div>
 
     <div class="product-impact__analysis">
-      <ProductImpactRadarChart
+      <div
         v-if="showRadar"
         class="product-impact__analysis-radar"
-        :values="filteredRadarValues"
-        :product-name="productName"
-      />
+      >
+        <div
+          v-if="radarControls.length"
+          class="product-impact__analysis-radar-controls"
+          role="group"
+          :aria-label="radarControlsAriaLabel"
+        >
+          <v-btn
+            v-for="control in radarControls"
+            :key="control.key"
+            class="product-impact__analysis-radar-toggle"
+            :class="{ 'product-impact__analysis-radar-toggle--active': isSeriesActive(control.key) }"
+            color="primary"
+            variant="tonal"
+            density="comfortable"
+            :aria-pressed="isSeriesActive(control.key)"
+            :title="control.label"
+            @click="toggleSeries(control.key)"
+          >
+            {{ control.label }}
+          </v-btn>
+        </div>
+
+        <ProductImpactRadarChart
+          class="product-impact__analysis-radar-chart"
+          :axes="radarAxes"
+          :series="chartSeries"
+          :product-name="productName"
+        />
+      </div>
       <ProductImpactDetailsTable
         class="product-impact__analysis-details"
         :class="{ 'product-impact__analysis-details--full': !showRadar }"
@@ -46,13 +73,40 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import type { PropType } from 'vue'
+import { useI18n } from 'vue-i18n'
 import ProductImpactEcoScoreCard from './impact/ProductImpactEcoScoreCard.vue'
 import ProductImpactRadarChart from './impact/ProductImpactRadarChart.vue'
 import ProductImpactDetailsTable from './impact/ProductImpactDetailsTable.vue'
 import ProductImpactSubscoreCard from './impact/ProductImpactSubscoreCard.vue'
 import type { ScoreView } from './impact/impact-types'
+
+type RadarSeriesKey = 'current' | 'best' | 'worst'
+
+interface RadarAxisEntry {
+  id: string
+  name: string
+}
+
+interface RadarSeriesEntry {
+  key: RadarSeriesKey
+  name: string
+  values: Array<number | null>
+}
+
+interface RadarDataset {
+  axes: RadarAxisEntry[]
+  series: RadarSeriesEntry[]
+}
+
+interface ChartSeriesEntry {
+  label: string
+  values: Array<number | null>
+  lineColor: string
+  areaColor: string
+  symbolColor: string
+}
 
 const props = defineProps({
   sectionId: {
@@ -63,9 +117,9 @@ const props = defineProps({
     type: Array as PropType<ScoreView[]>,
     default: () => [],
   },
-  radarValues: {
-    type: Array as PropType<Array<{ id: string; name: string; value: number }>>,
-    default: () => [],
+  radarData: {
+    type: Object as PropType<RadarDataset>,
+    default: () => ({ axes: [], series: [] }),
   },
   productName: {
     type: String,
@@ -81,20 +135,112 @@ const props = defineProps({
   },
 })
 
-const radarValues = toRef(props, 'radarValues')
+const radarData = toRef(props, 'radarData')
 const productName = toRef(props, 'productName')
 const verticalHomeUrl = toRef(props, 'verticalHomeUrl')
+const { t } = useI18n()
 
 const primaryScore = computed(() => props.scores[0] ?? null)
 const secondaryScores = computed(() => props.scores.slice(1))
 const detailScores = computed(() => props.scores.filter((score) => score.id !== 'ECOSCORE'))
-const filteredRadarValues = computed(() =>
-  radarValues.value
-    .filter((entry) => entry.id && entry.name && entry.name.trim().length && Number.isFinite(entry.value))
-    .filter((entry) => entry.id.toUpperCase() !== 'ECOSCORE')
-    .map((entry) => ({ name: entry.name, value: entry.value })),
+const radarAxes = computed<RadarAxisEntry[]>(() => radarData.value.axes ?? [])
+const availableSeries = computed<RadarSeriesEntry[]>(() => radarData.value.series ?? [])
+const availableSeriesKeys = computed<RadarSeriesKey[]>(() => availableSeries.value.map((entry) => entry.key))
+const activeSeriesKeys = ref<RadarSeriesKey[]>([])
+
+watch(
+  availableSeries,
+  (series) => {
+    const keys = series.map((entry) => entry.key)
+    if (!keys.length) {
+      activeSeriesKeys.value = []
+      return
+    }
+
+    const currentKeys = new Set(activeSeriesKeys.value)
+    const ordered = keys.filter((key) => currentKeys.has(key))
+    activeSeriesKeys.value = ordered.length ? ordered : [...keys]
+  },
+  { immediate: true },
 )
-const showRadar = computed(() => filteredRadarValues.value.length >= 3)
+
+const radarSeriesStyles: Record<RadarSeriesKey, { line: string; area: string; symbol: string }> = {
+  current: {
+    line: 'rgba(25, 118, 210, 0.85)',
+    area: 'rgba(25, 118, 210, 0.25)',
+    symbol: 'rgba(25, 118, 210, 1)',
+  },
+  best: {
+    line: 'rgba(46, 125, 50, 0.85)',
+    area: 'rgba(46, 125, 50, 0.25)',
+    symbol: 'rgba(46, 125, 50, 1)',
+  },
+  worst: {
+    line: 'rgba(198, 40, 40, 0.85)',
+    area: 'rgba(198, 40, 40, 0.2)',
+    symbol: 'rgba(198, 40, 40, 1)',
+  },
+}
+
+const translationKeys: Record<RadarSeriesKey, string> = {
+  current: 'product.impact.radarControls.current',
+  best: 'product.impact.radarControls.best',
+  worst: 'product.impact.radarControls.worst',
+}
+
+const radarControls = computed(() =>
+  availableSeries.value.map((entry) => ({
+    key: entry.key,
+    label: t(translationKeys[entry.key], { product: entry.name }),
+  })),
+)
+
+const radarControlsAriaLabel = computed(() => t('product.impact.radarControls.ariaLabel'))
+
+const isSeriesActive = (key: RadarSeriesKey) => activeSeriesKeys.value.includes(key)
+
+const toggleSeries = (key: RadarSeriesKey) => {
+  if (!availableSeriesKeys.value.includes(key)) {
+    return
+  }
+
+  const current = new Set(activeSeriesKeys.value)
+  if (current.has(key)) {
+    current.delete(key)
+    const ordered = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
+    activeSeriesKeys.value = ordered.length ? ordered : [key]
+    return
+  }
+
+  current.add(key)
+  activeSeriesKeys.value = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
+}
+
+const chartSeries = computed<ChartSeriesEntry[]>(() => {
+  if (!radarAxes.value.length) {
+    return []
+  }
+
+  return availableSeries.value
+    .filter((entry) => activeSeriesKeys.value.includes(entry.key))
+    .map((entry) => {
+      const style = radarSeriesStyles[entry.key]
+      const values = radarAxes.value.map((_, index) => {
+        const value = entry.values[index]
+        return typeof value === 'number' && Number.isFinite(value) ? value : null
+      })
+
+      return {
+        label: t(translationKeys[entry.key], { product: entry.name }),
+        values,
+        lineColor: style.line,
+        areaColor: style.area,
+        symbolColor: style.symbol,
+      }
+    })
+})
+
+const showRadar = computed(() => radarAxes.value.length >= 3 && chartSeries.value.length > 0)
 </script>
 
 <style scoped>
@@ -130,6 +276,32 @@ const showRadar = computed(() => filteredRadarValues.value.length >= 3)
   grid-template-columns: 1fr;
   gap: 1.5rem;
   align-items: stretch;
+}
+
+.product-impact__analysis-radar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.product-impact__analysis-radar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.product-impact__analysis-radar-toggle {
+  text-transform: none;
+  font-weight: 500;
+  border-radius: 999px;
+}
+
+.product-impact__analysis-radar-toggle--active {
+  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.15);
+}
+
+.product-impact__analysis-radar-chart {
+  flex: 1 1 auto;
 }
 
 .product-impact__analysis-details--full {

--- a/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.vue
+++ b/frontend/app/components/product/attributes/ProductAttributeSourcingLabel.vue
@@ -78,10 +78,9 @@
     </span>
 
     <span class="product-attribute-sourcing__value">
-      <slot :display-value="displayValue">
-        <span class="product-attribute-sourcing__value-text">
-          {{ displayValue }}
-        </span>
+      <slot :display-value="displayValue" :display-html="sanitizedDisplayHtml">
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <span class="product-attribute-sourcing__value-text" v-html="sanitizedDisplayHtml || displayValue" />
       </slot>
     </span>
   </span>
@@ -96,6 +95,7 @@ import type {
   ProductAttributeSourceDto,
   ProductSourcedAttributeDto,
 } from '~~/shared/api-client'
+import { _sanitizeHtml } from '~~/shared/utils/sanitizer'
 
 const props = defineProps({
   sourcing: {
@@ -132,7 +132,22 @@ const bestValue = computed(() => {
   return trimmed.length ? trimmed : null
 })
 
-const displayValue = computed(() => bestValue.value ?? props.value)
+const displayValue = computed(() => {
+  const candidate = bestValue.value ?? props.value ?? ''
+  return typeof candidate === 'string' ? candidate : String(candidate ?? '')
+})
+
+const sanitizedDisplayHtml = computed(() => {
+  const raw = displayValue.value
+  if (!raw.length) {
+    return ''
+  }
+
+  const { sanitizedHtml } = _sanitizeHtml(raw)
+  const sanitized = sanitizedHtml.value ?? ''
+
+  return sanitized.length ? sanitized : raw
+})
 
 const isIterable = <T,>(candidate: unknown): candidate is Iterable<T> =>
   Boolean(candidate && typeof (candidate as Iterable<T>)[Symbol.iterator] === 'function')

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1767,6 +1767,12 @@
       "subscoreEyebrow": "Impact indicator",
       "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
+      "radarControls": {
+        "ariaLabel": "Toggle radar comparison series",
+        "current": "This product: {product}",
+        "best": "Best: {product}",
+        "worst": "Worst: {product}"
+      },
       "scoreRanking": "Factor ranking",
       "scoreValue": "Relative score",
       "valueOutOf": "{value} / {max}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1767,6 +1767,12 @@
       "subscoreEyebrow": "Indicateur d'impact",
       "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
+      "radarControls": {
+        "ariaLabel": "Afficher ou masquer les produits à comparer sur le radar",
+        "current": "Ce produit : {product}",
+        "best": "Le mieux : {product}",
+        "worst": "Le pire : {product}"
+      },
       "scoreRanking": "Classement du facteur",
       "scoreValue": "Score relatif",
       "valueOutOf": "{value} / {max}",


### PR DESCRIPTION
## Summary
- extend the product breadcrumb builder to inject brand links with pre-filtered hashes and show model entries
- split hero brand/model display and allow sanitized HTML values in attribute sourcing labels
- expose best/worst/current radar comparison toggles with updated chart wiring and translations

## Testing
- pnpm lint
- pnpm vitest --run components/product/ProductHero.spec.ts components/product/attributes/ProductAttributeSourcingLabel.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a4c18c948322bbbcf7dedbf724b2)