### PR TITLE
Improve product hero breadcrumbs and radar legend

### DIFF
--- a/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationBreadcrumbs.vue
@@ -15,15 +15,23 @@
         itemscope
         itemtype="https://schema.org/ListItem"
       >
-        <component
-          :is="item.component"
-          v-if="item.isLink"
-          v-bind="item.componentProps"
+        <NuxtLink
+          v-if="item.type === 'internal'"
+          :to="item.href"
           class="category-navigation-breadcrumbs__link"
           itemprop="item"
         >
           <span class="category-navigation-breadcrumbs__label" itemprop="name">{{ item.title }}</span>
-        </component>
+        </NuxtLink>
+        <a
+          v-else-if="item.type === 'external'"
+          :href="item.href"
+          class="category-navigation-breadcrumbs__link"
+          rel="noopener noreferrer"
+          itemprop="item"
+        >
+          <span class="category-navigation-breadcrumbs__label" itemprop="name">{{ item.title }}</span>
+        </a>
         <span
           v-else
           class="category-navigation-breadcrumbs__link category-navigation-breadcrumbs__link--current"
@@ -51,13 +59,17 @@ interface BreadcrumbItem {
 type BreadcrumbRenderItem =
   | {
       title: string
-      isLink: true
-      component: string
-      componentProps: Record<string, unknown>
+      type: 'internal'
+      href: string
     }
   | {
       title: string
-      isLink: false
+      type: 'external'
+      href: string
+    }
+  | {
+      title: string
+      type: 'current'
     }
 
 const props = defineProps<{
@@ -77,27 +89,22 @@ const breadcrumbItems = computed<BreadcrumbRenderItem[]>(() => {
     if (!rawLink || isLast) {
       return {
         title: item.title,
-        isLink: false,
+        type: 'current',
       }
     }
 
     if (/^https?:\/\//i.test(rawLink)) {
       return {
         title: item.title,
-        isLink: true,
-        component: 'a',
-        componentProps: {
-          href: rawLink,
-          rel: 'noopener noreferrer',
-        },
+        type: 'external',
+        href: rawLink,
       }
     }
 
     return {
       title: item.title,
-      isLink: true,
-      component: 'NuxtLink',
-      componentProps: { to: rawLink },
+      type: 'internal',
+      href: rawLink.startsWith('/') ? rawLink : `/${rawLink}`,
     }
   })
 })

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -18,28 +18,6 @@
         v-if="showRadar"
         class="product-impact__analysis-radar"
       >
-        <div
-          v-if="radarControls.length"
-          class="product-impact__analysis-radar-controls"
-          role="group"
-          :aria-label="radarControlsAriaLabel"
-        >
-          <v-btn
-            v-for="control in radarControls"
-            :key="control.key"
-            class="product-impact__analysis-radar-toggle"
-            :class="{ 'product-impact__analysis-radar-toggle--active': isSeriesActive(control.key) }"
-            color="primary"
-            variant="tonal"
-            density="comfortable"
-            :aria-pressed="isSeriesActive(control.key)"
-            :title="control.label"
-            @click="toggleSeries(control.key)"
-          >
-            {{ control.label }}
-          </v-btn>
-        </div>
-
         <ProductImpactRadarChart
           class="product-impact__analysis-radar-chart"
           :axes="radarAxes"
@@ -73,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, toRef } from 'vue'
 import type { PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ProductImpactEcoScoreCard from './impact/ProductImpactEcoScoreCard.vue'
@@ -145,24 +123,6 @@ const secondaryScores = computed(() => props.scores.slice(1))
 const detailScores = computed(() => props.scores.filter((score) => score.id !== 'ECOSCORE'))
 const radarAxes = computed<RadarAxisEntry[]>(() => radarData.value.axes ?? [])
 const availableSeries = computed<RadarSeriesEntry[]>(() => radarData.value.series ?? [])
-const availableSeriesKeys = computed<RadarSeriesKey[]>(() => availableSeries.value.map((entry) => entry.key))
-const activeSeriesKeys = ref<RadarSeriesKey[]>([])
-
-watch(
-  availableSeries,
-  (series) => {
-    const keys = series.map((entry) => entry.key)
-    if (!keys.length) {
-      activeSeriesKeys.value = []
-      return
-    }
-
-    const currentKeys = new Set(activeSeriesKeys.value)
-    const ordered = keys.filter((key) => currentKeys.has(key))
-    activeSeriesKeys.value = ordered.length ? ordered : [...keys]
-  },
-  { immediate: true },
-)
 
 const radarSeriesStyles: Record<RadarSeriesKey, { line: string; area: string; symbol: string }> = {
   current: {
@@ -188,56 +148,26 @@ const translationKeys: Record<RadarSeriesKey, string> = {
   worst: 'product.impact.radarControls.worst',
 }
 
-const radarControls = computed(() =>
-  availableSeries.value.map((entry) => ({
-    key: entry.key,
-    label: t(translationKeys[entry.key], { product: entry.name }),
-  })),
-)
-
-const radarControlsAriaLabel = computed(() => t('product.impact.radarControls.ariaLabel'))
-
-const isSeriesActive = (key: RadarSeriesKey) => activeSeriesKeys.value.includes(key)
-
-const toggleSeries = (key: RadarSeriesKey) => {
-  if (!availableSeriesKeys.value.includes(key)) {
-    return
-  }
-
-  const current = new Set(activeSeriesKeys.value)
-  if (current.has(key)) {
-    current.delete(key)
-    const ordered = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
-    activeSeriesKeys.value = ordered.length ? ordered : [key]
-    return
-  }
-
-  current.add(key)
-  activeSeriesKeys.value = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
-}
-
 const chartSeries = computed<ChartSeriesEntry[]>(() => {
   if (!radarAxes.value.length) {
     return []
   }
 
-  return availableSeries.value
-    .filter((entry) => activeSeriesKeys.value.includes(entry.key))
-    .map((entry) => {
-      const style = radarSeriesStyles[entry.key]
-      const values = radarAxes.value.map((_, index) => {
-        const value = entry.values[index]
-        return typeof value === 'number' && Number.isFinite(value) ? value : null
-      })
-
-      return {
-        label: t(translationKeys[entry.key], { product: entry.name }),
-        values,
-        lineColor: style.line,
-        areaColor: style.area,
-        symbolColor: style.symbol,
-      }
+  return availableSeries.value.map((entry) => {
+    const style = radarSeriesStyles[entry.key]
+    const values = radarAxes.value.map((_, index) => {
+      const value = entry.values[index]
+      return typeof value === 'number' && Number.isFinite(value) ? value : null
     })
+
+    return {
+      label: t(translationKeys[entry.key], { product: entry.name }),
+      values,
+      lineColor: style.line,
+      areaColor: style.area,
+      symbolColor: style.symbol,
+    }
+  })
 })
 
 const showRadar = computed(() => radarAxes.value.length >= 3 && chartSeries.value.length > 0)
@@ -281,23 +211,7 @@ const showRadar = computed(() => radarAxes.value.length >= 3 && chartSeries.valu
 .product-impact__analysis-radar {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-}
-
-.product-impact__analysis-radar-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.product-impact__analysis-radar-toggle {
-  text-transform: none;
-  font-weight: 500;
-  border-radius: 999px;
-}
-
-.product-impact__analysis-radar-toggle--active {
-  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.15);
+  gap: 1.25rem;
 }
 
 .product-impact__analysis-radar-chart {

--- a/frontend/app/components/product/impact/ProductImpactRadarChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactRadarChart.vue
@@ -48,6 +48,7 @@ const option = computed<EChartsOption | null>(() => {
   }
 
   const indicator = props.axes.map((entry) => ({ name: entry.name, max: 5 }))
+  const legendLabels = props.series.map((entry) => entry.label)
   const seriesData = props.series.map((entry) => ({
     value: entry.values.map((value) => (typeof value === 'number' && Number.isFinite(value) ? value : null)),
     name: entry.label,
@@ -57,14 +58,38 @@ const option = computed<EChartsOption | null>(() => {
     symbolSize: 6,
   }))
 
+  const legendFormatter = (name: string) => `{pill|${name}}`
+
   return {
     color: props.series.map((entry) => entry.lineColor),
     tooltip: { trigger: 'item' },
     legend: {
-      data: props.series.map((entry) => entry.label),
+      data: legendLabels,
+      top: 0,
+      left: 'center',
+      icon: 'none',
+      itemGap: 16,
+      padding: [0, 0, 18, 0],
+      textStyle: {
+        color: 'rgba(15, 23, 42, 0.92)',
+        fontWeight: 600,
+        fontSize: 13,
+        rich: {
+          pill: {
+            padding: [6, 16],
+            backgroundColor: 'rgba(25, 118, 210, 0.12)',
+            borderColor: 'rgba(25, 118, 210, 0.35)',
+            borderWidth: 1,
+            borderRadius: 999,
+            color: 'rgba(15, 23, 42, 0.92)',
+          },
+        },
+      },
+      formatter: legendFormatter,
     },
     radar: {
       indicator,
+      center: ['50%', '60%'],
       radius: '70%',
       splitArea: {
         areaStyle: {

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -75,13 +75,13 @@ const formattedScore = computed(() =>
 const ratingSize = computed(() => {
   switch (props.size) {
     case 'small':
-      return 18
+      return 36
     case 'large':
-      return 32
+      return 64
     case 'xlarge':
-      return 40
+      return 80
     default:
-      return 24
+      return 48
   }
 })
 


### PR DESCRIPTION
## Summary
- render breadcrumb entries with NuxtLink for internal routes and anchors for externals so navigation items are clickable again
- double the ImpactScore rating size and remove the bespoke radar toggles in favour of styling the chart legend as clickable pills with extra spacing
- keep the radar dataset rendering in sync with the legend by plotting every available series while preserving translations

## Testing
- pnpm lint
- pnpm generate
- pnpm vitest run *(hangs with all tests queued in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fd559b188322a4ff67ccbcec0db7)