### PR TITLE
feat: link product breadcrumbs and tidy radar chart

### DIFF
--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -130,8 +130,8 @@ defineExpose({ headingId, t })
     :deep(.category-navigation-breadcrumbs__link)
       color: inherit
 
-    :deep(.category-navigation-breadcrumbs__link:hover),
-    :deep(.category-navigation-breadcrumbs__link:focus-visible)
+    :deep(.category-navigation-breadcrumbs__link--interactive:hover),
+    :deep(.category-navigation-breadcrumbs__link--interactive:focus-visible)
       color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
       text-decoration: underline
 

--- a/frontend/app/components/category/navigation/CategoryNavigationHero.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationHero.vue
@@ -110,13 +110,13 @@ const onUpdateModelValue = (value: string) => {
   color: rgba(var(--v-theme-hero-overlay-strong), 0.72);
 }
 
-.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link:hover),
-.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link:focus-visible) {
+.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link--interactive:hover),
+.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link--interactive:focus-visible) {
   color: rgb(var(--v-theme-hero-overlay-strong));
   text-decoration: underline;
 }
 
-.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link:focus-visible) {
+.category-navigation-hero__copy :deep(.category-navigation-breadcrumbs__link--interactive:focus-visible) {
   outline: 2px solid rgba(var(--v-theme-hero-overlay-strong), 0.8);
   outline-offset: 2px;
   border-radius: 0.25rem;

--- a/frontend/app/components/cms/XwikiFullPageRenderer.vue
+++ b/frontend/app/components/cms/XwikiFullPageRenderer.vue
@@ -287,8 +287,8 @@ useSeoMeta({
   :deep(.category-navigation-breadcrumbs__link)
     color: inherit
 
-  :deep(.category-navigation-breadcrumbs__link:hover),
-  :deep(.category-navigation-breadcrumbs__link:focus-visible)
+  :deep(.category-navigation-breadcrumbs__link--interactive:hover),
+  :deep(.category-navigation-breadcrumbs__link--interactive:focus-visible)
     color: rgba(var(--v-theme-hero-overlay-strong), 0.95)
     text-decoration: underline
 

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -18,28 +18,6 @@
         v-if="showRadar"
         class="product-impact__analysis-radar"
       >
-        <div
-          v-if="radarControls.length"
-          class="product-impact__analysis-radar-controls"
-          role="group"
-          :aria-label="radarControlsAriaLabel"
-        >
-          <v-btn
-            v-for="control in radarControls"
-            :key="control.key"
-            class="product-impact__analysis-radar-toggle"
-            :class="{ 'product-impact__analysis-radar-toggle--active': isSeriesActive(control.key) }"
-            color="primary"
-            variant="tonal"
-            density="comfortable"
-            :aria-pressed="isSeriesActive(control.key)"
-            :title="control.label"
-            @click="toggleSeries(control.key)"
-          >
-            {{ control.label }}
-          </v-btn>
-        </div>
-
         <ProductImpactRadarChart
           class="product-impact__analysis-radar-chart"
           :axes="radarAxes"
@@ -73,7 +51,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRef, watch } from 'vue'
+import { computed, toRef } from 'vue'
 import type { PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ProductImpactEcoScoreCard from './impact/ProductImpactEcoScoreCard.vue'
@@ -145,24 +123,6 @@ const secondaryScores = computed(() => props.scores.slice(1))
 const detailScores = computed(() => props.scores.filter((score) => score.id !== 'ECOSCORE'))
 const radarAxes = computed<RadarAxisEntry[]>(() => radarData.value.axes ?? [])
 const availableSeries = computed<RadarSeriesEntry[]>(() => radarData.value.series ?? [])
-const availableSeriesKeys = computed<RadarSeriesKey[]>(() => availableSeries.value.map((entry) => entry.key))
-const activeSeriesKeys = ref<RadarSeriesKey[]>([])
-
-watch(
-  availableSeries,
-  (series) => {
-    const keys = series.map((entry) => entry.key)
-    if (!keys.length) {
-      activeSeriesKeys.value = []
-      return
-    }
-
-    const currentKeys = new Set(activeSeriesKeys.value)
-    const ordered = keys.filter((key) => currentKeys.has(key))
-    activeSeriesKeys.value = ordered.length ? ordered : [...keys]
-  },
-  { immediate: true },
-)
 
 const radarSeriesStyles: Record<RadarSeriesKey, { line: string; area: string; symbol: string }> = {
   current: {
@@ -188,41 +148,12 @@ const translationKeys: Record<RadarSeriesKey, string> = {
   worst: 'product.impact.radarControls.worst',
 }
 
-const radarControls = computed(() =>
-  availableSeries.value.map((entry) => ({
-    key: entry.key,
-    label: t(translationKeys[entry.key], { product: entry.name }),
-  })),
-)
-
-const radarControlsAriaLabel = computed(() => t('product.impact.radarControls.ariaLabel'))
-
-const isSeriesActive = (key: RadarSeriesKey) => activeSeriesKeys.value.includes(key)
-
-const toggleSeries = (key: RadarSeriesKey) => {
-  if (!availableSeriesKeys.value.includes(key)) {
-    return
-  }
-
-  const current = new Set(activeSeriesKeys.value)
-  if (current.has(key)) {
-    current.delete(key)
-    const ordered = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
-    activeSeriesKeys.value = ordered.length ? ordered : [key]
-    return
-  }
-
-  current.add(key)
-  activeSeriesKeys.value = availableSeriesKeys.value.filter((candidate) => current.has(candidate))
-}
-
 const chartSeries = computed<ChartSeriesEntry[]>(() => {
   if (!radarAxes.value.length) {
     return []
   }
 
   return availableSeries.value
-    .filter((entry) => activeSeriesKeys.value.includes(entry.key))
     .map((entry) => {
       const style = radarSeriesStyles[entry.key]
       const values = radarAxes.value.map((_, index) => {
@@ -230,14 +161,25 @@ const chartSeries = computed<ChartSeriesEntry[]>(() => {
         return typeof value === 'number' && Number.isFinite(value) ? value : null
       })
 
+      const hasRenderableValue = values.some((value) => value !== null)
+      if (!hasRenderableValue) {
+        return null
+      }
+
+      const translationKey = translationKeys[entry.key]
+      const label = translationKey
+        ? t(translationKey, { product: entry.name })
+        : entry.name
+
       return {
-        label: t(translationKeys[entry.key], { product: entry.name }),
+        label,
         values,
         lineColor: style.line,
         areaColor: style.area,
         symbolColor: style.symbol,
       }
     })
+    .filter((seriesEntry): seriesEntry is ChartSeriesEntry => seriesEntry !== null)
 })
 
 const showRadar = computed(() => radarAxes.value.length >= 3 && chartSeries.value.length > 0)
@@ -282,22 +224,6 @@ const showRadar = computed(() => radarAxes.value.length >= 3 && chartSeries.valu
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.product-impact__analysis-radar-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.product-impact__analysis-radar-toggle {
-  text-transform: none;
-  font-weight: 500;
-  border-radius: 999px;
-}
-
-.product-impact__analysis-radar-toggle--active {
-  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.15);
 }
 
 .product-impact__analysis-radar-chart {


### PR DESCRIPTION
## Summary
- render breadcrumb links with `<NuxtLink>`/anchors while keeping the terminal crumb static and non-hoverable
- align hero breadcrumb styling with the new interactive class across category and CMS heroes
- drop the impact radar toggle buttons and automatically plot all available series with data

## Testing
- `pnpm lint`
- `pnpm generate`
- `pnpm vitest run` *(fails: runner never completes and remains queued on components/domains/blog/TheArticles.spec.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691101d1a24c8322b18a8c25df271185)