### PR TITLE
feat(front-api): enrich search suggestions with best price data

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/SearchController.java
@@ -163,6 +163,6 @@ public class SearchController {
 
     private SearchSuggestProductDto toProductDto(SearchService.ProductSuggestHit hit) {
         return new SearchSuggestProductDto(hit.model(), hit.brand(), hit.gtin(), hit.coverImagePath(), hit.verticalId(),
-                hit.ecoscoreValue(), hit.score());
+                hit.ecoscoreValue(), hit.bestPrice(), hit.bestPriceCurrency(), hit.score());
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/SearchSuggestProductDto.java
@@ -1,5 +1,7 @@
 package org.open4goods.nudgerfrontapi.dto.search;
 
+import org.open4goods.model.price.Currency;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -24,6 +26,12 @@ public record SearchSuggestProductDto(
 
         @Schema(description = "Eco-score value computed for the product when available.", example = "72.5")
         Double ecoscoreValue,
+
+        @Schema(description = "Best price available for the product when indexed.", example = "429.99")
+        Double bestPrice,
+
+        @Schema(description = "Currency associated with the best price when available.", example = "EUR")
+        Currency bestPriceCurrency,
 
         @Schema(description = "Native Elasticsearch score associated with the hit.", example = "1.85")
         Double score


### PR DESCRIPTION
## Summary
- add best price amount and currency to search suggestion DTOs and API mapping
- include best price data in suggest query results and fetch required fields from Elasticsearch
- ensure vertical suggestions retain vertical identifiers with OR-based matching for multi-word queries

## Testing
- mvn --offline -pl front-api -am test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fbc5d86c8322b701cb12383bd926)