### PR TITLE
feat: add quick search and community mega menu

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -1,18 +1,168 @@
 <template>
   <menu id="container-main-menu" class="d-none d-md-block">
-  <!-- Desktop menu -->
+    <!-- Desktop menu -->
     <div class="d-flex justify-end align-center ga-4">
-      <v-list class="d-flex justify-end font-weight-bold">
-        <v-list-item
-          v-for="item in menuItems"
-          :key="item.path"
-          class="main-menu-items"
-          :class="{ 'active': isActiveRoute(item.path) }"
-          @click="navigateToPage(item.path)"
-        >
-          <v-list-item-title>{{ item.label }}</v-list-item-title>
-        </v-list-item>
+      <div
+        v-if="showMenuSearch"
+        ref="menuSearchRef"
+        class="main-menu-search"
+        :class="{ 'main-menu-search--open': isSearchOpen }"
+      >
+        <v-btn
+          v-if="!isSearchOpen"
+          class="main-menu-search__activator"
+          icon="mdi-magnify"
+          variant="text"
+          :aria-label="t('siteIdentity.menu.search.openLabel')"
+          @click="openSearch"
+        />
+
+        <v-expand-x-transition>
+          <div v-if="isSearchOpen" class="main-menu-search__field-wrapper">
+            <SearchSuggestField
+              v-model="searchQuery"
+              class="main-menu-search__field"
+              :label="t('siteIdentity.menu.search.label')"
+              :placeholder="t('siteIdentity.menu.search.placeholder')"
+              :aria-label="t('siteIdentity.menu.search.ariaLabel')"
+              :min-chars="MIN_SEARCH_QUERY_LENGTH"
+              @submit="handleSearchSubmit"
+              @select-category="handleCategorySuggestion"
+              @select-product="handleProductSuggestion"
+              @update:model-value="updateSearchQuery"
+              @clear="handleSearchClear"
+            >
+              <template #append-inner>
+                <div class="main-menu-search__actions">
+                  <v-btn
+                    icon="mdi-arrow-right"
+                    variant="flat"
+                    color="primary"
+                    size="small"
+                    :aria-label="t('siteIdentity.menu.search.submitLabel')"
+                    @click.prevent="handleSearchSubmit"
+                  />
+                  <v-btn
+                    icon="mdi-close"
+                    variant="text"
+                    color="text-neutral-secondary"
+                    size="small"
+                    :aria-label="t('siteIdentity.menu.search.closeLabel')"
+                    @click.prevent="closeSearch"
+                  />
+                </div>
+              </template>
+            </SearchSuggestField>
+          </div>
+        </v-expand-x-transition>
+      </div>
+
+      <v-list class="d-flex justify-end font-weight-bold" role="menubar">
+        <template v-for="item in menuItems" :key="item.id">
+          <v-list-item
+            v-if="item.type === 'link'"
+            class="main-menu-items"
+            :class="{ active: isMenuItemActive(item) }"
+            role="menuitem"
+            @click="navigateToPage(item.path)"
+          >
+            <v-list-item-title>{{ item.label }}</v-list-item-title>
+          </v-list-item>
+
+          <div v-else class="main-menu-item main-menu-item--community">
+            <v-menu
+              open-on-hover
+              location="bottom"
+              transition="fade-transition"
+              :offset="[0, 12]"
+            >
+              <template #activator="{ props }">
+                <v-list-item
+                  v-bind="props"
+                  class="main-menu-items main-menu-items--community"
+                  :class="{ active: isMenuItemActive(item) }"
+                  role="menuitem"
+                >
+                  <v-list-item-title>{{ item.label }}</v-list-item-title>
+                  <v-icon icon="mdi-menu-down" size="16" class="main-menu-items__caret" />
+                </v-list-item>
+              </template>
+
+              <v-card class="community-menu" color="surface-default" elevation="8">
+                <div class="community-menu__header">
+                  <v-avatar class="community-menu__avatar" size="44" color="surface-primary-080">
+                    <v-icon icon="mdi-account-group" color="primary" />
+                  </v-avatar>
+                  <div>
+                    <p class="community-menu__title">{{ item.label }}</p>
+                    <p class="community-menu__subtitle">
+                      {{ t('siteIdentity.menu.community.tagline') }}
+                    </p>
+                  </div>
+                </div>
+
+                <v-divider class="community-menu__divider" />
+
+                <v-row class="community-menu__sections" justify="space-between" align="stretch">
+                  <v-col
+                    v-for="section in item.sections"
+                    :key="section.id"
+                    cols="12"
+                    sm="4"
+                    class="community-menu__section"
+                  >
+                    <p class="community-menu__section-title">{{ section.title }}</p>
+                    <p class="community-menu__section-description">
+                      {{ section.description }}
+                    </p>
+
+                    <v-list
+                      class="community-menu__section-list"
+                      bg-color="transparent"
+                      density="comfortable"
+                      nav
+                      lines="one"
+                    >
+                      <v-list-item
+                        v-for="link in section.links"
+                        :key="link.id"
+                        class="community-menu__link"
+                        :class="{ 'community-menu__link--external': link.external }"
+                        :to="link.to"
+                        :href="link.href"
+                        :target="link.external ? '_blank' : undefined"
+                        :rel="link.external ? 'noopener noreferrer' : undefined"
+                        role="menuitem"
+                      >
+                        <template #prepend>
+                          <v-avatar size="34" class="community-menu__link-icon">
+                            <v-icon :icon="link.icon" size="20" color="accent-primary-highlight" />
+                          </v-avatar>
+                        </template>
+
+                        <v-list-item-title class="community-menu__link-label">
+                          {{ link.label }}
+                        </v-list-item-title>
+                        <v-list-item-subtitle
+                          v-if="link.description"
+                          class="community-menu__link-description"
+                        >
+                          {{ link.description }}
+                        </v-list-item-subtitle>
+
+                        <template v-if="link.external" #append>
+                          <v-icon icon="mdi-open-in-new" size="18" class="community-menu__external-icon" />
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-col>
+                </v-row>
+              </v-card>
+            </v-menu>
+          </div>
+        </template>
       </v-list>
+
       <ThemeToggle test-id="hero-theme-toggle" />
       <v-menu
         v-if="isLoggedIn"
@@ -103,9 +253,19 @@
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
+import type {
+  CategorySuggestionItem,
+  ProductSuggestionItem,
+} from '~/components/search/SearchSuggestField.vue'
 import ThemeToggle from './ThemeToggle.vue'
 import { useI18n } from 'vue-i18n'
 import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+const SearchSuggestField = defineAsyncComponent({
+  loader: () => import('~/components/search/SearchSuggestField.vue'),
+  suspensible: false,
+})
 
 const route = useRoute()
 const router = useRouter()
@@ -113,6 +273,147 @@ const nuxtApp = useNuxtApp()
 const { isLoggedIn, logout, username, roles } = useAuth()
 const { t, locale } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
+
+const MIN_SEARCH_QUERY_LENGTH = 2
+
+const menuSearchRef = ref<HTMLElement | null>(null)
+const isSearchOpen = ref(false)
+const searchQuery = ref('')
+
+const homeRoutePath = computed(() => resolveLocalizedRoutePath('index', currentLocale.value))
+const searchRoutePath = computed(() => resolveLocalizedRoutePath('search', currentLocale.value))
+const showMenuSearch = computed(() => route.path !== homeRoutePath.value)
+
+const focusSearchInput = () => {
+  const root = menuSearchRef.value
+
+  if (!root) {
+    return
+  }
+
+  const input = root.querySelector('input')
+
+  if (input instanceof HTMLInputElement) {
+    input.focus()
+    input.select()
+  }
+}
+
+const openSearch = async () => {
+  if (isSearchOpen.value) {
+    focusSearchInput()
+    return
+  }
+
+  isSearchOpen.value = true
+  await nextTick()
+  focusSearchInput()
+}
+
+const closeSearch = () => {
+  isSearchOpen.value = false
+}
+
+const updateSearchQuery = (value: string) => {
+  searchQuery.value = value
+}
+
+const handleSearchClear = () => {
+  searchQuery.value = ''
+}
+
+watch(
+  () => route.path,
+  (path) => {
+    if (path === homeRoutePath.value) {
+      closeSearch()
+      handleSearchClear()
+    }
+  },
+)
+
+watch(homeRoutePath, (path) => {
+  if (route.path === path) {
+    closeSearch()
+    handleSearchClear()
+  }
+})
+
+watch(showMenuSearch, (visible) => {
+  if (!visible) {
+    closeSearch()
+  }
+})
+
+const navigateToSearch = (query?: string) => {
+  const normalizedQuery = query?.trim() ?? ''
+
+  router.push({
+    path: searchRoutePath.value,
+    query: normalizedQuery ? { q: normalizedQuery } : undefined,
+  })
+
+  closeSearch()
+}
+
+const normalizeVerticalHomeUrl = (raw: string | null | undefined): string | null => {
+  if (!raw) {
+    return null
+  }
+
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  if (/^https?:\/\//iu.test(trimmed)) {
+    return trimmed
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+const handleSearchSubmit = () => {
+  const trimmedQuery = searchQuery.value.trim()
+
+  if (trimmedQuery.length > 0 && trimmedQuery.length < MIN_SEARCH_QUERY_LENGTH) {
+    return
+  }
+
+  navigateToSearch(trimmedQuery)
+}
+
+const handleCategorySuggestion = (suggestion: CategorySuggestionItem) => {
+  searchQuery.value = suggestion.title
+
+  const normalizedUrl = normalizeVerticalHomeUrl(suggestion.url)
+
+  if (normalizedUrl) {
+    closeSearch()
+    router.push(normalizedUrl)
+    return
+  }
+
+  navigateToSearch(suggestion.title)
+}
+
+const handleProductSuggestion = (suggestion: ProductSuggestionItem) => {
+  searchQuery.value = suggestion.title
+
+  const gtin = suggestion.gtin?.trim()
+
+  if (gtin) {
+    closeSearch()
+    router.push({
+      name: 'gtin',
+      params: { gtin },
+    })
+    return
+  }
+
+  navigateToSearch(suggestion.title)
+}
 
 type FetchLike = (input: string, init?: Record<string, unknown>) => Promise<unknown>
 
@@ -201,29 +502,176 @@ defineEmits<{
   'toggle-drawer': []
 }>()
 
-interface MenuItemDefinition {
+interface LinkMenuItemDefinition {
+  id: string
   labelKey: string
   routeName: string
+  type: 'link'
 }
 
-interface MenuItem extends MenuItemDefinition {
+interface CommunityMenuItemDefinition {
+  id: string
+  labelKey: string
+  type: 'community'
+}
+
+type MenuItemDefinition = LinkMenuItemDefinition | CommunityMenuItemDefinition
+
+interface LinkMenuItem {
+  id: string
+  type: 'link'
   label: string
   path: string
 }
 
+interface CommunityLink {
+  id: string
+  label: string
+  description?: string
+  icon: string
+  to?: string
+  href?: string
+  external?: boolean
+}
+
+interface CommunitySection {
+  id: string
+  title: string
+  description: string
+  links: CommunityLink[]
+}
+
+interface CommunityMenuItem {
+  id: string
+  type: 'community'
+  label: string
+  sections: CommunitySection[]
+  activePaths: string[]
+}
+
+type MenuItem = LinkMenuItem | CommunityMenuItem
+
+const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
+
+const communitySections = computed<CommunitySection[]>(() => {
+  const feedbackLink: CommunityLink = {
+    id: 'feedback',
+    label: String(t('siteIdentity.menu.community.sections.connect.items.feedback.label')),
+    description: String(t('siteIdentity.menu.community.sections.connect.items.feedback.description')),
+    icon: 'mdi-message-draw',
+    to: resolveLocalizedRoutePath('feedback', currentLocale.value),
+  }
+
+  const contactLink: CommunityLink = {
+    id: 'contact',
+    label: String(t('siteIdentity.menu.community.sections.connect.items.contact.label')),
+    description: String(t('siteIdentity.menu.community.sections.connect.items.contact.description')),
+    icon: 'mdi-email-send-outline',
+    to: resolveLocalizedRoutePath('contact', currentLocale.value),
+  }
+
+  const followLink: CommunityLink = {
+    id: 'follow',
+    label: String(t('siteIdentity.menu.community.sections.connect.items.follow.label')),
+    description: String(t('siteIdentity.menu.community.sections.connect.items.follow.description')),
+    icon: 'mdi-linkedin',
+    href: linkedinUrl.value,
+    external: true,
+  }
+
+  const teamLink: CommunityLink = {
+    id: 'team',
+    label: String(t('siteIdentity.menu.community.sections.collaborate.items.team.label')),
+    description: String(t('siteIdentity.menu.community.sections.collaborate.items.team.description')),
+    icon: 'mdi-account-group-outline',
+    to: resolveLocalizedRoutePath('team', currentLocale.value),
+  }
+
+  const partnersLink: CommunityLink = {
+    id: 'partners',
+    label: String(t('siteIdentity.menu.community.sections.collaborate.items.partners.label')),
+    description: String(t('siteIdentity.menu.community.sections.collaborate.items.partners.description')),
+    icon: 'mdi-handshake-outline',
+    to: resolveLocalizedRoutePath('partners', currentLocale.value),
+  }
+
+  const openDataLink: CommunityLink = {
+    id: 'opendata',
+    label: String(t('siteIdentity.menu.community.sections.resources.items.opendata.label')),
+    description: String(t('siteIdentity.menu.community.sections.resources.items.opendata.description')),
+    icon: 'mdi-database-outline',
+    to: resolveLocalizedRoutePath('opendata', currentLocale.value),
+  }
+
+  const openSourceLink: CommunityLink = {
+    id: 'opensource',
+    label: String(t('siteIdentity.menu.community.sections.resources.items.opensource.label')),
+    description: String(t('siteIdentity.menu.community.sections.resources.items.opensource.description')),
+    icon: 'mdi-source-branch',
+    to: resolveLocalizedRoutePath('opensource', currentLocale.value),
+  }
+
+  return [
+    {
+      id: 'connect',
+      title: String(t('siteIdentity.menu.community.sections.connect.title')),
+      description: String(t('siteIdentity.menu.community.sections.connect.description')),
+      links: [feedbackLink, contactLink, followLink],
+    },
+    {
+      id: 'collaborate',
+      title: String(t('siteIdentity.menu.community.sections.collaborate.title')),
+      description: String(t('siteIdentity.menu.community.sections.collaborate.description')),
+      links: [teamLink, partnersLink],
+    },
+    {
+      id: 'resources',
+      title: String(t('siteIdentity.menu.community.sections.resources.title')),
+      description: String(t('siteIdentity.menu.community.sections.resources.description')),
+      links: [openDataLink, openSourceLink],
+    },
+  ]
+})
+
+const communityActivePaths = computed(() =>
+  communitySections.value
+    .flatMap((section) => section.links.map((link) => link.to))
+    .filter((path): path is string => typeof path === 'string' && path.length > 0),
+)
+
 const baseMenuItems: MenuItemDefinition[] = [
-  { labelKey: 'siteIdentity.menu.items.impactScore', routeName: 'impact-score' },
-  { labelKey: 'siteIdentity.menu.items.products', routeName: 'categories' },
-  { labelKey: 'siteIdentity.menu.items.blog', routeName: 'blog' },
-  { labelKey: 'siteIdentity.menu.items.contact', routeName: 'contact' },
+  {
+    id: 'impact-score',
+    type: 'link',
+    labelKey: 'siteIdentity.menu.items.impactScore',
+    routeName: 'impact-score',
+  },
+  { id: 'products', type: 'link', labelKey: 'siteIdentity.menu.items.products', routeName: 'categories' },
+  { id: 'blog', type: 'link', labelKey: 'siteIdentity.menu.items.blog', routeName: 'blog' },
+  { id: 'community', type: 'community', labelKey: 'siteIdentity.menu.items.contact' },
 ]
 
 const menuItems = computed<MenuItem[]>(() =>
-  baseMenuItems.map((item) => ({
-    ...item,
-    label: t(item.labelKey),
-    path: resolveLocalizedRoutePath(item.routeName, currentLocale.value),
-  })),
+  baseMenuItems.map((item) => {
+    const label = String(t(item.labelKey))
+
+    if (item.type === 'link') {
+      return {
+        id: item.id,
+        type: 'link' as const,
+        label,
+        path: resolveLocalizedRoutePath(item.routeName, currentLocale.value),
+      }
+    }
+
+    return {
+      id: item.id,
+      type: 'community' as const,
+      label,
+      sections: communitySections.value,
+      activePaths: communityActivePaths.value,
+    }
+  }),
 )
 
 const isActiveRoute = (path: string): boolean => {
@@ -241,9 +689,64 @@ const isActiveRoute = (path: string): boolean => {
 const navigateToPage = (path: string): void => {
   router.push(path)
 }
+
+const isMenuItemActive = (item: MenuItem): boolean => {
+  if (item.type === 'link') {
+    return isActiveRoute(item.path)
+  }
+
+  return item.activePaths.some((path) => isActiveRoute(path))
+}
 </script>
 
 <style scoped lang="sass">
+.main-menu-search
+  display: flex
+  align-items: center
+  gap: 0.5rem
+
+  &__activator
+    color: rgb(var(--v-theme-text-neutral-strong))
+    transition: color 0.3s ease, transform 0.3s ease
+    &:hover
+      color: rgb(var(--v-theme-accent-primary-highlight))
+      transform: scale(1.05)
+
+  &__field-wrapper
+    width: clamp(220px, 28vw, 320px)
+    max-width: 320px
+
+  &__actions
+    display: flex
+    align-items: center
+    gap: 0.25rem
+
+.main-menu-search__field
+  :deep(.v-field)
+    border-radius: 999px
+    background-color: rgba(var(--v-theme-surface-primary-080), 0.95)
+    box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+
+  :deep(.v-field__outline)
+    display: none
+
+  :deep(.v-field__input)
+    padding-inline-start: 1rem
+    min-height: 44px
+
+  :deep(.v-field__append-inner)
+    padding-inline-end: 0.25rem
+
+  :deep(.v-field__clearable)
+    margin-inline-end: 0.25rem
+
+.main-menu-search--open .main-menu-search__activator
+  opacity: 0
+  pointer-events: none
+
+.main-menu-item--community
+  display: flex
+
 .main-menu-items
   color: rgb(var(--v-theme-text-neutral-strong))
   font-size: 1rem
@@ -255,6 +758,97 @@ const navigateToPage = (path: string): void => {
   &.active
     color: rgb(var(--v-theme-accent-supporting))
     font-weight: 900
+
+.main-menu-items--community
+  gap: 0.35rem
+
+.main-menu-items__caret
+  margin-inline-start: 0.1rem
+  transition: transform 0.2s ease, color 0.2s ease
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.main-menu-items--community.active .main-menu-items__caret
+  transform: rotate(180deg)
+  color: rgb(var(--v-theme-accent-supporting))
+
+.community-menu
+  width: min(720px, 80vw)
+  padding: 1.5rem
+  border-radius: 1.25rem
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.95), rgba(var(--v-theme-surface-glass), 0.95))
+  box-shadow: 0 24px 48px rgba(var(--v-theme-shadow-primary-600), 0.16)
+
+  &__header
+    display: flex
+    align-items: center
+    gap: 1rem
+    margin-block-end: 0.75rem
+
+  &__avatar
+    background-color: rgba(var(--v-theme-surface-primary-120), 0.85)
+    box-shadow: 0 10px 30px rgba(var(--v-theme-shadow-primary-600), 0.2)
+
+  &__title
+    margin: 0
+    font-size: 1.1rem
+    font-weight: 700
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__subtitle
+    margin: 0
+    font-size: 0.9rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__divider
+    margin-block: 0.5rem 1rem
+    opacity: 0.4
+
+  &__sections
+    gap: 1rem
+    margin: 0
+
+  &__section
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+  &__section-title
+    margin: 0
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__section-description
+    margin: 0
+    font-size: 0.85rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    min-height: 2.5rem
+
+  &__section-list
+    padding: 0
+    background: transparent
+
+  &__link
+    border-radius: 0.75rem
+    transition: background-color 0.2s ease, transform 0.2s ease
+    margin-block: 0.125rem
+
+    &:hover
+      background-color: rgba(var(--v-theme-surface-primary-080), 0.8)
+      transform: translateY(-1px)
+
+  &__link-icon
+    background-color: rgba(var(--v-theme-surface-primary-120), 0.9)
+
+  &__link-label
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__link-description
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    white-space: normal
+
+  &__external-icon
+    color: rgb(var(--v-theme-accent-primary-highlight))
 
 .account-menu-activator
   text-transform: none
@@ -281,6 +875,9 @@ const navigateToPage = (path: string): void => {
   color: rgb(var(--v-theme-text-neutral-soft))
 
 @media (max-width: 1263px)
+  .community-menu
+    width: min(640px, 90vw)
+
   .account-menu-activator
     .account-username
       max-width: 96px

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -81,6 +81,7 @@ vi.mock('~/composables/useAuth', () => ({
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => key,
+    locale: ref('en-US'),
   }),
 }))
 
@@ -165,7 +166,15 @@ beforeAll(async () => {
 
 describe('Shared menu authentication controls', () => {
   let reloadSpy: ReturnType<typeof vi.spyOn> | undefined
-  const heroMountOptions = { attachTo: document.body, global: { stubs: { VMenu: vMenuStub } } }
+  const heroMountOptions = {
+    attachTo: document.body,
+    global: {
+      stubs: {
+        VMenu: vMenuStub,
+        SearchSuggestField: { template: '<div class="search-suggest-field-stub" />' },
+      },
+    },
+  }
   const mobileMountOptions = { global: { stubs: { VMenu: vMenuStub } } }
 
   beforeEach(() => {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1893,9 +1893,68 @@
       "closeLabel": "Close menu",
       "items": {
         "blog": "Blog",
-        "contact": "Contact",
+        "contact": "Community",
         "impactScore": "Impact Score",
         "products": "Products"
+      },
+      "search": {
+        "label": "Quick search",
+        "placeholder": "Find a product, brand or GTIN",
+        "ariaLabel": "Open the quick catalogue search",
+        "openLabel": "Open quick search",
+        "closeLabel": "Close quick search",
+        "submitLabel": "Search"
+      },
+      "community": {
+        "tagline": "Connect with the people and open resources behind Nudger.",
+        "sections": {
+          "connect": {
+            "title": "Stay in touch",
+            "description": "Share feedback or contact the team directly.",
+            "items": {
+              "feedback": {
+                "label": "Feedback",
+                "description": "Suggest ideas to improve Nudger."
+              },
+              "contact": {
+                "label": "Contact",
+                "description": "Reach out for partnerships or questions."
+              },
+              "follow": {
+                "label": "Follow us",
+                "description": "Get our updates on LinkedIn."
+              }
+            }
+          },
+          "collaborate": {
+            "title": "Collaborate",
+            "description": "Meet the people building Nudger every day.",
+            "items": {
+              "team": {
+                "label": "Team",
+                "description": "Discover who is behind the product."
+              },
+              "partners": {
+                "label": "Partners",
+                "description": "Explore the organisations supporting Nudger."
+              }
+            }
+          },
+          "resources": {
+            "title": "Open resources",
+            "description": "Use our data and contribute to the codebase.",
+            "items": {
+              "opendata": {
+                "label": "Open Data",
+                "description": "Access transparent product datasets."
+              },
+              "opensource": {
+                "label": "Open Source",
+                "description": "Contribute to our GitHub projects."
+              }
+            }
+          }
+        }
       },
       "theme": {
         "darkAriaLabel": "Activate dark theme",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1892,9 +1892,68 @@
       "closeLabel": "Fermer le menu",
       "items": {
         "blog": "Blog",
-        "contact": "Contact",
-        "impactScore": "Impact-score",
+        "contact": "Communauté",
+        "impactScore": "Impact Score",
         "products": "Les produits"
+      },
+      "search": {
+        "label": "Recherche rapide",
+        "placeholder": "Chercher un produit, une marque ou un GTIN",
+        "ariaLabel": "Ouvrir la recherche rapide du catalogue",
+        "openLabel": "Ouvrir la recherche rapide",
+        "closeLabel": "Fermer la recherche rapide",
+        "submitLabel": "Lancer la recherche"
+      },
+      "community": {
+        "tagline": "Retrouvez l'équipe et nos ressources ouvertes.",
+        "sections": {
+          "connect": {
+            "title": "Rester en lien",
+            "description": "Partagez vos retours ou contactez l'équipe directement.",
+            "items": {
+              "feedback": {
+                "label": "Feedback",
+                "description": "Proposez des idées pour améliorer Nudger."
+              },
+              "contact": {
+                "label": "Contact",
+                "description": "Discutez avec nous pour vos projets ou questions."
+              },
+              "follow": {
+                "label": "Nous suivre",
+                "description": "Recevez nos nouvelles sur LinkedIn."
+              }
+            }
+          },
+          "collaborate": {
+            "title": "Collaborer",
+            "description": "Rencontrez les personnes qui construisent Nudger.",
+            "items": {
+              "team": {
+                "label": "Équipe",
+                "description": "Découvrez qui anime la communauté Nudger."
+              },
+              "partners": {
+                "label": "Partenaires",
+                "description": "Explorez les organisations qui nous soutiennent."
+              }
+            }
+          },
+          "resources": {
+            "title": "Ressources ouvertes",
+            "description": "Utilisez nos données et contribuez au code.",
+            "items": {
+              "opendata": {
+                "label": "Open Data",
+                "description": "Accédez à nos jeux de données transparents."
+              },
+              "opensource": {
+                "label": "Open source",
+                "description": "Participez à notre code ouvert sur GitHub."
+              }
+            }
+          }
+        }
       },
       "theme": {
         "darkAriaLabel": "Activer le thème sombre",

--- a/frontend/shared/api-client/models/SearchSuggestProductDto.ts
+++ b/frontend/shared/api-client/models/SearchSuggestProductDto.ts
@@ -56,12 +56,36 @@ export interface SearchSuggestProductDto {
      */
     ecoscoreValue?: number;
     /**
+     * Best price available for the product when indexed.
+     * @type {number}
+     * @memberof SearchSuggestProductDto
+     */
+    bestPrice?: number;
+    /**
+     * Currency associated with the best price when available.
+     * @type {string}
+     * @memberof SearchSuggestProductDto
+     */
+    bestPriceCurrency?: SearchSuggestProductDtoBestPriceCurrencyEnum;
+    /**
      * Native Elasticsearch score associated with the hit.
      * @type {number}
      * @memberof SearchSuggestProductDto
      */
     score?: number;
 }
+
+
+/**
+ * @export
+ */
+export const SearchSuggestProductDtoBestPriceCurrencyEnum = {
+    Eur: 'EUR',
+    Usd: 'USD',
+    Cny: 'CNY'
+} as const;
+export type SearchSuggestProductDtoBestPriceCurrencyEnum = typeof SearchSuggestProductDtoBestPriceCurrencyEnum[keyof typeof SearchSuggestProductDtoBestPriceCurrencyEnum];
+
 
 /**
  * Check if a given object implements the SearchSuggestProductDto interface.
@@ -86,6 +110,8 @@ export function SearchSuggestProductDtoFromJSONTyped(json: any, ignoreDiscrimina
         'coverImagePath': json['coverImagePath'] == null ? undefined : json['coverImagePath'],
         'verticalId': json['verticalId'] == null ? undefined : json['verticalId'],
         'ecoscoreValue': json['ecoscoreValue'] == null ? undefined : json['ecoscoreValue'],
+        'bestPrice': json['bestPrice'] == null ? undefined : json['bestPrice'],
+        'bestPriceCurrency': json['bestPriceCurrency'] == null ? undefined : json['bestPriceCurrency'],
         'score': json['score'] == null ? undefined : json['score'],
     };
 }
@@ -107,6 +133,8 @@ export function SearchSuggestProductDtoToJSONTyped(value?: SearchSuggestProductD
         'coverImagePath': value['coverImagePath'],
         'verticalId': value['verticalId'],
         'ecoscoreValue': value['ecoscoreValue'],
+        'bestPrice': value['bestPrice'],
+        'bestPriceCurrency': value['bestPriceCurrency'],
         'score': value['score'],
     };
 }

--- a/model/src/main/java/org/open4goods/model/eprel/EprelProduct.java
+++ b/model/src/main/java/org/open4goods/model/eprel/EprelProduct.java
@@ -756,12 +756,15 @@ public class EprelProduct implements Serializable
     @JsonSetter("gtinIdentifier")
     public void setGtinIdentifier(String gtinIdentifier)
     {
-        this.gtinIdentifier = gtinIdentifier;
-        try {
-			this.numericGtin = Long.valueOf(gtinIdentifier);
-		} catch (NumberFormatException e) {
-			LOGGER.warn("Non numeric gtinIdentifier {} for {} ",gtinIdentifier,this);
-		}
+
+    	if (null != gtinIdentifier) {
+	        this.gtinIdentifier = gtinIdentifier;
+	        try {
+				this.numericGtin = Long.valueOf(gtinIdentifier);
+			} catch (NumberFormatException e) {
+				LOGGER.warn("Non numeric gtinIdentifier {} for {} ",gtinIdentifier,this);
+			}
+    	}
     }
 
     public Long getNumericGtin()


### PR DESCRIPTION
## Summary
- add a collapsible quick search trigger to the desktop hero menu and reuse the suggestion field component
- replace the contact item with a community mega menu and enrich locale strings for both languages
- stub the search field in menu tests so authentication behaviours continue to mount in isolation

## Testing
- pnpm lint
- pnpm test components/shared/menus/menus-auth.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911fdf910e483228a8fcccd4b5cf7ad)