### PR TITLE
feat(frontend): align homepage search and blog interactions

### DIFF
--- a/frontend/app/components/home/sections/HomeBlogSection.vue
+++ b/frontend/app/components/home/sections/HomeBlogSection.vue
@@ -7,7 +7,6 @@ interface BlogItem {
   formattedDate?: string
   image?: string | null
   link: string
-  isExternal: boolean
   hasImage: boolean
 }
 
@@ -54,14 +53,7 @@ const secondaryFallbackIconSize = 48
         </div>
         <template v-else>
           <div v-if="featuredItem" class="home-blog__featured">
-            <component
-              :is="featuredItem.isExternal ? 'a' : 'NuxtLink'"
-              class="home-blog__featured-link"
-              :href="featuredItem.isExternal ? featuredItem.link : undefined"
-              :to="!featuredItem.isExternal ? featuredItem.link : undefined"
-              :target="featuredItem.isExternal ? '_blank' : undefined"
-              :rel="featuredItem.isExternal ? 'noopener' : undefined"
-            >
+            <NuxtLink :to="featuredItem.link" class="home-blog__featured-link">
               <article class="home-blog__featured-card">
                 <div class="home-blog__media" aria-hidden="true">
                   <v-img
@@ -81,7 +73,7 @@ const secondaryFallbackIconSize = 48
                   <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
                 </div>
               </article>
-            </component>
+            </NuxtLink>
           </div>
 
           <v-row
@@ -98,14 +90,7 @@ const secondaryFallbackIconSize = 48
               lg="4"
               class="home-blog__col"
             >
-              <component
-                :is="article.isExternal ? 'a' : 'NuxtLink'"
-                class="home-blog__item"
-                :href="article.isExternal ? article.link : undefined"
-                :to="!article.isExternal ? article.link : undefined"
-                :target="article.isExternal ? '_blank' : undefined"
-                :rel="article.isExternal ? 'noopener' : undefined"
-              >
+              <NuxtLink :to="article.link" class="home-blog__item">
                 <article class="home-blog__card">
                   <div class="home-blog__media" aria-hidden="true">
                     <v-img
@@ -125,7 +110,7 @@ const secondaryFallbackIconSize = 48
                     <span class="home-blog__link-label">{{ t('home.blog.readMore') }}</span>
                   </div>
                 </article>
-              </component>
+              </NuxtLink>
             </v-col>
           </v-row>
 

--- a/frontend/app/components/home/sections/HomeCtaSection.vue
+++ b/frontend/app/components/home/sections/HomeCtaSection.vue
@@ -1,21 +1,33 @@
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
+import SearchSuggestField, {
+  type CategorySuggestionItem,
+  type ProductSuggestionItem,
+} from '~/components/search/SearchSuggestField.vue'
 
 type Emits = {
   'update:searchQuery': [value: string]
   submit: []
+  'select-category': [payload: CategorySuggestionItem]
+  'select-product': [payload: ProductSuggestionItem]
 }
 
-const props = defineProps<{
-  searchQuery: string
-  categoriesLandingUrl: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    searchQuery: string
+    categoriesLandingUrl: string
+    minSuggestionQueryLength?: number
+  }>(),
+  {
+    minSuggestionQueryLength: 2,
+  },
+)
 
 const emit = defineEmits<Emits>()
 
 const { t } = useI18n()
 
-const { categoriesLandingUrl } = toRefs(props)
+const { categoriesLandingUrl, minSuggestionQueryLength } = toRefs(props)
 
 const searchQueryValue = computed(() => props.searchQuery)
 
@@ -25,6 +37,14 @@ const handleSubmit = () => {
 
 const handleUpdate = (value: string) => {
   emit('update:searchQuery', value)
+}
+
+const handleCategorySelect = (value: CategorySuggestionItem) => {
+  emit('select-category', value)
+}
+
+const handleProductSelect = (value: ProductSuggestionItem) => {
+  emit('select-product', value)
 }
 </script>
 
@@ -38,17 +58,17 @@ const handleUpdate = (value: string) => {
             <p class="home-cta__subtitle">{{ t('home.cta.subtitle') }}</p>
             <div class="home-cta__actions">
               <form class="home-cta__form" role="search" @submit.prevent="handleSubmit">
-                <v-text-field
+                <SearchSuggestField
                   :model-value="searchQueryValue"
                   class="home-cta__search-input"
-                  variant="outlined"
-                  density="comfortable"
                   :label="t('home.hero.search.label')"
                   :placeholder="t('home.hero.search.placeholder')"
                   :aria-label="t('home.hero.search.ariaLabel')"
-                  prepend-inner-icon="mdi-magnify"
-                  hide-details="auto"
+                  :min-chars="minSuggestionQueryLength"
                   @update:model-value="handleUpdate"
+                  @submit="handleSubmit"
+                  @select-category="handleCategorySelect"
+                  @select-product="handleProductSelect"
                 >
                   <template #append-inner>
                     <v-btn
@@ -61,7 +81,7 @@ const handleUpdate = (value: string) => {
                       :aria-label="t('home.cta.searchSubmit')"
                     />
                   </template>
-                </v-text-field>
+                </SearchSuggestField>
               </form>
               <div class="home-cta__links">
                 <v-btn

--- a/frontend/app/components/search/SearchSuggestField.vue
+++ b/frontend/app/components/search/SearchSuggestField.vue
@@ -496,12 +496,20 @@ const handleClear = () => {
     background-color: rgba(var(--v-theme-hero-overlay-soft), 0.94)
     border-radius: 1rem
     box-shadow: 0 16px 30px -20px rgba(15, 23, 42, 0.55)
+    cursor: text
+
+  :deep(.v-field__overlay)
+    cursor: text
+
+  :deep(.v-field__field)
+    cursor: text
 
   :deep(.v-field__prepend-inner .v-icon)
     color: rgba(var(--v-theme-text-on-accent), 0.7)
 
   :deep(input)
     color: rgb(var(--v-theme-text-on-accent))
+    cursor: text
 
   :deep(.v-overlay__content)
     border-radius: 1rem

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -38,7 +38,7 @@ type CategoryCarouselItem = {
 }
 
 type HomeBlogItem = BlogPostDto & { formattedDate?: string; slug?: string }
-type EnrichedBlogItem = HomeBlogItem & { link: string; isExternal: boolean; hasImage: boolean }
+type EnrichedBlogItem = HomeBlogItem & { link: string; hasImage: boolean }
 
 const { categories: rawCategories, fetchCategories, loading: categoriesLoading } = useCategories()
 const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
@@ -475,13 +475,11 @@ const resolveBlogArticleLink = (article: BlogPostDto) => {
 const enrichedBlogItems = computed<EnrichedBlogItem[]>(() =>
   blogListItems.value.map((item) => {
     const link = resolveBlogArticleLink(item)
-    const isExternal = /^https?:\/\//i.test(link)
     const hasImage = hasRenderableImage(item.image)
 
     return {
       ...item,
       link,
-      isExternal,
       hasImage,
     }
   }),
@@ -604,7 +602,10 @@ useHead(() => ({
       <HomeCtaSection
         v-model:search-query="searchQuery"
         :categories-landing-url="categoriesLandingUrl"
+        :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
         @submit="handleSearchSubmit"
+        @select-category="handleCategorySuggestion"
+        @select-product="handleProductSuggestion"
       />
     </div>
   </div>


### PR DESCRIPTION
## Summary
- switch the homepage CTA form to `SearchSuggestField` so suggestions behave like the hero search
- remove external link handling and wrap blog cards with `NuxtLink` for consistent navigation
- adjust the search suggest field styling to always show a text cursor when hovering the input

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120066a05483229abb3de24b9d7b37)