### PR TITLE
feat(frontend): refresh product subscore visuals

### DIFF
--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -44,6 +44,10 @@
           :key="score.id"
           :score="score"
           :product-name="productName"
+          :product-brand="productBrand"
+          :product-model="productModel"
+          :product-image="productImage"
+          :vertical-title="verticalTitle"
         />
       </template>
     </div>
@@ -103,6 +107,18 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  productBrand: {
+    type: String,
+    default: '',
+  },
+  productModel: {
+    type: String,
+    default: '',
+  },
+  productImage: {
+    type: String,
+    default: '',
+  },
   loading: {
     type: Boolean,
     default: false,
@@ -111,11 +127,19 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  verticalTitle: {
+    type: String,
+    default: '',
+  },
 })
 
 const radarData = toRef(props, 'radarData')
 const productName = toRef(props, 'productName')
+const productBrand = toRef(props, 'productBrand')
+const productModel = toRef(props, 'productModel')
+const productImage = toRef(props, 'productImage')
 const verticalHomeUrl = toRef(props, 'verticalHomeUrl')
+const verticalTitle = toRef(props, 'verticalTitle')
 const { t } = useI18n()
 
 const primaryScore = computed(() => props.scores[0] ?? null)

--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.spec.ts
@@ -43,6 +43,10 @@ describe('ProductImpactSubscoreCard', () => {
       props: {
         score: baseScore,
         productName: 'Demo',
+        productBrand: 'EcoCorp',
+        productModel: 'X1',
+        productImage: '/cover.png',
+        verticalTitle: 'televisions',
       },
     })
 
@@ -54,6 +58,10 @@ describe('ProductImpactSubscoreCard', () => {
       props: {
         score: { ...baseScore, id: 'DATA_QUALITY' },
         productName: 'Demo',
+        productBrand: 'EcoCorp',
+        productModel: 'X1',
+        productImage: '/cover.png',
+        verticalTitle: 'televisions',
       },
     })
 

--- a/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreCard.vue
@@ -1,5 +1,13 @@
 <template>
-  <component :is="resolvedComponent" :score="score" :product-name="productName" />
+  <component
+    :is="resolvedComponent"
+    :score="score"
+    :product-name="productName"
+    :product-brand="productBrand"
+    :product-model="productModel"
+    :product-image="productImage"
+    :vertical-title="verticalTitle"
+  />
 </template>
 
 <script setup lang="ts">
@@ -17,6 +25,10 @@ import ProductImpactSubscoreDataQualityCard from './subscores/ProductImpactSubsc
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 
 const specializationMap: Record<string, Component> = {

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -24,12 +24,23 @@ describe('ProductImpactSubscoreGenericCard', () => {
         product: {
           impact: {
             absoluteValue: 'Absolute value',
-            explanationTitle: 'Explanation',
             percentile: 'Percentile',
             weightChip: 'Counts for {value}% of the total score',
             subscoreDetailsToggle: 'View indicator details',
             tableHeaders: {
               ranking: 'Rank',
+            },
+            subscores: {
+              default: {
+                ranking: 'Rank {ranking} out of {count}.',
+                readIndicator: {
+                  title: 'How to read this indicator',
+                  worst: 'Worst indicator is {worst}.',
+                  best: 'Best indicator is {best} across {count} {verticalTitle}.',
+                  average: 'Average is {average}, equivalent to {averageOn20}/20.',
+                  product: '{productName} scores {productOn20}/20.',
+                },
+              },
             },
           },
         },
@@ -43,6 +54,7 @@ describe('ProductImpactSubscoreGenericCard', () => {
     description: 'Lower is better',
     relativeValue: 3.6,
     absoluteValue: 42.5,
+    absolute: { min: 10, max: 100, avg: 55, count: 200, value: 42.5 },
     energyLetter: 'A',
     distribution: [
       { label: '1', value: 5 },
@@ -56,19 +68,19 @@ describe('ProductImpactSubscoreGenericCard', () => {
     },
   }
 
-  it('renders the header, score, chart and explanation details', () => {
+  it('renders the header, value summary, chart and explanation details', () => {
     const wrapper = mount(ProductImpactSubscoreGenericCard, {
-      props: { score, productName: 'Demo Product' },
+      props: {
+        score,
+        productName: 'Demo Product',
+        productBrand: 'EcoCorp',
+        productModel: 'Air 2000',
+        productImage: '/cover.png',
+        verticalTitle: 'televisions',
+      },
       global: {
         plugins: [i18n],
         stubs: {
-          ImpactScore: defineComponent({
-            name: 'ImpactScoreStub',
-            props: ['score'],
-            setup(props) {
-              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
-            },
-          }),
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
             props: ['value', 'labelKey', 'labelParams', 'tooltipKey', 'tooltipParams'],
@@ -112,15 +124,15 @@ describe('ProductImpactSubscoreGenericCard', () => {
 
     expect(wrapper.text()).toContain('coefficient:0.42')
     expect(wrapper.text()).toContain('17.3')
-    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
+    expect(wrapper.find('.impact-subscore__value-number').text()).toBe('42.5')
     expect(wrapper.text()).toContain('Absolute value')
-    expect(wrapper.text()).toContain('42.5')
-    expect(wrapper.text()).toContain('Explanation')
+    expect(wrapper.text()).toContain('How to read this indicator')
     expect(wrapper.text()).toContain('Lower is better')
     expect(wrapper.text()).toContain('View indicator details')
     expect(wrapper.text()).not.toContain('Percentile')
     expect(wrapper.text()).toContain('Rank')
     expect(wrapper.text()).toContain('3')
+    expect(wrapper.text()).toContain('Rank 3 out of 200.')
     expect(wrapper.text()).toContain('High')
   })
 })

--- a/frontend/app/components/product/impact/impact-types.ts
+++ b/frontend/app/components/product/impact/impact-types.ts
@@ -3,6 +3,14 @@ export type DistributionBucket = {
   value: number
 }
 
+export type ScoreAbsoluteStats = {
+  min?: number | null
+  max?: number | null
+  avg?: number | null
+  count?: number | null
+  value?: number | null
+}
+
 export type ScoreView = {
   id: string
   label: string
@@ -10,6 +18,7 @@ export type ScoreView = {
   relativeValue: number | null
   value?: number | null
   absoluteValue?: string | number | null
+  absolute?: ScoreAbsoluteStats | null
   coefficient?: number | null
   percent?: number | null
   ranking?: number | string | null

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreBrandSustainabilityCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreBrandSustainabilityCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreClasseEnergyCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreClasseEnergyCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreDataQualityCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreDataQualityCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionOffCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionOffCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionTypicalCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscorePowerConsumptionTypicalCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
@@ -9,5 +9,9 @@ import type { ScoreView } from '../impact-types'
 const props = defineProps<{
   score: ScoreView
   productName: string
+  productBrand: string
+  productModel: string
+  productImage: string
+  verticalTitle: string
 }>()
 </script>

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -49,7 +49,11 @@
             :radar-data="radarData"
             :loading="loadingAggregations"
             :product-name="productTitle"
+            :product-brand="productBrand"
+            :product-model="productModel"
+            :product-image="resolvedProductImageSource"
             :vertical-home-url="verticalHomeUrl"
+            :vertical-title="normalizedVerticalTitle"
           />
         </section>
 
@@ -148,7 +152,7 @@ import { buildCategoryHash } from '~/utils/_category-filter-state'
 const route = useRoute()
 const requestURL = useRequestURL()
 const runtimeConfig = useRuntimeConfig()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const { isLoggedIn } = useAuth()
 const display = useDisplay()
 
@@ -335,6 +339,36 @@ const productTitle = computed(() => {
 
 const heroPopularAttributes = computed(() => categoryDetail.value?.popularAttributes ?? [])
 const verticalHomeUrl = computed(() => categoryDetail.value?.verticalHomeUrl?.trim() ?? '')
+const verticalTitle = computed(() => {
+  const candidates = [
+    categoryDetail.value?.verticalHomeTitle,
+    categoryDetail.value?.verticalMetaTitle,
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length) {
+      return candidate.trim()
+    }
+  }
+
+  return ''
+})
+const normalizedVerticalTitle = computed(() => {
+  const title = verticalTitle.value
+  if (!title.length) {
+    return ''
+  }
+
+  try {
+    return title.toLocaleLowerCase(locale.value)
+  } catch (error) {
+    if (import.meta.dev) {
+      console.warn('Failed to localize vertical title casing.', error)
+    }
+
+    return title.toLowerCase()
+  }
+})
 
 const BRAND_FILTER_FIELD = 'attributes.referentielAttributes.BRAND' as const
 
@@ -589,6 +623,7 @@ const impactScores = computed(() => {
       relativeValue: typeof score.relativ?.value === 'number' ? score.relativ.value : null,
       value: typeof score.value === 'number' ? score.value : null,
       absoluteValue: score.absoluteValue ?? null,
+      absolute: score.absolute ?? null,
       coefficient: coefficients[score.id.toUpperCase()] ?? null,
       percent: score.percent ?? null,
       ranking: score.ranking ?? null,

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1765,6 +1765,28 @@
       "weightTooltip": "The {scoreName} score counts for {value}% of the total score",
       "subscoreDetailsToggle": "View indicator details",
       "subscoreEyebrow": "Impact indicator",
+      "subscores": {
+        "default": {
+          "ranking": "Rank {ranking} out of {count}.",
+          "readIndicator": {
+            "title": "How to read this indicator",
+            "worst": "The lowest {scoreLabelLower} recorded is {worst}, which corresponds to a 0/20 score.",
+            "best": "The highest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}, worth 20/20.",
+            "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}, equivalent to {averageOn20}/20.",
+            "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}, which converts to {productOn20}/20."
+          }
+        },
+        "repairability_index": {
+          "ranking": "Rank {ranking} out of {count}.",
+          "readIndicator": {
+            "title": "How to read this repairability indicator",
+            "worst": "The worst repairability index observed is {worst}, which yields a 0/20 score.",
+            "best": "The best repairability index among the {count} {verticalTitle} reaches {best}, worth 20/20.",
+            "average": "On average, the {count} {verticalTitle} with available data score {average}, i.e. {averageOn20}/20.",
+            "product": "{productName}, with a repairability index of {productAbsolute}, earns {productOn20}/20."
+          }
+        }
+      },
       "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
       "radarControls": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1765,6 +1765,28 @@
       "weightTooltip": "Le score {scoreName} compte pour {value}% de la note totale",
       "subscoreDetailsToggle": "Voir les détails de l'indicateur",
       "subscoreEyebrow": "Indicateur d'impact",
+      "subscores": {
+        "default": {
+          "ranking": "Classe {ranking} sur {count}.",
+          "readIndicator": {
+            "title": "Comment lire cet indicateur",
+            "worst": "Le plus faible {scoreLabelLower} observé est de {worst}, soit une note de 0/20.",
+            "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
+            "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
+            "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
+          }
+        },
+        "repairability_index": {
+          "ranking": "Classe {ranking} sur {count}.",
+          "readIndicator": {
+            "title": "Comment lire cet indicateur de réparabilité",
+            "worst": "Le pire indice de réparabilité est {worst}, ce qui vaut la note de 0/20.",
+            "best": "Le meilleur indice de réparabilité rencontré pour les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
+            "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
+            "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
+          }
+        }
+      },
       "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
       "radarControls": {


### PR DESCRIPTION
## Summary
- replace the ImpactScore block with a flexible value showcase and thread brand/model/image data into subscore cards
- enhance the distribution chart with ES-UNKNOWN filtering and a product marker rendered via ECharts graphics
- rework the indicator explanation, extend score metadata wiring, and add localized copy with updated component tests

## Testing
- pnpm lint
- pnpm test --run ProductImpactSubscoreGenericCard

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f65b69a88322b4f923b5f3fb1e6c)