### PR TITLE
Refine impact subscore UI and repairability visualization

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
@@ -1,7 +1,5 @@
 <template>
   <section v-if="hasContent" class="impact-subscore-explanation">
-    <p v-if="rankingSummary" class="impact-subscore-explanation__ranking">{{ rankingSummary }}</p>
-
     <div v-if="readIndicatorParagraphs.length || score.description" class="impact-subscore-explanation__card">
       <h5 class="impact-subscore-explanation__title">{{ readIndicatorTitle }}</h5>
       <p
@@ -48,7 +46,14 @@ const { n, t, te, locale } = useI18n()
 
 const normalizedScoreKey = computed(() => {
   const raw = props.score.id ?? ''
-  const normalized = raw.toString().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  const normalized = raw
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_')
+    .replace(/[^a-z0-9_]+/g, '')
+    .replace(/^_+|_+$/g, '')
+
   return normalized.length ? normalized : 'default'
 })
 
@@ -143,13 +148,6 @@ const computeOn20 = (value: number | null | undefined, min: number | null | unde
 
 const infoItems = computed(() => {
   const items: Array<{ label: string; value: string }> = []
-
-  if (props.absoluteValue) {
-    items.push({
-      label: t('product.impact.absoluteValue'),
-      value: props.absoluteValue,
-    })
-  }
 
   if (props.score.ranking != null && Number.isFinite(Number(props.score.ranking))) {
     items.push({
@@ -265,20 +263,8 @@ const readIndicatorParagraphs = computed(() => {
   return paragraphs.filter((paragraph) => paragraph?.toString().trim().length)
 })
 
-const rankingSummary = computed(() => {
-  if (!rankingValue.value || !populationValue.value) {
-    return ''
-  }
-
-  return resolveTranslation('ranking', {
-    ranking: rankingValue.value,
-    count: populationValue.value.formatted,
-  })
-})
-
 const hasContent = computed(
   () =>
-    Boolean(rankingSummary.value) ||
     readIndicatorParagraphs.value.length > 0 ||
     Boolean(props.score.description) ||
     infoItems.value.length > 0 ||
@@ -305,13 +291,6 @@ function formatMetadataLabel(rawKey: string): string {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-
-.impact-subscore-explanation__ranking {
-  margin: 0;
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: rgb(var(--v-theme-text-neutral-strong));
 }
 
 .impact-subscore-explanation__card {

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -23,7 +23,6 @@ describe('ProductImpactSubscoreGenericCard', () => {
       'en-US': {
         product: {
           impact: {
-            absoluteValue: 'Absolute value',
             percentile: 'Percentile',
             weightChip: 'Counts for {value}% of the total score',
             subscoreDetailsToggle: 'View indicator details',
@@ -39,6 +38,16 @@ describe('ProductImpactSubscoreGenericCard', () => {
                   best: 'Best indicator is {best} across {count} {verticalTitle}.',
                   average: 'Average is {average}, equivalent to {averageOn20}/20.',
                   product: '{productName} scores {productOn20}/20.',
+                },
+              },
+              repairability_index: {
+                ranking: 'Rank {ranking} out of {count}.',
+                readIndicator: {
+                  title: 'Repairability indicator guidance',
+                  worst: 'Worst repairability indicator is {worst}.',
+                  best: 'Best repairability indicator is {best} across {count} {verticalTitle}.',
+                  average: 'Average repairability is {average}, equivalent to {averageOn20}/20.',
+                  product: '{productName} repairability is {productOn20}/20.',
                 },
               },
             },
@@ -125,14 +134,76 @@ describe('ProductImpactSubscoreGenericCard', () => {
     expect(wrapper.text()).toContain('coefficient:0.42')
     expect(wrapper.text()).toContain('17.3')
     expect(wrapper.find('.impact-subscore__value-number').text()).toBe('42.5')
-    expect(wrapper.text()).toContain('Absolute value')
     expect(wrapper.text()).toContain('How to read this indicator')
     expect(wrapper.text()).toContain('Lower is better')
     expect(wrapper.text()).toContain('View indicator details')
     expect(wrapper.text()).not.toContain('Percentile')
     expect(wrapper.text()).toContain('Rank')
     expect(wrapper.text()).toContain('3')
-    expect(wrapper.text()).toContain('Rank 3 out of 200.')
     expect(wrapper.text()).toContain('High')
+    expect(wrapper.text()).not.toContain('Rank 3 out of 200.')
+  })
+
+  it('uses specialised translations when available', () => {
+    const specializedScore: ScoreView = {
+      ...score,
+      id: 'REPAIRABILITY_INDEX',
+      label: 'Repairability index',
+    }
+
+    const wrapper = mount(ProductImpactSubscoreGenericCard, {
+      props: {
+        score: specializedScore,
+        productName: 'Demo Product',
+        productBrand: 'EcoCorp',
+        productModel: 'Air 2000',
+        productImage: '/cover.png',
+        verticalTitle: 'televisions',
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          ImpactCoefficientBadge: defineComponent({
+            name: 'ImpactCoefficientBadgeStub',
+            props: ['value', 'labelKey', 'labelParams', 'tooltipKey', 'tooltipParams'],
+            setup(props) {
+              return () => h('span', { class: 'coefficient-stub' }, `coefficient:${props.value}`)
+            },
+          }),
+          'v-expansion-panels': defineComponent({
+            name: 'VExpansionPanelsStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panels-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel': defineComponent({
+            name: 'VExpansionPanelStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel-title': defineComponent({
+            name: 'VExpansionPanelTitleStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-title-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel-text': defineComponent({
+            name: 'VExpansionPanelTextStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-text-stub' }, slots.default?.())
+            },
+          }),
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => slots.default?.()
+            },
+          }),
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Repairability indicator guidance')
   })
 })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -3,7 +3,6 @@
     <ProductImpactSubscoreHeader
       :title="score.label"
       :on20="score.on20"
-      :coefficient="score.coefficient ?? null"
     />
 
     <div class="impact-subscore__value">
@@ -12,12 +11,19 @@
         :score="score"
         :absolute-value="absoluteValue"
         :relative-value="relativeScore"
+        :product-absolute-value="productAbsoluteValue"
       >
         <div class="impact-subscore__value-default">
           <span class="impact-subscore__value-number">{{ absoluteValue ?? '—' }}</span>
-          <span class="impact-subscore__value-label">{{ $t('product.impact.absoluteValue') }}</span>
         </div>
       </slot>
+
+      <ImpactCoefficientBadge
+        v-if="coefficientValue != null"
+        class="impact-subscore__coefficient"
+        :value="coefficientValue"
+        :tooltip-params="{ scoreName: score.label }"
+      />
     </div>
 
     <div v-if="score.energyLetter" class="impact-subscore__badge">
@@ -62,6 +68,7 @@ import { useI18n } from 'vue-i18n'
 import ProductImpactSubscoreHeader from './ProductImpactSubscoreHeader.vue'
 import ProductImpactSubscoreChart from './ProductImpactSubscoreChart.vue'
 import ProductImpactSubscoreExplanation from './ProductImpactSubscoreExplanation.vue'
+import ImpactCoefficientBadge from '~/components/shared/ui/ImpactCoefficientBadge.vue'
 import type { ScoreView } from './impact-types'
 
 const props = defineProps<{
@@ -135,6 +142,20 @@ const productBrand = computed(() => props.productBrand?.trim() ?? '')
 const productModel = computed(() => props.productModel?.trim() ?? '')
 const productImage = computed(() => props.productImage?.trim() ?? '')
 const verticalTitle = computed(() => props.verticalTitle?.trim() ?? '')
+
+const coefficientValue = computed(() => {
+  const rawCoefficient = props.score.coefficient
+  if (rawCoefficient == null) {
+    return null
+  }
+
+  if (typeof rawCoefficient === 'number') {
+    return Number.isFinite(rawCoefficient) ? rawCoefficient : null
+  }
+
+  const numeric = Number(rawCoefficient)
+  return Number.isFinite(numeric) ? numeric : null
+})
 </script>
 
 <style scoped>
@@ -151,8 +172,9 @@ const verticalTitle = computed(() => props.verticalTitle?.trim() ?? '')
 
 .impact-subscore__value {
   display: flex;
-  align-items: flex-start;
-  justify-content: flex-start;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1rem;
 }
 
 .impact-subscore__value-default {
@@ -168,10 +190,8 @@ const verticalTitle = computed(() => props.verticalTitle?.trim() ?? '')
   color: rgb(var(--v-theme-text-neutral-strong));
 }
 
-.impact-subscore__value-label {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+.impact-subscore__coefficient {
+  align-self: flex-start;
 }
 
 .impact-subscore__badge {

--- a/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
@@ -3,11 +3,6 @@
     <div class="impact-subscore-header__info">
       <h4 class="impact-subscore-header__title">{{ title }}</h4>
       <p v-if="subtitle" class="impact-subscore-header__subtitle">{{ subtitle }}</p>
-      <ImpactCoefficientBadge
-        v-if="coefficientValue != null"
-        :value="coefficientValue"
-        :tooltip-params="{ scoreName: title }"
-      />
     </div>
 
     <div v-if="on20Value" class="impact-subscore-header__score" aria-hidden="true">
@@ -20,30 +15,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
-import ImpactCoefficientBadge from '~/components/shared/ui/ImpactCoefficientBadge.vue'
-
 const props = defineProps<{
   title: string
   subtitle?: string
   on20?: number | null
   percent?: number | null
-  coefficient?: number | null
 }>()
 
 const { n } = useI18n()
-const coefficientValue = computed(() => {
-  if (props.coefficient == null) {
-    return null
-  }
-
-  const numeric = typeof props.coefficient === 'number' ? props.coefficient : Number(props.coefficient)
-  if (!Number.isFinite(numeric)) {
-    return null
-  }
-
-  return Math.min(Math.max(numeric, 0), 1)
-})
-
 const on20Value = computed(() => {
   if (typeof props.on20 !== 'number' || Number.isNaN(props.on20)) {
     return null

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.spec.ts
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.spec.ts
@@ -1,0 +1,132 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import ProductImpactSubscoreRepairabilityIndexCard from './ProductImpactSubscoreRepairabilityIndexCard.vue'
+import type { ScoreView } from '../impact-types'
+
+describe('ProductImpactSubscoreRepairabilityIndexCard', () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: {
+      'en-US': {
+        product: {
+          impact: {
+            weightChip: 'Counts for {value}% of the total score',
+            weightTooltip: 'The {scoreName} score counts for {value}% of the total score',
+            subscoreDetailsToggle: 'View indicator details',
+            tableHeaders: {
+              ranking: 'Rank',
+            },
+            subscores: {
+              default: {
+                ranking: 'Rank {ranking} out of {count}.',
+                readIndicator: {
+                  title: 'How to read this indicator',
+                  worst: 'Worst indicator is {worst}.',
+                  best: 'Best indicator is {best} across {count} {verticalTitle}.',
+                  average: 'Average is {average}, equivalent to {averageOn20}/20.',
+                  product: '{productName} scores {productOn20}/20.',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const baseScore: ScoreView = {
+    id: 'REPAIRABILITY_INDEX',
+    label: 'Repairability index',
+    description: null,
+    relativeValue: 6.4,
+    absoluteValue: 6.4,
+    absolute: { value: 6.37, min: 0.5, max: 9.5, avg: 5.5, count: 120 },
+    coefficient: 0.2,
+    ranking: 12,
+    on20: 15.6,
+    distribution: [],
+    energyLetter: null,
+    metadatas: null,
+  }
+
+  it('renders the repairability illustration associated with the score', () => {
+    const wrapper = mount(ProductImpactSubscoreRepairabilityIndexCard, {
+      props: {
+        score: baseScore,
+        productName: 'Demo Product',
+        productBrand: 'EcoCorp',
+        productModel: 'Air 2000',
+        productImage: '/cover.png',
+        verticalTitle: 'televisions',
+      },
+      global: {
+        plugins: [i18n],
+        stubs: {
+          NuxtImg: defineComponent({
+            name: 'NuxtImgStub',
+            props: ['src'],
+            setup(props) {
+              return () => h('img', { class: 'nuxt-img-stub', src: props.src as string })
+            },
+          }),
+          ImpactCoefficientBadge: defineComponent({
+            name: 'ImpactCoefficientBadgeStub',
+            props: ['value'],
+            setup(props) {
+              return () => h('span', `coefficient:${props.value}`)
+            },
+          }),
+          ProductImpactSubscoreChart: defineComponent({
+            name: 'ProductImpactSubscoreChartStub',
+            setup() {
+              return () => h('div', { class: 'chart-stub' })
+            },
+          }),
+          ProductImpactSubscoreExplanation: defineComponent({
+            name: 'ProductImpactSubscoreExplanationStub',
+            setup() {
+              return () => h('div', { class: 'explanation-stub' })
+            },
+          }),
+          'v-expansion-panels': defineComponent({
+            name: 'VExpansionPanelsStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panels-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel': defineComponent({
+            name: 'VExpansionPanelStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel-title': defineComponent({
+            name: 'VExpansionPanelTitleStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-title-stub' }, slots.default?.())
+            },
+          }),
+          'v-expansion-panel-text': defineComponent({
+            name: 'VExpansionPanelTextStub',
+            setup(_, { slots }) {
+              return () => h('div', { class: 'expansion-panel-text-stub' }, slots.default?.())
+            },
+          }),
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => slots.default?.()
+            },
+          }),
+        },
+      },
+    })
+
+    const image = wrapper.find('img.nuxt-img-stub')
+    expect(image.exists()).toBe(true)
+    expect(image.attributes('src')).toBe('/images/reparability/6.4.svg')
+  })
+})

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
@@ -1,9 +1,25 @@
 <template>
-  <ProductImpactSubscoreGenericCard v-bind="props" />
+  <ProductImpactSubscoreGenericCard v-bind="props">
+    <template #visual="{ absoluteValue }">
+      <div class="impact-subscore-repairability__visual">
+        <NuxtImg
+          v-if="repairabilityImageSrc"
+          :src="repairabilityImageSrc"
+          alt=""
+          class="impact-subscore-repairability__image"
+          width="144"
+          height="144"
+          loading="lazy"
+        />
+        <span v-else class="impact-subscore-repairability__fallback">{{ absoluteValue ?? '—' }}</span>
+      </div>
+    </template>
+  </ProductImpactSubscoreGenericCard>
 
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import ProductImpactSubscoreGenericCard from '../ProductImpactSubscoreGenericCard.vue'
 import type { ScoreView } from '../impact-types'
 
@@ -15,4 +31,82 @@ const props = defineProps<{
   productImage: string
   verticalTitle: string
 }>()
+
+const MIN_ASSET_VALUE = 0.1
+const MAX_ASSET_VALUE = 9.9
+
+const numericAbsoluteValue = computed<number | null>(() => {
+  const { score } = props
+
+  const candidates = [
+    score.absolute?.value,
+    score.value,
+    typeof score.absoluteValue === 'number' ? score.absoluteValue : parseLocalizedNumber(score.absoluteValue),
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+})
+
+const repairabilityImageKey = computed<string | null>(() => {
+  if (numericAbsoluteValue.value == null) {
+    return null
+  }
+
+  const clamped = Math.min(Math.max(numericAbsoluteValue.value, MIN_ASSET_VALUE), MAX_ASSET_VALUE)
+  const rounded = Math.round(clamped * 10) / 10
+  return rounded.toFixed(1)
+})
+
+const repairabilityImageSrc = computed<string | null>(() => {
+  if (!repairabilityImageKey.value) {
+    return null
+  }
+
+  return `/images/reparability/${repairabilityImageKey.value}.svg`
+})
+
+function parseLocalizedNumber(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.replace(/,/g, '.').trim()
+  if (!normalized.length) {
+    return null
+  }
+
+  const parsed = Number(normalized)
+  return Number.isFinite(parsed) ? parsed : null
+}
 </script>
+
+<style scoped>
+.impact-subscore-repairability__visual {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 144px;
+}
+
+.impact-subscore-repairability__image {
+  max-width: 100%;
+  height: auto;
+}
+
+.impact-subscore-repairability__fallback {
+  font-size: clamp(2.25rem, 2.2rem + 0.5vw, 2.75rem);
+  font-weight: 700;
+  line-height: 1.1;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1753,7 +1753,6 @@
           "attributeEqual": "Show products where {label} matches your product."
         }
       },
-      "absoluteValue": "Absolute value",
       "explanationTitle": "How to interpret this indicator",
       "detailsTitle": "Assessment details",
       "noPrimaryScore": "Impact score unavailable",
@@ -1761,7 +1760,7 @@
       "methodologyLink": "Access the methodology",
       "methodologyLinkAria": "Open the Impact Score methodology",
       "percentile": "Percentile",
-      "weightChip": "{value}% of the total score",
+      "weightChip": "Counts for {value}% of the total score",
       "weightTooltip": "The {scoreName} score counts for {value}% of the total score",
       "subscoreDetailsToggle": "View indicator details",
       "subscoreEyebrow": "Impact indicator",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1753,7 +1753,6 @@
           "attributeEqual": "Afficher les produits où {label} correspond à votre produit."
         }
       },
-      "absoluteValue": "Valeur absolue",
       "explanationTitle": "Comment lire cet indicateur",
       "detailsTitle": "Détails de l'évaluation",
       "noPrimaryScore": "Score indisponible",
@@ -1761,7 +1760,7 @@
       "methodologyLink": "Accéder à la méthodologie",
       "methodologyLinkAria": "Ouvrir la méthodologie de l'Impact Score",
       "percentile": "Percentile",
-      "weightChip": "{value}% de la note totale",
+      "weightChip": "Compte pour {value}% de la note totale",
       "weightTooltip": "Le score {scoreName} compte pour {value}% de la note totale",
       "subscoreDetailsToggle": "Voir les détails de l'indicateur",
       "subscoreEyebrow": "Indicateur d'impact",


### PR DESCRIPTION
## Summary
- move the subscore coefficient badge beside the absolute value display and clean up the default copy
- simplify the explanation accordion, remove the ranking banner, and fix score-specific translation lookup
- render repairability subscores with the dedicated SVG indicator and cover it with a component test
- update i18n strings to reflect the new chip wording and drop the unused absolute value label

## Testing
- pnpm lint
- pnpm vitest run app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913477ccef48322aa040d53b3784d33)