### PR TITLE
Fix duplicated shared token header injection

### DIFF
--- a/frontend/app/plugins/api-token.server.ts
+++ b/frontend/app/plugins/api-token.server.ts
@@ -17,11 +17,9 @@ export default defineNuxtPlugin(() => {
     return (input as any)?.url ?? ''
   }
   const withToken = (init: RequestInit = {}): RequestInit => {
-    const headers =
-      init.headers instanceof Headers
-        ? Object.fromEntries(init.headers.entries())
-        : { ...(init.headers as Record<string, string> | undefined) }
-    return { ...init, headers: { ...headers, 'X-Shared-Token': token } }
+    const headers = new Headers(init.headers ?? {})
+    headers.set('X-Shared-Token', token)
+    return { ...init, headers }
   }
   globalObj.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = toUrl(input)


### PR DESCRIPTION
## Summary
- normalise the server-side fetch plugin headers so X-Shared-Token is only set once

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691442eca84483229c75ba5f64cb164c)