### PR TITLE
Adjust home hero media and blog feed

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
+import { useDisplay } from 'vuetify'
 import HomeCategoryCarousel from '~/components/home/HomeCategoryCarousel.vue'
 import SearchSuggestField, {
   type CategorySuggestionItem,
@@ -36,11 +37,14 @@ const emit = defineEmits<{
 }>()
 
 const { t, tm } = useI18n()
+const display = useDisplay()
 
 const searchQueryValue = computed(() => props.searchQuery)
 
 const { minSuggestionQueryLength, heroVideoSrc, heroVideoPoster, categoryItems, categoriesLoading } =
   toRefs(props)
+
+const shouldShowHeroVideo = computed(() => display.mdAndUp.value)
 
 const updateSearchQuery = (value: string) => {
   emit('update:searchQuery', value)
@@ -157,21 +161,31 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
             </ul>
           </v-col>
 
-          <v-col cols="12" lg="6" class="home-hero__media" aria-hidden="true">
+          <v-col
+            cols="12"
+            lg="6"
+            class="home-hero__media"
+            :aria-hidden="!shouldShowHeroVideo"
+          >
             <v-sheet rounded="xl" elevation="8" class="home-hero__media-sheet">
-              <div class="home-hero__video-wrapper">
-                <video
-                  class="home-hero__video"
-                  :poster="heroVideoPoster"
-                  muted
-                  autoplay
-                  playsinline
-                  preload="metadata"
-                >
-                  <source :src="heroVideoSrc" type="video/mp4" />
-                </video>
-                <div class="home-hero__video-overlay" />
-              </div>
+              <ClientOnly>
+                <div v-if="shouldShowHeroVideo" class="home-hero__video-wrapper">
+                  <video
+                    class="home-hero__video"
+                    :poster="heroVideoPoster"
+                    muted
+                    autoplay
+                    playsinline
+                    preload="metadata"
+                  >
+                    <source :src="heroVideoSrc" type="video/mp4" />
+                  </video>
+                  <div class="home-hero__video-overlay" />
+                </div>
+              </ClientOnly>
+              <p v-if="heroVideoSrc" class="home-hero__media-link home-hero__sr-only">
+                <a :href="heroVideoSrc">{{ t('home.hero.video.accessibleLink') }}</a>
+              </p>
             </v-sheet>
           </v-col>
         </v-row>
@@ -280,6 +294,7 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
   padding: clamp(0.5rem, 2vw, 1rem)
   background: rgba(var(--v-theme-surface-glass), 0.85)
   overflow: hidden
+  position: relative
 
 .home-hero__video-wrapper
   position: relative
@@ -300,6 +315,20 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
   inset: 0
   background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.1), rgba(var(--v-theme-hero-gradient-end), 0.2))
   pointer-events: none
+
+.home-hero__media-link
+  margin: 0
+
+.home-hero__sr-only
+  position: absolute
+  width: 1px
+  height: 1px
+  padding: 0
+  margin: -1px
+  overflow: hidden
+  clip: rect(0, 0, 0, 0)
+  white-space: nowrap
+  border: 0
 
 .home-hero__categories
   position: absolute

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -48,6 +48,7 @@ const { t } = useI18n()
                 src="/images/home/nudger-screaming.webp"
                 :alt="t('home.solution.title')"
                 class="home-solution__image"
+                sizes="(min-width: 960px) 306px, 60vw"
                 loading="lazy"
               />
             </div>
@@ -147,9 +148,10 @@ const { t } = useI18n()
 .home-solution__image
   position: relative
   z-index: 1
-  width: 100%
+  width: min(66%, 306px)
   height: auto
   display: block
+  margin-inline: auto
 
 @media (max-width: 959px)
   .home-solution__col--visual

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -43,7 +43,7 @@ type EnrichedBlogItem = HomeBlogItem & { link: string; hasImage: boolean }
 const { categories: rawCategories, fetchCategories, loading: categoriesLoading } = useCategories()
 const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
 
-const BLOG_ARTICLES_LIMIT = 5
+const BLOG_ARTICLES_LIMIT = 4
 
 const toSafeString = (value: unknown) => {
   if (typeof value === 'string') {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -45,6 +45,9 @@
       "title": "Responsible choices aren’t a luxury",
       "subtitle": "Save time, stay true to your values. Compare effortlessly, choose freely.",
       "imageAlt": "Illustration of the Nudger comparison experience with product cards and impact charts.",
+      "video": {
+        "accessibleLink": "Open the hero presentation video (desktop experience)"
+      },
       "search": {
         "label": "Search for a product",
         "placeholder": "Search a product (e.g. television, smartphone…)",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -45,6 +45,9 @@
       "title": "Consommer responsable n’est plus un luxe",
       "subtitle": "Gagne du temps, garde tes valeurs. Compare simplement, choisis librement.",
       "imageAlt": "Illustration d’un comparateur Nudger affichant des cartes produits et des graphiques d’impact.",
+      "video": {
+        "accessibleLink": "Accéder à la vidéo de présentation (expérience desktop)"
+      },
       "search": {
         "label": "Rechercher un produit",
         "placeholder": "Recherchez un produit (ex. téléviseur, smartphone…)",


### PR DESCRIPTION
## Summary
- hide the hero section video on mobile, load it only when md and up, and add an accessible link for crawlers
- shrink the solution section illustration and add responsive image hints while reducing the blog feed to four posts
- localize the new hero video text for both English and French

## Testing
- pnpm lint
- pnpm test --run pages/index.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158b2d8ed083228adfbe231a86f5eb)