### PR TITLE
Fix ProductLifeTimeline spec enum references

### DIFF
--- a/frontend/app/components/product/ProductLifeTimeline.spec.ts
+++ b/frontend/app/components/product/ProductLifeTimeline.spec.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import { defineComponent, h } from 'vue'
 import {
-  ProductTimelineEventDtoSourceEnum,
-  ProductTimelineEventDtoTypeEnum,
+  ProductTimelineEventSource,
+  ProductTimelineEventType,
   type ProductTimelineDto,
 } from '~~/shared/api-client'
 
@@ -83,13 +83,13 @@ const VIconStub = defineComponent({
 const buildTimeline = (): ProductTimelineDto => ({
   events: [
     {
-      type: ProductTimelineEventDtoTypeEnum.PriceFirstSeenNew,
-      source: ProductTimelineEventDtoSourceEnum.PriceHistory,
+      type: ProductTimelineEventType.PriceFirstSeenNew,
+      source: ProductTimelineEventSource.PriceHistory,
       timestamp: Date.UTC(2024, 0, 5),
     },
     {
-      type: ProductTimelineEventDtoTypeEnum.EprelOnMarketStart,
-      source: ProductTimelineEventDtoSourceEnum.Eprel,
+      type: ProductTimelineEventType.EprelOnMarketStart,
+      source: ProductTimelineEventSource.Eprel,
       timestamp: Date.UTC(2024, 5, 1),
     },
   ],


### PR DESCRIPTION
## Summary
- update the ProductLifeTimeline spec to rely on the generated ProductTimelineEventType and ProductTimelineEventSource exports from the OpenAPI client
- ensure the test data uses the same constants as the runtime component, preventing undefined enum access at runtime

## Testing
- `pnpm test app/components/product/ProductLifeTimeline.spec.ts` *(fails: shared SearchSuggestField import requires the optional `vue-barcode-reader` dependency that is not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69158fac8130832281addb231cab518a)