### PR TITLE
Align ecoscore filters with relative scale

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
@@ -66,7 +66,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public class CategoriesController {
 
     private static final int TOP_PRODUCTS_LIMIT = 5;
-    private static final String SORT_FIELD_IMPACT_SCORE = "scores.ECOSCORE.value";
+    private static final String SORT_FIELD_IMPACT_SCORE = "scores.ECOSCORE.relativ.value";
     private static final String CONDITION_NEW = "NEW";
     private static final String CONDITION_OCCASION = "OCCASION";
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -90,6 +90,7 @@ public class ProductController {
     private static final String NUMERIC_VALUE_SUFFIX = ".numericValue";
     private static final String KEYWORD_VALUE_SUFFIX = ".value";
     private static final String INDEXED_ATTRIBUTE_PREFIX = "attributes.indexed.";
+    private static final String ECOSCORE_RELATIVE_FIELD = "scores.ECOSCORE.relativ.value";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProductController.class);
 
@@ -861,7 +862,7 @@ public class ProductController {
 
     private FieldMetadataDto buildEcoscoreField(VerticalConfig config) {
         LOGGER.info("Entering buildEcoscoreField(config={})", config);
-        String mapping = "scores.ECOSCORE.value";
+        String mapping = ECOSCORE_RELATIVE_FIELD;
         FieldMetadataDto.AggregationMetadata aggregation = resolveAggregationMetadata(config, mapping, "ECOSCORE");
         return new FieldMetadataDto(mapping, "impactscore", null, VALUE_TYPE_NUMERIC, aggregation);
     }
@@ -902,7 +903,7 @@ public class ProductController {
 
         List<FieldMetadataDto> results = new ArrayList<>();
         config.getAvailableImpactScoreCriterias().forEach((key, criteria) -> {
-            String mapping = "scores." + key + ".value";
+            String mapping = "scores." + key + ".relativ.value";
             String title = criteria.getTitle() != null ? localise(criteria.getTitle(), domainLanguage) : null;
             String description = criteria.getDescription() != null ? localise(criteria.getDescription(), domainLanguage) : null;
             FieldMetadataDto.AggregationMetadata aggregation = resolveAggregationMetadata(config, mapping, key);

--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -121,6 +121,8 @@ import type {
 } from '~~/shared/api-client'
 import { useI18n } from 'vue-i18n'
 
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+
 import CategoryFilterList from './filters/CategoryFilterList.vue'
 const props = withDefaults(
   defineProps<{
@@ -168,7 +170,7 @@ const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(
 
 const impactPrimary = computed<FieldMetadataDto[]>(() => {
   const entries = props.filterOptions?.impact ?? []
-  const ecoscore = entries.filter((item) => item.mapping === 'scores.ECOSCORE.value')
+  const ecoscore = entries.filter((item) => item.mapping === ECOSCORE_RELATIVE_FIELD)
   return ecoscore.length ? ecoscore : entries.slice(0, 1)
 })
 

--- a/frontend/app/components/category/products/CategoryProductTable.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductTable.spec.ts
@@ -5,6 +5,7 @@ import { createVuetify } from 'vuetify'
 import { defineComponent, h } from 'vue'
 import type { Component } from 'vue'
 import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
@@ -229,7 +230,7 @@ describe('CategoryProductTable', () => {
     expect(wrapper.emitted('update:sort-order')?.[1]?.[0]).toBe('desc')
 
     table.vm.$emit('update:sort-by', [{ key: 'impactScore' }])
-    expect(wrapper.emitted('update:sort-field')?.[2]?.[0]).toBe('scores.ECOSCORE.value')
+    expect(wrapper.emitted('update:sort-field')?.[2]?.[0]).toBe(ECOSCORE_RELATIVE_FIELD)
     expect(wrapper.emitted('update:sort-order')?.[2]?.[0]).toBe('asc')
   })
 })

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -68,6 +68,7 @@ import {
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
 import { resolveFilterFieldTitle } from '~/utils/_field-localization'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 
 type AttributeCellValue = string | null
 
@@ -225,7 +226,7 @@ const headers = computed(() => [
 const staticSortHeaderToFieldMapping: Record<string, string> = {
   brand: 'attributes.referentielAttributes.BRAND',
   model: 'attributes.referentielAttributes.MODEL',
-  impactScore: 'scores.ECOSCORE.value',
+  impactScore: ECOSCORE_RELATIVE_FIELD,
   bestPrice: 'price.minPrice.price',
   offersCount: 'offersCount',
 }

--- a/frontend/app/components/product/impact/ProductAlternatives.spec.ts
+++ b/frontend/app/components/product/impact/ProductAlternatives.spec.ts
@@ -4,6 +4,7 @@ import { createI18n } from 'vue-i18n'
 import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import ProductAlternatives from './ProductAlternatives.vue'
 import { flushPromises } from '@vue/test-utils'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 
 vi.mock('./ProductAlternativeCard.vue', () => ({
   default: {
@@ -125,7 +126,7 @@ describe('ProductAlternatives', () => {
     expect(initialFilters).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'price.minPrice.price', operator: 'range', max: 349.9 }),
-        expect.objectContaining({ field: 'scores.ECOSCORE.value', operator: 'range', min: 15 }),
+        expect.objectContaining({ field: ECOSCORE_RELATIVE_FIELD, operator: 'range', min: 15 }),
         expect.objectContaining({ field: 'attributes.indexed.POWER_CONSUMPTION.numericValue', operator: 'range', max: 55 }),
       ]),
     )
@@ -143,7 +144,7 @@ describe('ProductAlternatives', () => {
     const updatedFilters = updatedBody?.filters?.filters ?? []
     expect(updatedFilters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ field: 'scores.ECOSCORE.value', operator: 'range', min: 15 }),
+        expect.objectContaining({ field: ECOSCORE_RELATIVE_FIELD, operator: 'range', min: 15 }),
         expect.objectContaining({ field: 'attributes.indexed.POWER_CONSUMPTION.numericValue', operator: 'range', max: 55 }),
       ]),
     )

--- a/frontend/app/constants/scores.ts
+++ b/frontend/app/constants/scores.ts
@@ -1,0 +1,2 @@
+export const ECOSCORE_RELATIVE_FIELD = 'scores.ECOSCORE.relativ.value'
+

--- a/frontend/app/utils/_category-filter-state.spec.ts
+++ b/frontend/app/utils/_category-filter-state.spec.ts
@@ -6,6 +6,7 @@ import {
   serializeCategoryHashState,
   type CategoryHashState,
 } from './_category-filter-state'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 
 describe('category filter hash serialisation', () => {
   it('serialises and deserialises state payloads', () => {
@@ -18,7 +19,7 @@ describe('category filter hash serialisation', () => {
       filters: {
         filters: [
           {
-            field: 'scores.ECOSCORE.value',
+            field: ECOSCORE_RELATIVE_FIELD,
             operator: 'range',
             min: 80,
             max: 100,

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -1,4 +1,5 @@
 import type { FieldMetadataDto } from '~~/shared/api-client'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 
 type TranslateFn = (key: string, ...args: unknown[]) => string
 
@@ -17,7 +18,7 @@ const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {
   offersCount: 'category.products.sort.fields.offersCount',
   'attributes.referentielAttributes.BRAND': 'category.products.sort.fields.brand',
   'attributes.referentielAttributes.MODEL': 'category.products.sort.fields.model',
-  'scores.ECOSCORE.value': 'category.products.sort.fields.impactScore',
+  [ECOSCORE_RELATIVE_FIELD]: 'category.products.sort.fields.impactScore',
 }
 
 const resolveTranslation = (mapping: string, t: TranslateFn, keys: Record<string, string>): string | null => {

--- a/frontend/app/utils/_product-scores.ts
+++ b/frontend/app/utils/_product-scores.ts
@@ -25,6 +25,11 @@ export const resolvePrimaryImpactScore = (product: ProductDto): number | null =>
     return null
   }
 
+  const relative = impactEntry.relativ?.value
+  if (typeof relative === 'number' && Number.isFinite(relative)) {
+    return clampScore(relative)
+  }
+
   if (impactEntry.on20 != null && Number.isFinite(impactEntry.on20)) {
     return clampScore((impactEntry.on20 / 20) * 5)
   }

--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -333,7 +333,7 @@ public class ProductRepository {
 				;
 		NativeQueryBuilder initialQueryBuilder = new NativeQueryBuilder().withQuery(new CriteriaQuery(c));
 
-		initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.value")));
+                initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.relativ.value")));
 
 		NativeQuery initialQuery = initialQueryBuilder.build();
 
@@ -365,13 +365,13 @@ public class ProductRepository {
 	        criteria = criteria.and(new Criteria("excluded").is(false));
 	    }
 
-	    // Ensure scores.ECOSCORE.value is present
-	    criteria = criteria.and(new Criteria("scores.ECOSCORE.value").exists());
+            // Ensure scores.ECOSCORE.relativ.value is present
+            criteria = criteria.and(new Criteria("scores.ECOSCORE.relativ.value").exists());
 
 	    // Build sort with unmapped_type to avoid shard-level mapping issues
 	    SortOptions ecoscoreSort = new SortOptions.Builder()
 	        .field(new FieldSort.Builder()
-	            .field("scores.ECOSCORE.value")
+                .field("scores.ECOSCORE.relativ.value")
 	            .order(SortOrder.Desc)
 	            .unmappedType(FieldType.Float)
 	            .missing("_last")
@@ -418,7 +418,7 @@ public class ProductRepository {
 
 		NativeQueryBuilder initialQueryBuilder = new NativeQueryBuilder().withQuery(new CriteriaQuery(c));
 
-		initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.value")));
+                initialQueryBuilder =  initialQueryBuilder.withSort(Sort.by(org.springframework.data.domain.Sort.Order.desc("scores.ECOSCORE.relativ.value")));
 
 		NativeQuery initialQuery = initialQueryBuilder.build();
 

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -51,7 +51,7 @@ subsets:
  - id: "impact_high"  # Unique identifier for the subset
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.value"
+     - field: "scores.ECOSCORE.relativ.value"
        operator: "LOWER_THAN"
        value: "2"
    image: "example-image.png"
@@ -71,10 +71,10 @@ subsets:
  - id: "impact_medium"
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.value"
+     - field: "scores.ECOSCORE.relativ.value"
        operator: "GREATER_THAN"
        value: "2"
-     - field: "scores.ECOSCORE.value"
+     - field: "scores.ECOSCORE.relativ.value"
        operator: "LOWER_THAN"
        value: "4"
    image: "example-image.png"
@@ -94,7 +94,7 @@ subsets:
  - id: "impact_low"
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.value"
+     - field: "scores.ECOSCORE.relativ.value"
        operator: "GREATER_THAN"
        value: "4"
    image: "example-image.png"

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -326,28 +326,28 @@ subsets:
 
 
 aggregationConfiguration:
-  "scores.ECOSCORE.value":
+  "scores.ECOSCORE.relativ.value":
     interval: 5
     buckets: 20
-  "scores.REPAIRABILITY_INDEX.value":
+  "scores.REPAIRABILITY_INDEX.relativ.value":
     interval: 1
     buckets: 10
-  "scores.POWER_CONSUMPTION_TYPICAL.value":
+  "scores.POWER_CONSUMPTION_TYPICAL.relativ.value":
     interval: 25
     buckets: 12
-  "scores.POWER_CONSUMPTION_OFF.value":
+  "scores.POWER_CONSUMPTION_OFF.relativ.value":
     interval: 0.1
     buckets: 10
-  "scores.WEIGHT.value":
+  "scores.WEIGHT.relativ.value":
     interval: 1
     buckets: 5
-  "scores.BRAND_SUSTAINABILITY.value":
+  "scores.BRAND_SUSTAINABILITY.relativ.value":
     interval: 1
     buckets: 5
-  "scores.CLASSE_ENERGY.value":
+  "scores.CLASSE_ENERGY.relativ.value":
     interval: 1
     buckets: 5
-  "scores.DATA_QUALITY.value":
+  "scores.DATA_QUALITY.relativ.value":
     interval: 1
     buckets: 5
   "attributes.indexed.REPAIRABILITY_INDEX":


### PR DESCRIPTION
## Summary
- expose a shared ECOSCORE_RELATIVE_FIELD constant and update the category filters, product table, alternatives widget, score resolver, and related specs so that UI sorting/filtering always targets the relativ.value scale that matches what is displayed
- adjust the Nuxt field-localisation utilities, filter state serialisation, and impact score resolver while extending ProductAlternatives to prefer relative values and keep the UI consistent
- propagate the new relativ field mapping through the front-api controllers, product-repository queries, and vertical configurations so backend queries, sorts, and aggregations keep returning the expected metadata

## Testing
- mvn --offline -pl front-api,services/product-repository,verticals test
- pnpm test --run components/category/products/CategoryProductTable.spec.ts components/product/impact/ProductAlternatives.spec.ts app/utils/_category-filter-state.spec.ts *(fails: vitest never starts running the queued suites in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b7d482c88333b8ce57dddbc6bd6d)