### PR TITLE
refactor: normalize ecoscore handling

### DIFF
--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -121,7 +121,7 @@ import type {
 } from '~~/shared/api-client'
 import { useI18n } from 'vue-i18n'
 
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 import CategoryFilterList from './filters/CategoryFilterList.vue'
 const props = withDefaults(
@@ -170,7 +170,7 @@ const baselineAggregationMap = computed<Record<string, AggregationResponseDto>>(
 
 const impactPrimary = computed<FieldMetadataDto[]>(() => {
   const entries = props.filterOptions?.impact ?? []
-  const ecoscore = entries.filter((item) => item.mapping === ECOSCORE_RELATIVE_FIELD)
+  const ecoscore = entries.filter((item) => item.mapping === ECOSCORE_VALUE_FIELD)
   return ecoscore.length ? ecoscore : entries.slice(0, 1)
 })
 

--- a/frontend/app/components/category/products/CategoryProductTable.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductTable.spec.ts
@@ -5,7 +5,7 @@ import { createVuetify } from 'vuetify'
 import { defineComponent, h } from 'vue'
 import type { Component } from 'vue'
 import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({
@@ -230,7 +230,7 @@ describe('CategoryProductTable', () => {
     expect(wrapper.emitted('update:sort-order')?.[1]?.[0]).toBe('desc')
 
     table.vm.$emit('update:sort-by', [{ key: 'impactScore' }])
-    expect(wrapper.emitted('update:sort-field')?.[2]?.[0]).toBe(ECOSCORE_RELATIVE_FIELD)
+    expect(wrapper.emitted('update:sort-field')?.[2]?.[0]).toBe(ECOSCORE_VALUE_FIELD)
     expect(wrapper.emitted('update:sort-order')?.[2]?.[0]).toBe('asc')
   })
 })

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -68,7 +68,7 @@ import {
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
 import { resolveFilterFieldTitle } from '~/utils/_field-localization'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 type AttributeCellValue = string | null
 
@@ -226,7 +226,7 @@ const headers = computed(() => [
 const staticSortHeaderToFieldMapping: Record<string, string> = {
   brand: 'attributes.referentielAttributes.BRAND',
   model: 'attributes.referentielAttributes.MODEL',
-  impactScore: ECOSCORE_RELATIVE_FIELD,
+  impactScore: ECOSCORE_VALUE_FIELD,
   bestPrice: 'price.minPrice.price',
   offersCount: 'offersCount',
 }

--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -215,13 +215,14 @@ describe('ProductHero', () => {
     scores: {
       ecoscore: {
         id: 'ECOSCORE',
-        relativeValue: '3',
-        relativ: { value: 3 },
+        relativeValue: '3.5',
+        value: 3.5,
       },
       scores: {
         ECOSCORE: {
           id: 'ECOSCORE',
           on20: 14,
+          value: 3.5,
         },
       },
     },
@@ -424,8 +425,7 @@ describe('ProductHero', () => {
     it.each([
       ['on20 values', { on20: 18 }, '4.5'],
       ['percentages', { percent: 70 }, '3.5'],
-      ['absolute max ranges', { absolute: { value: 80, max: 160 } }, '2.5'],
-      ['relative fallbacks', { relativ: { value: 4.2 } }, '4.2'],
+      ['value fallbacks', { value: 4.2 }, '4.2'],
     ])('normalises %s to a five point scale', async (
       _,
       scoreEntry: Partial<ProductScoreDto>,

--- a/frontend/app/components/product/impact/ProductAlternatives.spec.ts
+++ b/frontend/app/components/product/impact/ProductAlternatives.spec.ts
@@ -4,7 +4,7 @@ import { createI18n } from 'vue-i18n'
 import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import ProductAlternatives from './ProductAlternatives.vue'
 import { flushPromises } from '@vue/test-utils'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 vi.mock('./ProductAlternativeCard.vue', () => ({
   default: {
@@ -126,7 +126,7 @@ describe('ProductAlternatives', () => {
     expect(initialFilters).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'price.minPrice.price', operator: 'range', max: 349.9 }),
-        expect.objectContaining({ field: ECOSCORE_RELATIVE_FIELD, operator: 'range', min: 15 }),
+        expect.objectContaining({ field: ECOSCORE_VALUE_FIELD, operator: 'range', min: 15 }),
         expect.objectContaining({ field: 'attributes.indexed.POWER_CONSUMPTION.numericValue', operator: 'range', max: 55 }),
       ]),
     )
@@ -144,7 +144,7 @@ describe('ProductAlternatives', () => {
     const updatedFilters = updatedBody?.filters?.filters ?? []
     expect(updatedFilters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ field: ECOSCORE_RELATIVE_FIELD, operator: 'range', min: 15 }),
+        expect.objectContaining({ field: ECOSCORE_VALUE_FIELD, operator: 'range', min: 15 }),
         expect.objectContaining({ field: 'attributes.indexed.POWER_CONSUMPTION.numericValue', operator: 'range', max: 55 }),
       ]),
     )

--- a/frontend/app/components/product/impact/ProductAlternatives.vue
+++ b/frontend/app/components/product/impact/ProductAlternatives.vue
@@ -83,7 +83,7 @@ import type {
 import { ProductsIncludeEnum } from '~~/shared/api-client'
 import ProductAlternativeCard from './ProductAlternativeCard.vue'
 import { resolveAttributeRawValueByKey } from '~/utils/_product-attributes'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 const props = defineProps({
   product: {
@@ -131,17 +131,10 @@ const formatCurrency = (value: number, currency?: string | null) => {
   }
 }
 
-const resolveScoreNumericValue = (
-  score: { relativ?: { value?: number | null } | null; value?: number | null } | null | undefined,
-): number | null => {
-  const relative = score?.relativ?.value
-  if (typeof relative === 'number' && Number.isFinite(relative)) {
-    return relative
-  }
-
-  const absolute = score?.value
-  if (typeof absolute === 'number' && Number.isFinite(absolute)) {
-    return absolute
+const resolveScoreNumericValue = (score: { value?: number | null } | null | undefined): number | null => {
+  const numericValue = score?.value
+  if (typeof numericValue === 'number' && Number.isFinite(numericValue)) {
+    return numericValue
   }
 
   return null
@@ -269,7 +262,7 @@ const ecoscoreFilterDefinition = computed<AlternativeFilterDefinition | null>(()
     defaultSelected: true,
     disabled: false,
     resolveClause: () => ({
-      field: ECOSCORE_RELATIVE_FIELD,
+      field: ECOSCORE_VALUE_FIELD,
       operator: 'range',
       min: value,
     }),
@@ -481,7 +474,7 @@ const fetchAlternatives = async () => {
       ProductsIncludeEnum.Resources,
     ],
     sort: {
-      field: ECOSCORE_RELATIVE_FIELD,
+      field: ECOSCORE_VALUE_FIELD,
       order: 'DESC',
     },
   }

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -52,12 +52,12 @@ const props = defineProps<{
 type DetailedScore = ScoreView & { displayValue: number | null; coefficient: number | null }
 
 const resolveScoreValue = (score: ScoreView): number | null => {
-  if (score.relativeValue != null && Number.isFinite(score.relativeValue)) {
-    return Number(score.relativeValue)
-  }
-
   if (score.value != null && Number.isFinite(score.value)) {
     return Number(score.value)
+  }
+
+  if (score.relativeValue != null && Number.isFinite(score.relativeValue)) {
+    return Number(score.relativeValue)
   }
 
   return null

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -76,7 +76,14 @@ const props = defineProps<{
 
 const { n } = useI18n()
 
-const relativeScore = computed(() => (props.score.relativeValue ?? 0) || 0)
+const relativeScore = computed(() => {
+  if (typeof props.score.value === 'number' && Number.isFinite(props.score.value)) {
+    return props.score.value
+  }
+
+  const fallback = props.score.relativeValue
+  return (typeof fallback === 'number' && Number.isFinite(fallback) ? fallback : 0) || 0
+})
 
 const absoluteValue = computed(() => {
   const value = props.score.absoluteValue
@@ -114,14 +121,14 @@ const hasDetails = computed(() => {
 })
 
 const productAbsoluteValue = computed(() => {
-  const absoluteValue = props.score.absolute?.value
-  if (typeof absoluteValue === 'number' && Number.isFinite(absoluteValue)) {
-    return absoluteValue
-  }
-
   const directValue = props.score.value
   if (typeof directValue === 'number' && Number.isFinite(directValue)) {
     return directValue
+  }
+
+  const absoluteValue = props.score.absolute?.value
+  if (typeof absoluteValue === 'number' && Number.isFinite(absoluteValue)) {
+    return absoluteValue
   }
 
   if (typeof props.score.absoluteValue === 'number' && Number.isFinite(props.score.absoluteValue)) {

--- a/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
+++ b/frontend/app/components/product/impact/subscores/ProductImpactSubscoreRepairabilityIndexCard.vue
@@ -39,8 +39,8 @@ const numericAbsoluteValue = computed<number | null>(() => {
   const { score } = props
 
   const candidates = [
-    score.absolute?.value,
     score.value,
+    score.absolute?.value,
     typeof score.absoluteValue === 'number' ? score.absoluteValue : parseLocalizedNumber(score.absoluteValue),
   ]
 

--- a/frontend/app/constants/scores.ts
+++ b/frontend/app/constants/scores.ts
@@ -1,2 +1,2 @@
-export const ECOSCORE_RELATIVE_FIELD = 'scores.ECOSCORE.relativ.value'
+export const ECOSCORE_VALUE_FIELD = 'scores.ECOSCORE.value'
 

--- a/frontend/app/pages/compare/index.spec.ts
+++ b/frontend/app/pages/compare/index.spec.ts
@@ -337,10 +337,10 @@ describe('Ecological scores', () => {
           base: {},
           offers: {},
           scores: {
-            ecoscore: { relativ: { value: 3.456 } },
+            ecoscore: { value: 3.456 },
             scores: {
-              BRAND_SUSTAINABILITY: { relativ: { value: 2.1 } },
-              DATA_QUALITY: { relativ: { value: 4.789 } },
+              BRAND_SUSTAINABILITY: { value: 2.1 },
+              DATA_QUALITY: { value: 4.789 },
             },
           },
           attributes: {},
@@ -356,10 +356,10 @@ describe('Ecological scores', () => {
           base: {},
           offers: {},
           scores: {
-            ecoscore: { relativ: { value: 2.1 } },
+            ecoscore: { value: 2.1 },
             scores: {
-              BRAND_SUSTAINABILITY: { relativ: { value: 4.123 } },
-              DATA_QUALITY: { relativ: { value: 3.5 } },
+              BRAND_SUSTAINABILITY: { value: 4.123 },
+              DATA_QUALITY: { value: 3.5 },
             },
           },
           attributes: {},

--- a/frontend/app/pages/compare/index.vue
+++ b/frontend/app/pages/compare/index.vue
@@ -1071,22 +1071,32 @@ const resolveScoreValue = (score: ProductScoreDto | null | undefined): { display
     return { display: null, numeric: null }
   }
 
-  const relativeValueCandidates: Array<number | null> = [
-    typeof score.relativ?.value === 'number' && Number.isFinite(score.relativ.value)
-      ? score.relativ.value
-      : null,
-    (() => {
-      const legacyRelative = (score as { relative?: { value?: number | null } }).relative?.value
-      return typeof legacyRelative === 'number' && Number.isFinite(legacyRelative) ? legacyRelative : null
-    })(),
-  ]
-
-  const relativeValue = relativeValueCandidates.find((value): value is number => value != null) ?? null
-
-  if (relativeValue != null) {
+  if (typeof score.value === 'number' && Number.isFinite(score.value)) {
     return {
-      display: n(relativeValue, { maximumFractionDigits: 2 }),
-      numeric: relativeValue,
+      display: n(score.value, { maximumFractionDigits: 2 }),
+      numeric: score.value,
+    }
+  }
+
+  const parsedRelativeValue = (() => {
+    const relative = score.relativeValue
+    if (typeof relative === 'number' && Number.isFinite(relative)) {
+      return relative
+    }
+
+    if (typeof relative === 'string') {
+      const parsed = Number.parseFloat(relative)
+      return Number.isFinite(parsed) ? parsed : null
+    }
+
+    const legacyRelative = (score as { relative?: { value?: number | null } }).relative?.value
+    return typeof legacyRelative === 'number' && Number.isFinite(legacyRelative) ? legacyRelative : null
+  })()
+
+  if (parsedRelativeValue != null) {
+    return {
+      display: n(parsedRelativeValue, { maximumFractionDigits: 2 }),
+      numeric: parsedRelativeValue,
     }
   }
 

--- a/frontend/app/utils/_category-filter-state.spec.ts
+++ b/frontend/app/utils/_category-filter-state.spec.ts
@@ -6,7 +6,7 @@ import {
   serializeCategoryHashState,
   type CategoryHashState,
 } from './_category-filter-state'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 describe('category filter hash serialisation', () => {
   it('serialises and deserialises state payloads', () => {
@@ -19,7 +19,7 @@ describe('category filter hash serialisation', () => {
       filters: {
         filters: [
           {
-            field: ECOSCORE_RELATIVE_FIELD,
+            field: ECOSCORE_VALUE_FIELD,
             operator: 'range',
             min: 80,
             max: 100,

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -1,5 +1,5 @@
 import type { FieldMetadataDto } from '~~/shared/api-client'
-import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { ECOSCORE_VALUE_FIELD } from '~/constants/scores'
 
 type TranslateFn = (key: string, ...args: unknown[]) => string
 
@@ -18,7 +18,7 @@ const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {
   offersCount: 'category.products.sort.fields.offersCount',
   'attributes.referentielAttributes.BRAND': 'category.products.sort.fields.brand',
   'attributes.referentielAttributes.MODEL': 'category.products.sort.fields.model',
-  [ECOSCORE_RELATIVE_FIELD]: 'category.products.sort.fields.impactScore',
+  [ECOSCORE_VALUE_FIELD]: 'category.products.sort.fields.impactScore',
 }
 
 const resolveTranslation = (mapping: string, t: TranslateFn, keys: Record<string, string>): string | null => {

--- a/frontend/app/utils/_product-scores.ts
+++ b/frontend/app/utils/_product-scores.ts
@@ -27,6 +27,10 @@ export const resolvePrimaryImpactScore = (product: ProductDto): number | null =>
     return null
   }
 
+  if (isFiniteNumber(impactEntry.value)) {
+    return clampScore(impactEntry.value)
+  }
+
   if (isFiniteNumber(impactEntry.on20)) {
     return clampScore((impactEntry.on20 / 20) * 5)
   }
@@ -35,20 +39,18 @@ export const resolvePrimaryImpactScore = (product: ProductDto): number | null =>
     return clampScore((impactEntry.percent / 100) * 5)
   }
 
-  const absoluteValue = impactEntry.absolute?.value
-  const absoluteMax = impactEntry.absolute?.max
+  const isEcoscore = impactEntry.id?.toUpperCase() === 'ECOSCORE'
+  if (!isEcoscore) {
+    const absoluteValue = impactEntry.absolute?.value
+    const absoluteMax = impactEntry.absolute?.max
 
-  if (isFiniteNumber(absoluteValue) && isFiniteNumber(absoluteMax) && absoluteMax > 0) {
-    return clampScore((absoluteValue / absoluteMax) * 5)
-  }
+    if (isFiniteNumber(absoluteValue) && isFiniteNumber(absoluteMax) && absoluteMax > 0) {
+      return clampScore((absoluteValue / absoluteMax) * 5)
+    }
 
-  if (isFiniteNumber(absoluteValue)) {
-    return clampScore(absoluteValue)
-  }
-
-  const relativeValue = impactEntry.relativ?.value
-  if (isFiniteNumber(relativeValue)) {
-    return clampScore(relativeValue)
+    if (isFiniteNumber(absoluteValue)) {
+      return clampScore(absoluteValue)
+    }
   }
 
   return null


### PR DESCRIPTION
## Summary
- switch the ecoscore mapping constant to `scores.ECOSCORE.value` and update the category filters, product tables and localization helpers to use it for filters, sorting and API requests
- refactor the score utilities plus the product, compare and slug pages so every ecoscore flow relies on `ProductScoreDto.value`, simplifying value extraction, schema metadata and product alternative filters
- align dependent components/tests (ProductHero, impact cards, repairability card, compare specs, etc.) with the new value source and keep numeric rendering consistent

## Testing
- pnpm lint
- pnpm vitest run components/product/ProductHero.spec.ts
- pnpm vitest run components/product/impact/ProductAlternatives.spec.ts
- pnpm vitest run pages/compare/index.spec.ts
- pnpm vitest run components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
- pnpm vitest run components/category/products/CategoryProductTable.spec.ts
- pnpm vitest run app/utils/_category-filter-state.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f76a309083339922c0b5dff637a9)