### PR TITLE
Fix duplicate IDs in mobile menu list

### DIFF
--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -153,7 +153,7 @@
                 :href="link.href"
                 :target="link.external ? '_blank' : undefined"
                 :rel="link.external ? 'noopener noreferrer' : undefined"
-                :value="false"
+                :value="link.id"
                 @click="handleCommunityNavigation(link)"
               >
                 <template #prepend>


### PR DESCRIPTION
## Summary
- ensure mobile menu community links register unique ids with Vuetify by binding the list item value to the link id
- this prevents Vuetify from logging duplicate node id warnings and keeps keyboard navigation predictable

## Testing
- pnpm lint
- pnpm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918516f7f2c8333a6b3a1733807c523)