### PR TITLE
Add Nitro caching for category APIs

### DIFF
--- a/frontend/app/composables/categories/useCategoryNavigation.spec.ts
+++ b/frontend/app/composables/categories/useCategoryNavigation.spec.ts
@@ -66,47 +66,48 @@ describe('useCategoryNavigation composable', () => {
       useCategoriesService: () => ({ getNavigation: getNavigationMock }),
     }))
 
-    vi.doMock('h3', () => {
-      const caches = new Map<string, { payload: unknown; expiresAt: number }>()
+    const caches = new Map<string, { payload: unknown; expiresAt: number }>()
 
-      return {
-        getQuery: (event: { context?: { query?: Record<string, unknown> } }) =>
-          event.context?.query ?? {},
-        cachedEventHandler: (
-          handler: (event: unknown) => unknown | Promise<unknown>,
-          options?: { name?: string; maxAge?: number; getKey?: (event: unknown) => string },
-        ) => {
-          const name = options?.name ?? 'default'
-          const maxAgeMs = (options?.maxAge ?? 0) * 1000
+    vi.doMock('nitropack/runtime/internal/cache', () => ({
+      cachedEventHandler: (
+        handler: (event: unknown) => unknown | Promise<unknown>,
+        options?: { name?: string; maxAge?: number; getKey?: (event: unknown) => string },
+      ) => {
+        const name = options?.name ?? 'default'
+        const maxAgeMs = (options?.maxAge ?? 0) * 1000
 
-          return async (event: unknown) => {
-            const keySegment = options?.getKey?.(event) ?? ''
-            const cacheKey = `${name}:${keySegment}`
-            const now = Date.now()
-            const cached = caches.get(cacheKey)
+        return async (event: unknown) => {
+          const keySegment = options?.getKey?.(event) ?? ''
+          const cacheKey = `${name}:${keySegment}`
+          const now = Date.now()
+          const cached = caches.get(cacheKey)
 
-            if (cached && cached.expiresAt > now) {
-              return cached.payload
-            }
-
-            const payload = await handler(event)
-            caches.set(cacheKey, { payload, expiresAt: now + maxAgeMs })
-            return payload
+          if (cached && cached.expiresAt > now) {
+            return cached.payload
           }
-        },
-        setResponseHeader: (
-          event: { node: { res: { headers: Record<string, string> } } },
-          name: string,
-          value: string,
-        ) => {
-          event.node.res.headers[name.toLowerCase()] = value
-        },
-        createError: (input: unknown) => ({
-          ...(typeof input === 'object' && input ? input : {}),
-          isCreateError: true,
-        }),
-      }
-    })
+
+          const payload = await handler(event)
+          caches.set(cacheKey, { payload, expiresAt: now + maxAgeMs })
+          return payload
+        }
+      },
+    }))
+
+    vi.doMock('h3', () => ({
+      getQuery: (event: { context?: { query?: Record<string, unknown> } }) =>
+        event.context?.query ?? {},
+      setResponseHeader: (
+        event: { node: { res: { headers: Record<string, string> } } },
+        name: string,
+        value: string,
+      ) => {
+        event.node.res.headers[name.toLowerCase()] = value
+      },
+      createError: (input: unknown) => ({
+        ...(typeof input === 'object' && input ? input : {}),
+        isCreateError: true,
+      }),
+    }))
 
     const { default: handler } = await import('../../../server/api/categories/navigation.get')
 
@@ -129,6 +130,7 @@ describe('useCategoryNavigation composable', () => {
     expect(getNavigationMock).toHaveBeenCalledTimes(1)
 
     vi.doUnmock('~~/shared/api-client/services/categories.services')
+    vi.doUnmock('nitropack/runtime/internal/cache')
     vi.doUnmock('h3')
     vi.resetModules()
 

--- a/frontend/app/composables/categories/useCategoryNavigation.spec.ts
+++ b/frontend/app/composables/categories/useCategoryNavigation.spec.ts
@@ -51,4 +51,87 @@ describe('useCategoryNavigation composable', () => {
     expect(error.value).toBe('Network error')
     expect(navigation.value).toBeNull()
   })
+
+  it('reuses the cached navigation payload when the server TTL has not expired', async () => {
+    vi.useFakeTimers()
+
+    const navigationResponse = {
+      category: { title: 'Cached root' },
+      childCategories: [],
+    }
+
+    const getNavigationMock = vi.fn().mockResolvedValue(navigationResponse)
+
+    vi.doMock('~~/shared/api-client/services/categories.services', () => ({
+      useCategoriesService: () => ({ getNavigation: getNavigationMock }),
+    }))
+
+    vi.doMock('h3', () => {
+      const caches = new Map<string, { payload: unknown; expiresAt: number }>()
+
+      return {
+        getQuery: (event: { context?: { query?: Record<string, unknown> } }) =>
+          event.context?.query ?? {},
+        cachedEventHandler: (
+          handler: (event: unknown) => unknown | Promise<unknown>,
+          options?: { name?: string; maxAge?: number; getKey?: (event: unknown) => string },
+        ) => {
+          const name = options?.name ?? 'default'
+          const maxAgeMs = (options?.maxAge ?? 0) * 1000
+
+          return async (event: unknown) => {
+            const keySegment = options?.getKey?.(event) ?? ''
+            const cacheKey = `${name}:${keySegment}`
+            const now = Date.now()
+            const cached = caches.get(cacheKey)
+
+            if (cached && cached.expiresAt > now) {
+              return cached.payload
+            }
+
+            const payload = await handler(event)
+            caches.set(cacheKey, { payload, expiresAt: now + maxAgeMs })
+            return payload
+          }
+        },
+        setResponseHeader: (
+          event: { node: { res: { headers: Record<string, string> } } },
+          name: string,
+          value: string,
+        ) => {
+          event.node.res.headers[name.toLowerCase()] = value
+        },
+        createError: (input: unknown) => ({
+          ...(typeof input === 'object' && input ? input : {}),
+          isCreateError: true,
+        }),
+      }
+    })
+
+    const { default: handler } = await import('../../../server/api/categories/navigation.get')
+
+    const event = {
+      context: { query: {} },
+      node: {
+        req: { headers: { host: 'nudger.com' } },
+        res: { headers: {} as Record<string, string> },
+      },
+    }
+
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'))
+
+    const firstResponse = await handler(event as never)
+    expect(firstResponse).toEqual(navigationResponse)
+    expect(getNavigationMock).toHaveBeenCalledTimes(1)
+
+    const secondResponse = await handler(event as never)
+    expect(secondResponse).toEqual(navigationResponse)
+    expect(getNavigationMock).toHaveBeenCalledTimes(1)
+
+    vi.doUnmock('~~/shared/api-client/services/categories.services')
+    vi.doUnmock('h3')
+    vi.resetModules()
+
+    vi.useRealTimers()
+  })
 })

--- a/frontend/server/api/categories/index.ts
+++ b/frontend/server/api/categories/index.ts
@@ -1,4 +1,5 @@
-import { cachedEventHandler, getQuery } from 'h3'
+import { cachedEventHandler } from 'nitropack/runtime/internal/cache'
+import { getQuery } from 'h3'
 import type { H3Event } from 'h3'
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
 import type { VerticalConfigDto } from '~~/shared/api-client'

--- a/frontend/server/api/categories/index.ts
+++ b/frontend/server/api/categories/index.ts
@@ -1,26 +1,32 @@
-import { getQuery } from 'h3'
+import { cachedEventHandler, getQuery } from 'h3'
+import type { H3Event } from 'h3'
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
 
-/**
- * Categories API endpoint
- * Handles GET requests for categories with caching
- */
-export default defineEventHandler(async (event): Promise<VerticalConfigDto[]> => {
-  // Set cache headers for 1 hour
-  setDomainLanguageCacheHeaders(
-    event,
-    'public, max-age=3600, s-maxage=3600'
-  )
+type CategoriesListCacheContext = {
+  domainLanguage: string
+  onlyEnabled: boolean
+}
+
+declare module 'h3' {
+  interface H3EventContext {
+    categoriesListCacheContext?: CategoriesListCacheContext
+  }
+}
+
+const resolveCategoriesListCacheContext = (
+  event: H3Event,
+): CategoriesListCacheContext => {
+  if (event.context.categoriesListCacheContext) {
+    return event.context.categoriesListCacheContext
+  }
 
   const rawHost =
     event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
   const { domainLanguage } = resolveDomainLanguage(rawHost)
-
-  const categoriesService = useCategoriesService(domainLanguage)
   const query = getQuery(event)
   const onlyEnabledParam = Array.isArray(query.onlyEnabled)
     ? query.onlyEnabled[0]
@@ -28,9 +34,31 @@ export default defineEventHandler(async (event): Promise<VerticalConfigDto[]> =>
 
   const onlyEnabled = onlyEnabledParam === 'true' || onlyEnabledParam === true
 
+  const context: CategoriesListCacheContext = {
+    domainLanguage,
+    onlyEnabled,
+  }
+
+  event.context.categoriesListCacheContext = context
+
+  return context
+}
+
+/**
+ * Categories API endpoint
+ * Handles GET requests for categories with caching
+ */
+const handler = async (event: H3Event): Promise<VerticalConfigDto[]> => {
+  setDomainLanguageCacheHeaders(
+    event,
+    'public, max-age=3600, s-maxage=3600'
+  )
+
+  const { domainLanguage, onlyEnabled } = resolveCategoriesListCacheContext(event)
+  const categoriesService = useCategoriesService(domainLanguage)
+
   try {
-    const response = await categoriesService.getCategories(onlyEnabled)
-    return response
+    return await categoriesService.getCategories(onlyEnabled)
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
     console.error(
@@ -45,4 +73,15 @@ export default defineEventHandler(async (event): Promise<VerticalConfigDto[]> =>
       cause: error,
     })
   }
+}
+
+export default cachedEventHandler(handler, {
+  name: 'categories-list',
+  maxAge: 3600,
+  getKey: (event) => {
+    const { domainLanguage, onlyEnabled } =
+      resolveCategoriesListCacheContext(event)
+
+    return `${domainLanguage}:${onlyEnabled}`
+  },
 })

--- a/frontend/server/api/categories/navigation.get.ts
+++ b/frontend/server/api/categories/navigation.get.ts
@@ -1,3 +1,5 @@
+import { cachedEventHandler, getQuery } from 'h3'
+import type { H3Event } from 'h3'
 import type { CategoryNavigationDto } from '~~/shared/api-client'
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
@@ -5,8 +7,22 @@ import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
 
-export default defineEventHandler(async (event): Promise<CategoryNavigationDto> => {
-  setDomainLanguageCacheHeaders(event, 'public, max-age=1800, s-maxage=1800')
+type NavigationCacheContext = {
+  domainLanguage: string
+  googleCategoryId?: number
+  path?: string
+}
+
+declare module 'h3' {
+  interface H3EventContext {
+    categoryNavigationCacheContext?: NavigationCacheContext
+  }
+}
+
+const resolveNavigationCacheContext = (event: H3Event): NavigationCacheContext => {
+  if (event.context.categoryNavigationCacheContext) {
+    return event.context.categoryNavigationCacheContext
+  }
 
   const query = getQuery(event)
 
@@ -20,25 +36,53 @@ export default defineEventHandler(async (event): Promise<CategoryNavigationDto> 
 
       throw createError({
         statusCode: 400,
-        statusMessage: 'googleCategoryId must be a valid integer when provided',
+        statusMessage:
+          'googleCategoryId must be a valid integer when provided',
       })
     }
 
     return undefined
   })()
 
-  const path = typeof query.path === 'string' && query.path.length > 0 ? query.path : undefined
+  const path =
+    typeof query.path === 'string' && query.path.length > 0
+      ? query.path
+      : undefined
 
-  const rawHost = event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
   const { domainLanguage } = resolveDomainLanguage(rawHost)
 
+  const context: NavigationCacheContext = {
+    domainLanguage,
+    googleCategoryId,
+    path,
+  }
+
+  event.context.categoryNavigationCacheContext = context
+
+  return context
+}
+
+const handler = async (event: H3Event): Promise<CategoryNavigationDto> => {
+  setDomainLanguageCacheHeaders(
+    event,
+    'public, max-age=1800, s-maxage=1800'
+  )
+
+  const { domainLanguage, googleCategoryId, path } =
+    resolveNavigationCacheContext(event)
   const categoriesService = useCategoriesService(domainLanguage)
 
   try {
     return await categoriesService.getNavigation({ googleCategoryId, path })
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
-    console.error('Error fetching category navigation:', backendError.logMessage, backendError)
+    console.error(
+      'Error fetching category navigation:',
+      backendError.logMessage,
+      backendError
+    )
 
     throw createError({
       statusCode: backendError.statusCode,
@@ -46,4 +90,19 @@ export default defineEventHandler(async (event): Promise<CategoryNavigationDto> 
       cause: error,
     })
   }
+}
+
+export default cachedEventHandler(handler, {
+  name: 'category-navigation',
+  maxAge: 1800,
+  getKey: (event) => {
+    const { domainLanguage, googleCategoryId, path } =
+      resolveNavigationCacheContext(event)
+
+    return JSON.stringify({
+      domainLanguage,
+      googleCategoryId: googleCategoryId ?? null,
+      path: path ?? null,
+    })
+  },
 })

--- a/frontend/server/api/categories/navigation.get.ts
+++ b/frontend/server/api/categories/navigation.get.ts
@@ -1,4 +1,5 @@
-import { cachedEventHandler, getQuery } from 'h3'
+import { cachedEventHandler } from 'nitropack/runtime/internal/cache'
+import { getQuery } from 'h3'
 import type { H3Event } from 'h3'
 import type { CategoryNavigationDto } from '~~/shared/api-client'
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'


### PR DESCRIPTION
## Summary
- wrap the category list and navigation server routes in Nitro's cached event handler so they reuse backend payloads per domain language and relevant params for the duration advertised by their cache headers
- compute deterministic cache keys for both handlers and persist context on the event so repeated invocations reuse the same resolution work
- extend the category navigation composable spec with a regression test proving that repeated fetches within the TTL reuse the cached payload

## Testing
- `pnpm vitest run app/composables/categories/useCategoryNavigation.spec.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186e8aa74483339ec3a2011b14b3d3)