### PR TITLE
Memoize hero video discovery

### DIFF
--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -78,26 +78,12 @@ if (import.meta.server) {
   await fetchCategories(true)
   await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
 
-  try {
-    const [{ readdir }, { join }] = await Promise.all([
-      import('node:fs/promises'),
-      import('node:path'),
-    ])
+  const { getHeroVideoSources } = await import('~~/server/utils/hero-videos')
+  const videoCandidates = await getHeroVideoSources()
 
-    const heroVideosDirectory = join(process.cwd(), 'app/public/videos')
-    const entries = await readdir(heroVideosDirectory, { withFileTypes: true })
-    const videoCandidates = entries
-      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.mp4'))
-      .map((entry) => `/videos/${entry.name}`)
-
-    if (videoCandidates.length > 0) {
-      const randomIndex = Math.floor(Math.random() * videoCandidates.length)
-      heroVideoSrc.value = videoCandidates[randomIndex]
-    }
-  } catch (error) {
-    if (import.meta.dev) {
-      console.warn('Unable to select hero video from directory', error)
-    }
+  if (videoCandidates.length > 0) {
+    const randomIndex = Math.floor(Math.random() * videoCandidates.length)
+    heroVideoSrc.value = videoCandidates[randomIndex]
   }
 } else {
   if (rawCategories.value.length === 0) {

--- a/frontend/server/utils/hero-videos.spec.ts
+++ b/frontend/server/utils/hero-videos.spec.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type MockDirent = {
+  name: string
+  isFile: () => boolean
+}
+
+const createDirent = (name: string, isFile = true): MockDirent => ({
+  name,
+  isFile: () => isFile,
+})
+
+afterEach(() => {
+  vi.resetModules()
+  vi.unmock('node:fs/promises')
+})
+
+describe('getHeroVideoSources', () => {
+  it('returns cached results when called repeatedly', async () => {
+    const readdirMock = vi.fn().mockResolvedValue([
+      createDirent('first.mp4'),
+      createDirent('ignored.txt'),
+    ])
+
+    vi.doMock('node:fs/promises', () => ({
+      readdir: readdirMock,
+      default: { readdir: readdirMock },
+    }))
+
+    const { getHeroVideoSources } = await import('~~/server/utils/hero-videos')
+
+    const firstCall = await getHeroVideoSources()
+    const secondCall = await getHeroVideoSources()
+
+    expect(firstCall).toEqual(['/videos/first.mp4'])
+    expect(secondCall).toEqual(firstCall)
+    expect(readdirMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/server/utils/hero-videos.ts
+++ b/frontend/server/utils/hero-videos.ts
@@ -1,0 +1,75 @@
+import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const HERO_VIDEOS_DIRECTORY = join(process.cwd(), 'app/public/videos')
+const HERO_VIDEO_EXTENSIONS = ['.mp4']
+export const HERO_VIDEOS_CACHE_TTL_MS = 1000 * 60 * 60 // 1 hour
+
+type HeroVideosCacheEntry = {
+  videos: string[]
+  lastUpdated: number
+}
+
+let heroVideosCache: HeroVideosCacheEntry | null = null
+let inflightReadPromise: Promise<string[]> | null = null
+
+const hasValidCache = (now: number) => {
+  if (!heroVideosCache) {
+    return false
+  }
+
+  if (now - heroVideosCache.lastUpdated > HERO_VIDEOS_CACHE_TTL_MS) {
+    heroVideosCache = null
+    return false
+  }
+
+  return true
+}
+
+const extractHeroVideoPaths = (entries: Array<{ isFile: () => boolean; name: string }>): string[] =>
+  entries
+    .filter((entry) => entry.isFile() && HERO_VIDEO_EXTENSIONS.some((extension) => entry.name.toLowerCase().endsWith(extension)))
+    .map((entry) => `/videos/${entry.name}`)
+
+const discoverHeroVideos = async (): Promise<string[]> => {
+  const entries = await readdir(HERO_VIDEOS_DIRECTORY, { withFileTypes: true })
+  return extractHeroVideoPaths(entries)
+}
+
+const loadHeroVideos = async () => {
+  try {
+    const videos = await discoverHeroVideos()
+    heroVideosCache = {
+      videos,
+      lastUpdated: Date.now(),
+    }
+    return videos
+  } catch (error) {
+    if (import.meta.dev) {
+      console.warn('Unable to select hero video from directory', error)
+    }
+
+    heroVideosCache = {
+      videos: [],
+      lastUpdated: Date.now(),
+    }
+
+    return []
+  } finally {
+    inflightReadPromise = null
+  }
+}
+
+export const getHeroVideoSources = async (): Promise<string[]> => {
+  const now = Date.now()
+
+  if (hasValidCache(now)) {
+    return heroVideosCache!.videos
+  }
+
+  if (!inflightReadPromise) {
+    inflightReadPromise = loadHeroVideos()
+  }
+
+  return inflightReadPromise
+}


### PR DESCRIPTION
## Summary
- add a server-only `getHeroVideoSources` helper that memoizes hero video discovery with a long TTL
- update the home page to use the memoized helper instead of reading the filesystem directly
- cover the helper with a Vitest that confirms the cached result avoids repeated filesystem reads

## Testing
- pnpm lint
- pnpm test --run server/utils/hero-videos.spec.ts pages/index.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186ea4ce348333b0ac59f6bf5ffece)