### PR TITLE
feat(frontend): share menu search controls

### DIFF
--- a/frontend/app/composables/menus/useMenuSearchControls.ts
+++ b/frontend/app/composables/menus/useMenuSearchControls.ts
@@ -1,0 +1,171 @@
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type {
+  CategorySuggestionItem,
+  ProductSuggestionItem,
+} from '~/components/search/SearchSuggestField.vue'
+import { normalizeLocale, resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+export interface UseMenuSearchControlsOptions {
+  /**
+   * Optional callback triggered whenever navigation occurs as a result of search interactions.
+   * Useful for closing drawers or menus after search submits or suggestion clicks.
+   */
+  onNavigate?: () => void
+  /**
+   * When false the composable will not close the search input automatically after navigation.
+   * Defaults to true to preserve the desktop menu behaviour.
+   */
+  closeSearchOnNavigate?: boolean
+}
+
+export const MIN_SEARCH_QUERY_LENGTH = 2
+
+export const useMenuSearchControls = (options: UseMenuSearchControlsOptions = {}) => {
+  const route = useRoute()
+  const router = useRouter()
+  const { locale } = useI18n()
+
+  const searchQuery = ref('')
+  const isSearchOpen = ref(false)
+
+  const currentLocale = computed(() => normalizeLocale(locale.value))
+  const homeRoutePath = computed(() => resolveLocalizedRoutePath('index', currentLocale.value))
+  const searchRoutePath = computed(() => resolveLocalizedRoutePath('search', currentLocale.value))
+  const showMenuSearch = computed(() => route.path !== homeRoutePath.value)
+
+  const openSearch = () => {
+    isSearchOpen.value = true
+  }
+
+  const closeSearch = () => {
+    isSearchOpen.value = false
+  }
+
+  const handleSearchClear = () => {
+    searchQuery.value = ''
+  }
+
+  watch(
+    () => route.path,
+    (path) => {
+      if (path === homeRoutePath.value) {
+        closeSearch()
+        handleSearchClear()
+      }
+    },
+  )
+
+  watch(homeRoutePath, (path) => {
+    if (route.path === path) {
+      closeSearch()
+      handleSearchClear()
+    }
+  })
+
+  watch(showMenuSearch, (visible) => {
+    if (!visible) {
+      closeSearch()
+      handleSearchClear()
+    }
+  })
+
+  const finalizeNavigation = () => {
+    if (options.closeSearchOnNavigate !== false) {
+      closeSearch()
+    }
+
+    options.onNavigate?.()
+  }
+
+  const navigateToSearch = (query?: string) => {
+    const normalizedQuery = query?.trim() ?? ''
+
+    router.push({
+      path: searchRoutePath.value,
+      query: normalizedQuery ? { q: normalizedQuery } : undefined,
+    })
+
+    finalizeNavigation()
+  }
+
+  const normalizeSuggestionUrl = (raw: string | null | undefined): string | null => {
+    if (!raw) {
+      return null
+    }
+
+    const trimmed = raw.trim()
+
+    if (!trimmed) {
+      return null
+    }
+
+    if (/^https?:\/\//iu.test(trimmed)) {
+      return trimmed
+    }
+
+    return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  }
+
+  const handleCategorySuggestion = (suggestion: CategorySuggestionItem) => {
+    searchQuery.value = suggestion.title
+
+    const normalizedUrl = normalizeSuggestionUrl(suggestion.url)
+
+    if (normalizedUrl) {
+      if (/^https?:\/\//iu.test(normalizedUrl) && typeof window !== 'undefined') {
+        window.open(normalizedUrl, '_blank', 'noopener,noreferrer')
+        finalizeNavigation()
+        return
+      }
+
+      router.push(normalizedUrl)
+      finalizeNavigation()
+      return
+    }
+
+    navigateToSearch(suggestion.title)
+  }
+
+  const handleProductSuggestion = (suggestion: ProductSuggestionItem) => {
+    searchQuery.value = suggestion.title
+
+    const gtin = suggestion.gtin?.trim()
+
+    if (gtin) {
+      router.push({
+        name: 'gtin',
+        params: { gtin },
+      })
+      finalizeNavigation()
+      return
+    }
+
+    navigateToSearch(suggestion.title)
+  }
+
+  const handleSearchSubmit = () => {
+    const trimmedQuery = searchQuery.value.trim()
+
+    if (trimmedQuery.length > 0 && trimmedQuery.length < MIN_SEARCH_QUERY_LENGTH) {
+      return
+    }
+
+    navigateToSearch(trimmedQuery)
+  }
+
+  return {
+    searchQuery,
+    isSearchOpen,
+    showMenuSearch,
+    homeRoutePath,
+    searchRoutePath,
+    openSearch,
+    closeSearch,
+    handleSearchClear,
+    handleSearchSubmit,
+    handleCategorySuggestion,
+    handleProductSuggestion,
+    navigateToSearch,
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `useMenuSearchControls` composable so both hero and mobile menus reuse the same search refs, watchers, and handlers
- refactor `The-hero-menu` and `The-mobile-menu` to consume the shared composable, keeping their scripts focused on UI wiring
- expand `menus-auth.spec.ts` to mock the new composable and verify search visibility/query clearing alongside the existing auth flows

## Testing
- pnpm vitest run app/components/shared/menus/menus-auth.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69186eb6118c8333bab9591ace737332)