### PR TITLE
Fix lz-string import for category hash state

### DIFF
--- a/frontend/app/utils/_category-filter-state.ts
+++ b/frontend/app/utils/_category-filter-state.ts
@@ -1,5 +1,7 @@
-import { decompressFromBase64, compressToBase64 } from 'lz-string'
+import LZString from 'lz-string'
 import type { FilterRequestDto, SortRequestDto } from '~~/shared/api-client'
+
+const { decompressFromBase64, compressToBase64 } = LZString
 
 export type CategoryViewMode = 'cards' | 'list' | 'table'
 


### PR DESCRIPTION
## Summary
- switch the `lz-string` usage in `app/utils/_category-filter-state.ts` to rely on the package's default export so that base64 compression utilities remain available in production

## Testing
- pnpm lint
- pnpm test --run components/category/CategoryFastFilters.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187aafcf6c8322871c106724d7a725)