### PR TITLE
Hide desktop PWA install prompt

### DIFF
--- a/frontend/app/components/pwa/PwaInstallPrompt.spec.ts
+++ b/frontend/app/components/pwa/PwaInstallPrompt.spec.ts
@@ -137,7 +137,8 @@ describe('PwaInstallPrompt', () => {
     resetState()
   })
 
-  it('renders the install banner when installation is supported and prompted', async () => {
+  it('renders the install banner on mobile when installation is supported and prompted', async () => {
+    mobileBreakpoint.value = true
     const wrapper = mountPrompt()
     installPromptVisible.value = true
     isInstallSupported.value = true
@@ -147,8 +148,7 @@ describe('PwaInstallPrompt', () => {
     expect(wrapper.text()).toContain('Install Nudger')
   })
 
-  it('hides the install banner on mobile displays', async () => {
-    mobileBreakpoint.value = true
+  it('hides the install banner on desktop displays', async () => {
     const wrapper = mountPrompt()
     installPromptVisible.value = true
     isInstallSupported.value = true
@@ -158,6 +158,7 @@ describe('PwaInstallPrompt', () => {
   })
 
   it('triggers install actions from the CTA and dismiss buttons', async () => {
+    mobileBreakpoint.value = true
     const wrapper = mountPrompt()
     installPromptVisible.value = true
     isInstallSupported.value = true

--- a/frontend/app/components/pwa/PwaInstallPrompt.vue
+++ b/frontend/app/components/pwa/PwaInstallPrompt.vue
@@ -124,7 +124,7 @@ const {
 const display = useDisplay()
 
 const showInstallBanner = computed(() => isInstallSupported.value && installPromptVisible.value)
-const shouldRenderInstallBanner = computed(() => showInstallBanner.value && !display.smAndDown.value)
+const shouldRenderInstallBanner = computed(() => showInstallBanner.value && display.smAndDown.value)
 const showUpdateBanner = computed(() => updateAvailable.value)
 const installTitle = computed(() => String(t('pwa.install.title')))
 const installDescription = computed(() => String(t('pwa.install.description')))


### PR DESCRIPTION
## Summary
- show the PWA install banner only on small/mobile viewports so desktop visitors no longer see the prompt
- update the PwaInstallPrompt unit tests to reflect the new responsive behaviour and keep CTA interactions covered

## Testing
- pnpm lint
- pnpm test --run app/components/pwa/PwaInstallPrompt.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187c9e252483229bc69d6e48fb3d62)