### PR TITLE
feat: lazy load hero video

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, toRefs, watch } from 'vue'
-import { useIntersectionObserver, usePreferredReducedData } from '@vueuse/core'
+import { useIntersectionObserver, useMediaQuery } from '@vueuse/core'
 import { useDisplay } from 'vuetify'
 import HomeCategoryCarousel from '~/components/home/HomeCategoryCarousel.vue'
 import SearchSuggestField, {
@@ -54,7 +54,9 @@ const heroVideoElementRef = ref<HTMLVideoElement | null>(null)
 const shouldLoadVideo = ref(false)
 const shouldPlayVideo = ref(false)
 const isHeroMediaNearViewport = ref(false)
-const prefersReducedData = usePreferredReducedData()
+const prefersReducedData = import.meta.client
+  ? useMediaQuery('(prefers-reduced-data: reduce)')
+  : ref(false)
 const shouldRespectReducedData = computed(() => prefersReducedData.value === true)
 
 const updateVideoPlaybackIntent = () => {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -26,7 +26,8 @@ const requestURL = useRequestURL()
 const searchQuery = ref('')
 
 const MIN_SUGGESTION_QUERY_LENGTH = 2
-const heroVideoSrc = useState<string>('home-hero-video-src', () => '/videos/video-concept1.mp4')
+const heroVideoSrc = useState<string | null>('home-hero-video-src', () => null)
+const heroVideoCandidates = useState<string[]>('home-hero-video-candidates', () => [])
 const heroVideoPoster = '/images/home/hero-placeholder.svg'
 
 type CategoryCarouselItem = {
@@ -82,8 +83,7 @@ if (import.meta.server) {
   const videoCandidates = await getHeroVideoSources()
 
   if (videoCandidates.length > 0) {
-    const randomIndex = Math.floor(Math.random() * videoCandidates.length)
-    heroVideoSrc.value = videoCandidates[randomIndex]
+    heroVideoCandidates.value = videoCandidates
   }
 } else {
   if (rawCategories.value.length === 0) {
@@ -92,6 +92,11 @@ if (import.meta.server) {
 
   if (paginatedArticles.value.length === 0) {
     await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
+  }
+
+  if (!heroVideoSrc.value && heroVideoCandidates.value.length > 0) {
+    const randomIndex = Math.floor(Math.random() * heroVideoCandidates.value.length)
+    heroVideoSrc.value = heroVideoCandidates.value[randomIndex]
   }
 }
 


### PR DESCRIPTION
## Summary
- delay mounting/playing the home hero video until the section nears the viewport, show a poster placeholder, and respect prefers-reduced-data while keeping autoplay in sync with canplay events
- stop referencing the hero mp4 during SSR by hydrating the client with the candidate list and only selecting a random video after the browser takes over

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187ed800fc832294542650ddcaea89)