### PR TITLE
Allow requesting excluded products via filter

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
@@ -54,7 +54,9 @@ public record FilterRequestDto(
         @Schema(description = "Filter on the country resolved from the GTIN prefix", example = "country")
         country("gtinInfos.country", FilterValueType.keyword),
         @Schema(description = "Filter on the datasources contributing to the aggregation", example = "datasource")
-        datasource("datasourceCodes", FilterValueType.keyword);
+        datasource("datasourceCodes", FilterValueType.keyword),
+        @Schema(description = "Filter on the exclusion flag to include or hide moderated products", example = "excluded")
+        excluded("excluded", FilterValueType.keyword);
 
         private final String fieldPath;
         private final FilterValueType valueType;


### PR DESCRIPTION
## Summary
- inspect the incoming filters before composing the product search criteria so the `excluded=false` guard is only enforced when the caller did not explicitly request another value, and expose the `excluded` field in `FilterRequestDto`
- cover the new behaviour with a dedicated service test that asserts the query clauses change when a caller asks for excluded products

## Testing
- `mvn --offline -pl front-api -am test`
- `pnpm generate:api` *(fails: unable to reach https://beta.front-api.nudger.fr/v3/api-docs/front)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a7d9cdec83339990478a1fed74ae)