### PR TITLE
feat: align admin access helper with runtime config

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -124,6 +124,14 @@ Every downstream call should be wrapped in a thin service that:
 4. Guards against accidental client-side usage to keep secrets such as
    `MACHINE_TOKEN` out of the browser bundle.
 
+## Admin access helpers
+- Admin-only UI such as the category filters rely on `hasAdminAccess` from
+  `shared/utils/_roles.ts`.
+- `hasAdminAccess` compares the authenticated user's roles with
+  `config.public.editRoles` (defaults to `ROLE_SITEEDITOR,XWIKIADMINGROUP`).
+- Update the `EDITOR_ROLES` environment variable if new roles must be allowed;
+  avoid hardcoding role names anywhere else.
+
 ## When Unsure
 - Prefer incremental changes aligned with existing code style and project architecture.
 - Ask for clarification before introducing new patterns or deviating from these guardrails.

--- a/frontend/shared/utils/_roles.spec.ts
+++ b/frontend/shared/utils/_roles.spec.ts
@@ -8,20 +8,21 @@ describe('hasAdminAccess', () => {
     expect(hasAdminAccess([])).toBe(false)
   })
 
-  it('matches lowercase admin role', () => {
-    expect(hasAdminAccess(['admin'])).toBe(true)
+  it('matches configured roles regardless of casing', () => {
+    expect(hasAdminAccess(['content_editor'], { allowedRoles: ['CONTENT_EDITOR'] })).toBe(true)
   })
 
-  it('matches uppercase admin role', () => {
-    expect(hasAdminAccess(['ADMIN'])).toBe(true)
-  })
-
-  it('matches prefixed admin role', () => {
-    expect(hasAdminAccess(['ROLE_ADMIN'])).toBe(true)
+  it('allows XWIKIADMINGROUP by default', () => {
+    expect(hasAdminAccess(['XWIKIADMINGROUP'])).toBe(true)
+    expect(hasAdminAccess(['xwikiadmingroup'])).toBe(true)
   })
 
   it('ignores roles without admin privileges', () => {
-    expect(hasAdminAccess(['user'])).toBe(false)
-    expect(hasAdminAccess(['domain'])).toBe(false)
+    expect(hasAdminAccess(['user'], { allowedRoles: ['ROLE_SITEEDITOR'] })).toBe(false)
+    expect(hasAdminAccess(['domain'], { allowedRoles: ['ROLE_SITEEDITOR'] })).toBe(false)
+  })
+
+  it('rejects users without configured admin roles', () => {
+    expect(hasAdminAccess(['content-editor'], { allowedRoles: ['ROLE_SITEEDITOR'] })).toBe(false)
   })
 })

--- a/frontend/shared/utils/_roles.ts
+++ b/frontend/shared/utils/_roles.ts
@@ -1,7 +1,36 @@
-export const hasAdminAccess = (roles?: readonly (string | null | undefined)[] | null) => {
+import { useRuntimeConfig } from '#imports'
+
+const DEFAULT_EDIT_ROLES = ['ROLE_SITEEDITOR', 'XWIKIADMINGROUP']
+
+const normalizeRoles = (roles: readonly (string | null | undefined)[]) =>
+  roles.map((role) => role?.trim().toLowerCase()).filter((role): role is string => Boolean(role))
+
+const getNormalizedEditRoles = (override?: readonly (string | null | undefined)[] | null) => {
+  if (override && override.length > 0) {
+    return normalizeRoles(override)
+  }
+
+  const config = useRuntimeConfig()
+  const configuredRoles = config?.public?.editRoles
+
+  const roles = Array.isArray(configuredRoles) && configuredRoles.length > 0 ? configuredRoles : DEFAULT_EDIT_ROLES
+
+  return normalizeRoles(roles)
+}
+
+type AdminAccessOptions = {
+  allowedRoles?: readonly (string | null | undefined)[] | null
+}
+
+export const hasAdminAccess = (
+  roles?: readonly (string | null | undefined)[] | null,
+  options?: AdminAccessOptions,
+) => {
   if (!roles || roles.length === 0) {
     return false
   }
+
+  const allowedRoles = getNormalizedEditRoles(options?.allowedRoles)
 
   return roles.some((role) => {
     if (!role) {
@@ -9,6 +38,6 @@ export const hasAdminAccess = (roles?: readonly (string | null | undefined)[] | 
     }
 
     const normalized = role.trim().toLowerCase()
-    return normalized === 'admin' || normalized === 'role_admin'
+    return allowedRoles.includes(normalized)
   })
 }


### PR DESCRIPTION
## Summary
- update `hasAdminAccess` to normalize roles from `config.public.editRoles` and allow optional overrides for tests
- refresh the accompanying unit tests to cover configured roles, XWIKIADMINGROUP, and non-admin scenarios
- document how admin-only surfaces rely on `hasAdminAccess` and the `EDITOR_ROLES` runtime configuration

## Testing
- `pnpm lint`
- `pnpm test --run`
- `pnpm generate`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a7db237c833382672e4f707bffbb)