### PR TITLE
Add fullscreen homepage variant without video

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroFullscreenSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroFullscreenSection.vue
@@ -1,0 +1,382 @@
+<script setup lang="ts">
+import { computed, toRefs } from 'vue'
+import HomeCategoryCarousel from '~/components/home/HomeCategoryCarousel.vue'
+import SearchSuggestField, {
+  type CategorySuggestionItem,
+  type ProductSuggestionItem,
+} from '~/components/search/SearchSuggestField.vue'
+
+type CategoryCarouselItem = {
+  id: string
+  title: string
+  href: string
+  image?: string | null
+  impactScoreHref: string
+}
+
+type HeroHelperItem = {
+  icon: string
+  label: string
+}
+
+const props = defineProps<{
+  searchQuery: string
+  minSuggestionQueryLength: number
+  categoryItems: CategoryCarouselItem[]
+  categoriesLoading: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:searchQuery': [value: string]
+  submit: []
+  'select-category': [payload: CategorySuggestionItem]
+  'select-product': [payload: ProductSuggestionItem]
+}>()
+
+const { t, tm } = useI18n()
+
+const { minSuggestionQueryLength, categoryItems, categoriesLoading } = toRefs(props)
+
+const searchQueryValue = computed(() => props.searchQuery)
+
+const normalizeHelperItems = (items: unknown): HeroHelperItem[] => {
+  if (!Array.isArray(items)) {
+    return []
+  }
+
+  return items
+    .map((rawItem) => {
+      if (typeof rawItem !== 'object' || rawItem == null) {
+        return null
+      }
+
+      const { icon, label } = rawItem as { icon?: unknown; label?: unknown }
+      const normalizedLabel = typeof label === 'string' ? label.trim() : ''
+
+      if (!normalizedLabel) {
+        return null
+      }
+
+      const normalizedIcon = typeof icon === 'string' && icon.trim().length > 0 ? icon.trim() : '•'
+
+      return {
+        icon: normalizedIcon,
+        label: normalizedLabel,
+      }
+    })
+    .filter((item): item is HeroHelperItem => item != null)
+}
+
+const heroHelperItems = computed<HeroHelperItem[]>(() => {
+  const translatedItems = normalizeHelperItems(tm('home.hero.search.helpers'))
+
+  if (translatedItems.length > 0) {
+    return translatedItems
+  }
+
+  const fallback = String(t('home.hero.search.helper'))
+  const trimmedFallback = fallback.trim()
+
+  if (!trimmedFallback || trimmedFallback === 'home.hero.search.helper') {
+    return []
+  }
+
+  return [
+    {
+      icon: '⚡',
+      label: trimmedFallback,
+    },
+  ]
+})
+
+const updateSearchQuery = (value: string) => {
+  emit('update:searchQuery', value)
+}
+
+const handleSubmit = () => {
+  emit('submit')
+}
+
+const handleCategorySelect = (payload: CategorySuggestionItem) => {
+  emit('select-category', payload)
+}
+
+const handleProductSelect = (payload: ProductSuggestionItem) => {
+  emit('select-product', payload)
+}
+</script>
+
+<template>
+  <HeroSurface tag="section" class="home-hero-fullscreen" aria-labelledby="home-hero-fullscreen-title" :bleed="true">
+    <div class="home-hero-fullscreen__parallax" aria-hidden="true">
+      <div class="home-hero-fullscreen__glow home-hero-fullscreen__glow--primary" />
+      <div class="home-hero-fullscreen__glow home-hero-fullscreen__glow--secondary" />
+      <div class="home-hero-fullscreen__grid" />
+    </div>
+
+    <v-container fluid class="home-hero-fullscreen__container">
+      <div class="home-hero-fullscreen__inner">
+        <v-row class="home-hero-fullscreen__layout" justify="center" align="center">
+          <v-col cols="12" lg="10" xl="8" class="home-hero-fullscreen__content">
+            <p class="home-hero-fullscreen__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+            <h1 id="home-hero-fullscreen-title" class="home-hero-fullscreen__title">
+              {{ t('home.hero.title') }}
+            </h1>
+            <p class="home-hero-fullscreen__subtitle">{{ t('home.hero.subtitle') }}</p>
+
+            <form class="home-hero-fullscreen__search" role="search" @submit.prevent="handleSubmit">
+              <SearchSuggestField
+                :model-value="searchQueryValue"
+                class="home-hero-fullscreen__search-input"
+                :label="t('home.hero.search.label')"
+                :placeholder="t('home.hero.search.placeholder')"
+                :aria-label="t('home.hero.search.ariaLabel')"
+                :min-chars="minSuggestionQueryLength"
+                @update:model-value="updateSearchQuery"
+                @submit="handleSubmit"
+                @select-category="handleCategorySelect"
+                @select-product="handleProductSelect"
+              >
+                <template #append-inner>
+                  <v-btn
+                    class="home-hero-fullscreen__search-submit"
+                    icon="mdi-arrow-right"
+                    variant="flat"
+                    color="primary"
+                    size="small"
+                    type="submit"
+                    :aria-label="t('home.hero.search.cta')"
+                  />
+                </template>
+              </SearchSuggestField>
+            </form>
+
+            <ul v-if="heroHelperItems.length" class="home-hero-fullscreen__helpers">
+              <li
+                v-for="(item, index) in heroHelperItems"
+                :key="`hero-fullscreen-helper-${index}`"
+                class="home-hero-fullscreen__helper"
+              >
+                <span class="home-hero-fullscreen__helper-icon" aria-hidden="true">{{ item.icon }}</span>
+                <span class="home-hero-fullscreen__helper-text">{{ item.label }}</span>
+              </li>
+            </ul>
+          </v-col>
+        </v-row>
+      </div>
+    </v-container>
+
+    <div class="home-hero-fullscreen__categories" :aria-label="t('home.categories.bannerAriaLabel')">
+      <v-container fluid class="home-hero-fullscreen__categories-container">
+        <div class="home-hero-fullscreen__categories-inner">
+          <HomeCategoryCarousel :items="categoryItems" :loading="categoriesLoading" />
+        </div>
+      </v-container>
+    </div>
+  </HeroSurface>
+</template>
+
+<style scoped lang="sass">
+.home-hero-fullscreen
+  position: relative
+  min-height: clamp(640px, 88dvh, 980px)
+  padding-block: clamp(3.5rem, 10vw, 6rem)
+  display: flex
+  flex-direction: column
+  justify-content: center
+  overflow: hidden
+  --hero-cat-h: var(--cat-height, 168px)
+  --hero-cat-in-hero-base: calc(var(--hero-cat-h) / 2)
+  --hero-cat-overlap-base: calc(var(--hero-cat-h) - var(--hero-cat-in-hero-base))
+  --hero-cat-in-hero: var(--cat-in-hero, var(--hero-cat-in-hero-base))
+  --hero-cat-overlap: var(--cat-overlap, var(--hero-cat-overlap-base))
+
+.home-hero-fullscreen__parallax
+  position: absolute
+  inset: 0
+  overflow: hidden
+  pointer-events: none
+
+.home-hero-fullscreen__glow
+  position: absolute
+  border-radius: 999px
+  filter: blur(80px)
+  opacity: 0.28
+  transform: translate3d(0, 0, 0)
+  animation: heroFloat 16s ease-in-out infinite alternate
+
+.home-hero-fullscreen__glow--primary
+  width: clamp(320px, 35vw, 520px)
+  height: clamp(320px, 35vw, 520px)
+  background: radial-gradient(circle, rgba(var(--v-theme-hero-gradient-start), 0.6), transparent 70%)
+  top: 6%
+  left: clamp(4%, 10vw, 12%)
+
+.home-hero-fullscreen__glow--secondary
+  width: clamp(280px, 32vw, 440px)
+  height: clamp(280px, 32vw, 440px)
+  background: radial-gradient(circle, rgba(var(--v-theme-hero-gradient-end), 0.55), transparent 70%)
+  bottom: 8%
+  right: clamp(4%, 10vw, 12%)
+  animation-delay: 3s
+
+.home-hero-fullscreen__grid
+  position: absolute
+  inset: -40%
+  background: radial-gradient(circle at 30% 30%, rgba(var(--v-theme-hero-overlay-soft), 0.2), transparent 35%), radial-gradient(circle at 70% 60%, rgba(var(--v-theme-hero-overlay-strong), 0.16), transparent 30%), linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.08) 0%, rgba(var(--v-theme-hero-gradient-mid), 0.08) 40%, rgba(var(--v-theme-hero-gradient-end), 0.08) 100%)
+  opacity: 0.6
+  background-attachment: fixed
+  mask: linear-gradient(180deg, rgba(255, 255, 255, 0.92) 0%, rgba(255, 255, 255, 0.4) 100%)
+  transform: translate3d(0, 0, 0)
+
+.home-hero-fullscreen__container
+  position: relative
+  z-index: 1
+  padding-inline: clamp(1.5rem, 5vw, 4rem)
+
+.home-hero-fullscreen__inner
+  margin: 0 auto
+  max-width: 1200px
+  display: flex
+  flex-direction: column
+  gap: clamp(1.75rem, 6vw, 2.5rem)
+  align-items: center
+  text-align: center
+
+.home-hero-fullscreen__layout
+  width: 100%
+
+.home-hero-fullscreen__content
+  display: flex
+  flex-direction: column
+  gap: clamp(1.25rem, 3vw, 1.75rem)
+  align-items: center
+  text-align: center
+
+.home-hero-fullscreen__eyebrow
+  margin: 0
+  font-weight: 700
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-hero-gradient-end), 0.95)
+
+.home-hero-fullscreen__title
+  margin: 0
+  font-size: clamp(2.6rem, 6vw, 4rem)
+  line-height: 1.05
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.home-hero-fullscreen__subtitle
+  margin: 0
+  max-width: min(900px, 90vw)
+  font-size: clamp(1.1rem, 2.8vw, 1.35rem)
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-hero-fullscreen__search
+  width: min(760px, 100%)
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-hero-fullscreen__search-input
+  border-radius: clamp(1.4rem, 4vw, 1.9rem)
+  background: rgba(var(--v-theme-surface-default), 0.82)
+  box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  backdrop-filter: blur(8px)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
+
+.home-hero-fullscreen__search-submit
+  box-shadow: none
+
+.home-hero-fullscreen__helpers
+  display: grid
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))
+  gap: 0.6rem 1.25rem
+  margin: 0
+  padding: 0
+  list-style: none
+  width: min(820px, 100%)
+
+.home-hero-fullscreen__helper
+  display: inline-flex
+  align-items: center
+  gap: 0.5rem
+  justify-content: center
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-weight: 500
+
+.home-hero-fullscreen__helper-icon
+  font-size: 1.1rem
+
+.home-hero-fullscreen__helper-text
+  line-height: 1.35
+
+.home-hero-fullscreen__categories
+  position: absolute
+  inset-inline: 0
+  bottom: calc(-1 * var(--hero-cat-overlap))
+  display: flex
+  justify-content: center
+  z-index: 3
+  pointer-events: none
+
+.home-hero-fullscreen__categories-container
+  width: 100%
+
+.home-hero-fullscreen__categories-inner
+  position: relative
+  width: min(100%, 1200px)
+  margin-inline: auto
+  padding: clamp(0.4rem, 1.5vw, 0.8rem) clamp(0.75rem, 3vw, 1.5rem)
+  border-radius: clamp(1.5rem, 4vw, 2rem)
+  background: linear-gradient(
+    180deg,
+    rgba(var(--v-theme-hero-gradient-start), 0.18) 0%,
+    rgba(var(--v-theme-surface-default), 0.96) 60%,
+    rgb(var(--v-theme-surface-muted)) 100%
+  )
+  box-shadow: 0 22px 38px rgba(var(--v-theme-shadow-primary-600), 0.16)
+  display: flex
+  align-items: center
+  justify-content: center
+  pointer-events: auto
+  height: var(--hero-cat-h)
+
+.home-hero-fullscreen__categories-inner :deep(.home-category-carousel)
+  height: 100%
+  display: flex
+
+.home-hero-fullscreen__categories-inner::before
+  content: ''
+  position: absolute
+  inset: 0
+  border-radius: inherit
+  background: linear-gradient(
+    120deg,
+    rgba(var(--v-theme-hero-gradient-start), 0.16) 0%,
+    rgba(var(--v-theme-hero-gradient-end), 0.18) 45%,
+    rgba(var(--v-theme-surface-default), 0) 100%
+  )
+  pointer-events: none
+  mix-blend-mode: screen
+
+.home-hero-fullscreen__categories-inner > *
+  position: relative
+  z-index: 1
+
+@media (max-width: 959px)
+  .home-hero-fullscreen
+    min-height: clamp(560px, 90dvh, 820px)
+    padding-block: clamp(3rem, 18vw, 4.5rem)
+    --hero-cat-h: var(--cat-height, 160px)
+    --hero-cat-in-hero-base: calc(var(--hero-cat-h) / 2)
+
+  .home-hero-fullscreen__helpers
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr))
+
+@keyframes heroFloat
+  0%
+    transform: translate3d(0, 0, 0)
+  100%
+    transform: translate3d(0, 28px, 0)
+</style>

--- a/frontend/app/pages/index-fullscreen.vue
+++ b/frontend/app/pages/index-fullscreen.vue
@@ -1,0 +1,607 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+import type { BlogPostDto, VerticalConfigDto } from '~~/shared/api-client'
+import HomeHeroFullscreenSection from '~/components/home/sections/HomeHeroFullscreenSection.vue'
+import HomeProblemsSection from '~/components/home/sections/HomeProblemsSection.vue'
+import HomeSolutionSection from '~/components/home/sections/HomeSolutionSection.vue'
+import HomeFeaturesSection from '~/components/home/sections/HomeFeaturesSection.vue'
+import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
+import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
+import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
+import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
+import type { CategorySuggestionItem, ProductSuggestionItem } from '~/components/search/SearchSuggestField.vue'
+import { useCategories } from '~/composables/categories/useCategories'
+import { useBlog } from '~/composables/blog/useBlog'
+
+definePageMeta({
+  ssr: true,
+})
+
+const { t, locale, availableLocales } = useI18n()
+const router = useRouter()
+const localePath = useLocalePath()
+const requestURL = useRequestURL()
+
+const searchQuery = ref('')
+
+const MIN_SUGGESTION_QUERY_LENGTH = 2
+
+type CategoryCarouselItem = {
+  id: string
+  title: string
+  href: string
+  image?: string | null
+  impactScoreHref: string
+}
+
+type HomeBlogItem = BlogPostDto & { formattedDate?: string; slug?: string }
+type EnrichedBlogItem = HomeBlogItem & { link: string; hasImage: boolean }
+
+const { categories: rawCategories, fetchCategories, loading: categoriesLoading } = useCategories()
+const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
+
+const BLOG_ARTICLES_LIMIT = 4
+
+const toSafeString = (value: unknown) => {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value == null) {
+    return ''
+  }
+
+  return String(value)
+}
+
+const toTrimmedString = (value: unknown) => toSafeString(value).trim()
+
+const stripHtmlComments = (value: string) => {
+  let previous
+  let input = value
+  do {
+    previous = input
+    input = input.replace(/<!--[\s\S]*?-->/g, '')
+  } while (input !== previous)
+  return input
+}
+
+const sanitizeBlogSummary = (value: unknown) => stripHtmlComments(toSafeString(value)).trim()
+
+const hasRenderableImage = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+if (import.meta.server) {
+  await fetchCategories(true)
+  await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
+} else {
+  if (rawCategories.value.length === 0) {
+    await fetchCategories(true)
+  }
+
+  if (paginatedArticles.value.length === 0) {
+    await fetchArticles(1, BLOG_ARTICLES_LIMIT, null)
+  }
+}
+
+const problemItems = computed(() => [
+  {
+    icon: 'mdi-sign-direction',
+    text: String(t('home.problems.items.labelsOverload')),
+  },
+  {
+    icon: 'mdi-scale-balance',
+    text: String(t('home.problems.items.budgetVsEcology')),
+  },
+  {
+    icon: 'mdi-table-multiple',
+    text: String(t('home.problems.items.tooManyTabs')),
+  },
+])
+
+const solutionBenefits = computed(() => [
+  {
+    emoji: '⏱️',
+    label: String(t('home.solution.benefits.time.title')),
+    description: String(t('home.solution.benefits.time.description')),
+  },
+  {
+    emoji: '💰',
+    label: String(t('home.solution.benefits.savings.title')),
+    description: String(t('home.solution.benefits.savings.description')),
+  },
+  {
+    emoji: '🌍',
+    label: String(t('home.solution.benefits.planet.title')),
+    description: String(t('home.solution.benefits.planet.description')),
+  },
+  {
+    emoji: '🛡️',
+    label: String(t('home.solution.benefits.trust.title')),
+    description: String(t('home.solution.benefits.trust.description')),
+  },
+])
+
+const featureCards = computed(() => [
+  {
+    icon: 'mdi-leaf-circle',
+    title: String(t('home.features.cards.impactScore.title')),
+    description: String(t('home.features.cards.impactScore.description')),
+  },
+  {
+    icon: 'mdi-chart-line',
+    title: String(t('home.features.cards.priceComparison.title')),
+    description: String(t('home.features.cards.priceComparison.description')),
+  },
+  {
+    icon: 'mdi-source-branch',
+    title: String(t('home.features.cards.openIndependent.title')),
+    description: String(t('home.features.cards.openIndependent.description')),
+  },
+  {
+    icon: 'mdi-shield-off-outline',
+    title: String(t('home.features.cards.noTracking.title')),
+    description: String(t('home.features.cards.noTracking.description')),
+  },
+  {
+    icon: 'mdi-database',
+    title: String(t('home.features.cards.massiveBase.title')),
+    description: String(t('home.features.cards.massiveBase.description')),
+  },
+])
+
+const objectionItems = computed(() => [
+  {
+    icon: 'mdi-lightning-bolt',
+    question: String(t('home.objections.items.aiEnergy.question')),
+    answer: String(t('home.objections.items.aiEnergy.answer')),
+  },
+  {
+    icon: 'mdi-recycle',
+    question: String(t('home.objections.items.reuse.question')),
+    answer: String(t('home.objections.items.reuse.answer')),
+  },
+  {
+    icon: 'mdi-scale-balance',
+    question: String(t('home.objections.items.independence.question')),
+    answer: String(t('home.objections.items.independence.answer')),
+  },
+])
+
+const faqItems = computed(() => [
+  {
+    question: String(t('home.faq.items.free.question')),
+    answer: String(t('home.faq.items.free.answer')),
+  },
+  {
+    question: String(t('home.faq.items.account.question')),
+    answer: String(t('home.faq.items.account.answer')),
+  },
+  {
+    question: String(t('home.faq.items.categories.question')),
+    answer: String(t('home.faq.items.categories.answer')),
+  },
+  {
+    question: String(t('home.faq.items.impactScore.question')),
+    answer: String(t('home.faq.items.impactScore.answer')),
+  },
+  {
+    question: String(t('home.faq.items.dataFreshness.question')),
+    answer: String(t('home.faq.items.dataFreshness.answer')),
+  },
+  {
+    question: String(t('home.faq.items.suggestProduct.question')),
+    answer: String(t('home.faq.items.suggestProduct.answer')),
+  },
+])
+
+const faqPanels = computed(() =>
+  faqItems.value.map((item, index) => ({
+    ...item,
+    blocId: `HOME-FULLSCREEN:FAQ:${index + 1}`,
+  })),
+)
+
+const faqJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.value.map((item) => ({
+    '@type': 'Question',
+    name: item.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.answer,
+    },
+  })),
+}))
+
+const canonicalUrl = computed(
+  () => new URL(resolveLocalizedRoutePath('index-fullscreen', locale.value), requestURL.origin).toString(),
+)
+
+const alternateLinks = computed(() =>
+  availableLocales.map((availableLocale) => ({
+    rel: 'alternate' as const,
+    hreflang: availableLocale,
+    href: new URL(resolveLocalizedRoutePath('index-fullscreen', availableLocale), requestURL.origin).toString(),
+  })),
+)
+
+const searchLandingUrl = computed(() => localePath({ name: 'search' }))
+const categoriesLandingUrl = computed(() => localePath({ name: 'categories' }))
+
+const normalizeVerticalHomeUrl = (raw: string | null | undefined): string | null => {
+  if (!raw) {
+    return null
+  }
+
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+const resolveCategoryHref = (category: VerticalConfigDto) => {
+  const normalizedUrl = normalizeVerticalHomeUrl(category.verticalHomeUrl)
+
+  if (normalizedUrl) {
+    return normalizedUrl
+  }
+
+  const normalizedTitle = category.verticalHomeTitle?.trim()
+
+  if (normalizedTitle) {
+    return localePath({ name: 'search', query: { q: normalizedTitle } })
+  }
+
+  return searchLandingUrl.value
+}
+
+const resolveCategoryImage = (category: VerticalConfigDto) => {
+  const candidates = [
+    category.imageLarge,
+    category.imageMedium,
+    category.imageSmall,
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim()
+      if (trimmed.length > 0) {
+        return trimmed
+      }
+    }
+  }
+
+  return null
+}
+
+const resolveImpactScoreHref = (href: string) => {
+  const trimmed = href?.trim?.() ?? ''
+
+  if (!trimmed) {
+    return ''
+  }
+
+  if (trimmed.includes('?')) {
+    return ''
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+      url.pathname = `${url.pathname.replace(/\/?$/, '')}/ecoscore`
+      return url.toString()
+    } catch {
+      return ''
+    }
+  }
+
+  const normalized = trimmed.replace(/\/?$/, '')
+  return `${normalized}/ecoscore`
+}
+
+const categoryCarouselItems = computed<CategoryCarouselItem[]>(() => {
+  const categories = [...rawCategories.value]
+    .filter((category) => category.enabled !== false)
+    .sort((a, b) => {
+      if (a.popular !== b.popular) {
+        return (b.popular ? 1 : 0) - (a.popular ? 1 : 0)
+      }
+
+      const orderA = a.order ?? Number.MAX_SAFE_INTEGER
+      const orderB = b.order ?? Number.MAX_SAFE_INTEGER
+
+      if (orderA !== orderB) {
+        return orderA - orderB
+      }
+
+      return (a.verticalHomeTitle ?? '').localeCompare(b.verticalHomeTitle ?? '')
+    })
+
+  if (categories.length === 0) {
+    return []
+  }
+
+  return categories.map((category, index) => {
+    const title = category.verticalHomeTitle?.trim() || String(t('home.categories.fallbackTitle'))
+    const href = resolveCategoryHref(category)
+
+    return {
+      id: category.id ?? category.verticalHomeUrl ?? `${title}-${index}`,
+      title,
+      href,
+      image: resolveCategoryImage(category),
+      impactScoreHref: resolveImpactScoreHref(href),
+    }
+  })
+})
+
+const blogDateFormatter = computed(
+  () => new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' }),
+)
+
+const fallbackBlogEntries = computed<HomeBlogItem[]>(() => [
+  {
+    url: localePath({ name: 'blog-slug', params: { slug: 'impact-score-ia' } }),
+    title: String(t('home.blog.items.first.title')),
+    summary: String(t('home.blog.items.first.excerpt')),
+    formattedDate: String(t('home.blog.items.first.date')),
+    slug: 'impact-score-ia',
+  },
+  {
+    url: localePath({ name: 'blog-slug', params: { slug: 'prioriser-durabilite' } }),
+    title: String(t('home.blog.items.second.title')),
+    summary: String(t('home.blog.items.second.excerpt')),
+    formattedDate: String(t('home.blog.items.second.date')),
+    slug: 'prioriser-durabilite',
+  },
+  {
+    url: localePath({ name: 'blog-slug', params: { slug: 'equilibrer-prix-impact' } }),
+    title: String(t('home.blog.items.third.title')),
+    summary: String(t('home.blog.items.third.excerpt')),
+    formattedDate: String(t('home.blog.items.third.date')),
+    slug: 'equilibrer-prix-impact',
+  },
+])
+
+const blogListItems = computed<HomeBlogItem[]>(() => {
+  const articles = paginatedArticles.value.slice(0, BLOG_ARTICLES_LIMIT)
+
+  if (!articles.length) {
+    return fallbackBlogEntries.value
+  }
+
+  return articles.map((article) => {
+    const formattedDate = article.createdMs
+      ? blogDateFormatter.value.format(new Date(article.createdMs))
+      : ''
+
+    const title = toTrimmedString(article.title)
+    const summary = sanitizeBlogSummary(article.summary)
+    const image = typeof article.image === 'string' ? article.image.trim() : null
+
+    return {
+      ...article,
+      title,
+      summary,
+      image,
+      formattedDate,
+      slug: toTrimmedString((article as { slug?: string }).slug) || undefined,
+    }
+  })
+})
+
+const extractBlogSlug = (article: BlogPostDto): string | null => {
+  const pickSlugSegment = (value: unknown): string | null => {
+    if (typeof value !== 'string') {
+      return null
+    }
+
+    const trimmed = value.trim()
+
+    if (!trimmed) {
+      return null
+    }
+
+    let working = trimmed
+
+    if (/^https?:\/\//i.test(trimmed)) {
+      try {
+        const parsedUrl = new URL(trimmed)
+        working = parsedUrl.pathname
+      } catch {
+        return null
+      }
+    }
+
+    const sanitized = working.replace(/[?#].*$/, '').replace(/^\/+/, '')
+
+    if (!sanitized) {
+      return null
+    }
+
+    const segments = sanitized.split('/').filter(Boolean)
+    const candidate = segments.pop()
+
+    if (!candidate || candidate.toLowerCase() === 'blog') {
+      return null
+    }
+
+    return candidate
+  }
+
+  return pickSlugSegment((article as { slug?: string }).slug) ?? pickSlugSegment(article.url)
+}
+
+const resolveBlogArticleLink = (article: BlogPostDto) => {
+  const slug = extractBlogSlug(article)
+
+  if (!slug) {
+    return localePath({ name: 'blog' })
+  }
+
+  return localePath({ name: 'blog-slug', params: { slug } })
+}
+
+const enrichedBlogItems = computed<EnrichedBlogItem[]>(() =>
+  blogListItems.value.map((item) => {
+    const link = resolveBlogArticleLink(item)
+    const hasImage = hasRenderableImage(item.image)
+
+    return {
+      ...item,
+      link,
+      hasImage,
+    }
+  }),
+)
+
+const featuredBlogItem = computed(() => enrichedBlogItems.value[0] ?? null)
+const secondaryBlogItems = computed(() => enrichedBlogItems.value.slice(1))
+
+const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
+
+const navigateToSearch = (query?: string) => {
+  const normalizedQuery = query?.trim() ?? ''
+
+  router.push(
+    localePath({
+      name: 'search',
+      query: normalizedQuery ? { q: normalizedQuery } : undefined,
+    }),
+  )
+}
+
+const handleSearchSubmit = () => {
+  const trimmedQuery = searchQuery.value.trim()
+
+  if (trimmedQuery.length > 0 && trimmedQuery.length < MIN_SUGGESTION_QUERY_LENGTH) {
+    return
+  }
+
+  navigateToSearch(trimmedQuery)
+}
+
+const handleCategorySuggestion = (suggestion: CategorySuggestionItem) => {
+  searchQuery.value = suggestion.title
+
+  const normalizedUrl = normalizeVerticalHomeUrl(suggestion.url)
+
+  if (normalizedUrl) {
+    router.push(normalizedUrl)
+    return
+  }
+
+  navigateToSearch(suggestion.title)
+}
+
+const handleProductSuggestion = (suggestion: ProductSuggestionItem) => {
+  searchQuery.value = suggestion.title
+  const gtin = suggestion.gtin?.trim()
+
+  if (gtin) {
+    router.push(
+      localePath({
+        name: 'gtin',
+        params: { gtin },
+      }),
+    )
+    return
+  }
+
+  navigateToSearch(suggestion.title)
+}
+
+useSeoMeta({
+  title: () => String(t('home.seo.title')),
+  description: () => String(t('home.seo.description')),
+  ogTitle: () => String(t('home.seo.title')),
+  ogDescription: () => String(t('home.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+  ogSiteName: () => String(t('siteIdentity.siteName')),
+  ogLocale: () => locale.value.replace('-', '_'),
+  ogImageAlt: () => String(t('home.seo.imageAlt')),
+})
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+    ...alternateLinks.value,
+  ],
+  script: [
+    {
+      key: 'home-fullscreen-faq-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(faqJsonLd.value),
+    },
+  ],
+}))
+</script>
+
+<template>
+  <div class="home-page">
+    <HomeHeroFullscreenSection
+      v-model:search-query="searchQuery"
+      :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
+      :category-items="categoryCarouselItems"
+      :categories-loading="categoriesLoading"
+      @submit="handleSearchSubmit"
+      @select-category="handleCategorySuggestion"
+      @select-product="handleProductSuggestion"
+    />
+    <div class="home-page__sections">
+      <HomeProblemsSection :items="problemItems" />
+
+      <HomeSolutionSection :benefits="solutionBenefits" />
+
+      <HomeFeaturesSection :features="featureCards" />
+
+      <HomeBlogSection
+        :loading="blogLoading"
+        :featured-item="featuredBlogItem"
+        :secondary-items="secondaryBlogItems"
+      />
+
+      <HomeObjectionsSection :items="objectionItems" />
+
+      <HomeFaqSection :items="faqPanels" />
+
+      <HomeCtaSection
+        v-model:search-query="searchQuery"
+        :categories-landing-url="categoriesLandingUrl"
+        :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
+        @submit="handleSearchSubmit"
+        @select-category="handleCategorySuggestion"
+        @select-product="handleProductSuggestion"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="sass">
+.home-page
+  --cat-height: 150px
+  --cat-in-hero: calc(var(--cat-height) / 2)
+  --cat-overlap: calc(var(--cat-height) - var(--cat-in-hero))
+  display: flex
+  flex-direction: column
+  gap: 0
+  background-color: rgb(var(--v-theme-surface-default))
+
+.home-page__sections
+  display: flex
+  flex-direction: column
+  gap: clamp(3rem, 7vw, 5rem)
+  padding-top: var(--cat-overlap)
+</style>


### PR DESCRIPTION
## Summary
- add a new `/index-fullscreen` page that reuses the home content with a static fullscreen hero layout
- introduce a parallax-inspired hero component with expanded text space and category carousel without video playback

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3c3c27388333a40599310f92e448)