### PR TITLE
Refactor product timeline layout and tooling

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1674,31 +1674,47 @@
       },
       "timeline": {
         "title": "Lifecycle milestones",
-        "subtitle": "Track when the product appeared on the market and how availability evolved.",
+        "subtitle": "Key market dates at a glance.",
         "empty": "Lifecycle information is not available yet.",
+        "ariaYear": "Milestones for {year}",
         "sources": {
           "priceHistory": "Price history",
           "eprel": "EPREL registry",
           "generic": "Lifecycle event"
         },
-        "conditions": {
-          "new": "New",
-          "occasion": "Second-hand",
-          "generic": "Condition"
+        "tooltip": {
+          "date": "Date",
+          "source": "Source",
+          "ariaLabel": "{label} on {date} · {source}"
         },
         "events": {
-          "priceFirstSeenNew": "First new offer spotted",
-          "priceFirstSeenOccasion": "First second-hand offer spotted",
-          "priceLastSeenNew": "Latest new offer recorded",
-          "priceLastSeenOccasion": "Latest second-hand offer recorded",
-          "eprelOnMarketStart": "EPREL on-market start",
-          "eprelOnMarketEnd": "EPREL on-market end",
-          "eprelOnMarketFirstStart": "First EU market approval",
-          "eprelFirstPublication": "EPREL first publication",
-          "eprelLastPublication": "EPREL last publication",
+          "priceFirstSeenNew": "First new offer",
+          "priceFirstSeenOccasion": "First second-hand offer",
+          "priceLastSeenNew": "Latest new offer",
+          "priceLastSeenOccasion": "Latest second-hand offer",
+          "eprelOnMarketStart": "Market start (EPREL)",
+          "eprelOnMarketEnd": "Market end (EPREL)",
+          "eprelOnMarketFirstStart": "First EU market start",
+          "eprelFirstPublication": "First EPREL publication",
+          "eprelLastPublication": "Latest EPREL publication",
           "eprelExport": "EPREL export",
           "eprelImported": "Imported into Nudger",
           "eprelOrganisationClosed": "Organisation closed",
+          "generic": "Lifecycle event"
+        },
+        "descriptions": {
+          "priceFirstSeenNew": "First new offer detected in the price history.",
+          "priceFirstSeenOccasion": "First second-hand offer detected in the price history.",
+          "priceLastSeenNew": "Most recent new offer recorded in the price history.",
+          "priceLastSeenOccasion": "Most recent second-hand offer recorded in the price history.",
+          "eprelOnMarketStart": "EPREL declared on-market start date.",
+          "eprelOnMarketEnd": "EPREL declared on-market end date.",
+          "eprelOnMarketFirstStart": "EPREL first on-market start date.",
+          "eprelFirstPublication": "EPREL first publication date.",
+          "eprelLastPublication": "EPREL most recent publication date.",
+          "eprelExport": "EPREL export timestamp.",
+          "eprelImported": "Date when the EPREL entry was imported.",
+          "eprelOrganisationClosed": "EPREL organisation close date.",
           "generic": "Lifecycle event"
         }
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1674,31 +1674,47 @@
       },
       "timeline": {
         "title": "Moments clés",
-        "subtitle": "Visualisez les dates importantes de commercialisation et de disponibilité.",
+        "subtitle": "Dates clés du marché en un clin d'œil.",
         "empty": "Aucune information sur le cycle de vie n'est disponible pour le moment.",
+        "ariaYear": "Événements de l'année {year}",
         "sources": {
           "priceHistory": "Historique des prix",
           "eprel": "Registre EPREL",
           "generic": "Événement du cycle de vie"
         },
-        "conditions": {
-          "new": "Neuf",
-          "occasion": "Occasion",
-          "generic": "État"
+        "tooltip": {
+          "date": "Date",
+          "source": "Source",
+          "ariaLabel": "Événement {label} le {date} · {source}"
         },
         "events": {
-          "priceFirstSeenNew": "Première offre neuve détectée",
-          "priceFirstSeenOccasion": "Première offre d'occasion détectée",
-          "priceLastSeenNew": "Dernière offre neuve relevée",
-          "priceLastSeenOccasion": "Dernière offre d'occasion relevée",
-          "eprelOnMarketStart": "Mise sur le marché EPREL",
-          "eprelOnMarketEnd": "Fin de commercialisation EPREL",
-          "eprelOnMarketFirstStart": "Première autorisation en Europe",
+          "priceFirstSeenNew": "Première offre neuve",
+          "priceFirstSeenOccasion": "Première offre d'occasion",
+          "priceLastSeenNew": "Dernière offre neuve",
+          "priceLastSeenOccasion": "Dernière offre d'occasion",
+          "eprelOnMarketStart": "Début commercialisation (EPREL)",
+          "eprelOnMarketEnd": "Fin commercialisation (EPREL)",
+          "eprelOnMarketFirstStart": "Première mise sur le marché UE",
           "eprelFirstPublication": "Première publication EPREL",
           "eprelLastPublication": "Dernière publication EPREL",
           "eprelExport": "Export EPREL",
           "eprelImported": "Importé dans Nudger",
           "eprelOrganisationClosed": "Organisation fermée",
+          "generic": "Événement du cycle de vie"
+        },
+        "descriptions": {
+          "priceFirstSeenNew": "Première offre neuve détectée dans l'historique des prix.",
+          "priceFirstSeenOccasion": "Première offre d'occasion détectée dans l'historique des prix.",
+          "priceLastSeenNew": "Dernière offre neuve enregistrée dans l'historique des prix.",
+          "priceLastSeenOccasion": "Dernière offre d'occasion enregistrée dans l'historique des prix.",
+          "eprelOnMarketStart": "Date de début de commercialisation déclarée sur EPREL.",
+          "eprelOnMarketEnd": "Date de fin de commercialisation déclarée sur EPREL.",
+          "eprelOnMarketFirstStart": "Première date de mise sur le marché déclarée sur EPREL.",
+          "eprelFirstPublication": "Date de première publication EPREL.",
+          "eprelLastPublication": "Date de dernière publication EPREL.",
+          "eprelExport": "Horodatage d'export EPREL.",
+          "eprelImported": "Date d'import de l'entrée EPREL.",
+          "eprelOrganisationClosed": "Date de fermeture de l'organisation EPREL.",
           "generic": "Événement du cycle de vie"
         }
       },


### PR DESCRIPTION
## Summary
- redesign the product lifecycle timeline as a compact horizontal rail with tooltip details and year grouping
- simplify date formatting, aria labels, and new i18n strings for event labels and descriptions in English and French
- update the timeline component tests to assert the new layout and condensed month labels

## Testing
- pnpm lint
- CI=1 pnpm test -- --runInBand --filter ProductLifeTimeline
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a47c1bd9c8333847f9c2c149cc0ce)