### PR TITLE
Adjust product timeline layout

### DIFF
--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -115,7 +115,7 @@
         ]"
       >
         <div v-if="timeline" class="product-attributes__timeline-column">
-          <ProductLifeTimeline :timeline="timeline" alternate />
+          <ProductLifeTimeline :timeline="timeline" />
         </div>
 
         <div class="product-attributes__details-panel">
@@ -822,11 +822,6 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
     grid-template-columns: minmax(240px, 1fr) minmax(0, 3fr);
     gap: 1.5rem;
     align-items: flex-start;
-  }
-
-  .product-attributes__timeline-column {
-    position: sticky;
-    top: 1.5rem;
   }
 
   .product-attributes__details-panel {


### PR DESCRIPTION
## Summary
- remove sticky positioning from the product timeline column so it scrolls with the rest of the details
- render timeline years/events in a single stacked column by using the default layout

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af7ff2e308333a1c94cd027ea7d1a)