### PR TITLE
Add ecoscore redirects to impact score page

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -159,6 +159,8 @@ export default defineNuxtConfig({
     // Admin area rendered on the client side
     '/admin/**': { ssr: false },
     '/offline': { prerender: true },
+    '/ecoscore': { redirect: { to: '/impact-score', statusCode: 301 } },
+    '/eco-score': { redirect: { to: '/impact-score', statusCode: 301 } },
   },
   modules: [
     "vuetify-nuxt-module",


### PR DESCRIPTION
## Summary
- add Nuxt route rules redirecting `/ecoscore` and `/eco-score` to `/impact-score`

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0d9eb2b883339649d20862c0de79)