### PR TITLE
Fix product score aggregation fields

### DIFF
--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -121,8 +121,6 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { createError } from 'h3'
 import {
-  AggTypeEnum,
-  type Agg,
   type AggregationBucketDto,
   type AggregationResponseDto,
   type CommercialEvent,
@@ -148,6 +146,7 @@ import { useAuth } from '~/composables/useAuth'
 import { useDisplay } from 'vuetify'
 import { useI18n } from 'vue-i18n'
 import { buildCategoryHash } from '~/utils/_category-filter-state'
+import { buildScoreAggregations } from '~/utils/_score-aggregations'
 
 const route = useRoute()
 const requestURL = useRequestURL()
@@ -294,12 +293,7 @@ const scoreAggregations = async () => {
 
   loadingAggregations.value = true
 
-  const aggs: Agg[] = scores.map((scoreId) => ({
-    name: `score_${scoreId}`,
-    field: `scores.${scoreId}.relativ.value`,
-    type: AggTypeEnum.Range,
-    step: 0.5,
-  }))
+  const aggs = buildScoreAggregations(scores)
 
   try {
     const response = await $fetch<ProductSearchResponseDto>('/api/products/search', {

--- a/frontend/app/utils/_score-aggregations.spec.ts
+++ b/frontend/app/utils/_score-aggregations.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { AggTypeEnum } from '~~/shared/api-client'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { buildScoreAggregations } from './_score-aggregations'
+
+describe('buildScoreAggregations', () => {
+  it('builds range aggregations for provided scores using absolute values', () => {
+    const aggs = buildScoreAggregations(['DURABILITY', 'REPAIRABILITY'])
+
+    expect(aggs).toEqual([
+      {
+        name: 'score_DURABILITY',
+        field: 'scores.DURABILITY.value',
+        type: AggTypeEnum.Range,
+        step: 0.5,
+      },
+      {
+        name: 'score_REPAIRABILITY',
+        field: 'scores.REPAIRABILITY.value',
+        type: AggTypeEnum.Range,
+        step: 0.5,
+      },
+    ])
+  })
+
+  it('uses the ecoscore constant for the ECOSCORE aggregation', () => {
+    const aggs = buildScoreAggregations(['ECOSCORE'])
+
+    expect(aggs).toEqual([
+      {
+        name: 'score_ECOSCORE',
+        field: ECOSCORE_RELATIVE_FIELD,
+        type: AggTypeEnum.Range,
+        step: 0.5,
+      },
+    ])
+  })
+})

--- a/frontend/app/utils/_score-aggregations.ts
+++ b/frontend/app/utils/_score-aggregations.ts
@@ -1,0 +1,21 @@
+import { AggTypeEnum, type Agg } from '~~/shared/api-client'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+
+export const buildScoreAggregations = (scoreIds: readonly string[]): Agg[] => {
+  return scoreIds
+    .map((scoreId) => (typeof scoreId === 'string' ? scoreId.trim() : ''))
+    .filter((scoreId) => scoreId.length)
+    .map((scoreId) => {
+      const normalizedId = scoreId.toUpperCase()
+      const field = normalizedId === 'ECOSCORE'
+        ? ECOSCORE_RELATIVE_FIELD
+        : `scores.${scoreId}.value`
+
+      return {
+        name: `score_${scoreId}`,
+        field,
+        type: AggTypeEnum.Range,
+        step: 0.5,
+      }
+    })
+}


### PR DESCRIPTION
## Summary
- update product page score aggregations to use absolute score values and the shared ecoscore field constant
- extract score aggregation builder into a reusable helper
- add unit tests covering aggregation field paths and parameters

## Testing
- pnpm test --run app/utils/_score-aggregations.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b13fa10dc8333a6da50c9c12c3288)