### PR TITLE
Refactor score value handling

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -104,8 +104,8 @@ describe('ProductImpactDetailsTable', () => {
     expect(rows).toHaveLength(1)
     const rowText = rows[0]?.text() ?? ''
     expect(rowText).toContain('CO2')
-    expect(rowText).toContain('rating:3.1')
-    expect(rowText).toContain('3.1 / 5')
+    expect(rowText).toContain('rating:2.8')
+    expect(rowText).toContain('2.8 / 5')
     expect(rowText).toContain('coefficient:0.3')
     expect(wrapper.text()).not.toContain('Eco')
   })

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -52,12 +52,12 @@ const props = defineProps<{
 type DetailedScore = ScoreView & { displayValue: number | null; coefficient: number | null }
 
 const resolveScoreValue = (score: ScoreView): number | null => {
-  if (score.relativeValue != null && Number.isFinite(score.relativeValue)) {
-    return Number(score.relativeValue)
-  }
-
   if (score.value != null && Number.isFinite(score.value)) {
     return Number(score.value)
+  }
+
+  if (score.relativeValue != null && Number.isFinite(score.relativeValue)) {
+    return Number(score.relativeValue)
   }
 
   return null

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -144,7 +144,11 @@ const normalizedScore = computed(() => {
     ? Number(props.score?.value)
     : Number.isFinite(props.score?.relativeValue)
       ? Number(props.score?.relativeValue)
-      : 0
+      : null
+
+  if (rawValue == null) {
+    return 0
+  }
 
   return Math.max(0, Math.min(rawValue, 5))
 })

--- a/frontend/app/pages/compare/index.spec.ts
+++ b/frontend/app/pages/compare/index.spec.ts
@@ -337,9 +337,9 @@ describe('Ecological scores', () => {
           base: {},
           offers: {},
           scores: {
-            ecoscore: { relativ: { value: 3.456 } },
+            ecoscore: { value: 4.5, relativ: { value: 3.456 } },
             scores: {
-              BRAND_SUSTAINABILITY: { relativ: { value: 2.1 } },
+              BRAND_SUSTAINABILITY: { value: 1.5, relativ: { value: 2.1 } },
               DATA_QUALITY: { relativ: { value: 4.789 } },
             },
           },
@@ -356,9 +356,9 @@ describe('Ecological scores', () => {
           base: {},
           offers: {},
           scores: {
-            ecoscore: { relativ: { value: 2.1 } },
+            ecoscore: { value: 2.1, relativ: { value: 4.3 } },
             scores: {
-              BRAND_SUSTAINABILITY: { relativ: { value: 4.123 } },
+              BRAND_SUSTAINABILITY: { value: 4.0, relativ: { value: 4.123 } },
               DATA_QUALITY: { relativ: { value: 3.5 } },
             },
           },
@@ -391,7 +391,7 @@ describe('Ecological scores', () => {
 
     const ecoscoreCells = ecoscoreRow!.findAll('.compare-grid__value')
     expect(ecoscoreCells).toHaveLength(2)
-    expect(ecoscoreCells[0].text()).toContain('3,46')
+    expect(ecoscoreCells[0].text()).toContain('4,5')
     expect(ecoscoreCells[1].text()).toContain('2,1')
     expect(ecoscoreCells[0].classes()).toContain('compare-grid__value--highlight')
     expect(ecoscoreCells[1].classes()).not.toContain('compare-grid__value--highlight')
@@ -403,8 +403,8 @@ describe('Ecological scores', () => {
     expect(brandRow).toBeTruthy()
 
     const brandCells = brandRow!.findAll('.compare-grid__value')
-    expect(brandCells[0].text()).toContain('2,1')
-    expect(brandCells[1].text()).toContain('4,12')
+    expect(brandCells[0].text()).toContain('1,5')
+    expect(brandCells[1].text()).toContain('4')
     expect(brandCells[1].classes()).toContain('compare-grid__value--highlight')
   })
 })

--- a/frontend/app/utils/score-values.spec.ts
+++ b/frontend/app/utils/score-values.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { ProductScoreDto } from 'shared/api-client'
+import { extractScoreValue, resolveScoreNumericValue } from './score-values'
+
+describe('score value helpers', () => {
+  const baseScore: ProductScoreDto = {
+    id: 'TEST',
+    name: 'Test score',
+  }
+
+  it('prioritises the canonical value field', () => {
+    const resolved = resolveScoreNumericValue({ ...baseScore, value: 4.2, relativ: { value: 1.1 } })
+
+    expect(resolved).toEqual({ value: 4.2, source: 'value' })
+  })
+
+  it('falls back to relativ and legacy relative values', () => {
+    const relativScore = resolveScoreNumericValue({ ...baseScore, relativ: { value: 3.3 } })
+    const legacyScore = resolveScoreNumericValue({ ...baseScore, relative: { value: 2.5 } })
+
+    expect(relativScore).toEqual({ value: 3.3, source: 'relative' })
+    expect(legacyScore).toEqual({ value: 2.5, source: 'legacyRelative' })
+  })
+
+  it('uses percent or on20 when no relative values exist', () => {
+    const percentScore = resolveScoreNumericValue({ ...baseScore, percent: 75 })
+    const on20Score = resolveScoreNumericValue({ ...baseScore, on20: 12 })
+
+    expect(percentScore).toEqual({ value: 75, source: 'percent' })
+    expect(on20Score).toEqual({ value: 12, source: 'on20' })
+  })
+
+  it('returns null when no usable value is present', () => {
+    expect(resolveScoreNumericValue(baseScore)).toBeNull()
+  })
+
+  it('extracts only the numeric value', () => {
+    expect(extractScoreValue({ ...baseScore, value: 4.6 })).toBe(4.6)
+    expect(extractScoreValue({ ...baseScore, relativ: { value: 2.4 } })).toBe(2.4)
+    expect(extractScoreValue(baseScore)).toBeNull()
+  })
+})

--- a/frontend/app/utils/score-values.ts
+++ b/frontend/app/utils/score-values.ts
@@ -1,0 +1,46 @@
+import type { ProductScoreDto } from 'shared/api-client'
+
+export type ScoreValueSource = 'value' | 'relative' | 'legacyRelative' | 'percent' | 'on20'
+
+export interface ResolvedScoreValue {
+  value: number
+  source: ScoreValueSource
+}
+
+export const resolveScoreNumericValue = (
+  score: ProductScoreDto | null | undefined,
+): ResolvedScoreValue | null => {
+  if (!score) {
+    return null
+  }
+
+  const { value, relativ, percent, on20 } = score
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return { value, source: 'value' }
+  }
+
+  const relativeValue = relativ?.value
+  if (typeof relativeValue === 'number' && Number.isFinite(relativeValue)) {
+    return { value: relativeValue, source: 'relative' }
+  }
+
+  const legacyRelative = (score as { relative?: { value?: number | null } }).relative?.value
+  if (typeof legacyRelative === 'number' && Number.isFinite(legacyRelative)) {
+    return { value: legacyRelative, source: 'legacyRelative' }
+  }
+
+  if (typeof percent === 'number' && Number.isFinite(percent)) {
+    return { value: percent, source: 'percent' }
+  }
+
+  if (typeof on20 === 'number' && Number.isFinite(on20)) {
+    return { value: on20, source: 'on20' }
+  }
+
+  return null
+}
+
+export const extractScoreValue = (score: ProductScoreDto | null | undefined): number | null => {
+  return resolveScoreNumericValue(score)?.value ?? null
+}


### PR DESCRIPTION
## Summary
- add shared score value resolver that prioritises canonical score.value with fallbacks for legacy fields
- update compare page and product impact computations to populate ScoreView values from the canonical source
- adjust impact and compare tests and add coverage for radar score extraction and helper logic

## Testing
- pnpm test app/utils/score-values.spec.ts app/pages/compare/index.spec.ts app/components/product/impact/ProductImpactDetailsTable.spec.ts app/components/product/impact/ProductImpactEcoScoreCard.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b13fc9238833386c127ef4f72fe43)