### PR TITLE
Use ImpactScore for ecoscore rendering

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import { defineComponent, h } from 'vue'
 import ProductImpactEcoScoreCard from './ProductImpactEcoScoreCard.vue'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import type { ScoreView } from './impact-types'
 
 describe('ProductImpactEcoScoreCard', () => {
@@ -18,6 +19,11 @@ describe('ProductImpactEcoScoreCard', () => {
             noPrimaryScore: 'No score',
             methodologyLink: 'Access the methodology',
             methodologyLinkAria: 'Open the Impact Score methodology',
+          },
+        },
+        components: {
+          impactScore: {
+            tooltip: 'Score: {value} / {max}',
           },
         },
       },
@@ -39,13 +45,6 @@ describe('ProductImpactEcoScoreCard', () => {
       global: {
         plugins: [i18n],
         stubs: {
-          ImpactScore: defineComponent({
-            name: 'ImpactScoreStub',
-            props: ['score', 'max', 'showValue', 'size'],
-            setup(props) {
-              return () => h('div', { class: 'impact-score-stub' }, `score:${props.score}`)
-            },
-          }),
           NuxtLink: defineComponent({
             name: 'NuxtLinkStub',
             props: ['to', 'ariaLabel'],
@@ -58,6 +57,36 @@ describe('ProductImpactEcoScoreCard', () => {
                 )
             },
           }),
+          'v-tooltip': defineComponent({
+            name: 'VTooltipStub',
+            props: ['text'],
+            setup(props, { slots }) {
+              return () =>
+                h(
+                  'div',
+                  { class: 'v-tooltip-stub', 'data-text': props.text },
+                  slots.activator?.({ props: {} }) ?? slots.default?.(),
+                )
+            },
+          }),
+          'v-rating': defineComponent({
+            name: 'VRatingStub',
+            props: ['modelValue', 'length', 'size', 'color', 'bgColor', 'density', 'halfIncrements', 'readonly'],
+            setup(props) {
+              return () =>
+                h('div', {
+                  class: 'v-rating-stub',
+                  'data-model-value': props.modelValue,
+                  'data-length': props.length,
+                  'data-size': props.size,
+                  'data-color': props.color,
+                  'data-bg-color': props.bgColor,
+                  'data-density': props.density,
+                  'data-half-increments': props.halfIncrements,
+                  'data-readonly': props.readonly,
+                })
+            },
+          }),
           'v-icon': defineComponent({
             name: 'VIconStub',
             props: ['icon', 'size'],
@@ -67,8 +96,11 @@ describe('ProductImpactEcoScoreCard', () => {
       },
     })
 
-    expect(wrapper.find('.impact-score-stub').exists()).toBe(true)
-    expect(wrapper.text()).toContain('score:3.6')
+    const impactScore = wrapper.findComponent(ImpactScore)
+
+    expect(impactScore.exists()).toBe(true)
+    expect(wrapper.find('.impact-score').text()).toContain('3.6 / 5')
+    expect(wrapper.find('.impact-score').attributes('aria-label')).toBe('Score: 3.6 / 5')
     expect(wrapper.find('.impact-ecoscore__cta').text()).toContain('Access the methodology')
     expect(wrapper.text()).not.toContain('Absolute value')
   })

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -17,7 +17,7 @@
     </header>
 
     <div class="impact-ecoscore__score">
-      <ImpactScore :score="normalizedScore" :max="5" size="large" show-value />
+      <ImpactScore :score="impactScoreValue" :max="5" size="large" show-value />
     </div>
 
     <div v-if="hasDetailContent" class="impact-ecoscore__analysis">
@@ -139,15 +139,9 @@ const toggleSubscores = () => {
   isSubscoreExpanded.value = !isSubscoreExpanded.value
 }
 
-const normalizedScore = computed(() => {
-  const rawValue = Number.isFinite(props.score?.value)
-    ? Number(props.score?.value)
-    : Number.isFinite(props.score?.relativeValue)
-      ? Number(props.score?.relativeValue)
-      : 0
-
-  return Math.max(0, Math.min(rawValue, 5))
-})
+const impactScoreValue = computed(() =>
+  Number.isFinite(props.score?.value) ? Number(props.score?.value) : 0,
+)
 
 const normalizedVerticalEcoscorePath = computed(() => {
   const raw = props.verticalHomeUrl?.trim()


### PR DESCRIPTION
## Summary
- pass the ecoscore card’s canonical value into the shared ImpactScore component and drop local normalization logic
- expand the ecoscore spec to include ImpactScore tooltip messaging and Vuetify stubs
- assert ecoscore rendering now flows through ImpactScore with the formatted value and tooltip

## Testing
- pnpm exec vitest run app/components/product/impact/ProductImpactEcoScoreCard.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b13fde93883339d851b35c5e357dd)