### PR TITLE
Align ecoscore filters to new field

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -905,7 +905,7 @@ public class ProductController {
 
         List<FieldMetadataDto> results = new ArrayList<>();
         config.getAvailableImpactScoreCriterias().forEach((key, criteria) -> {
-            String mapping = "scores." + key + ".relativ.value";
+            String mapping = "scores." + key + ".value";
             String title = criteria.getTitle() != null ? localise(criteria.getTitle(), domainLanguage) : null;
             String description = criteria.getDescription() != null ? localise(criteria.getDescription(), domainLanguage) : null;
             FieldMetadataDto.AggregationMetadata aggregation = resolveAggregationMetadata(config, mapping, key);

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -297,7 +297,7 @@ const scoreAggregations = async () => {
 
   const aggs: Agg[] = scores.map((scoreId) => ({
     name: `score_${scoreId}`,
-    field: `scores.${scoreId}.relativ.value`,
+    field: `scores.${scoreId}.value`,
     type: AggTypeEnum.Range,
     step: 0.5,
   }))

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -51,7 +51,7 @@ subsets:
  - id: "impact_high"  # Unique identifier for the subset
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.relativ.value"
+     - field: "scores.ECOSCORE.value"
        operator: "LOWER_THAN"
        value: "2"
    image: "example-image.png"
@@ -71,10 +71,10 @@ subsets:
  - id: "impact_medium"
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.relativ.value"
+     - field: "scores.ECOSCORE.value"
        operator: "GREATER_THAN"
        value: "2"
-     - field: "scores.ECOSCORE.relativ.value"
+     - field: "scores.ECOSCORE.value"
        operator: "LOWER_THAN"
        value: "4"
    image: "example-image.png"
@@ -94,7 +94,7 @@ subsets:
  - id: "impact_low"
    group: "impactscore"
    criterias:
-     - field: "scores.ECOSCORE.relativ.value"
+     - field: "scores.ECOSCORE.value"
        operator: "GREATER_THAN"
        value: "4"
    image: "example-image.png"

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -347,25 +347,25 @@ aggregationConfiguration:
   "scores.ECOSCORE.value":
     interval: 5
     buckets: 20
-  "scores.REPAIRABILITY_INDEX.relativ.value":
+  "scores.REPAIRABILITY_INDEX.value":
     interval: 1
     buckets: 10
-  "scores.POWER_CONSUMPTION_TYPICAL.relativ.value":
+  "scores.POWER_CONSUMPTION_TYPICAL.value":
     interval: 25
     buckets: 12
-  "scores.POWER_CONSUMPTION_OFF.relativ.value":
+  "scores.POWER_CONSUMPTION_OFF.value":
     interval: 0.1
     buckets: 10
-  "scores.WEIGHT.relativ.value":
+  "scores.WEIGHT.value":
     interval: 1
     buckets: 5
-  "scores.BRAND_SUSTAINABILITY.relativ.value":
+  "scores.BRAND_SUSTAINABILITY.value":
     interval: 1
     buckets: 5
-  "scores.CLASSE_ENERGY.relativ.value":
+  "scores.CLASSE_ENERGY.value":
     interval: 1
     buckets: 5
-  "scores.DATA_QUALITY.relativ.value":
+  "scores.DATA_QUALITY.value":
     interval: 1
     buckets: 5
   "attributes.indexed.REPAIRABILITY_INDEX":

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -344,7 +344,7 @@ subsets:
 
 
 aggregationConfiguration:
-  "scores.ECOSCORE.relativ.value":
+  "scores.ECOSCORE.value":
     interval: 5
     buckets: 20
   "scores.REPAIRABILITY_INDEX.relativ.value":


### PR DESCRIPTION
## Summary
- update the default vertical subset definitions to reference `scores.ECOSCORE.value` instead of the deprecated relative field
- update the TV vertical aggregation configuration to align with the new field name

## Testing
- `mvn --offline -pl verticals -am clean install`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b36d162608322874baf5d60981283)