### PR TITLE
Add Spring Boot Admin client to front-api

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -119,6 +119,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.codecentric</groupId>
+      <artifactId>spring-boot-admin-starter-client</artifactId>
+      <version>3.5.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8082
   forward-headers-strategy: framework
 spring:
+  application:
+    name: open4goods-front-api
   mail:
     host: ${SPRING_MAIL_HOST:localhost}
     port: ${SPRING_MAIL_PORT:25}


### PR DESCRIPTION
## Summary
- add the Spring Boot Admin client dependency to the front-api module so it can register with the monitoring server
- set a dedicated `spring.application.name` for front-api to match the naming pattern used by the other services

## Testing
- `mvn -pl front-api test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b56deacbc8322b98ec8bd7861aefe)