### PR TITLE
Add CI enforcement for vertical YAML configs

### DIFF
--- a/.github/workflows/vertical-config-validation.yml
+++ b/.github/workflows/vertical-config-validation.yml
@@ -1,0 +1,39 @@
+name: Vertical config validation
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'verticals/src/main/resources/**/*.yml'
+      - 'verticals/src/main/resources/**/*.yaml'
+      - 'verticals/src/test/resources/**/*.yml'
+      - 'verticals/src/test/resources/**/*.yaml'
+      - 'verticals/src/test/java/**/*.java'
+      - '.github/workflows/vertical-config-validation.yml'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'verticals/src/main/resources/**/*.yml'
+      - 'verticals/src/main/resources/**/*.yaml'
+      - 'verticals/src/test/resources/**/*.yml'
+      - 'verticals/src/test/resources/**/*.yaml'
+      - 'verticals/src/test/java/**/*.java'
+      - '.github/workflows/vertical-config-validation.yml'
+  workflow_dispatch:
+
+jobs:
+  validate-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run vertical YAML validation tests
+        run: mvn -B -pl verticals -am -Dtest=VerticalYamlValidationTest test

--- a/verticals/pom.xml
+++ b/verticals/pom.xml
@@ -33,6 +33,12 @@
        <artifactId>remotefilecaching</artifactId>
        <version>${global.version}</version>
     </dependency>
+
+    <dependency>
+       <groupId>jakarta.servlet</groupId>
+       <artifactId>jakarta.servlet-api</artifactId>
+       <scope>provided</scope>
+    </dependency>
     </dependencies>
 
    <build>

--- a/verticals/src/test/java/org/open4goods/verticals/VerticalYamlValidationTest.java
+++ b/verticals/src/test/java/org/open4goods/verticals/VerticalYamlValidationTest.java
@@ -1,0 +1,102 @@
+package org.open4goods.verticals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Validates that every vertical YAML file can be instantiated into a {@link VerticalConfig}
+ * and that their impact score weights are well-defined.
+ */
+class VerticalYamlValidationTest {
+
+    private static final String DEFAULT_CONFIG_FILENAME = "_default.yml";
+    private static final String CLASSPATH_VERTICALS = "classpath:/verticals/*.yml";
+
+    private static VerticalsConfigService verticalsConfigService;
+    private static List<Resource> verticalResources;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        SerialisationService serialisationService = new SerialisationService();
+        GoogleTaxonomyService googleTaxonomyService = mock(GoogleTaxonomyService.class);
+        ResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
+
+        verticalsConfigService = new VerticalsConfigService(serialisationService, googleTaxonomyService, resourceResolver);
+        verticalResources = loadVerticalResources(resourceResolver);
+
+        assertThat(verticalsConfigService.getDefaultConfig()).as("Default config must load").isNotNull();
+        assertThat(verticalResources).as("At least one vertical YAML must be present").isNotEmpty();
+    }
+
+    private static List<Resource> loadVerticalResources(ResourcePatternResolver resolver) throws IOException {
+        return Arrays.stream(resolver.getResources(CLASSPATH_VERTICALS))
+            .filter(resource -> !DEFAULT_CONFIG_FILENAME.equals(resource.getFilename()))
+            .collect(Collectors.toList());
+    }
+
+    @Test
+    void shouldLoadSameNumberOfConfigsAsYamlFiles() {
+        assertThat(verticalsConfigService.getConfigsWithoutDefault())
+            .as("Each YAML file should be represented in VerticalsConfigService")
+            .hasSameSizeAs(verticalResources)
+            .allSatisfy(config -> assertVerticalConfig(config, config.getId()));
+    }
+
+    @Test
+    void shouldInstantiateEachYamlIndividually() throws Exception {
+        for (Resource resource : verticalResources) {
+            try (InputStream inputStream = resource.getInputStream()) {
+                VerticalConfig config = verticalsConfigService.getConfig(inputStream, verticalsConfigService.getDefaultConfig());
+                assertVerticalConfig(config, resource.getFilename());
+            }
+        }
+    }
+
+    private static void assertVerticalConfig(VerticalConfig config, String sourceName) {
+        assertThat(config).as("Vertical config should not be null for %s", sourceName).isNotNull();
+        assertThat(config.getId()).as("Each vertical needs an ID (%s)", sourceName).isNotBlank();
+        assertThat(config.getImpactScoreConfig())
+            .as("Impact score configuration is required (%s)", sourceName)
+            .isNotNull();
+
+        Map<String, Double> weights = config.getImpactScoreConfig().getCriteriasPonderation();
+        assertThat(weights)
+            .as("Impact score weights must be defined (%s)", sourceName)
+            .isNotNull()
+            .isNotEmpty();
+
+        assertThat(weights.entrySet())
+            .as("Impact score weights must contain names and values (%s)", sourceName)
+            .allSatisfy(entry -> {
+                assertThat(entry.getKey()).as("Criterion name should be provided (%s)", sourceName).isNotBlank();
+                assertThat(entry.getValue()).as("Criterion weight must be provided (%s)", sourceName).isNotNull();
+            });
+
+        double total = weights.values().stream()
+            .filter(Objects::nonNull)
+            .mapToDouble(Double::doubleValue)
+            .sum();
+
+        assertThat(total)
+            .as("Impact score weights must sum to 1 (%s)", sourceName)
+            .isCloseTo(1.0d, within(1e-6));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow that runs the vertical YAML validation tests whenever the configs change
- add `VerticalYamlValidationTest` to instantiate every YAML file, check critical fields, and ensure the impact score weights sum to one
- bring in the Jakarta Servlet API as a provided dependency so Jackson can reflectively load `HttpServletRequest` while deserializing the configs

## Testing
- `mvn -pl verticals -am test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b582a59c48322930fda7c0f9d5c84)