### PR TITLE
Set html lang and centralize canonical URLs

### DIFF
--- a/frontend/app/app.vue
+++ b/frontend/app/app.vue
@@ -1,5 +1,28 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { getDomainLanguageFromHostname } from '~~/shared/utils/domain-language'
+
+let requestURL: URL | null = null
+
+try {
+  requestURL = useRequestURL()
+} catch {
+  requestURL = null
+}
+
+const documentLanguage = computed(
+  () => getDomainLanguageFromHostname(requestURL?.hostname ?? null).domainLanguage,
+)
+
+useHead(() => ({
+  htmlAttrs: {
+    lang: documentLanguage.value,
+  },
+}))
+</script>
+
 <template>
   <NuxtLayout>
-      <NuxtPage />
+    <NuxtPage />
   </NuxtLayout>
 </template>

--- a/frontend/app/components/cms/XwikiFullPageRenderer.spec.ts
+++ b/frontend/app/components/cms/XwikiFullPageRenderer.spec.ts
@@ -52,8 +52,14 @@ vi.mock('#app', () => ({
   useRuntimeConfig: () => ({ public: { editRoles: [] } }),
 }))
 
+const useSeoMetaMock = vi.fn()
+const useHeadMock = vi.fn()
+const useCanonicalUrlMock = vi.fn(() => ref('https://example.com/cms/page'))
+
 vi.mock('#imports', () => ({
-  useSeoMeta: vi.fn(),
+  useSeoMeta: (...args: unknown[]) => useSeoMetaMock(...args),
+  useHead: (...args: unknown[]) => useHeadMock(...args),
+  useCanonicalUrl: (...args: unknown[]) => useCanonicalUrlMock(...args),
   useI18n: () => ({
     t: (key: string) => {
       const dictionary: Record<string, string> = {

--- a/frontend/app/components/cms/XwikiFullPageRenderer.vue
+++ b/frontend/app/components/cms/XwikiFullPageRenderer.vue
@@ -167,6 +167,8 @@ const isWideLayout = computed(() => (props.layoutVariant ?? 'default') === 'wide
 const heroImage = computed(() => props.heroImage?.trim() ?? '')
 const hasHeroImage = computed(() => heroImage.value.length > 0)
 
+const canonicalUrl = useCanonicalUrl()
+
 const { isLoggedIn, hasRole } = useAuth()
 const allowedRoles = computed(() => (config.public.editRoles as string[]) || [])
 const canEdit = computed(() => {
@@ -204,7 +206,19 @@ useSeoMeta({
   description: () => effectiveMetaDescription.value || undefined,
   ogTitle: () => metaTitle.value || effectivePageTitle.value,
   ogDescription: () => effectiveMetaDescription.value || undefined,
+  ogUrl: () => canonicalUrl.value || undefined,
 })
+
+useHead(() => ({
+  link: canonicalUrl.value
+    ? [
+        {
+          rel: 'canonical',
+          href: canonicalUrl.value,
+        },
+      ]
+    : [],
+}))
 </script>
 
 <style scoped lang="sass">

--- a/frontend/app/composables/useCanonicalUrl.ts
+++ b/frontend/app/composables/useCanonicalUrl.ts
@@ -1,0 +1,43 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { useRequestURL, useRoute } from '#imports'
+
+const useSafeRequestURL = (): URL | null => {
+  try {
+    return useRequestURL()
+  } catch {
+    if (import.meta.client && typeof window !== 'undefined' && window.location) {
+      try {
+        return new URL(window.location.href)
+      } catch {
+        return null
+      }
+    }
+
+    return null
+  }
+}
+
+export const useCanonicalUrl = (
+  path?: MaybeRefOrGetter<string | null | undefined>,
+) => {
+  const route = useRoute()
+  const requestURL = useSafeRequestURL()
+
+  return computed(() => {
+    const origin = requestURL?.origin
+
+    if (!origin) {
+      return null
+    }
+
+    const rawPath = path ? toValue(path) ?? '' : route.fullPath ?? ''
+    const [pathWithoutHash] = rawPath.split('#')
+    const normalizedPath = pathWithoutHash && pathWithoutHash.length > 0 ? pathWithoutHash : '/'
+
+    try {
+      return new URL(normalizedPath, origin).toString()
+    } catch {
+      return null
+    }
+  })
+}

--- a/frontend/app/pages/auth/login.vue
+++ b/frontend/app/pages/auth/login.vue
@@ -43,6 +43,23 @@ const valid = ref(true)
 const router = useRouter()
 const route = useRoute()
 
+const canonicalUrl = useCanonicalUrl()
+
+useHead(() => ({
+  link: canonicalUrl.value
+    ? [
+        {
+          rel: 'canonical',
+          href: canonicalUrl.value,
+        },
+      ]
+    : [],
+}))
+
+useSeoMeta({
+  ogUrl: () => canonicalUrl.value || undefined,
+})
+
 const isSafeRedirectTarget = (target: unknown): target is string => typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')
 
 const resolveRedirectTarget = () => {

--- a/frontend/app/pages/blog/test-images.vue
+++ b/frontend/app/pages/blog/test-images.vue
@@ -55,6 +55,23 @@ import { useBlog } from '~/composables/blog/useBlog'
 
 const { articles, loading, error, fetchArticles } = useBlog()
 
+const canonicalUrl = useCanonicalUrl()
+
+useHead(() => ({
+  link: canonicalUrl.value
+    ? [
+        {
+          rel: 'canonical',
+          href: canonicalUrl.value,
+        },
+      ]
+    : [],
+}))
+
+useSeoMeta({
+  ogUrl: () => canonicalUrl.value || undefined,
+})
+
 // Fetch articles on component mount
 onMounted(() => {
   fetchArticles()

--- a/frontend/app/pages/compare/index.vue
+++ b/frontend/app/pages/compare/index.vue
@@ -849,6 +849,23 @@ const router = useRouter()
 const route = useRoute()
 const heroId = useId()
 
+const canonicalUrl = useCanonicalUrl()
+
+useHead(() => ({
+  link: canonicalUrl.value
+    ? [
+        {
+          rel: 'canonical',
+          href: canonicalUrl.value,
+        },
+      ]
+    : [],
+}))
+
+useSeoMeta({
+  ogUrl: () => canonicalUrl.value || undefined,
+})
+
 definePageMeta({
   name: 'compare',
   ssr: false,

--- a/frontend/app/pages/impact-score/index.vue
+++ b/frontend/app/pages/impact-score/index.vue
@@ -277,6 +277,23 @@ const props = defineProps({
 const { t, locale } = useI18n()
 const display = useDisplay()
 
+const canonicalUrl = useCanonicalUrl()
+
+useHead(() => ({
+  link: canonicalUrl.value
+    ? [
+        {
+          rel: 'canonical',
+          href: canonicalUrl.value,
+        },
+      ]
+    : [],
+}))
+
+useSeoMeta({
+  ogUrl: () => canonicalUrl.value || undefined,
+})
+
 const { data: fetchedVerticals } = await useAsyncData<VerticalConfigDto[]>(
   'impact-score-verticals',
   () =>


### PR DESCRIPTION
## Summary
- bind the `<html lang>` attribute to the resolved domain language instead of injecting a bespoke `source-lang` meta tag
- extract a reusable `useCanonicalUrl` composable so the CMS renderer, login screen, blog debug page, Impact Score hub, and compare experience all share the same canonical URL logic
- update the CMS renderer test mocks to provide the new composable

## Testing
- `pnpm lint`
- `pnpm test --run XwikiFullPageRenderer`
- `pnpm generate`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2deeacd08322b68f9e4ede534f14)