### PR TITLE
Add expiring cache and configurability to front API rate limiter

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -128,6 +128,10 @@
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-mail</artifactId>
     </dependency>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/RateLimitProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/RateLimitProperties.java
@@ -1,5 +1,7 @@
 package org.open4goods.nudgerfrontapi.config.properties;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -13,6 +15,9 @@ public class RateLimitProperties {
 
     /** Maximum requests per minute for authenticated users. */
     private int authenticated = 1000;
+
+    /** Duration after which idle counters are purged from memory. */
+    private Duration counterTtl = Duration.ofSeconds(75);
 
     public int getAnonymous() {
         return anonymous;
@@ -28,5 +33,13 @@ public class RateLimitProperties {
 
     public void setAuthenticated(int authenticated) {
         this.authenticated = authenticated;
+    }
+
+    public Duration getCounterTtl() {
+        return counterTtl;
+    }
+
+    public void setCounterTtl(Duration counterTtl) {
+        this.counterTtl = counterTtl;
     }
 }

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -114,6 +114,12 @@
       "defaultValue": 1000
     },
     {
+      "name": "front.rate-limit.counter-ttl",
+      "type": "java.time.Duration",
+      "description": "Duration before idle rate-limit counters are purged from memory.",
+      "defaultValue": "PT1M15S"
+    },
+    {
       "name": "front.affiliation-partners.api-base-url",
       "type": "java.lang.String",
       "description": "Base URL of the affiliation partner back-office API."

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptorTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/interceptor/RateLimitingInterceptorTest.java
@@ -2,6 +2,9 @@ package org.open4goods.nudgerfrontapi.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.open4goods.nudgerfrontapi.config.properties.RateLimitProperties;
@@ -9,6 +12,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.github.benmanes.caffeine.cache.Ticker;
 
 /**
  * Tests for {@link RateLimitingInterceptor}.
@@ -44,5 +49,61 @@ class RateLimitingInterceptorTest {
         assertThat(interceptor.preHandle(request, response, new Object())).isFalse();
         assertThat(response.getStatus()).isEqualTo(429);
         SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void multipleIpsAreTrackedIndependently() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        assertThat(interceptor.preHandle(requestForIp("10.0.0.1"), response, new Object())).isTrue();
+        assertThat(interceptor.preHandle(requestForIp("10.0.0.1"), response, new Object())).isFalse();
+
+        MockHttpServletResponse otherResponse = new MockHttpServletResponse();
+        assertThat(interceptor.preHandle(requestForIp("10.0.0.2"), otherResponse, new Object())).isTrue();
+        assertThat(interceptor.preHandle(requestForIp("10.0.0.2"), otherResponse, new Object())).isFalse();
+
+        assertThat(interceptor.getActiveCounterCount()).isEqualTo(2);
+    }
+
+    @Test
+    void countersAreEvictedAfterConfiguredTtl() {
+        RateLimitProperties props = new RateLimitProperties();
+        props.setAnonymous(1);
+        props.setAuthenticated(2);
+        props.setCounterTtl(Duration.ofSeconds(2));
+        MutableTicker ticker = new MutableTicker();
+        RateLimitingInterceptor shortLivedInterceptor = new RateLimitingInterceptor(props, ticker);
+
+        for (int i = 0; i < 5; i++) {
+            assertThat(shortLivedInterceptor.preHandle(requestForIp("10.0.0." + i), new MockHttpServletResponse(), new Object())).isTrue();
+        }
+        assertThat(shortLivedInterceptor.getActiveCounterCount()).isEqualTo(5);
+
+        ticker.advance(Duration.ofSeconds(3));
+        assertThat(shortLivedInterceptor.getActiveCounterCount()).isZero();
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest request = requestForIp("10.0.0.1");
+        assertThat(shortLivedInterceptor.preHandle(request, response, new Object())).isTrue();
+        assertThat(shortLivedInterceptor.preHandle(request, response, new Object())).isFalse();
+        assertThat(response.getStatus()).isEqualTo(429);
+    }
+
+    private static MockHttpServletRequest requestForIp(String ip) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRemoteAddr(ip);
+        return request;
+    }
+
+    private static final class MutableTicker implements Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+
+        void advance(Duration duration) {
+            nanos.addAndGet(duration.toNanos());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the ad-hoc request counter map with a Caffeine cache that expires entries based on a configurable TTL
- expose the new `front.rate-limit.counter-ttl` property in `RateLimitProperties` and the configuration metadata, and add the Caffeine dependency
- strengthen the rate-limiter tests with multi-IP scenarios and eviction coverage using a fake ticker

## Testing
- `mvn -pl front-api -am test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d72d5a4008322bffd246b4f933776)