### PR TITLE
Guard vertical image mapping and validate configs

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -619,48 +619,43 @@ public class CategoryMappingService {
      * Build the URL to the medium sized vertical illustration.
      */
     private String mapVerticalImageMedium(VerticalConfig verticalConfig) {
-        if (verticalConfig == null || !StringUtils.hasText(apiProperties.getResourceRootPath())) {
-            return null;
-        }
-
-        if (verticalConfig.getVerticalImage().startsWith("/")) {
-        	// In case of relativ path, assume the image is weared on the frontend
-        	return verticalConfig.getVerticalImage();
-        } else {
-        	// Else, a ressource handled by the static server
-        	return apiProperties.getResourceRootPath() + IMAGE_PREFIX + verticalConfig.getId() + "-360.webp";
-        }
+        return mapVerticalImage(verticalConfig, "-360.webp");
     }
 
     /**
      * Build the URL to the small sized vertical illustration.
      */
     private String mapVerticalImageSmall(VerticalConfig verticalConfig) {
-        if (verticalConfig == null || !StringUtils.hasText(apiProperties.getResourceRootPath())) {
-            return null;
-        }
-        if (verticalConfig.getVerticalImage().startsWith("/")) {
-        	// In case of relativ path, assume the image is weared on the frontend
-        	return verticalConfig.getVerticalImage();
-        } else {
-        	// Else, a ressource handled by the static server
-        	return apiProperties.getResourceRootPath() + IMAGE_PREFIX + verticalConfig.getId() + "-100.webp";
-        }
+        return mapVerticalImage(verticalConfig, "-100.webp");
     }
 
     /**
      * Build the URL to the large vertical illustration used on landing pages.
      */
     private String mapVerticalImageLarge(VerticalConfig verticalConfig) {
-        if (verticalConfig == null || !StringUtils.hasText(apiProperties.getResourceRootPath())) {
+        return mapVerticalImage(verticalConfig, ".webp");
+    }
+
+    private String mapVerticalImage(VerticalConfig verticalConfig, String suffix) {
+        if (verticalConfig == null) {
             return null;
         }
-        if (verticalConfig.getVerticalImage().startsWith("/")) {
-        	// In case of relativ path, assume the image is weared on the frontend
-        	return verticalConfig.getVerticalImage();
-        } else {
-        	// Else, a ressource handled by the static server
-        	return apiProperties.getResourceRootPath() + IMAGE_PREFIX + verticalConfig.getId() + ".webp";
+
+        String configuredImage = verticalConfig.getVerticalImage();
+        if (!StringUtils.hasText(configuredImage)) {
+            return null;
         }
+
+        if (configuredImage.startsWith("/")) {
+            // In case of relative path, assume the image is served by the frontend.
+            return configuredImage;
+        }
+
+        if (!StringUtils.hasText(apiProperties.getResourceRootPath())) {
+            return null;
+        }
+
+        // Else, a resource handled by the static server
+        return apiProperties.getResourceRootPath() + IMAGE_PREFIX + verticalConfig.getId() + suffix;
     }
 }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceVerticalConfigTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/CategoryMappingServiceVerticalConfigTest.java
@@ -15,6 +15,7 @@ import org.open4goods.model.vertical.ProductI18nElements;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.category.CategoryBreadcrumbItemDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.verticals.GoogleTaxonomyService;
@@ -45,6 +46,23 @@ class CategoryMappingServiceVerticalConfigTest {
         CategoryBreadcrumbItemDto terminal = dto.breadCrumb().get(dto.breadCrumb().size() - 1);
         assertThat(terminal.title()).isEqualTo("Téléviseurs");
         assertThat(terminal.link()).isEqualTo("/televisions-url");
+    }
+
+    @Test
+    void toVerticalConfigDtoIgnoresMissingVerticalImages() {
+        ApiProperties properties = new ApiProperties();
+        properties.setResourceRootPath("https://static.example");
+
+        CategoryMappingService serviceWithResources = new CategoryMappingService(properties, googleTaxonomyService);
+        VerticalConfig config = createVerticalConfig("washing-machines", 3);
+        config.setVerticalImage("   ");
+
+        VerticalConfigDto dto = serviceWithResources.toVerticalConfigDto(config, DomainLanguage.fr);
+
+        assertThat(dto).isNotNull();
+        assertThat(dto.imageSmall()).isNull();
+        assertThat(dto.imageMedium()).isNull();
+        assertThat(dto.imageLarge()).isNull();
     }
 
     private VerticalConfig createVerticalConfig(String id, int googleTaxonomyId) {

--- a/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
@@ -26,6 +26,7 @@ import org.springframework.cache.annotation.Cacheable;
 import com.fasterxml.jackson.annotation.JsonMerge;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 
@@ -72,8 +73,9 @@ public class VerticalConfig{
 	/**
 	 * Absolute path to the vertical image (should be hosted on nudger to avoid recaching failures). Provide a large one, thumnails will be generated automaticaly. MUST be PNG or JPG
 	 */
-	@JsonMerge
-	private String verticalImage ;
+        @JsonMerge
+        @NotBlank
+        private String verticalImage ;
 
 
 	/**


### PR DESCRIPTION
## Summary
- make the category mapping image helpers null-safe and centralize the fallback handling
- mark `verticalImage` as mandatory in `VerticalConfig` so invalid YAML is rejected during validation
- extend the category mapping test suite to cover the no-image scenario

## Testing
- `mvn --offline -pl front-api -am test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d7005653c8322bdea18eda0462c2c)