### PR TITLE
Add localized breadcrumbs for open data datasets

### DIFF
--- a/frontend/app/pages/opendata/gtin.vue
+++ b/frontend/app/pages/opendata/gtin.vue
@@ -4,11 +4,7 @@
       :eyebrow="t('opendata.datasets.gtin.hero.eyebrow')"
       :title="t('opendata.datasets.gtin.hero.title')"
       description-bloc-id="webpages:opendata:gtin-hero-overview"
-      :breadcrumb="{
-        label: String(t('opendata.datasets.common.breadcrumb.label')),
-        ariaLabel: String(t('opendata.datasets.common.breadcrumb.ariaLabel')),
-        href: localePath('opendata'),
-      }"
+      :breadcrumb="datasetBreadcrumb"
     />
 
     <v-progress-linear
@@ -143,6 +139,12 @@ const { data, pending, error, refresh } = await useAsyncData<DatasetPayload>('op
 
 const dataset = computed(() => data.value?.dataset)
 const overview = computed(() => data.value?.overview)
+
+const datasetBreadcrumb = computed(() => ({
+  label: String(t('opendata.datasets.gtin.breadcrumb.label')),
+  ariaLabel: String(t('opendata.datasets.gtin.breadcrumb.ariaLabel')),
+  href: localePath('opendata'),
+}))
 
 const placeholder = computed(() => String(t('opendata.datasets.common.placeholder')))
 

--- a/frontend/app/pages/opendata/isbn.vue
+++ b/frontend/app/pages/opendata/isbn.vue
@@ -4,11 +4,7 @@
       :eyebrow="t('opendata.datasets.isbn.hero.eyebrow')"
       :title="t('opendata.datasets.isbn.hero.title')"
       description-bloc-id="webpages:opendata:isbn-hero-overview"
-      :breadcrumb="{
-        label: String(t('opendata.datasets.common.breadcrumb.label')),
-        ariaLabel: String(t('opendata.datasets.common.breadcrumb.ariaLabel')),
-        href: localePath('opendata'),
-      }"
+      :breadcrumb="datasetBreadcrumb"
     />
 
     <v-progress-linear
@@ -143,6 +139,13 @@ const { data, pending, error, refresh } = await useAsyncData<DatasetPayload>('op
 
 const dataset = computed(() => data.value?.dataset)
 const overview = computed(() => data.value?.overview)
+
+const datasetBreadcrumb = computed(() => ({
+  label: String(t('opendata.datasets.isbn.breadcrumb.label')),
+  ariaLabel: String(t('opendata.datasets.isbn.breadcrumb.ariaLabel')),
+  href: localePath('opendata'),
+}))
+
 const placeholder = computed(() => String(t('opendata.datasets.common.placeholder')))
 
 const summaryItems = computed(() => [

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1100,6 +1100,10 @@
           },
           "title": "Barcode data for consumer products"
         },
+        "breadcrumb": {
+          "ariaLabel": "Back to the open data overview for the GTIN dataset",
+          "label": "Open data / GTIN dataset"
+        },
         "seo": {
           "description": "Access Nudger's GTIN dataset with weekly updates, download options and schema details for your barcode data projects.",
           "title": "GTIN open data – download the barcode catalogue"
@@ -1235,6 +1239,10 @@
             "updated": "Last updated"
           },
           "title": "Comprehensive metadata for books"
+        },
+        "breadcrumb": {
+          "ariaLabel": "Back to the open data overview for the ISBN dataset",
+          "label": "Open data / ISBN dataset"
         },
         "seo": {
           "description": "Retrieve Nudger's ISBN dataset with weekly refreshes, download mirrors and schema information for publishing analytics.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1100,6 +1100,10 @@
           },
           "title": "Base de données de codes-barres"
         },
+        "breadcrumb": {
+          "ariaLabel": "Retour à la page open data depuis le dataset GTIN",
+          "label": "Open data / base GTIN"
+        },
         "seo": {
           "description": "Accédez à la base GTIN de Nudger, mise à jour chaque semaine, avec les options de téléchargement et le schéma détaillé pour vos projets data sur les codes-barres.",
           "title": "Données ouvertes GTIN – télécharger le catalogue de codes-barres"
@@ -1235,6 +1239,10 @@
             "updated": "Dernière mise à jour"
           },
           "title": "Base de données livres (ISBN)"
+        },
+        "breadcrumb": {
+          "ariaLabel": "Retour à la page open data depuis le dataset ISBN",
+          "label": "Open data / base ISBN"
         },
         "seo": {
           "description": "Téléchargez la base ISBN de Nudger, actualisée chaque semaine, avec les miroirs de téléchargement et le schéma détaillé pour vos analyses du secteur du livre.",


### PR DESCRIPTION
## Summary
- add computed breadcrumbs to the GTIN and ISBN open data pages so the hero component receives a localized label and aria text
- extend the English and French locale files with dataset-specific breadcrumb entries for both datasets

## Testing
- `pnpm lint` *(fails: existing lint error in app/pages/[...slug].vue about unused variable `resolvedValue`)*
- `pnpm test` *(fails: Vitest hangs while queuing components/domains/blog/TheArticles.spec.ts and needs to be interrupted)*
- `pnpm generate`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de2fa88948322841bbb73a84736ac)