### PR TITLE
Remove best/worst score selection logic

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/AbstractScoreAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/AbstractScoreAggregationService.java
@@ -83,38 +83,24 @@ public abstract class AbstractScoreAggregationService extends  AbstractAggregati
 		
 
 			
-		////////////////////////
-		// Setting the ranking and worse / best bags
-		////////////////////////
-		
-		for (String scoreName : batchDatas.keySet()) {
-			// Sort in the list
-			List<Product> sorted = datas.stream(). sorted((e1, e2) -> Double.compare(
-				    e1.getScores().get(scoreName).getRelativ().getValue(),
-				    e2.getScores().get(scoreName).getRelativ().getValue()
-				)).toList();
-			
-			Long worseGtin = sorted.getFirst().getId();
-			Long bestGtin = sorted.getLast().getId();
-			
-			for (int i = 0 ; i < sorted.size(); i ++ ) {
-				Product d = sorted.get(i);
-				d.getScores().get(scoreName).setRanking(i);
-				d.getScores().get(scoreName).setLowestScoreId(worseGtin);
-				d.getScores().get(scoreName).setHighestScoreId(bestGtin);
-				
-				// Putting in the worse bag if match
-				if (i < vConf.getWorseLimit()) {
-					d.getWorsesScores().add(scoreName);
-				}
-				
-				// Putting in the best bag if match
-				if (i >  sorted.size() -  vConf.getBettersLimit()) {
-					d.getBestsScores().add(scoreName);
-				}
-				
-			}
-		}
+                ////////////////////////
+                // Setting the ranking
+                ////////////////////////
+
+                for (String scoreName : batchDatas.keySet()) {
+                        List<Product> sorted = datas.stream().sorted((e1, e2) -> Double.compare(
+                                    e1.getScores().get(scoreName).getRelativ().getValue(),
+                                    e2.getScores().get(scoreName).getRelativ().getValue()
+                                )).toList();
+
+                        for (int i = 0 ; i < sorted.size(); i ++ ) {
+                                Product d = sorted.get(i);
+                                Score score = d.getScores().get(scoreName);
+                                if (score != null) {
+                                        score.setRanking(i);
+                                }
+                        }
+                }
 		
 		
 	}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
@@ -105,10 +105,6 @@ public record VerticalConfigFullDto(
         @Schema(description = "Scoring aggregation configuration.")
         ScoringAggregationConfig scoringAggregationConfig,
         @Schema(description = "Feature groups ordering attributes for UI rendering with localised labels.")
-        List<FeatureGroupDto> featureGroups,
-        @Schema(description = "Threshold defining how many low scores are considered worsts.")
-        Integer worseLimit,
-        @Schema(description = "Threshold defining how many high scores are considered bests.")
-        Integer bettersLimit
+        List<FeatureGroupDto> featureGroups
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoreDto.java
@@ -26,10 +26,6 @@ public record ProductScoreDto(
         Map<String, String> metadatas,
         @Schema(description = "Ranking of the product for this score", nullable = true)
         Integer ranking,
-        @Schema(description = "Details for the product with the lowest score", implementation = ProductReferenceDto.class, nullable = true)
-        ProductReferenceDto lowestScore,
-        @Schema(description = "Details for the product with the highest score", implementation = ProductReferenceDto.class, nullable = true)
-        ProductReferenceDto highestScore,
         @Schema(description = "Percentage representation of the score on a 0-100 scale", nullable = true)
         Long percent,
         @Schema(description = "Score scaled on 0-20", nullable = true)

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoresDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductScoresDto.java
@@ -1,8 +1,6 @@
 package org.open4goods.nudgerfrontapi.dto.product;
 
 import java.util.Map;
-import java.util.Set;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -13,10 +11,6 @@ public record ProductScoresDto(
         Map<String, ProductScoreDto> scores,
         @Schema(description = "Ecoscore when available", nullable = true)
         ProductScoreDto ecoscore,
-        @Schema(description = "Score identifiers where the product ranks amongst the worst")
-        Set<String> worstScores,
-        @Schema(description = "Score identifiers where the product ranks amongst the best")
-        Set<String> bestScores,
         @Schema(description = "Ecoscore derived rankings", nullable = true)
         ProductRankingDto ranking
 ) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -153,9 +153,7 @@ public class CategoryMappingService {
                 verticalConfig.getRecommandationsConfig(),
                 verticalConfig.getDescriptionsAggregationConfig(),
                 verticalConfig.getScoringAggregationConfig(),
-                mapFeatureGroups(verticalConfig.getFeatureGroups(), domainLanguage),
-                verticalConfig.getWorseLimit(),
-                verticalConfig.getBettersLimit());
+                mapFeatureGroups(verticalConfig.getFeatureGroups(), domainLanguage));
     }
 
     /**

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -125,8 +125,6 @@ class ProductMappingServiceTest {
         product.setVertical("phones");
 
         Score score = new Score("ENERGY", 10.0);
-        score.setLowestScoreId(111L);
-        score.setHighestScoreId(222L);
         HashMap<String, Score> scores = new HashMap<>();
         scores.put("ENERGY", score);
         product.setScores(scores);
@@ -175,14 +173,10 @@ class ProductMappingServiceTest {
         assertThat(dto.scores()).isNotNull();
         ProductScoreDto mappedScore = dto.scores().scores().get("ENERGY");
         assertThat(mappedScore).isNotNull();
-        assertThat(mappedScore.lowestScore()).isNotNull();
-        assertThat(mappedScore.lowestScore().id()).isEqualTo(111L);
-        assertThat(mappedScore.lowestScore().fullSlug()).isEqualTo("/phones/lowest");
-        assertThat(mappedScore.highestScore()).isNotNull();
-        assertThat(mappedScore.highestScore().id()).isEqualTo(222L);
         assertThat(dto.scores().ranking()).isNotNull();
         assertThat(dto.scores().ranking().globalBest()).isNotNull();
         assertThat(dto.scores().ranking().globalBest().id()).isEqualTo(111L);
+        assertThat(dto.scores().ranking().globalBest().fullSlug()).isEqualTo("/phones/lowest");
     }
 
     @Test

--- a/frontend/shared/api-client/models/ProductScoreDto.ts
+++ b/frontend/shared/api-client/models/ProductScoreDto.ts
@@ -20,16 +20,8 @@ import {
     ProductCardinalityDtoToJSON,
     ProductCardinalityDtoToJSONTyped,
 } from './ProductCardinalityDto';
-import type { ProductReferenceDto } from './ProductReferenceDto';
-import {
-    ProductReferenceDtoFromJSON,
-    ProductReferenceDtoFromJSONTyped,
-    ProductReferenceDtoToJSON,
-    ProductReferenceDtoToJSONTyped,
-} from './ProductReferenceDto';
-
 /**
- * 
+ *
  * @export
  * @interface ProductScoreDto
  */
@@ -89,18 +81,6 @@ export interface ProductScoreDto {
      */
     ranking?: number;
     /**
-     * Details for the product with the lowest score
-     * @type {ProductReferenceDto}
-     * @memberof ProductScoreDto
-     */
-    lowestScore?: ProductReferenceDto;
-    /**
-     * Details for the product with the highest score
-     * @type {ProductReferenceDto}
-     * @memberof ProductScoreDto
-     */
-    highestScore?: ProductReferenceDto;
-    /**
      * Percentage representation of the score on a 0-100 scale
      * @type {number}
      * @memberof ProductScoreDto
@@ -158,8 +138,6 @@ export function ProductScoreDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
         'relativ': json['relativ'] == null ? undefined : ProductCardinalityDtoFromJSON(json['relativ']),
         'metadatas': json['metadatas'] == null ? undefined : json['metadatas'],
         'ranking': json['ranking'] == null ? undefined : json['ranking'],
-        'lowestScore': json['lowestScore'] == null ? undefined : ProductReferenceDtoFromJSON(json['lowestScore']),
-        'highestScore': json['highestScore'] == null ? undefined : ProductReferenceDtoFromJSON(json['highestScore']),
         'percent': json['percent'] == null ? undefined : json['percent'],
         'on20': json['on20'] == null ? undefined : json['on20'],
         'absoluteValue': json['absoluteValue'] == null ? undefined : json['absoluteValue'],
@@ -188,8 +166,6 @@ export function ProductScoreDtoToJSONTyped(value?: ProductScoreDto | null, ignor
         'relativ': ProductCardinalityDtoToJSON(value['relativ']),
         'metadatas': value['metadatas'],
         'ranking': value['ranking'],
-        'lowestScore': ProductReferenceDtoToJSON(value['lowestScore']),
-        'highestScore': ProductReferenceDtoToJSON(value['highestScore']),
         'percent': value['percent'],
         'on20': value['on20'],
         'absoluteValue': value['absoluteValue'],

--- a/frontend/shared/api-client/models/ProductScoresDto.ts
+++ b/frontend/shared/api-client/models/ProductScoresDto.ts
@@ -47,18 +47,6 @@ export interface ProductScoresDto {
      */
     ecoscore?: ProductScoreDto;
     /**
-     * Score identifiers where the product ranks amongst the worst
-     * @type {Set<string>}
-     * @memberof ProductScoresDto
-     */
-    worstScores?: Set<string>;
-    /**
-     * Score identifiers where the product ranks amongst the best
-     * @type {Set<string>}
-     * @memberof ProductScoresDto
-     */
-    bestScores?: Set<string>;
-    /**
      * Ecoscore derived rankings
      * @type {ProductRankingDto}
      * @memberof ProductScoresDto
@@ -82,11 +70,9 @@ export function ProductScoresDtoFromJSONTyped(json: any, ignoreDiscriminator: bo
         return json;
     }
     return {
-        
+
         'scores': json['scores'] == null ? undefined : (mapValues(json['scores'], ProductScoreDtoFromJSON)),
         'ecoscore': json['ecoscore'] == null ? undefined : ProductScoreDtoFromJSON(json['ecoscore']),
-        'worstScores': json['worstScores'] == null ? undefined : new Set(json['worstScores']),
-        'bestScores': json['bestScores'] == null ? undefined : new Set(json['bestScores']),
         'ranking': json['ranking'] == null ? undefined : ProductRankingDtoFromJSON(json['ranking']),
     };
 }
@@ -101,11 +87,9 @@ export function ProductScoresDtoToJSONTyped(value?: ProductScoresDto | null, ign
     }
 
     return {
-        
+
         'scores': value['scores'] == null ? undefined : (mapValues(value['scores'], ProductScoreDtoToJSON)),
         'ecoscore': ProductScoreDtoToJSON(value['ecoscore']),
-        'worstScores': value['worstScores'] == null ? undefined : Array.from(value['worstScores'] as Set<any>),
-        'bestScores': value['bestScores'] == null ? undefined : Array.from(value['bestScores'] as Set<any>),
         'ranking': ProductRankingDtoToJSON(value['ranking']),
     };
 }

--- a/frontend/shared/api-client/models/VerticalConfigFullDto.ts
+++ b/frontend/shared/api-client/models/VerticalConfigFullDto.ts
@@ -383,18 +383,6 @@ export interface VerticalConfigFullDto {
      * @memberof VerticalConfigFullDto
      */
     featureGroups?: Array<FeatureGroupDto>;
-    /**
-     * Threshold defining how many low scores are considered worsts.
-     * @type {number}
-     * @memberof VerticalConfigFullDto
-     */
-    worseLimit?: number;
-    /**
-     * Threshold defining how many high scores are considered bests.
-     * @type {number}
-     * @memberof VerticalConfigFullDto
-     */
-    bettersLimit?: number;
 }
 
 /**
@@ -457,8 +445,6 @@ export function VerticalConfigFullDtoFromJSONTyped(json: any, ignoreDiscriminato
         'descriptionsAggregationConfig': json['descriptionsAggregationConfig'] == null ? undefined : DescriptionsAggregationConfigFromJSON(json['descriptionsAggregationConfig']),
         'scoringAggregationConfig': json['scoringAggregationConfig'] == null ? undefined : ScoringAggregationConfigFromJSON(json['scoringAggregationConfig']),
         'featureGroups': json['featureGroups'] == null ? undefined : ((json['featureGroups'] as Array<any>).map(FeatureGroupDtoFromJSON)),
-        'worseLimit': json['worseLimit'] == null ? undefined : json['worseLimit'],
-        'bettersLimit': json['bettersLimit'] == null ? undefined : json['bettersLimit'],
     };
 }
 
@@ -516,8 +502,6 @@ export function VerticalConfigFullDtoToJSONTyped(value?: VerticalConfigFullDto |
         'descriptionsAggregationConfig': DescriptionsAggregationConfigToJSON(value['descriptionsAggregationConfig']),
         'scoringAggregationConfig': ScoringAggregationConfigToJSON(value['scoringAggregationConfig']),
         'featureGroups': value['featureGroups'] == null ? undefined : ((value['featureGroups'] as Array<any>).map(FeatureGroupDtoToJSON)),
-        'worseLimit': value['worseLimit'],
-        'bettersLimit': value['bettersLimit'],
     };
 }
 

--- a/model/src/main/java/org/open4goods/model/product/Product.java
+++ b/model/src/main/java/org/open4goods/model/product/Product.java
@@ -158,17 +158,7 @@ public class Product implements Standardisable {
 	 */
 	private Map<String,String> categoriesByDatasources = new HashMap<String, String>();
 
-	private Map<String, Score> scores = new HashMap<>();
-
-	/**
-	 * A bag containg the scorenames for which this product matches the N worth scores (--> tag on "ugly" scores)
-	 */
-	private Set<String> worsesScores = new HashSet<String>();
-
-	/**
-	 * A bag containg the scorenames for which this product matches the N bestsScores (--> tag on "top" scores)
-	 */
-	private Set<String> bestsScores = new HashSet<String>();
+        private Map<String, Score> scores = new HashMap<>();
 
 	/**
 	 * The ai generated review for this product
@@ -968,25 +958,9 @@ public class Product implements Standardisable {
 		this.excludedCauses = excludedCauses;
 	}
 
-	public Set<String> getWorsesScores() {
-		return worsesScores;
-	}
-
-	public void setWorsesScores(Set<String> worses) {
-		this.worsesScores = worses;
-	}
-
-	public Set<String> getBestsScores() {
-		return bestsScores;
-	}
-
-	public void setBestsScores(Set<String> betters) {
-		this.bestsScores = betters;
-	}
-
-	public Localisable<String, AiReviewHolder> getReviews() {
-		return reviews;
-	}
+        public Localisable<String, AiReviewHolder> getReviews() {
+                return reviews;
+        }
 
 	public void setReviews(Localisable<String, AiReviewHolder> aiReviews) {
 		this.reviews = aiReviews;

--- a/model/src/main/java/org/open4goods/model/product/Score.java
+++ b/model/src/main/java/org/open4goods/model/product/Score.java
@@ -41,21 +41,6 @@ public class Score  implements Validable {
 	 */
 	private Integer ranking;
 	
-	/**
-	 * The GTIN id of the prouct having the lowest score
-	 */
-	private Long lowestScoreId;
-	
-	
-	/**
-	 * The GTIN id of the product having the highest score
-	 */
-	private Long highestScoreId;
-	
-	
-	
-	
-	
 	
 	////////////////////////////////////////
 	// Contracts
@@ -312,27 +297,6 @@ public class Score  implements Validable {
 	public void setRanking(Integer ranking) {
 		this.ranking = ranking;
 	}
-
-
-	public Long getLowestScoreId() {
-		return lowestScoreId;
-	}
-
-
-	public void setLowestScoreId(Long lowestScoreId) {
-		this.lowestScoreId = lowestScoreId;
-	}
-
-
-	public Long getHighestScoreId() {
-		return highestScoreId;
-	}
-
-
-	public void setHighestScoreId(Long highestScoreId) {
-		this.highestScoreId = highestScoreId;
-	}
-
 
 
 }

--- a/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
@@ -268,18 +268,6 @@ public class VerticalConfig{
 	// A local cache for token names
 	private Set<String> cacheTokenNames;
 
-	/**
-	 * If an item has a score is the last "worseLimit", then it will be bagged in product.worsesScores
-	 */
-	private Integer worseLimit = 3;
-
-
-	/**
-	 * If an item has a score is the top "bettersLimit", then it will be bagged in product.bestsScores
-	 */
-	private Integer bettersLimit = 3;
-
-
 
 
 	@Override
@@ -909,25 +897,9 @@ public class VerticalConfig{
 		this.availableImpactScoreCriterias = availableImpactScoreCriterias;
 	}
 
-	public Integer getWorseLimit() {
-		return worseLimit;
-	}
-
-	public void setWorseLimit(Integer worseLimit) {
-		this.worseLimit = worseLimit;
-	}
-
-	public Integer getBettersLimit() {
-		return bettersLimit;
-	}
-
-	public void setBettersLimit(Integer bettersLimit) {
-		this.bettersLimit = bettersLimit;
-	}
-
-	public List<VerticalSubset> getSubsets() {
-		return subsets;
-	}
+        public List<VerticalSubset> getSubsets() {
+                return subsets;
+        }
 
 	public void setSubsets(List<VerticalSubset> subsets) {
 		this.subsets = subsets;

--- a/model/src/main/resources/product-mappings.json
+++ b/model/src/main/resources/product-mappings.json
@@ -259,14 +259,6 @@
             "type": "object",
             "enabled": false
         },
-         "bestsScores": {
-            "type": "object",
-            "enabled": false
-        },
-        "worsesScores": {
-            "type": "object",
-            "enabled": false
-        },
         "scores": {
             "dynamic": "true",
             "properties": {
@@ -284,16 +276,6 @@
                 },
                 "ranking": {
                     "type": "integer",
-                    "index": false
-                },
-
-                "highestScoreId": {
-                    "type": "long",
-                    "index": false
-                },
-
-                "lowestScoreId": {
-                    "type": "long",
                     "index": false
                 },
 


### PR DESCRIPTION
## Summary
- remove best/worst score bagging and extreme references from model and aggregation services
- simplify front API DTOs/mapping and drop worst/best score exposure
- update frontend product page and shared client models to stop relying on score extremes

## Testing
- mvn --offline -pl front-api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0a7ab6b48322bc9123bb47d3c293)