### PR TITLE
Improve impact score fallbacks

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -438,6 +438,17 @@ describe('ProductHero', () => {
 
       await wrapper.unmount()
     })
+
+    it('renders the impact score stub when only relative values are available', async () => {
+      rewriteImpactScoreEntry({ relativ: { value: 6.2 } })
+
+      const wrapper = await mountComponent()
+
+      expect(wrapper.get('.impact-score-stub').text()).toBe('5')
+      expect(wrapper.get('.product-hero__impact-overview').exists()).toBe(true)
+
+      await wrapper.unmount()
+    })
   })
 
   it('toggles compare state with visual feedback', async () => {

--- a/frontend/app/utils/_product-scores.spec.ts
+++ b/frontend/app/utils/_product-scores.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { ProductDto, ProductScoreDto } from '~~/shared/api-client'
+import { resolvePrimaryImpactScore } from './_product-scores'
+
+const buildProduct = (score: Partial<ProductScoreDto>): ProductDto => ({
+  scores: {
+    scores: {
+      ECOSCORE: {
+        id: 'ECOSCORE',
+        ...score,
+      } as ProductScoreDto,
+    },
+  },
+}) as ProductDto
+
+describe('resolvePrimaryImpactScore', () => {
+  it('prioritises canonical conversions before fallbacks', () => {
+    const product = buildProduct({
+      on20: 10,
+      percent: 80,
+      value: 4.8,
+      relativeValue: '3.2',
+      relativ: { value: 2 },
+    })
+
+    expect(resolvePrimaryImpactScore(product)).toBe(2.5)
+  })
+
+  it('handles relativeValue strings as five point scores', () => {
+    const product = buildProduct({ relativeValue: '4.4' })
+
+    expect(resolvePrimaryImpactScore(product)).toBe(4.4)
+  })
+
+  it('clamps relative scores to the allowed range', () => {
+    const product = buildProduct({ relativ: { value: 7.2 } })
+
+    expect(resolvePrimaryImpactScore(product)).toBe(5)
+  })
+})

--- a/frontend/app/utils/_product-scores.ts
+++ b/frontend/app/utils/_product-scores.ts
@@ -3,6 +3,19 @@ import type { ProductDto } from '~~/shared/api-client'
 const clampScore = (score: number) => Math.max(0, Math.min(score, 5))
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value)
+const toNumber = (value: unknown): number | null => {
+  if (isFiniteNumber(value)) {
+    return value
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
 
 /**
  * Resolve the primary impact score for a product on a five-point scale.
@@ -27,23 +40,45 @@ export const resolvePrimaryImpactScore = (product: ProductDto): number | null =>
     return null
   }
 
-  if (isFiniteNumber(impactEntry.on20)) {
-    return clampScore((impactEntry.on20 / 20) * 5)
+  const on20Value = toNumber(impactEntry.on20)
+
+  if (on20Value !== null) {
+    return clampScore((on20Value / 20) * 5)
   }
 
-  if (isFiniteNumber(impactEntry.percent)) {
-    return clampScore((impactEntry.percent / 100) * 5)
+  const percentValue = toNumber(impactEntry.percent)
+
+  if (percentValue !== null) {
+    return clampScore((percentValue / 100) * 5)
   }
 
-  const absoluteValue = impactEntry.absolute?.value
-  const absoluteMax = impactEntry.absolute?.max
+  const absoluteValue = toNumber(impactEntry.absolute?.value)
+  const absoluteMax = toNumber(impactEntry.absolute?.max)
 
-  if (isFiniteNumber(absoluteValue) && isFiniteNumber(absoluteMax) && absoluteMax > 0) {
+  if (absoluteValue !== null && absoluteMax !== null && absoluteMax > 0) {
     return clampScore((absoluteValue / absoluteMax) * 5)
   }
 
-  if (isFiniteNumber(absoluteValue)) {
+  if (absoluteValue !== null) {
     return clampScore(absoluteValue)
+  }
+
+  const rawValue = toNumber(impactEntry.value)
+
+  if (rawValue !== null) {
+    return clampScore(rawValue)
+  }
+
+  const relativeValue = toNumber(impactEntry.relativeValue)
+
+  if (relativeValue !== null) {
+    return clampScore(relativeValue)
+  }
+
+  const relativValue = toNumber(impactEntry.relativ?.value)
+
+  if (relativValue !== null) {
+    return clampScore(relativValue)
   }
 
 


### PR DESCRIPTION
## Summary
- normalise impact score resolution to prefer on20/percent/absolute values before falling back to direct impact scores with clamping
- add unit coverage for resolvePrimaryImpactScore fallbacks and ProductHero rendering when only relative impact values exist

## Testing
- pnpm test app/utils/_product-scores.spec.ts app/components/product/ProductHero.spec.ts --run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee30423648322bba681a4a78f83c6)