### PR TITLE
Implement guided filters wizard CTA and tests

### DIFF
--- a/frontend/app/components/category/guided-filters/CategoryGuidedFiltersWizard.spec.ts
+++ b/frontend/app/components/category/guided-filters/CategoryGuidedFiltersWizard.spec.ts
@@ -1,0 +1,294 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import type { ModalFilterWizardDto } from '~~/shared/api-client'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const map: Record<string, string> = {
+        'category.guidedFilters.progressLabel': `Step ${params?.current ?? ''} of ${params?.total ?? ''}`,
+        'category.guidedFilters.stepTitle': `Step ${params?.current ?? ''}/${params?.total ?? ''}`,
+        'category.guidedFilters.close': 'Close',
+        'category.guidedFilters.skip': 'Skip',
+        'category.guidedFilters.previous': 'Previous',
+        'category.guidedFilters.next': 'Next',
+        'category.guidedFilters.apply': 'Apply filters',
+        'category.guidedFilters.resultsLoading': 'Loading…',
+        'category.guidedFilters.resultsLabel': `${params?.count ?? ''} products match in ${params?.category ?? ''}`,
+        'category.guidedFilters.resultsFallback': 'Select an option to preview results.',
+        'category.guidedFilters.defaultCategory': 'this category',
+      }
+
+      return map[key] ?? key
+    },
+    n: (value: number) => value.toString(),
+  }),
+}))
+
+const createSimpleStub = (tag: string) =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () => h(tag, attrs, slots.default ? slots.default() : [])
+    },
+  })
+
+const VDialogStub = defineComponent({
+  name: 'VDialogStub',
+  props: {
+    modelValue: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { slots }) {
+    return () => (props.modelValue ? h('div', { class: 'v-dialog-stub' }, slots.default?.()) : null)
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  props: {
+    type: { type: String, default: 'button' },
+  },
+  emits: ['click'],
+  setup(props, { slots, emit, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          type: props.type,
+          class: ['v-btn-stub', attrs?.class].filter(Boolean).join(' '),
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const VSheetStub = defineComponent({
+  name: 'VSheetStub',
+  props: {
+    tag: { type: String, default: 'div' },
+    disabled: { type: Boolean, default: false },
+  },
+  setup(props, { slots, attrs }) {
+    return () =>
+      h(
+        props.tag === 'button' ? 'button' : props.tag,
+        {
+          ...attrs,
+          disabled: props.disabled,
+          type: props.tag === 'button' ? 'button' : undefined,
+        },
+        slots.default?.(),
+      )
+  },
+})
+
+const wizardFixture: ModalFilterWizardDto = {
+  questions: [
+    {
+      id: 'usage',
+      title: 'Main usage',
+      subtitle: 'How will you use it?',
+      description: 'Tell us more about your expectations.',
+      selectionType: 'SINGLE',
+      choices: [
+        {
+          id: 'movies',
+          title: 'Movie nights',
+          expression: {
+            operator: 'AND',
+            clauses: [
+              { field: 'screenType', operator: 'TERM', terms: ['OLED'] },
+            ],
+          },
+        },
+        {
+          id: 'sports',
+          title: 'Sports',
+          expression: {
+            operator: 'AND',
+            clauses: [
+              { field: 'refreshRate', operator: 'RANGE', min: 120 },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      id: 'size',
+      title: 'Preferred size',
+      selectionType: 'SINGLE',
+      choices: [
+        {
+          id: 'medium',
+          title: 'Between 50" and 60"',
+          expression: {
+            operator: 'AND',
+            clauses: [
+              { field: 'screenSize', operator: 'RANGE', min: 50, max: 60 },
+            ],
+          },
+        },
+        {
+          id: 'large',
+          title: '65" and more',
+          expression: {
+            operator: 'AND',
+            clauses: [
+              { field: 'screenSize', operator: 'RANGE', min: 65 },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const multiWizardFixture: ModalFilterWizardDto = {
+  questions: [
+    {
+      id: 'features',
+      title: 'Key features',
+      selectionType: 'MULTIPLE',
+      maxSelections: 2,
+      combinationOperator: 'OR',
+      choices: [
+        {
+          id: 'hdr',
+          title: 'HDR',
+          expression: {
+            operator: 'AND',
+            clauses: [{ field: 'hasHdr', operator: 'TERM', terms: ['true'] }],
+          },
+        },
+        {
+          id: 'gaming',
+          title: 'Gaming',
+          expression: {
+            operator: 'AND',
+            clauses: [{ field: 'gamingMode', operator: 'TERM', terms: ['true'] }],
+          },
+        },
+        {
+          id: 'cinema',
+          title: 'Cinema',
+          expression: {
+            operator: 'AND',
+            clauses: [{ field: 'cinemaPreset', operator: 'TERM', terms: ['true'] }],
+          },
+        },
+      ],
+    },
+  ],
+}
+
+const rippleDirective = {
+  mounted: vi.fn(),
+  beforeUnmount: vi.fn(),
+}
+
+type WizardProps = {
+  modelValue: boolean
+  wizard: ModalFilterWizardDto | null
+  productCount: number | null
+  loadingCount: boolean
+  categoryName?: string | null
+}
+
+const mountWizard = async (props: Partial<WizardProps> = {}) => {
+  const module = await import('./CategoryGuidedFiltersWizard.vue')
+  const Component = module.default
+
+  return mount(Component, {
+    props: {
+      modelValue: true,
+      wizard: wizardFixture,
+      productCount: null,
+      loadingCount: false,
+      categoryName: 'Televisions',
+      ...props,
+    },
+    global: {
+      stubs: {
+        VDialog: VDialogStub,
+        VCard: createSimpleStub('div'),
+        VCardText: createSimpleStub('div'),
+        VCardActions: createSimpleStub('div'),
+        VProgressLinear: createSimpleStub('div'),
+        VProgressCircular: createSimpleStub('div'),
+        VBtn: VBtnStub,
+        VSheet: VSheetStub,
+        VIcon: createSimpleStub('span'),
+        VImg: createSimpleStub('img'),
+        VAlert: createSimpleStub('div'),
+        VSpacer: createSimpleStub('div'),
+      },
+      directives: { ripple: rippleDirective },
+    },
+  })
+}
+
+describe('CategoryGuidedFiltersWizard', () => {
+  it('emits filters-change when selecting a choice', async () => {
+    const wrapper = await mountWizard()
+    const choices = wrapper.findAll('.category-guided-wizard__choice')
+
+    await choices.at(0)?.trigger('click')
+    await nextTick()
+
+    const emissions = wrapper.emitted('filters-change') ?? []
+    const lastEmission = emissions.at(-1)
+    expect(lastEmission?.[0]).toEqual({
+      filters: [
+        { field: 'screenType', operator: 'term', terms: ['OLED'] },
+      ],
+    })
+  })
+
+  it('limits the number of selections for multiple choice questions', async () => {
+    const wrapper = await mountWizard({ wizard: multiWizardFixture })
+    const choices = wrapper.findAll('.category-guided-wizard__choice')
+
+    await choices.at(0)?.trigger('click')
+    await choices.at(1)?.trigger('click')
+    await nextTick()
+    await choices.at(2)?.trigger('click')
+    await nextTick()
+
+    const selected = wrapper
+      .findAll('.category-guided-wizard__choice--selected')
+      .map((choice) => choice.find('.category-guided-wizard__choice-title').text())
+
+    expect(selected).toEqual(['HDR', 'Gaming'])
+  })
+
+  it('emits apply payload with filters across all steps', async () => {
+    const wrapper = await mountWizard()
+    const firstChoices = wrapper.findAll('.category-guided-wizard__choice')
+    await firstChoices.at(1)?.trigger('click')
+    await nextTick()
+
+    const nextButton = wrapper.findAll('.v-btn-stub').find((button) => button.text() === 'Next')
+    await nextButton?.trigger('click')
+    await nextTick()
+
+    const secondChoices = wrapper.findAll('.category-guided-wizard__choice')
+    await secondChoices.at(0)?.trigger('click')
+    await nextTick()
+
+    const applyButton = wrapper.findAll('.v-btn-stub').find((button) => button.text() === 'Apply filters')
+    await applyButton?.trigger('click')
+    await nextTick()
+
+    const applyEvents = wrapper.emitted('apply') ?? []
+    expect(applyEvents.at(0)?.[0]).toEqual({
+      filters: [
+        { field: 'refreshRate', operator: 'range', min: 120 },
+        { field: 'screenSize', operator: 'range', min: 50, max: 60 },
+      ],
+    })
+  })
+})

--- a/frontend/app/components/category/guided-filters/CategoryGuidedFiltersWizard.vue
+++ b/frontend/app/components/category/guided-filters/CategoryGuidedFiltersWizard.vue
@@ -1,0 +1,482 @@
+<template>
+  <v-dialog v-model="localModel" :scrim="true" transition="dialog-bottom-transition">
+    <v-card
+      v-if="wizard && wizard.questions && wizard.questions.length"
+      class="category-guided-wizard"
+      elevation="12"
+      max-width="760"
+    >
+      <div class="category-guided-wizard__header">
+        <div class="category-guided-wizard__progress">
+          <v-progress-linear
+            :model-value="progressValue"
+            color="primary"
+            height="6"
+            rounded
+            class="category-guided-wizard__progress-bar"
+          />
+          <span class="category-guided-wizard__progress-label">
+            {{
+              t('category.guidedFilters.progressLabel', {
+                current: currentStepDisplay,
+                total: totalSteps,
+              })
+            }}
+          </span>
+        </div>
+        <v-btn
+          icon
+          variant="text"
+          density="comfortable"
+          :aria-label="t('category.guidedFilters.close')"
+          @click="closeWizard"
+        >
+          <v-icon icon="mdi-close" />
+        </v-btn>
+      </div>
+
+      <v-card-text>
+        <div v-if="currentQuestion" class="category-guided-wizard__question">
+          <div class="category-guided-wizard__question-copy">
+            <p class="category-guided-wizard__eyebrow">
+              {{ t('category.guidedFilters.stepTitle', { current: currentStepDisplay, total: totalSteps }) }}
+            </p>
+            <h3 class="category-guided-wizard__title">
+              {{ currentQuestion.title }}
+            </h3>
+            <p v-if="currentQuestion.subtitle" class="category-guided-wizard__subtitle">
+              {{ currentQuestion.subtitle }}
+            </p>
+            <p v-if="currentQuestion.description" class="category-guided-wizard__description">
+              {{ currentQuestion.description }}
+            </p>
+            <v-alert
+              v-if="currentQuestion.moreInformations"
+              type="info"
+              variant="tonal"
+              border="start"
+              class="mt-3"
+            >
+              {{ currentQuestion.moreInformations }}
+            </v-alert>
+            <v-btn
+              v-if="currentQuestion.linkUrl && currentQuestion.linkTitle"
+              class="mt-4"
+              :href="currentQuestion.linkUrl"
+              target="_blank"
+              variant="text"
+              color="primary"
+              append-icon="mdi-open-in-new"
+            >
+              {{ currentQuestion.linkTitle }}
+            </v-btn>
+          </div>
+
+          <div v-if="currentQuestion.image" class="category-guided-wizard__question-media">
+            <v-img :src="currentQuestion.image" alt="" cover />
+          </div>
+        </div>
+
+        <div v-if="currentQuestion" class="category-guided-wizard__choices">
+          <v-sheet
+            v-for="choice in currentQuestion.choices ?? []"
+            :key="choice.id"
+            v-ripple
+            :tag="'button'"
+            class="category-guided-wizard__choice"
+            :class="{
+              'category-guided-wizard__choice--selected': isChoiceSelected(choice.id ?? ''),
+              'category-guided-wizard__choice--list': choice.display === 'BULLET_LIST',
+            }"
+            :disabled="isChoiceDisabled(choice.id ?? '')"
+            role="button"
+            :aria-pressed="isChoiceSelected(choice.id ?? '').toString()"
+            :aria-disabled="isChoiceDisabled(choice.id ?? '') ? 'true' : 'false'"
+            type="button"
+            @click="onToggleChoice(choice.id ?? '')"
+            @keydown.enter.prevent="onToggleChoice(choice.id ?? '')"
+            @keydown.space.prevent="onToggleChoice(choice.id ?? '')"
+          >
+            <div class="category-guided-wizard__choice-content">
+              <div>
+                <p class="category-guided-wizard__choice-title">
+                  {{ choice.title }}
+                </p>
+                <p v-if="choice.description" class="category-guided-wizard__choice-description">
+                  {{ choice.description }}
+                </p>
+                <ul v-if="choice.display === 'BULLET_LIST' && choice.bulletPoints?.length" class="category-guided-wizard__choice-bullets">
+                  <li v-for="point in choice.bulletPoints" :key="point">
+                    <v-icon icon="mdi-check-circle" size="18" color="primary" />
+                    <span>{{ point }}</span>
+                  </li>
+                </ul>
+              </div>
+              <v-icon
+                v-if="isChoiceSelected(choice.id ?? '')"
+                icon="mdi-check-circle"
+                color="primary"
+                size="28"
+              />
+            </div>
+          </v-sheet>
+        </div>
+
+        <div v-if="showResultsSection" class="category-guided-wizard__results" aria-live="polite">
+          <v-progress-circular
+            v-if="loadingCount"
+            indeterminate
+            color="primary"
+            size="20"
+            class="mr-2"
+          />
+          <p>
+            {{
+              loadingCount
+                ? t('category.guidedFilters.resultsLoading')
+                : t('category.guidedFilters.resultsLabel', {
+                    count: formattedResultsCount,
+                    category: resolvedWizardCategory,
+                  })
+            }}
+          </p>
+        </div>
+      </v-card-text>
+
+      <v-card-actions class="category-guided-wizard__actions">
+        <v-btn variant="text" color="secondary" @click="skipCurrentQuestion">
+          {{ t('category.guidedFilters.skip') }}
+        </v-btn>
+        <v-spacer />
+        <v-btn
+          variant="text"
+          color="secondary"
+          :disabled="currentStepDisplay === 1"
+          @click="goToPrevious"
+        >
+          {{ t('category.guidedFilters.previous') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          :loading="false"
+          :disabled="!hasSelectionForCurrent && !isLastStep"
+          @click="onPrimaryAction"
+        >
+          {{ isLastStep ? t('category.guidedFilters.apply') : t('category.guidedFilters.next') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { FilterRequestDto, ModalFilterWizardDto } from '~~/shared/api-client'
+
+import {
+  buildWizardFilterRequest,
+  type ModalWizardSelections,
+  isSelectionLimitReached,
+} from '~/utils/guided-modal-filters'
+
+const props = defineProps<{
+  modelValue: boolean
+  wizard: ModalFilterWizardDto | null
+  productCount: number | null
+  loadingCount: boolean
+  categoryName?: string | null
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [boolean]
+  'filters-change': [FilterRequestDto | null]
+  apply: [FilterRequestDto | null]
+}>()
+
+const { t, n } = useI18n()
+
+const resolvedWizardCategory = computed(() => {
+  const name = props.categoryName?.trim()
+  if (name) {
+    return name
+  }
+
+  return t('category.guidedFilters.defaultCategory')
+})
+
+const localModel = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+})
+
+const currentStep = ref(0)
+const selections = ref<ModalWizardSelections>({})
+const questions = computed(() => props.wizard?.questions ?? [])
+const totalSteps = computed(() => questions.value.length || 1)
+const currentQuestion = computed(() => questions.value[currentStep.value] ?? null)
+const currentStepDisplay = computed(() => Math.min(currentStep.value + 1, totalSteps.value))
+const progressValue = computed(() => (totalSteps.value ? (currentStepDisplay.value / totalSteps.value) * 100 : 0))
+const selectionForCurrent = computed(() => {
+  if (!currentQuestion.value?.id) {
+    return []
+  }
+  return selections.value[currentQuestion.value.id] ?? []
+})
+const hasSelectionForCurrent = computed(() => selectionForCurrent.value.length > 0)
+const isLastStep = computed(() => currentStepDisplay.value === totalSteps.value)
+const formattedResultsCount = computed(() =>
+  props.productCount == null ? t('category.guidedFilters.resultsFallback') : n(props.productCount, 'decimal'),
+)
+const showResultsSection = computed(() => props.loadingCount || props.productCount != null)
+
+const resetWizard = () => {
+  selections.value = {}
+  currentStep.value = 0
+}
+
+const emitFiltersChange = () => {
+  if (!props.modelValue) {
+    return
+  }
+
+  const filters = buildWizardFilterRequest(props.wizard, selections.value, currentStep.value)
+  emit('filters-change', filters)
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) {
+      currentStep.value = 0
+      emitFiltersChange()
+      return
+    }
+
+    emit('filters-change', null)
+    resetWizard()
+  },
+)
+
+watch(
+  () => props.wizard,
+  () => {
+    resetWizard()
+  },
+)
+
+watch(
+  selections,
+  () => {
+    emitFiltersChange()
+  },
+  { deep: true },
+)
+
+const isChoiceSelected = (choiceId: string): boolean => {
+  if (!choiceId || !currentQuestion.value?.id) {
+    return false
+  }
+  const selected = selections.value[currentQuestion.value.id] ?? []
+  return selected.includes(choiceId)
+}
+
+const isChoiceDisabled = (choiceId: string): boolean => {
+  if (!currentQuestion.value || !choiceId) {
+    return false
+  }
+  const selected = selections.value[currentQuestion.value.id] ?? []
+  return !selected.includes(choiceId) && isSelectionLimitReached(currentQuestion.value, selected, choiceId)
+}
+
+const onToggleChoice = (choiceId: string) => {
+  if (!choiceId || !currentQuestion.value?.id) {
+    return
+  }
+
+  const questionId = currentQuestion.value.id
+  const currentSelection = selections.value[questionId] ?? []
+
+  if ((currentQuestion.value.selectionType ?? 'SINGLE') === 'SINGLE') {
+    selections.value = { ...selections.value, [questionId]: [choiceId] }
+    return
+  }
+
+  const exists = currentSelection.includes(choiceId)
+  const next = exists
+    ? currentSelection.filter((value) => value !== choiceId)
+    : isChoiceDisabled(choiceId)
+      ? currentSelection
+      : [...currentSelection, choiceId]
+
+  selections.value = { ...selections.value, [questionId]: next }
+}
+
+const skipCurrentQuestion = () => {
+  if (currentQuestion.value?.id) {
+    const questionId = currentQuestion.value.id
+    const { [questionId]: _removed, ...remaining } = selections.value
+    selections.value = remaining
+  }
+
+  if (!isLastStep.value) {
+    currentStep.value = Math.min(currentStep.value + 1, totalSteps.value - 1)
+    emitFiltersChange()
+  }
+}
+
+const goToPrevious = () => {
+  if (currentStepDisplay.value === 1) {
+    return
+  }
+
+  currentStep.value = Math.max(0, currentStep.value - 1)
+  emitFiltersChange()
+}
+
+const closeWizard = () => {
+  emit('update:modelValue', false)
+}
+
+const onPrimaryAction = () => {
+  if (isLastStep.value) {
+    const filters = buildWizardFilterRequest(props.wizard, selections.value)
+    emit('apply', filters)
+    emit('update:modelValue', false)
+    return
+  }
+
+  if (!hasSelectionForCurrent.value) {
+    return
+  }
+
+  currentStep.value = Math.min(currentStep.value + 1, totalSteps.value - 1)
+  emitFiltersChange()
+}
+</script>
+
+<style scoped lang="sass">
+.category-guided-wizard
+  display: flex
+  flex-direction: column
+  width: 100%
+  max-width: 760px
+  border-radius: 20px
+  background: rgb(var(--v-theme-surface-default))
+
+  &__header
+    display: flex
+    align-items: center
+    justify-content: space-between
+    padding: 1.5rem 1.5rem 0
+
+  &__progress
+    flex: 1
+    margin-right: 1rem
+
+  &__progress-label
+    display: inline-flex
+    margin-top: 0.35rem
+    font-size: 0.85rem
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+
+  &__question
+    display: grid
+    gap: 1.5rem
+    align-items: flex-start
+
+  &__question-copy
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+  &__eyebrow
+    text-transform: uppercase
+    letter-spacing: 0.08em
+    font-size: 0.75rem
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+
+  &__title
+    margin: 0
+    font-weight: 700
+    font-size: 1.5rem
+
+  &__subtitle
+    margin: 0
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+  &__description
+    margin: 0
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+  &__question-media
+    display: none
+
+  &__choices
+    display: grid
+    gap: 0.75rem
+    margin-top: 1.5rem
+
+  &__choice
+    border-radius: 16px
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+    padding: 1rem 1.25rem
+    cursor: pointer
+    text-align: left
+    transition: border-color 0.2s ease, box-shadow 0.2s ease
+
+    &:disabled
+      opacity: 0.5
+      cursor: not-allowed
+
+    &--selected
+      border-color: rgba(var(--v-theme-primary), 0.6)
+      box-shadow: 0 8px 20px rgba(var(--v-theme-shadow-primary-600), 0.25)
+
+  &__choice-content
+    display: flex
+    align-items: flex-start
+    justify-content: space-between
+    gap: 0.75rem
+
+  &__choice-title
+    margin: 0
+    font-weight: 600
+    font-size: 1rem
+
+  &__choice-description
+    margin: 0.25rem 0 0
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+  &__choice-bullets
+    list-style: none
+    padding: 0
+    margin: 0.5rem 0 0
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
+    li
+      display: flex
+      align-items: center
+      gap: 0.5rem
+
+  &__results
+    display: flex
+    align-items: center
+    gap: 0.5rem
+    margin-top: 1rem
+    font-weight: 600
+
+  &__actions
+    padding: 1.5rem
+
+@media (min-width: 720px)
+  .category-guided-wizard__question
+    grid-template-columns: minmax(0, 1fr) 200px
+
+  .category-guided-wizard__question-media
+    display: block
+
+  .category-guided-wizard__choices
+    grid-template-columns: repeat(2, minmax(0, 1fr))
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -441,6 +441,23 @@
         "ariaLabel": "Open the Eco-score guide"
       }
     },
+    "guidedFilters": {
+      "cta": "Guided assistant",
+      "ctaAria": "Open the guided filters for {category}",
+      "heroHelper": "Answer a few quick questions to surface the best products in {category}.",
+      "fabAriaLabel": "Open the guided filters assistant",
+      "progressLabel": "Step {current} of {total}",
+      "close": "Close the guided assistant",
+      "stepTitle": "Step {current}/{total}",
+      "skip": "No preference",
+      "previous": "Previous",
+      "next": "Next",
+      "apply": "Apply filters",
+      "resultsLoading": "Calculating matching products…",
+      "resultsLabel": "{count} products match so far in {category}",
+      "resultsFallback": "Select an option to preview matching products.",
+      "defaultCategory": "this category"
+    },
     "admin": {
       "title": "Admin filters",
       "helper": "Restricted tools for Nudger teammates. Inspect exclusion causes for catalog entries here.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -441,6 +441,23 @@
         "ariaLabel": "Ouvrir le guide Eco-score"
       }
     },
+    "guidedFilters": {
+      "cta": "Assistant guidé",
+      "ctaAria": "Ouvrir les filtres guidés pour {category}",
+      "heroHelper": "Répondez à quelques questions pour mettre en avant les meilleurs produits de {category}.",
+      "fabAriaLabel": "Ouvrir l'assistant de filtres guidés",
+      "progressLabel": "Étape {current} sur {total}",
+      "close": "Fermer l'assistant guidé",
+      "stepTitle": "Étape {current}/{total}",
+      "skip": "Peu importe",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "apply": "Appliquer les filtres",
+      "resultsLoading": "Calcul des produits correspondants…",
+      "resultsLabel": "{count} produits correspondent pour {category}",
+      "resultsFallback": "Choisissez une option pour afficher un aperçu des résultats.",
+      "defaultCategory": "cette catégorie"
+    },
     "admin": {
       "title": "Filtres admin",
       "helper": "Outils réservés aux coéquipiers Nudger pour analyser les causes d'exclusion des fiches.",


### PR DESCRIPTION
## Summary
- add the hero CTA, floating action button, and wizard wiring on the category page so the modal flow can drive filters and preview counts
- enhance the modal wizard component with accessibility tweaks, real-time preview handling, localisation fallbacks, and internationalised strings for both English and French
- introduce dedicated component tests that cover selection, multi-choice limits, and apply flows for the guided wizard

## Testing
- pnpm lint
- pnpm exec vitest run app/components/category/guided-filters/CategoryGuidedFiltersWizard.spec.ts --reporter=basic

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691caac3daf0832ab6bcc089fa776f53)