### PR TITLE
Add sitemap legacy proxy route

### DIFF
--- a/frontend/shared/utils/sitemap-config.ts
+++ b/frontend/shared/utils/sitemap-config.ts
@@ -10,10 +10,10 @@ export const SITEMAP_PATH_PREFIX = '/sitemap'
 export const APP_ROUTES_SITEMAP_KEY = 'main-pages'
 
 const DEFAULT_ADDITIONAL_SITEMAP_PATHS = [
-  'https://static.nudger.fr/sitemap/blog-posts.xml',
-  'https://static.nudger.fr/sitemap/category-pages.xml',
-  'https://static.nudger.fr/sitemap/product-pages.xml',
-  'https://static.nudger.fr/sitemap/wiki-pages.xml',
+  'https://nudger.fr/sitemap_legacy/blog-posts.xml',
+  'https://nudger.fr/sitemap_legacy/category-pages.xml',
+  'https://nudger.fr/sitemap_legacy/product-pages.xml',
+  'https://nudger.fr/sitemap_legacy/wiki-pages.xml',
 ] as const
 
 export interface DomainLanguageSitemapConfig {


### PR DESCRIPTION
## Summary
- add a Nitro route that proxies `/sitemap_legacy/*` requests to the configured static server sitemap
- forward query parameters and headers while preserving upstream status and handling only GET/HEAD

## Testing
- pnpm lint
- pnpm vitest run components/product/attributes/ProductAttributeSourcingLabel.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920876303988333959221d8693d7e04)