### PR TITLE
Exclude offline route from main sitemap

### DIFF
--- a/frontend/shared/utils/sitemap-main-pages.spec.ts
+++ b/frontend/shared/utils/sitemap-main-pages.spec.ts
@@ -17,6 +17,7 @@ describe('getMainPagePathsForDomainLanguage', () => {
     expect(paths).toContain('/opendata/gtin')
     expect(paths).toContain('/opendata/isbn')
     expect(paths).toContain('/opensource')
+    expect(paths).not.toContain('/offline')
   })
 
   it('returns localized french paths', () => {
@@ -32,5 +33,6 @@ describe('getMainPagePathsForDomainLanguage', () => {
     expect(paths).toContain('/opendata/gtin')
     expect(paths).toContain('/opendata/isbn')
     expect(paths).toContain('/opensource')
+    expect(paths).not.toContain('/offline')
   })
 })

--- a/frontend/shared/utils/sitemap-main-pages.ts
+++ b/frontend/shared/utils/sitemap-main-pages.ts
@@ -26,6 +26,14 @@ const parseRouteNames = (value: unknown): string[] => {
   return []
 }
 
+const EXCLUDED_STATIC_ROUTE_NAMES = new Set(['offline'])
+
+const isExcludedStaticRouteName = (routeName: string): boolean => {
+  const normalizedName = routeName.replace(/^\/+/, '')
+
+  return EXCLUDED_STATIC_ROUTE_NAMES.has(normalizedName)
+}
+
 const getRuntimeConfiguredRouteNames = (): string[] => {
   try {
     const { staticMainPageRoutes, public: publicConfig } = useRuntimeConfig()
@@ -57,13 +65,15 @@ const resolveStaticRouteNames = (): string[] => {
   const routeNames = new Set<string>()
 
   for (const routeName of getRuntimeConfiguredRouteNames()) {
-    if (routeName) {
+    if (routeName && !isExcludedStaticRouteName(routeName)) {
       routeNames.add(routeName)
     }
   }
 
   for (const routeName of Object.keys(LOCALIZED_ROUTE_PATHS)) {
-    routeNames.add(routeName)
+    if (!isExcludedStaticRouteName(routeName)) {
+      routeNames.add(routeName)
+    }
   }
 
   staticRouteNamesCache = Array.from(routeNames).sort((a, b) => a.localeCompare(b))


### PR DESCRIPTION
## Summary
- exclude the offline fallback route from the main-pages sitemap generation
- add coverage to ensure sitemap paths omit the offline page for both languages

## Testing
- pnpm lint
- pnpm test --run shared/utils/sitemap-main-pages.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ddda79048333b5b832948f6ebfc1)