### PR TITLE
Fix sitemap exclusion for offline route

### DIFF
--- a/frontend/shared/utils/sitemap-main-pages.ts
+++ b/frontend/shared/utils/sitemap-main-pages.ts
@@ -29,7 +29,9 @@ const parseRouteNames = (value: unknown): string[] => {
 const EXCLUDED_STATIC_ROUTE_NAMES = new Set(['offline'])
 
 const isExcludedStaticRouteName = (routeName: string): boolean => {
-  const normalizedName = routeName.replace(/^\/+/, '')
+  const normalizedName = routeName
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
 
   return EXCLUDED_STATIC_ROUTE_NAMES.has(normalizedName)
 }


### PR DESCRIPTION
## Summary
- normalize excluded sitemap route names to ignore trailing slashes
- reset sitemap helper modules in tests and cover trailing-slash runtime config values

## Testing
- pnpm vitest run sitemap-main-pages


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692409e9a3cc83339cb98cf247dbdc1b)