### PR TITLE
Align primary impact score with ecoscore value

### DIFF
--- a/frontend/app/utils/_product-scores.ts
+++ b/frontend/app/utils/_product-scores.ts
@@ -5,49 +5,16 @@ const isFiniteNumber = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value)
 
 /**
- * Resolve the primary impact score for a product on a five-point scale.
- * Falls back to any score whose identifier mentions "impact" when the
- * ECOSCORE entry is missing.
+ * Resolve the ECOSCORE value for a product on a five-point scale.
+ * The ECOSCORE value is already expected to be between 0 and 5.
  */
 export const resolvePrimaryImpactScore = (product: ProductDto): number | null => {
-  const scores = product.scores?.scores
+  const value = product.scores?.scores?.ECOSCORE?.value
 
-  if (!scores) {
+  if (!isFiniteNumber(value)) {
     return null
   }
 
-  const preferredKeys = ['ECOSCORE']
-
-  const impactEntry =
-    preferredKeys.map((key) => scores[key]).find((entry) => entry != null) ??
-    Object.values(scores).find((entry) => entry?.id?.toLowerCase()?.includes('impact')) ??
-    null
-
-  if (!impactEntry) {
-    return null
-  }
-
-  if (isFiniteNumber(impactEntry.on20)) {
-    return clampScore((impactEntry.on20 / 20) * 5)
-  }
-
-  if (isFiniteNumber(impactEntry.percent)) {
-    return clampScore((impactEntry.percent / 100) * 5)
-  }
-
-  const absoluteValue = impactEntry.absolute?.value
-  const absoluteMax = impactEntry.absolute?.max
-
-  if (isFiniteNumber(absoluteValue) && isFiniteNumber(absoluteMax) && absoluteMax > 0) {
-    return clampScore((absoluteValue / absoluteMax) * 5)
-  }
-
-  if (isFiniteNumber(absoluteValue)) {
-    return clampScore(absoluteValue)
-  }
-
-
-
-  return null
+  return clampScore(value)
 }
 


### PR DESCRIPTION
## Summary
- simplify primary impact score resolution to return ECOSCORE.value clamped to the five-point scale

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256cb1e2c88333a49c46d4858a9026)