### PR TITLE
Fix product radar chart values and tooltips

### DIFF
--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -41,6 +41,7 @@ type RadarSeriesKey = 'current' | 'best' | 'worst'
 interface RadarAxisEntry {
   id: string
   name: string
+  attributeValue: string | null
 }
 
 interface RadarSeriesEntry {

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -90,6 +90,7 @@ import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 interface RadarAxisEntry {
   id: string
   name: string
+  attributeValue: string | null
 }
 
 interface RadarSeriesEntry {


### PR DESCRIPTION
## Summary
- use absolute score values and reference absolute data when building radar chart datasets, including indexed attribute values for axes
- display indexed attribute values in radar tooltips while normalizing the radar scale against the padded maximum observed score
- propagate updated radar axis metadata through product impact components

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257064734c83338ba0c45571a2afb1)