### PR TITLE
Fix ecoscore prerequisites and preserve cardinality statistics

### DIFF
--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/AbstractScoreAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/AbstractScoreAggregationServiceTest.java
@@ -1,0 +1,59 @@
+package org.open4goods.api.services.aggregation.services.batch.scores;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.StandardiserService;
+import org.open4goods.model.exceptions.ValidationException;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.product.Score;
+import org.open4goods.model.rating.Cardinality;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link AbstractScoreAggregationService} shared logic.
+ */
+class AbstractScoreAggregationServiceTest {
+
+    private static final class DummyScoreService extends AbstractScoreAggregationService {
+
+        DummyScoreService() {
+            super(LoggerFactory.getLogger(DummyScoreService.class));
+        }
+
+        @Override
+        public void onProduct(Product data, VerticalConfig vConf) {
+            // No-op: this dummy implementation only exposes protected helpers for testing.
+        }
+    }
+
+    @Test
+    void relativizeKeepsAbsoluteCountAndSum() throws ValidationException {
+        DummyScoreService service = new DummyScoreService();
+
+        Cardinality absoluteCardinality = new Cardinality();
+        absoluteCardinality.setMin(1.0);
+        absoluteCardinality.setMax(3.0);
+        absoluteCardinality.setAvg(2.0);
+        absoluteCardinality.setCount(4);
+        absoluteCardinality.setSum(8.0);
+
+        service.batchDatas.put("TEST", absoluteCardinality);
+
+        Score score = new Score("TEST", 2.0);
+        Cardinality absolute = new Cardinality(absoluteCardinality);
+        absolute.setValue(score.getValue());
+        score.setAbsolute(absolute);
+
+        service.relativize(score);
+
+        Cardinality relativ = score.getRelativ();
+        assertThat(relativ.getCount()).isEqualTo(4);
+        assertThat(relativ.getSum()).isEqualTo(8.0);
+        assertThat(relativ.getMin()).isZero();
+        assertThat(relativ.getMax()).isEqualTo(StandardiserService.DEFAULT_MAX_RATING);
+        assertThat(relativ.getAvg()).isEqualTo(2.5);
+        assertThat(relativ.getValue()).isEqualTo(2.5);
+    }
+}

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/DataCompletion2ScoreAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/DataCompletion2ScoreAggregationServiceTest.java
@@ -1,0 +1,41 @@
+package org.open4goods.api.services.aggregation.services.batch.scores;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.StandardiserService;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.product.Score;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link DataCompletion2ScoreAggregationService}.
+ */
+class DataCompletion2ScoreAggregationServiceTest {
+
+    @Test
+    void shouldComputeDataQualityWhenBrandMissing() {
+        Product product = new Product(1L);
+        // Preload a real score so data-quality counts one non-virtual score.
+        product.getScores().put("OTHER", new Score("OTHER", 3.5));
+
+        DataCompletion2ScoreAggregationService service =
+                new DataCompletion2ScoreAggregationService(LoggerFactory.getLogger(DataCompletion2ScoreAggregationServiceTest.class));
+
+        List<Product> dataset = List.of(product);
+        service.init(dataset);
+        service.onProduct(product, new VerticalConfig());
+        service.done(dataset, new VerticalConfig());
+
+        Score dataQuality = product.getScores().get("DATA_QUALITY");
+
+        assertThat(dataQuality).isNotNull();
+        assertThat(dataQuality.getVirtual()).isFalse();
+        assertThat(dataQuality.getAbsolute()).isNotNull();
+        assertThat(dataQuality.getAbsolute().getValue()).isEqualTo(1.0);
+        assertThat(dataQuality.getRelativ().getValue()).isEqualTo(StandardiserService.DEFAULT_MAX_RATING);
+    }
+}


### PR DESCRIPTION
## Summary
- allow data quality scoring to run without brand information and document the behavior
- keep cardinality counts and sums absolute during relativisation while leaving value scaling intact
- add unit tests covering data quality scoring, ecoscore aggregation, and relativised cardinalities

## Testing
- mvn --offline -pl api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258847e20083339c2164b6bc27a5d8)