### PR TITLE
Refactor score direction handling

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationService.java
@@ -9,6 +9,7 @@ import org.open4goods.model.exceptions.ValidationException;
 import org.open4goods.model.product.Product;
 import org.open4goods.model.product.Score;
 import org.open4goods.model.rating.Cardinality;
+import org.open4goods.model.vertical.AttributeComparisonRule;
 import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.AttributesConfig;
 import org.open4goods.model.vertical.VerticalConfig;
@@ -118,7 +119,11 @@ public class Attribute2ScoreAggregationService extends AbstractScoreAggregationS
 		/////////////////////////////////////////////////
 
 		// Selecting the scores to reverse
-		List<String> scoresToReverse = vConf.getAttributesConfig().getConfigs().stream().filter(e -> e.isReverseScore()).map(e -> e.getKey()).toList();
+                List<String> scoresToReverse = vConf.getAttributesConfig().getConfigs().stream()
+                                .filter(AttributeConfig::isAsScore)
+                                .filter(config -> AttributeComparisonRule.LOWER.equals(config.getBetterIs()))
+                                .map(AttributeConfig::getKey)
+                                .toList();
 
 		// For each score to reverse
 		for (String key : scoresToReverse) {

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/batch/scores/Attribute2ScoreAggregationServiceTest.java
@@ -13,6 +13,7 @@ import org.open4goods.model.attribute.AttributeType;
 import org.open4goods.model.attribute.IndexedAttribute;
 import org.open4goods.model.product.Product;
 import org.open4goods.model.product.Score;
+import org.open4goods.model.vertical.AttributeComparisonRule;
 import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.AttributesConfig;
 import org.open4goods.model.vertical.VerticalConfig;
@@ -31,7 +32,7 @@ class Attribute2ScoreAggregationServiceTest {
     }
 
     @Test
-    void reverseScoresUseRecomputedCardinality() {
+    void lowerScoresUseRecomputedCardinality() {
         VerticalConfig verticalConfig = buildVerticalConfig(true);
 
         Product better = productWithAttribute(1L, "REPAIR", "4.0");
@@ -71,7 +72,7 @@ class Attribute2ScoreAggregationServiceTest {
     }
 
     @Test
-    void reverseScoresUseCanonicalKeyForSynonyms() {
+    void lowerScoresUseCanonicalKeyForSynonyms() {
         String canonicalKey = "POWER_CONSUMPTION_TYPICAL";
         String synonymKey = "CONSO_PLEINE_PUISSANCE";
         VerticalConfig verticalConfig = buildVerticalConfig(canonicalKey, synonymKey, true);
@@ -103,15 +104,15 @@ class Attribute2ScoreAggregationServiceTest {
         return product;
     }
 
-    private static VerticalConfig buildVerticalConfig(boolean reverse) {
-        return buildVerticalConfig("REPAIR", null, reverse);
+    private static VerticalConfig buildVerticalConfig(boolean lowerIsBetter) {
+        return buildVerticalConfig("REPAIR", null, lowerIsBetter);
     }
 
-    private static VerticalConfig buildVerticalConfig(String key, String synonym, boolean reverse) {
+    private static VerticalConfig buildVerticalConfig(String key, String synonym, boolean lowerIsBetter) {
         AttributeConfig attributeConfig = new AttributeConfig();
         attributeConfig.setKey(key);
         attributeConfig.setAsScore(true);
-        attributeConfig.setReverseScore(reverse);
+        attributeConfig.setBetterIs(lowerIsBetter ? AttributeComparisonRule.LOWER : AttributeComparisonRule.GREATER);
         attributeConfig.setFilteringType(AttributeType.NUMERIC);
         if (synonym != null) {
             Map<String, Set<String>> synonyms = new HashMap<>();

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/AttributeConfigDto.java
@@ -30,8 +30,6 @@ public record AttributeConfigDto(
         Set<String> icecatFeaturesIds,
         @Schema(description = "Indicates whether this attribute is exposed as a score.")
         boolean asScore,
-        @Schema(description = "Indicates whether lower values should yield higher scores.")
-        boolean reverseScore,
         @Schema(description = "Comparison rule applied to determine which values are considered better.")
         AttributeComparisonRule betterIs,
         @Schema(description = "Ordering applied when displaying attribute values.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -440,7 +440,6 @@ public class CategoryMappingService {
                 attributeConfig.getFilteringType(),
                 defaultSet(attributeConfig.getIcecatFeaturesIds()),
                 attributeConfig.isAsScore(),
-                attributeConfig.isReverseScore(),
                 attributeConfig.getBetterIs(),
                 attributeConfig.getAttributeValuesOrdering(),
                 attributeConfig.getAttributeValuesReverseOrder(),

--- a/frontend/shared/api-client/models/AttributeConfigDto.ts
+++ b/frontend/shared/api-client/models/AttributeConfigDto.ts
@@ -76,12 +76,6 @@ export interface AttributeConfigDto {
      */
     asScore?: boolean;
     /**
-     * Indicates whether lower values should yield higher scores.
-     * @type {boolean}
-     * @memberof AttributeConfigDto
-     */
-    reverseScore?: boolean;
-    /**
      * Comparison rule applied to determine which values are considered better.
      * @type {string}
      * @memberof AttributeConfigDto
@@ -181,7 +175,6 @@ export function AttributeConfigDtoFromJSONTyped(json: any, ignoreDiscriminator: 
         'filteringType': json['filteringType'] == null ? undefined : json['filteringType'],
         'icecatFeaturesIds': json['icecatFeaturesIds'] == null ? undefined : new Set(json['icecatFeaturesIds']),
         'asScore': json['asScore'] == null ? undefined : json['asScore'],
-        'reverseScore': json['reverseScore'] == null ? undefined : json['reverseScore'],
         'betterIs': json['betterIs'] == null ? undefined : json['betterIs'],
         'attributeValuesOrdering': json['attributeValuesOrdering'] == null ? undefined : json['attributeValuesOrdering'],
         'attributeValuesReverseOrder': json['attributeValuesReverseOrder'] == null ? undefined : json['attributeValuesReverseOrder'],
@@ -211,7 +204,6 @@ export function AttributeConfigDtoToJSONTyped(value?: AttributeConfigDto | null,
         'filteringType': value['filteringType'],
         'icecatFeaturesIds': value['icecatFeaturesIds'] == null ? undefined : Array.from(value['icecatFeaturesIds'] as Set<any>),
         'asScore': value['asScore'],
-        'reverseScore': value['reverseScore'],
         'betterIs': value['betterIs'],
         'attributeValuesOrdering': value['attributeValuesOrdering'],
         'attributeValuesReverseOrder': value['attributeValuesReverseOrder'],

--- a/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/AttributeConfig.java
@@ -83,11 +83,6 @@ public class AttributeConfig {
 	private boolean asScore = false;
 
         /**
-         * If true, attribute value to score will be reversed (ie : for weight, the better score is the lowest weight)
-         */
-        private boolean reverseScore = false;
-
-        /**
          * Indicates which comparison rule should be applied to determine the most
          * desirable value when comparing products.
          */
@@ -370,14 +365,6 @@ public class AttributeConfig {
 	public void setIcecatFeaturesIds(Set<String> icecatFeaturesIds) {
 		this.icecatFeaturesIds = icecatFeaturesIds;
 	}
-
-        public boolean isReverseScore() {
-                return reverseScore;
-        }
-
-        public void setReverseScore(boolean reverseScore) {
-                this.reverseScore = reverseScore;
-        }
 
         /**
          * Gets the comparison rule describing which values are considered better for

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -693,8 +693,7 @@ attributesConfig:
       fr: "kg"
     filteringType: "NUMERIC"
     asScore: true
-    reverseScore: true
-    
+
     synonyms:
       all:
       - "POIDS"
@@ -733,7 +732,6 @@ attributesConfig:
     betterIs: "LOWER"
     filteringType: "NUMERIC"
     asScore: true
-    reverseScore: true    
     faIcon: "mdi-power-plug"
   
     icecatFeaturesIds:      
@@ -773,7 +771,6 @@ attributesConfig:
     betterIs: "LOWER"
     filteringType: "NUMERIC"
     asScore: true
-    reverseScore: true    
     faIcon: "mdi-power-plug-off"
   
     icecatFeaturesIds:      

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -545,14 +545,13 @@ attributesConfig:
        betterIs: "LOWER"
        filteringType: "NUMERIC"
        asScore: true
-       reverseScore: true    
        faIcon: "mdi-power-plug-off"
      
 
          
        name:
-            default: "Power consumption (off)"
-            fr: "Consommation électrique (arrêt/veille)"
+             default: "Power consumption (standby networked)"
+             fr: "Consommation électrique (arrêt/veille/réseau)"
          
        synonyms:
             all:
@@ -584,14 +583,13 @@ attributesConfig:
        betterIs: "LOWER"
        filteringType: "NUMERIC"
        asScore: true
-       reverseScore: true    
        faIcon: "mdi-power-plug-off"
      
 
          
        name:
-            default: "Power consumption (SDR)"
-            fr: "Consommation électrique (Basse définition)"
+             default: "Power consumption (SDR)"
+             fr: "Consommation électrique (basse définition)"
          
        synonyms:
             all:
@@ -622,14 +620,13 @@ attributesConfig:
        betterIs: "LOWER"
        filteringType: "NUMERIC"
        asScore: true
-       reverseScore: true    
        faIcon: "mdi-power-plug-off"
      
 
          
        name:
-            default: "Power consumption (HDR)"
-            fr: "Consommation électrique (Hauté définition)"
+             default: "Power consumption (HDR)"
+             fr: "Consommation électrique (haute définition)"
          
        synonyms:
             all:


### PR DESCRIPTION
## Summary
- remove the reverseScore flag across the model, DTOs, and YAML definitions in favour of the betterIs comparison rule
- update score aggregation logic and tests to treat LOWER comparison rules as reversed scales
- tidy power consumption attribute labels in the vertical configurations

## Testing
- `mvn --offline -pl api -am -Dtest=Attribute2ScoreAggregationServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692745a9cc708333a2306e9bf890c54e)