### PR TITLE
Add cache sizing configuration and metrics

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/CacheConfig.java
@@ -3,19 +3,20 @@ package org.open4goods.nudgerfrontapi.config;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.nudgerfrontapi.config.properties.CacheProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.cache.Cache;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 /**
  * Cache configuration backed by a bounded {@link Caffeine} cache to avoid
@@ -28,23 +29,67 @@ public class CacheConfig {
 
 
 
-	@Bean
-	CacheManager cacheManager(@Autowired final Ticker ticker) {
-		final CaffeineCache fCache = buildExpiryCache(CacheConstants.FOREVER_LOCAL_CACHE_NAME, ticker, 30000000);
-		final CaffeineCache hCache = buildExpiryCache(CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, ticker, 60);
-		final CaffeineCache mCache = buildExpiryCache(CacheConstants.ONE_MINUTE_LOCAL_CACHE_NAME, ticker, 1);
-		final CaffeineCache dCache = buildExpiryCache(CacheConstants.ONE_DAY_LOCAL_CACHE_NAME, ticker, 60 * 24);
-		final SimpleCacheManager manager = new SimpleCacheManager();
-		manager.setCaches(Arrays.asList(fCache, dCache, hCache, mCache));
-		return manager;
-	}
+    /**
+     * Builds the cache manager with bounded Caffeine caches configured from properties.
+     *
+     * @param ticker          ticker used for cache eviction timing
+     * @param cacheProperties cache sizing and TTL configuration
+     * @return configured cache manager
+     */
+    @Bean
+    CacheManager cacheManager(@Autowired final Ticker ticker, @Autowired final CacheProperties cacheProperties) {
+        final CaffeineCache foreverCache = buildCache(CacheConstants.FOREVER_LOCAL_CACHE_NAME, ticker, cacheProperties.getForeverMaximumSize(), null);
+        final CaffeineCache hourCache = buildCache(CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, ticker, cacheProperties.getOneHourMaximumSize(), cacheProperties.getOneHourTtl());
+        final CaffeineCache minuteCache = buildCache(CacheConstants.ONE_MINUTE_LOCAL_CACHE_NAME, ticker, cacheProperties.getOneMinuteMaximumSize(), cacheProperties.getOneMinuteTtl());
+        final CaffeineCache dayCache = buildCache(CacheConstants.ONE_DAY_LOCAL_CACHE_NAME, ticker, cacheProperties.getOneDayMaximumSize(), cacheProperties.getOneDayTtl());
+        final SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(Arrays.asList(foreverCache, dayCache, hourCache, minuteCache));
+        return manager;
+    }
 
-	private CaffeineCache buildExpiryCache(final String name, final Ticker ticker, final int minutesToExpire) {
-		return new CaffeineCache(name, Caffeine.newBuilder().recordStats().expireAfterWrite(minutesToExpire, TimeUnit.MINUTES).ticker(ticker).build());
-	}
+    /**
+     * Builds a single Caffeine cache with the provided configuration.
+     *
+     * @param name        cache name
+     * @param ticker      ticker used for time-based eviction
+     * @param maximumSize maximum number of entries allowed in the cache
+     * @param ttl         expiry duration, or {@code null} to keep entries indefinitely
+     * @return configured {@link CaffeineCache}
+     */
+    private CaffeineCache buildCache(final String name, final Ticker ticker, final long maximumSize, final Duration ttl) {
+        final Caffeine<Object, Object> builder = Caffeine.newBuilder()
+                .recordStats()
+                .ticker(ticker)
+                .maximumSize(maximumSize);
+        if (ttl != null) {
+            builder.expireAfterWrite(ttl);
+        }
+        return new CaffeineCache(name, builder.build());
+    }
 
-	@Bean
-	Ticker ticker() {
-		return Ticker.systemTicker();
-	}
+    /**
+     * Exposes Micrometer metrics for all configured Caffeine caches to validate evictions under load.
+     *
+     * @param cacheManager cache manager containing the Caffeine caches
+     * @return binder registering cache metrics
+     */
+    @Bean
+    MeterBinder caffeineCacheMetricsBinder(@Autowired final CacheManager cacheManager) {
+        return registry -> cacheManager.getCacheNames().forEach(cacheName -> {
+            final Cache cache = cacheManager.getCache(cacheName);
+            if (cache instanceof CaffeineCache caffeineCache) {
+                CaffeineCacheMetrics.monitor(registry, caffeineCache.getNativeCache(), cacheName);
+            }
+        });
+    }
+
+    /**
+     * Shared ticker for all caches.
+     *
+     * @return system ticker
+     */
+    @Bean
+    Ticker ticker() {
+        return Ticker.systemTicker();
+    }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/CacheProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/CacheProperties.java
@@ -2,6 +2,8 @@ package org.open4goods.nudgerfrontapi.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 /**
  * Configuration properties for front cache settings.
  */
@@ -11,6 +13,27 @@ public class CacheProperties {
     /** Path used to store cached files. */
     private String path = "./cache";
 
+    /** Expiry applied to the ONE_MINUTE_LOCAL_CACHE_NAME cache. */
+    private Duration oneMinuteTtl = Duration.ofMinutes(1);
+
+    /** Maximum entries stored in the ONE_MINUTE_LOCAL_CACHE_NAME cache. */
+    private long oneMinuteMaximumSize = 2_000L;
+
+    /** Expiry applied to the ONE_HOUR_LOCAL_CACHE_NAME cache. */
+    private Duration oneHourTtl = Duration.ofHours(1);
+
+    /** Maximum entries stored in the ONE_HOUR_LOCAL_CACHE_NAME cache. */
+    private long oneHourMaximumSize = 5_000L;
+
+    /** Expiry applied to the ONE_DAY_LOCAL_CACHE_NAME cache. */
+    private Duration oneDayTtl = Duration.ofDays(1);
+
+    /** Maximum entries stored in the ONE_DAY_LOCAL_CACHE_NAME cache. */
+    private long oneDayMaximumSize = 10_000L;
+
+    /** Maximum entries stored in the FOREVER_LOCAL_CACHE_NAME cache. */
+    private long foreverMaximumSize = 20_000L;
+
 
 
     public String getPath() {
@@ -19,6 +42,62 @@ public class CacheProperties {
 
     public void setPath(String path) {
         this.path = path;
+    }
+
+    public Duration getOneMinuteTtl() {
+        return oneMinuteTtl;
+    }
+
+    public void setOneMinuteTtl(Duration oneMinuteTtl) {
+        this.oneMinuteTtl = oneMinuteTtl;
+    }
+
+    public long getOneMinuteMaximumSize() {
+        return oneMinuteMaximumSize;
+    }
+
+    public void setOneMinuteMaximumSize(long oneMinuteMaximumSize) {
+        this.oneMinuteMaximumSize = oneMinuteMaximumSize;
+    }
+
+    public Duration getOneHourTtl() {
+        return oneHourTtl;
+    }
+
+    public void setOneHourTtl(Duration oneHourTtl) {
+        this.oneHourTtl = oneHourTtl;
+    }
+
+    public long getOneHourMaximumSize() {
+        return oneHourMaximumSize;
+    }
+
+    public void setOneHourMaximumSize(long oneHourMaximumSize) {
+        this.oneHourMaximumSize = oneHourMaximumSize;
+    }
+
+    public Duration getOneDayTtl() {
+        return oneDayTtl;
+    }
+
+    public void setOneDayTtl(Duration oneDayTtl) {
+        this.oneDayTtl = oneDayTtl;
+    }
+
+    public long getOneDayMaximumSize() {
+        return oneDayMaximumSize;
+    }
+
+    public void setOneDayMaximumSize(long oneDayMaximumSize) {
+        this.oneDayMaximumSize = oneDayMaximumSize;
+    }
+
+    public long getForeverMaximumSize() {
+        return foreverMaximumSize;
+    }
+
+    public void setForeverMaximumSize(long foreverMaximumSize) {
+        this.foreverMaximumSize = foreverMaximumSize;
     }
 
 

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -102,6 +102,18 @@
       "defaultValue": "./cache"
     },
     {
+      "name": "front.cache.one-minute-ttl",
+      "type": "java.time.Duration",
+      "description": "Time to live applied to the ONE_MINUTE_LOCAL_CACHE_NAME cache.",
+      "defaultValue": "PT1M"
+    },
+    {
+      "name": "front.cache.one-minute-maximum-size",
+      "type": "java.lang.Long",
+      "description": "Maximum number of entries stored in the ONE_MINUTE_LOCAL_CACHE_NAME cache.",
+      "defaultValue": 2000
+    },
+    {
       "name": "front.cache.one-hour-ttl",
       "type": "java.time.Duration",
       "description": "Time to live applied to the ONE_HOUR_LOCAL_CACHE_NAME cache.",
@@ -112,6 +124,24 @@
       "type": "java.lang.Long",
       "description": "Maximum number of entries stored in the ONE_HOUR_LOCAL_CACHE_NAME cache.",
       "defaultValue": 5000
+    },
+    {
+      "name": "front.cache.one-day-ttl",
+      "type": "java.time.Duration",
+      "description": "Time to live applied to the ONE_DAY_LOCAL_CACHE_NAME cache.",
+      "defaultValue": "PT24H"
+    },
+    {
+      "name": "front.cache.one-day-maximum-size",
+      "type": "java.lang.Long",
+      "description": "Maximum number of entries stored in the ONE_DAY_LOCAL_CACHE_NAME cache.",
+      "defaultValue": 10000
+    },
+    {
+      "name": "front.cache.forever-maximum-size",
+      "type": "java.lang.Long",
+      "description": "Maximum number of entries stored in the FOREVER_LOCAL_CACHE_NAME cache.",
+      "defaultValue": 20000
     },
     {
       "name": "front.rate-limit.anonymous",

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -22,8 +22,13 @@ front:
   max-page-size: 50
   cache:
     path: ./cache
+    one-minute-ttl: 1m
+    one-minute-maximum-size: 2000
     one-hour-ttl: 60m
     one-hour-maximum-size: 5000
+    one-day-ttl: 24h
+    one-day-maximum-size: 10000
+    forever-maximum-size: 20000
   contact:
     email: ${FRONT_CONTACT_EMAIL}
   security:


### PR DESCRIPTION
## Summary
- add configurable TTL and maximum sizes for Caffeine caches and document defaults
- expose Micrometer metrics for all caches to verify eviction behaviour
- update Spring configuration metadata and sample application settings

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692748f039d883338b7d00c921708d52)