### PR TITLE
Make attribute best value election deterministic

### DIFF
--- a/model/src/main/java/org/open4goods/model/attribute/ProductAttribute.java
+++ b/model/src/main/java/org/open4goods/model/attribute/ProductAttribute.java
@@ -46,19 +46,21 @@ public class ProductAttribute extends SourcableAttribute implements IAttribute {
 		return false;
 	}
 
-	/**
-	 * Add a "matched" attribute, with dynamic type detection
-	 * 
-	 * @param parsed Should handle language ?
-	 */
-	public void addSourceAttribute(SourcedAttribute attr)
-			throws NumberFormatException {
+        /**
+         * Add a "matched" attribute, with dynamic type detection
+         *
+         * @param parsed Should handle language ?
+         */
+        public void addSourceAttribute(SourcedAttribute attr)
+                        throws NumberFormatException {
 
-		// Guard
-		if (this.name != null && !name.equals(this.name)) {
-			// TODO
-			System.out.println("ERROR : Name mismatch in add attribute");
-		}
+                // Guard
+                if (this.name == null) {
+                        this.name = attr.getName();
+                } else if (attr.getName() != null && !attr.getName().equals(this.name)) {
+                        throw new IllegalArgumentException(
+                                        "Attribute name mismatch : expected " + this.name + " but received " + attr.getName());
+                }
 
 		source.remove(attr);
 		source.add(attr);

--- a/model/src/test/java/org/open4goods/model/attribute/SourcableAttributeTest.java
+++ b/model/src/test/java/org/open4goods/model/attribute/SourcableAttributeTest.java
@@ -1,0 +1,74 @@
+package org.open4goods.model.attribute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class SourcableAttributeTest {
+
+        @AfterEach
+        void resetTrustedSources() {
+                SourcableAttribute.resetTrustedSourcePriority();
+        }
+
+        @Test
+        void selectsTrustedSourceBeforeHigherVoteCount() {
+                SourcableAttribute.setTrustedSourcePriority(List.of("priority-source", "secondary"));
+
+                ProductAttribute attribute = buildAttribute("COLOR",
+                                sourced("COLOR", "Blue", "other"),
+                                sourced("COLOR", "Blue", "another"),
+                                sourced("COLOR", "Crimson", "priority-source"));
+
+                assertThat(attribute.getValue()).isEqualTo("Crimson");
+        }
+
+        @Test
+        void normalizesValuesBeforeCounting() {
+                ProductAttribute attribute = buildAttribute("COLOR",
+                                sourced("COLOR", "Noir", "sourceA"),
+                                sourced("COLOR", "  noir  ", "sourceB"));
+
+                assertThat(attribute.getValue()).isEqualTo("Noir");
+        }
+
+        @Test
+        void resolvesTiesLexicographically() {
+                ProductAttribute attribute = buildAttribute("TYPE",
+                                sourced("TYPE", "Beta", "sourceA"),
+                                sourced("TYPE", "Alpha", "sourceB"));
+
+                assertThat(attribute.getValue()).isEqualTo("Alpha");
+        }
+
+        @Test
+        void rejectsMismatchedAttributeNames() {
+                ProductAttribute attribute = new ProductAttribute();
+                attribute.setName("COLOR");
+
+                assertThatThrownBy(() -> attribute.addSourceAttribute(sourced("MODEL", "123", "sourceA")))
+                                .isInstanceOf(IllegalArgumentException.class)
+                                .hasMessageContaining("expected COLOR");
+        }
+
+        private ProductAttribute buildAttribute(String name, SourcedAttribute... sourcedAttributes) {
+                ProductAttribute attribute = new ProductAttribute();
+                attribute.setName(name);
+                for (SourcedAttribute sourcedAttribute : sourcedAttributes) {
+                        attribute.addSourceAttribute(sourcedAttribute);
+                }
+                return attribute;
+        }
+
+        private SourcedAttribute sourced(String name, String value, String datasource) {
+                SourcedAttribute attribute = new SourcedAttribute();
+                attribute.setName(name);
+                attribute.setValue(value);
+                attribute.setDataSourcename(datasource);
+                return attribute;
+        }
+}


### PR DESCRIPTION
## Summary
- normalize and deterministically elect attribute values using configurable trusted source priority and stable tie-breakers
- validate incoming source attributes against the expected attribute name
- add unit tests covering priority, normalization, lexical tie-breaks, and name validation

## Testing
- mvn -pl model -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692961ab34b88333afe8a2cee4eab425)