### PR TITLE
Render HTML in opendata hero subtitle

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -45,7 +45,8 @@ const handlePrimaryClick = (event: MouseEvent) => {
           <div class="opendata-hero__header">
             <span v-if="eyebrow" class="opendata-hero__eyebrow" role="text">{{ eyebrow }}</span>
             <h1 id="opendata-hero-heading" class="opendata-hero__title">{{ title }}</h1>
-            <p class="opendata-hero__subtitle">{{ subtitle }}</p>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <p class="opendata-hero__subtitle" v-html="subtitle" />
           </div>
 
 


### PR DESCRIPTION
## Summary
- render the Open Data hero subtitle using v-html so HTML markup from translations is displayed

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69297f5b06648333a3e14ed78b25737d)