### PR TITLE
Improve impact subscore guidance

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -26,6 +26,7 @@ describe('ProductImpactSubscoreGenericCard', () => {
             percentile: 'Percentile',
             weightChip: 'Counts for {value}% of the total score',
             subscoreDetailsToggle: 'View indicator details',
+            importanceTitle: 'Why it matters',
             tableHeaders: {
               ranking: 'Rank',
             },
@@ -34,20 +35,36 @@ describe('ProductImpactSubscoreGenericCard', () => {
                 ranking: 'Rank {ranking} out of {count}.',
                 readIndicator: {
                   title: 'How to read this indicator',
-                  worst: 'Worst indicator is {worst}.',
-                  best: 'Best indicator is {best} across {count} {verticalTitle}.',
-                  average: 'Average is {average}, equivalent to {averageOn20}/20.',
-                  product: '{productName} scores {productOn20}/20.',
+                  higher: {
+                    worst: 'Worst indicator is {worst}.',
+                    best: 'Best indicator is {best} across {count} {verticalTitle}.',
+                    average: 'Average is {average}, equivalent to {averageOn20}/20.',
+                    product: '{productName} scores {productOn20}/20.',
+                  },
+                  lower: {
+                    worst: 'Highest indicator is {worst}.',
+                    best: 'Lowest indicator is {best} across {count} {verticalTitle}.',
+                    average: 'Average is {average}, equivalent to {averageOn20}/20.',
+                    product: '{productName} scores {productOn20}/20.',
+                  },
                 },
               },
               repairability_index: {
                 ranking: 'Rank {ranking} out of {count}.',
                 readIndicator: {
                   title: 'Repairability indicator guidance',
-                  worst: 'Worst repairability indicator is {worst}.',
-                  best: 'Best repairability indicator is {best} across {count} {verticalTitle}.',
-                  average: 'Average repairability is {average}, equivalent to {averageOn20}/20.',
-                  product: '{productName} repairability is {productOn20}/20.',
+                  higher: {
+                    worst: 'Worst repairability indicator is {worst}.',
+                    best: 'Best repairability indicator is {best} across {count} {verticalTitle}.',
+                    average: 'Average repairability is {average}, equivalent to {averageOn20}/20.',
+                    product: '{productName} repairability is {productOn20}/20.',
+                  },
+                  lower: {
+                    worst: 'Highest repairability indicator is {worst}.',
+                    best: 'Lowest repairability indicator is {best} across {count} {verticalTitle}.',
+                    average: 'Average repairability is {average}, equivalent to {averageOn20}/20.',
+                    product: '{productName} repairability is {productOn20}/20.',
+                  },
                 },
               },
             },

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -6,17 +6,23 @@
     />
 
     <div class="impact-subscore__value">
-      <slot
-        name="visual"
-        :score="score"
-        :absolute-value="absoluteValue"
-        :relative-value="relativeScore"
-        :product-absolute-value="productAbsoluteValue"
-      >
-        <div class="impact-subscore__value-default">
-          <span class="impact-subscore__value-number">{{ absoluteValue ?? '—' }}</span>
-        </div>
-      </slot>
+      <div class="impact-subscore__value-primary">
+        <slot
+          name="visual"
+          :score="score"
+          :absolute-value="absoluteValue"
+          :relative-value="relativeScore"
+          :product-absolute-value="productAbsoluteValue"
+          :unit="absoluteUnit"
+        >
+          <div class="impact-subscore__value-default">
+            <span class="impact-subscore__value-number">
+              {{ absoluteValue ?? '—' }}
+              <span v-if="absoluteUnit" class="impact-subscore__value-unit">{{ absoluteUnit }}</span>
+            </span>
+          </div>
+        </slot>
+      </div>
 
       <ImpactCoefficientBadge
         v-if="coefficientValue != null"
@@ -49,6 +55,7 @@
             :product-brand="productBrand"
             :product-model="productModel"
             :vertical-title="verticalTitle"
+            :importance-description="importanceDescription"
           />
         </v-expansion-panel-text>
       </v-expansion-panel>
@@ -91,6 +98,8 @@ const absoluteValue = computed(() => {
   return String(value)
 })
 
+const absoluteUnit = computed(() => props.score.unit?.toString().trim() || null)
+
 const hasDistribution = computed(() => Boolean(props.score.distribution?.length))
 const hasMetadata = computed(() =>
   Object.values(props.score.metadatas ?? {})
@@ -110,8 +119,11 @@ const hasRanking = computed(() => {
 
 const hasDetails = computed(() => {
   const hasDescription = typeof props.score.description === 'string' && props.score.description.trim().length > 0
-  return hasDescription || Boolean(absoluteValue.value) || hasRanking.value || hasMetadata.value
+  return hasDescription || Boolean(absoluteValue.value) || hasRanking.value || hasMetadata.value || hasImportance.value
 })
+
+const importanceDescription = computed(() => props.score.importanceDescription?.toString().trim() || '')
+const hasImportance = computed(() => importanceDescription.value.length > 0)
 
 const productAbsoluteValue = computed(() => {
   const absoluteValue = props.score.absolute?.value
@@ -165,15 +177,22 @@ const coefficientValue = computed(() => {
 
 .impact-subscore__value {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.impact-subscore__value-primary {
+  display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 0.75rem 1rem;
+  align-items: baseline;
+  gap: 0.5rem 0.75rem;
 }
 
 .impact-subscore__value-default {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
 .impact-subscore__value-number {
@@ -181,6 +200,15 @@ const coefficientValue = computed(() => {
   font-weight: 700;
   line-height: 1.1;
   color: rgb(var(--v-theme-text-neutral-strong));
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.impact-subscore__value-unit {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
 }
 
 .impact-subscore__coefficient {

--- a/frontend/app/components/product/impact/impact-types.ts
+++ b/frontend/app/components/product/impact/impact-types.ts
@@ -27,6 +27,9 @@ export type ScoreView = {
   distribution?: DistributionBucket[]
   energyLetter?: string | null
   metadatas?: Record<string, string> | null
+  unit?: string | null
+  betterIs?: 'GREATER' | 'LOWER' | null
+  importanceDescription?: string | null
 }
 
 export type RankingInfo = {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1831,25 +1831,42 @@
       "weightTooltip": "The {scoreName} score counts for {value}% of the total score",
       "subscoreDetailsToggle": "View indicator details",
       "subscoreEyebrow": "Impact indicator",
+      "importanceTitle": "Why it matters",
       "subscores": {
         "default": {
           "ranking": "Rank {ranking} out of {count}.",
           "readIndicator": {
             "title": "How to read this indicator",
-            "worst": "The lowest {scoreLabelLower} recorded is {worst}, which corresponds to a 0/20 score.",
-            "best": "The highest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}, worth 20/20.",
-            "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}, equivalent to {averageOn20}/20.",
-            "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}, which converts to {productOn20}/20."
+            "higher": {
+              "worst": "The lowest {scoreLabelLower} recorded is {worst}, which corresponds to a 0/20 score.",
+              "best": "The highest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}, worth 20/20.",
+              "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}, equivalent to {averageOn20}/20.",
+              "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}, which converts to {productOn20}/20."
+            },
+            "lower": {
+              "worst": "The highest {scoreLabelLower} recorded is {worst}, which corresponds to a 0/20 score.",
+              "best": "The lowest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}, worth 20/20.",
+              "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}, equivalent to {averageOn20}/20.",
+              "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}, which converts to {productOn20}/20."
+            }
           }
         },
         "repairability_index": {
           "ranking": "Rank {ranking} out of {count}.",
           "readIndicator": {
             "title": "How to read this repairability indicator",
-            "worst": "The worst repairability index observed is {worst}, which yields a 0/20 score.",
-            "best": "The best repairability index among the {count} {verticalTitle} reaches {best}, worth 20/20.",
-            "average": "On average, the {count} {verticalTitle} with available data score {average}, i.e. {averageOn20}/20.",
-            "product": "{productName}, with a repairability index of {productAbsolute}, earns {productOn20}/20."
+            "higher": {
+              "worst": "The worst repairability index observed is {worst}, which yields a 0/20 score.",
+              "best": "The best repairability index among the {count} {verticalTitle} reaches {best}, worth 20/20.",
+              "average": "On average, the {count} {verticalTitle} with available data score {average}, i.e. {averageOn20}/20.",
+              "product": "{productName}, with a repairability index of {productAbsolute}, earns {productOn20}/20."
+            },
+            "lower": {
+              "worst": "The highest repairability index recorded is {worst}, which yields a 0/20 score.",
+              "best": "The lowest repairability index among the {count} {verticalTitle} reaches {best}, worth 20/20.",
+              "average": "On average, the {count} {verticalTitle} with available data score {average}, i.e. {averageOn20}/20.",
+              "product": "{productName}, with a repairability index of {productAbsolute}, earns {productOn20}/20."
+            }
           }
         }
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1831,25 +1831,42 @@
       "weightTooltip": "Le score {scoreName} compte pour {value}% de la note totale",
       "subscoreDetailsToggle": "Voir les détails de l'indicateur",
       "subscoreEyebrow": "Indicateur d'impact",
+      "importanceTitle": "Pourquoi c'est important ?",
       "subscores": {
         "default": {
           "ranking": "Classe {ranking} sur {count}.",
           "readIndicator": {
             "title": "Comment lire cet indicateur",
-            "worst": "Le plus faible {scoreLabelLower} observé est de {worst}, soit une note de 0/20.",
-            "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
-            "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
-            "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
+            "higher": {
+              "worst": "Le plus faible {scoreLabelLower} observé est de {worst}, soit une note de 0/20.",
+              "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
+              "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
+            },
+            "lower": {
+              "worst": "Le {scoreLabelLower} le plus élevé observé est de {worst}, ce qui vaut la note de 0/20.",
+              "best": "Le {scoreLabelLower} le plus faible constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
+              "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
+            }
           }
         },
         "repairability_index": {
           "ranking": "Classe {ranking} sur {count}.",
           "readIndicator": {
             "title": "Comment lire cet indicateur de réparabilité",
-            "worst": "Le pire indice de réparabilité est {worst}, ce qui vaut la note de 0/20.",
-            "best": "Le meilleur indice de réparabilité rencontré pour les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
-            "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
-            "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
+            "higher": {
+              "worst": "Le pire indice de réparabilité est {worst}, ce qui vaut la note de 0/20.",
+              "best": "Le meilleur indice de réparabilité rencontré pour les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
+              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
+              "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
+            },
+            "lower": {
+              "worst": "L'indice de réparabilité le plus élevé observé est {worst}, ce qui vaut la note de 0/20.",
+              "best": "L'indice de réparabilité le plus bas constaté parmi les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
+              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
+              "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary
- display subscore absolute values with their units and stack coefficients beneath the primary value
- propagate vertical criteria metadata to subscores and show a localized "Pourquoi c'est important ?" panel
- honor attribute better-is rules in guidance copy, scaling, and translations for indicator explanations

## Testing
- CI=true pnpm vitest run --passWithNoTests --silent app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b97fba7c8333b8fd5621c0cba46c)