### PR TITLE
Handle AI review insufficient data states

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/ReviewGenerationClientException.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/exception/ReviewGenerationClientException.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.service.exception;
+
+import org.springframework.http.HttpStatusCode;
+
+/**
+ * Exception raised when the back-office review generation endpoints cannot be reached
+ * or return an error payload.
+ */
+public class ReviewGenerationClientException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
+
+    public ReviewGenerationClientException(String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = null;
+    }
+
+    public ReviewGenerationClientException(String message, HttpStatusCode statusCode, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1621,7 +1621,8 @@
       "empty": "Summary not requested yet.",
       "errors": {
         "captcha": "Please validate the captcha before continuing.",
-        "generic": "An error occurred while generating the summary."
+        "generic": "An error occurred while generating the summary.",
+        "notEnoughData": "Not enough reliable data was found to generate a summary."
       },
       "generatedAt": "Summary generated on {date}",
       "requestButton": "Request the summary",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1621,7 +1621,8 @@
       "empty": "Synthèse non encore demandée.",
       "errors": {
         "captcha": "Merci de valider le captcha avant de continuer.",
-        "generic": "Une erreur est survenue lors de la génération."
+        "generic": "Une erreur est survenue lors de la génération.",
+        "notEnoughData": "Pas assez de données fiables pour générer une synthèse."
       },
       "generatedAt": "Synthèse générée le {date}",
       "requestButton": "Demander la synthèse",

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationService.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationService.java
@@ -442,8 +442,13 @@ public class ReviewGenerationService implements HealthIndicator {
                 status.setStatus(ReviewGenerationStatus.Status.SUCCESS);
                 meterRegistry.counter("review.generation.success").increment();
             } catch (NotEnoughDataException e) {
-            	logger.warn("Not enought data for generating ai review for {}",product);
-            	holder.setEnoughData(false);
+                logger.warn("Not enought data for generating ai review for {}", product);
+                holder.setEnoughData(false);
+                status.setResult(holder);
+                status.setStatus(ReviewGenerationStatus.Status.FAILED);
+                status.setErrorMessage("Not enough data to generate an AI review for this product.");
+                meterRegistry.counter("review.generation.failed").increment();
+                lastGenerationFailed = true;
             } catch (Exception e) {
                 logger.error("Asynchronous review generation failed for UPC {}: {}", upc, e.getMessage(), e);
                 status.setStatus(ReviewGenerationStatus.Status.FAILED);


### PR DESCRIPTION
## Summary
- surface not-enough-data outcomes as failed review generation in the backend and expose errors to the front API
- harden front API client and controller to propagate review status failures instead of returning null
- stop frontend polling when generation ends without content and show a localized insufficient-data message

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929bfdccc888333a7a18a103da9ad7d)