### PR TITLE
Handle EPREL brand filtering

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
@@ -64,10 +64,14 @@ public class AttributeRealtimeAggregationService extends AbstractAggregationServ
 		// take in account modifications of configurable brandAlias() and brandExclusions()
 		/////////////////////////////////////////////////
 
-		if (null != data.getEprelDatas()) {
-			String supplier = data.getEprelDatas().getSupplierOrTrademark();
-			data.getAttributes().getReferentielAttributes().put(ReferentielKey.BRAND, supplier);
-			data.addBrand("eprel", supplier, null, null);
+                if (null != data.getEprelDatas()) {
+                        String supplier = data.getEprelDatas().getSupplierOrTrademark();
+                        String cleanedBrand = data.addBrand("eprel", supplier, vConf.getBrandsExclusion(), vConf.getBrandsAlias());
+                        if (!StringUtils.isEmpty(cleanedBrand)) {
+                                data.getAttributes().getReferentielAttributes().put(ReferentielKey.BRAND, cleanedBrand);
+                        } else {
+                                data.getAttributes().getReferentielAttributes().remove(ReferentielKey.BRAND);
+                        }
 
 			String model = data.getEprelDatas().getModelIdentifier();
 			data.getAttributes().getReferentielAttributes().put(ReferentielKey.MODEL, model);

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
@@ -1,0 +1,46 @@
+package org.open4goods.api.services.aggregation.services.realtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.brand.service.BrandService;
+import org.open4goods.commons.exceptions.AggregationSkipException;
+import org.open4goods.icecat.services.IcecatService;
+import org.open4goods.model.eprel.EprelProduct;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.Logger;
+
+class AttributeRealtimeAggregationServiceTest {
+
+    @Test
+    void onProductFiltersEprelBrandUsingExclusions() throws AggregationSkipException {
+        VerticalsConfigService verticalConfigService = Mockito.mock(VerticalsConfigService.class);
+        BrandService brandService = Mockito.mock(BrandService.class);
+        IcecatService icecatService = Mockito.mock(IcecatService.class);
+        Logger logger = Mockito.mock(Logger.class);
+
+        AttributeRealtimeAggregationService service = new AttributeRealtimeAggregationService(verticalConfigService, brandService, logger, icecatService);
+
+        VerticalConfig verticalConfig = new VerticalConfig();
+        verticalConfig.setAttributesConfig(new AttributesConfig());
+        verticalConfig.getBrandsExclusion().add("BANNED BRAND");
+
+        Product product = new Product(123L);
+        EprelProduct eprelProduct = new EprelProduct();
+        eprelProduct.setSupplierOrTrademark("Banned Brand");
+        eprelProduct.setModelIdentifier("ModelX123");
+        product.setEprelDatas(eprelProduct);
+
+        service.onProduct(product, verticalConfig);
+
+        assertThat(product.brand()).isNull();
+        assertThat(product.getAkaBrands()).isEmpty();
+        assertThat(product.isExcluded()).isTrue();
+        assertThat(product.getExcludedCauses()).contains("missing_brand");
+        assertThat(product.model()).isEqualTo("ModelX123");
+    }
+}

--- a/model/src/main/java/org/open4goods/model/product/Product.java
+++ b/model/src/main/java/org/open4goods/model/product/Product.java
@@ -716,37 +716,39 @@ public class Product implements Standardisable {
 	 * Add the brand referentiel attribute, applying some sanitisation mechanism
 	 * @param value
 	 */
-	public void addBrand(String datasource, String value, Set<String> brandExclusions, Map<String,String> brandsMappings) {
+        public String addBrand(String datasource, String value, Set<String> brandExclusions, Map<String,String> brandsMappings) {
 
-		if (StringUtils.isEmpty(value)) {
-			return;
-		}
+                if (StringUtils.isEmpty(value)) {
+                        return null;
+                }
 
-		String brand = StringUtils.stripAccents(StringUtils.normalizeSpace(value)).toUpperCase();
+                String brand = StringUtils.stripAccents(StringUtils.normalizeSpace(value)).toUpperCase();
 
-		if (null != brandExclusions && brandExclusions.contains(brand)) {
-			logger.info("Excluding brand {}", brand);
-			return;
-		}
+                if (null != brandExclusions && brandExclusions.contains(brand)) {
+                        logger.info("Excluding brand {}", brand);
+                        return null;
+                }
 
-		if (null != brandsMappings) {
-			String replacement = brandsMappings.get(brand);
-			if (null != replacement) {
-				brand = replacement;
-				logger.info("replacing brand {} with {}", brand, replacement);
-			}
-		}
+                if (null != brandsMappings) {
+                        String replacement = brandsMappings.get(brand);
+                        if (null != replacement) {
+                                logger.info("replacing brand {} with {}", brand, replacement);
+                                brand = replacement;
+                        }
+                }
 
 
-		if (StringUtils.isEmpty(brand()) ) {
-			attributes.addReferentielAttribute(ReferentielKey.BRAND, brand);
-		} else {
-			if (!akaBrands.values().contains(brand)) {
-				akaBrands.put(datasource, brand);
-			}
+                if (StringUtils.isEmpty(brand()) ) {
+                        attributes.addReferentielAttribute(ReferentielKey.BRAND, brand);
+                } else {
+                        if (!akaBrands.values().contains(brand)) {
+                                akaBrands.put(datasource, brand);
+                        }
 
-		}
-	}
+                }
+
+                return brand;
+        }
 
 	/**
 	 *


### PR DESCRIPTION
## Summary
- apply vertical brand exclusions and aliases to EPREL supplier brands and persist the cleaned value
- return the normalized brand from `Product.addBrand` to keep referential and alias brands in sync
- add a unit test covering EPREL products with excluded brands to ensure filtered brands are not retained

## Testing
- mvn --offline -pl api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9031f7f48333bfd920fa23836fdd)