### PR TITLE
Add caching to front API content and catalog endpoints

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.open4goods.model.RolesConstants;
+import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.model.product.Product;
 import org.open4goods.model.vertical.ProductCategory;
 import org.open4goods.model.vertical.VerticalConfig;
@@ -32,6 +33,7 @@ import org.open4goods.services.blog.model.BlogPost;
 import org.open4goods.services.blog.service.BlogService;
 import org.open4goods.verticals.GoogleTaxonomyService;
 import org.open4goods.verticals.VerticalsConfigService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
@@ -111,6 +113,7 @@ public class CategoriesController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<List<VerticalConfigDto>> categories(
             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
             @RequestParam(name = "onlyEnabled", defaultValue = "true") boolean onlyEnabled) {
@@ -145,6 +148,7 @@ public class CategoriesController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<VerticalConfigFullDto> category(@PathVariable("categoryId") String categoryId,
                                                           @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
         VerticalConfig config = verticalsConfigService.getConfigById(categoryId);
@@ -187,6 +191,7 @@ public class CategoriesController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<CategoryNavigationDto> navigation(
             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
             @RequestParam(name = "googleCategoryId", required = false) Integer googleCategoryId,

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContentsController.java
@@ -3,12 +3,14 @@ package org.open4goods.nudgerfrontapi.controller.api;
 import java.util.Locale;
 
 import org.open4goods.model.RolesConstants;
+import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
 import org.open4goods.nudgerfrontapi.dto.xwiki.FullPageDto;
 import org.open4goods.nudgerfrontapi.dto.xwiki.XwikiContentBlocDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.xwiki.services.XWikiHtmlService;
 import org.open4goods.nudgerfrontapi.service.XwikiFullPageService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -71,6 +73,7 @@ public class ContentsController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<XwikiContentBlocDto> contentBloc(@PathVariable String blocId,
                                                            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
                                                            Locale locale,
@@ -106,6 +109,7 @@ public class ContentsController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<FullPageDto> page(@PathVariable String xwikiPageId,
                                             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
                                             Locale locale) {

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/TeamController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/TeamController.java
@@ -1,9 +1,11 @@
 package org.open4goods.nudgerfrontapi.controller.api;
 
 import org.open4goods.model.RolesConstants;
+import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.nudgerfrontapi.config.properties.TeamProperties;
 import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -62,6 +64,7 @@ public class TeamController {
                     @ApiResponse(responseCode = "500", description = "Internal server error")
             }
     )
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<TeamProperties> team(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
         return ResponseEntity.ok()
                 .cacheControl(CacheControlConstants.ONE_HOUR_PUBLIC_CACHE)

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/XwikiFullPageService.java
@@ -9,9 +9,11 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.nudgerfrontapi.dto.xwiki.FullPageDto;
 import org.open4goods.xwiki.model.FullPage;
 import org.open4goods.xwiki.services.XwikiFacadeService;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.xwiki.rest.model.jaxb.Page;
 
@@ -38,6 +40,7 @@ public class XwikiFullPageService {
      * @param languageTag language tag used to retrieve the localised page
      * @return flattened DTO representation of the XWiki page
      */
+    @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public FullPageDto getFullPage(String pageId, String languageTag) {
         FullPage fullPage = xwikiFacadeService.getFullPage(pageId, languageTag);
         return mapToDto(fullPage);


### PR DESCRIPTION
## Summary
- cache XWiki bloc and page responses and reuse cached full-page conversions
- add caching to category listing, detail, and navigation endpoints
- cache the static team roster response alongside existing HTTP cache headers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db3697aa08333a1c63e630145febf)