### PR TITLE
Fix Icecat completion refresh logic and attribute source tracking

### DIFF
--- a/api/src/test/java/org/open4goods/api/services/completion/IcecatCompletionServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/completion/IcecatCompletionServiceTest.java
@@ -1,0 +1,89 @@
+package org.open4goods.api.services.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import ch.qos.logback.classic.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.IcecatCompletionConfig;
+import org.open4goods.api.services.AggregationFacadeService;
+import org.open4goods.api.services.aggregation.aggregator.StandardAggregator;
+import org.open4goods.commons.services.DataSourceConfigService;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+
+@ExtendWith(MockitoExtension.class)
+class IcecatCompletionServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private VerticalsConfigService verticalConfigService;
+
+    @Mock
+    private ApiProperties apiProperties;
+
+    @Mock
+    private DataSourceConfigService dataSourceConfigService;
+
+    @Mock
+    private AggregationFacadeService aggregationFacadeService;
+
+    @Mock
+    private StandardAggregator standardAggregator;
+
+    @Mock
+    private VerticalConfig verticalConfig;
+
+    private IcecatCompletionService service;
+
+    @BeforeEach
+    void setUp() {
+        when(apiProperties.logsFolder()).thenReturn("/tmp");
+        when(apiProperties.aggLogLevel()).thenReturn(Level.INFO);
+        when(apiProperties.getIcecatCompletionConfig()).thenReturn(new IcecatCompletionConfig());
+        when(aggregationFacadeService.getStandardAggregator(anyString())).thenReturn(standardAggregator);
+
+        service = new IcecatCompletionService(productRepository, verticalConfigService, apiProperties, dataSourceConfigService, aggregationFacadeService);
+    }
+
+    @Test
+    void shouldProcessWhenNeverProcessed() {
+        Product product = new Product();
+
+        assertThat(service.shouldProcess(verticalConfig, product)).isTrue();
+    }
+
+    @Test
+    void shouldSkipWhenRecentlyProcessed() {
+        Product product = new Product();
+        long recentTimestamp = System.currentTimeMillis() - Duration.ofDays(1).toMillis();
+        product.getDatasourceCodes().put(service.getDatasourceName(), recentTimestamp);
+
+        assertThat(service.shouldProcess(verticalConfig, product)).isFalse();
+    }
+
+    @Test
+    void shouldProcessWhenStale() {
+        Product product = new Product();
+        long staleTimestamp = System.currentTimeMillis() - Duration.ofDays(REFRESH_AGE_IN_DAYS()).toMillis() - Duration.ofHours(1).toMillis();
+        product.getDatasourceCodes().put(service.getDatasourceName(), staleTimestamp);
+
+        assertThat(service.shouldProcess(verticalConfig, product)).isTrue();
+    }
+
+    private static long REFRESH_AGE_IN_DAYS() {
+        return 30;
+    }
+}

--- a/model/src/main/java/org/open4goods/model/attribute/Attribute.java
+++ b/model/src/main/java/org/open4goods/model/attribute/Attribute.java
@@ -35,16 +35,21 @@ public class Attribute implements Validable,IAttribute {
 	 */
 	private String language;
 
-	/**
-	 * The attribute raw rawValue
-	 */
-	private String rawValue;
+/**
+ * The attribute raw rawValue
+ */
+private String rawValue;
 
 
-	/***
-	 * The optionl icecat feature id 
-	 */
-	private Integer icecatFeatureId;
+/**
+ * The datasource that provided this attribute.
+ */
+private String source;
+
+/***
+ * The optionl icecat feature id
+ */
+private Integer icecatFeatureId;
 	
 	public Attribute() {
 
@@ -281,18 +286,26 @@ public class Attribute implements Validable,IAttribute {
 		this.name = name;
 	}
 
-	public String getRawValue() {
-		return rawValue;
-	}
+    public String getRawValue() {
+            return rawValue;
+    }
 
-	public void setRawValue(final String rawValue) {
-		this.rawValue = rawValue;
-	}
+    public void setRawValue(final String rawValue) {
+            this.rawValue = rawValue;
+    }
 
-	@Override
-	public String getLanguage() {
-		return language;
-	}
+    public String getSource() {
+            return source;
+    }
+
+    public void setSource(final String source) {
+            this.source = source;
+    }
+
+    @Override
+    public String getLanguage() {
+            return language;
+    }
 
 	public void setLanguage(final String language) {
 		this.language = language;

--- a/model/src/main/java/org/open4goods/model/datafragment/DataFragment.java
+++ b/model/src/main/java/org/open4goods/model/datafragment/DataFragment.java
@@ -545,7 +545,16 @@ public class DataFragment implements Standardisable, Validable {
 	 * @return
 	 */
 	public void addAttribute(final String name, final String value, final String language, String  categoryFeatureId ) {
-		if (null == value || value.isBlank()) {
+
+		addAttribute(name, value, language, categoryFeatureId, null);
+
+
+	}
+
+	public void addAttribute(final String name, final String value, final String language, String  categoryFeatureId, String source ) {
+
+
+		if (StringUtils.isBlank(name) || null == value || value.isBlank()) {
 			logger.debug("Cannot add null or empty values for attribute " + name);
 			return ;
 		}
@@ -556,7 +565,7 @@ public class DataFragment implements Standardisable, Validable {
 			logger.warn("Evicting a too big value for attribute {}:{}", name,value);
 			return;
 		}
-		
+
 		final Attribute attr = new Attribute();
 
 		// Attributye name normalisation
@@ -566,15 +575,16 @@ public class DataFragment implements Standardisable, Validable {
 			sanitizedName = sanitizedName.substring(0, sanitizedName.length() -1).trim();
 		}
 
-		
+
 		attr.setName(sanitizedName);
 		attr.setLanguage(language);
 		attr.setRawValue(value);
-		
+		attr.setSource(source);
+
 		try {
 			if (null != categoryFeatureId) {
 				attr.setIcecatFeatureId(Integer.valueOf(  categoryFeatureId));
-				
+
 			}
 		} catch (NumberFormatException e) {
 			logger.error("Error while converting icecatFeatureID : {}",categoryFeatureId);
@@ -590,7 +600,7 @@ public class DataFragment implements Standardisable, Validable {
 		attr.normalize();
 
 		attributes.add(attr);
-	
+
 
 	}
 

--- a/model/src/test/java/org/open4goods/model/datafragment/DataFragmentTest.java
+++ b/model/src/test/java/org/open4goods/model/datafragment/DataFragmentTest.java
@@ -1,0 +1,19 @@
+package org.open4goods.model.datafragment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.attribute.Attribute;
+
+class DataFragmentTest {
+
+    @Test
+    void addAttributeStoresSource() {
+        DataFragment fragment = new DataFragment();
+
+        fragment.addAttribute("Color", "Red", "en", "123", "icecat.biz");
+
+        Attribute attribute = fragment.getAttributes().iterator().next();
+        assertThat(attribute.getSource()).isEqualTo("icecat.biz");
+    }
+}


### PR DESCRIPTION
## Summary
- correct the Icecat refresh gating to rerun stale products and add coverage
- capture datasource provenance on attributes and pass Icecat source through completion
- add unit tests for attribute source storage and Icecat completion processing rules

## Testing
- mvn --offline -pl api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692db239e0a88333881db69aa67ebf9e)