### PR TITLE
Fix Icecat refresh logic and add regression test

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/completion/IcecatCompletionService.java
+++ b/api/src/main/java/org/open4goods/api/services/completion/IcecatCompletionService.java
@@ -3,6 +3,7 @@ package org.open4goods.api.services.completion;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -80,16 +81,17 @@ public class IcecatCompletionService extends AbstractCompletionService {
 		
 	}
 
-	@Override
-	public boolean shouldProcess(VerticalConfig vertical, Product data) {
-		// TODO(p2,perf) : should adda check on unprocessed resources
-		Long lastProcessed = data.getDatasourceCodes().get(getDatasourceName());
-		if (null != lastProcessed &&  REFRESH_IN_DAYS * 1000 * 3600 * 24 < System.currentTimeMillis() - lastProcessed ) {
-			return false;
-		} else {
-			return true;
-		}
-	}
+        @Override
+        public boolean shouldProcess(VerticalConfig vertical, Product data) {
+                // TODO(p2,perf) : should adda check on unprocessed resources
+                Long lastProcessed = data.getDatasourceCodes().get(getDatasourceName());
+                if (null == lastProcessed) {
+                        return true;
+                }
+
+                long refreshIntervalMs = Duration.ofDays(REFRESH_IN_DAYS).toMillis();
+                return System.currentTimeMillis() - lastProcessed >= refreshIntervalMs;
+        }
 
 	@Override
 	public String getDatasourceName() {

--- a/api/src/test/java/org/open4goods/api/services/completion/IcecatCompletionServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/completion/IcecatCompletionServiceTest.java
@@ -1,0 +1,42 @@
+package org.open4goods.api.services.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+
+class IcecatCompletionServiceTest {
+
+        private IcecatCompletionService service;
+        private VerticalConfig vertical;
+        private Product product;
+
+        @BeforeEach
+        void setUp() {
+                service = Mockito.mock(IcecatCompletionService.class, Mockito.CALLS_REAL_METHODS);
+                vertical = new VerticalConfig();
+                product = new Product(1L);
+        }
+
+        @Test
+        void shouldSkipProcessingWhenLastProcessedIsFresh() {
+                long freshTimestamp = System.currentTimeMillis() - Duration.ofDays(30).toMillis() + 1_000L;
+                product.getDatasourceCodes().put(service.getDatasourceName(), freshTimestamp);
+
+                assertThat(service.shouldProcess(vertical, product)).isFalse();
+        }
+
+        @Test
+        void shouldProcessWhenLastProcessedIsStale() {
+                long staleTimestamp = System.currentTimeMillis() - Duration.ofDays(30).toMillis() - 1_000L;
+                product.getDatasourceCodes().put(service.getDatasourceName(), staleTimestamp);
+
+                assertThat(service.shouldProcess(vertical, product)).isTrue();
+        }
+}
+


### PR DESCRIPTION
## Summary
- correct Icecat completion refresh check to only skip when data is still fresh
- add regression tests verifying fresh and stale timestamps for Icecat completion

## Testing
- mvn -pl api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc058176483338d4108c13bc2370e)