### PR TITLE
Add canonical and structured data to category pages

### DIFF
--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -180,7 +180,49 @@ const resultSummary = computed(() =>
   ),
 )
 
-const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
+const httpsOrigin = computed(() => {
+  const url = new URL(requestURL.origin)
+  url.protocol = 'https:'
+  return url.origin
+})
+
+const canonicalUrl = computed(() => {
+  const url = new URL(route.fullPath, httpsOrigin.value)
+  url.protocol = 'https:'
+  return url.toString()
+})
+
+const buildAbsoluteUrl = (path?: string) => {
+  if (!path) {
+    return canonicalUrl.value
+  }
+
+  const url = new URL(path, httpsOrigin.value)
+  url.protocol = 'https:'
+  return url.toString()
+}
+
+const breadcrumbJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: breadcrumbs.value.map((breadcrumb, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: breadcrumb.title,
+    item: buildAbsoluteUrl(breadcrumb.link ?? route.fullPath),
+  })),
+}))
+
+const itemListJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: filteredCategories.value.map((category, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: category.title ?? '',
+    url: buildAbsoluteUrl(category.path ? `/categories/${category.path}` : undefined),
+  })),
+}))
 const ogImageUrl = computed(() => new URL('/nudger-icon-512x512.png', requestURL.origin).toString())
 
 useSeoMeta({
@@ -192,6 +234,24 @@ useSeoMeta({
   ogType: () => 'website',
   ogImage: () => ogImageUrl.value,
 })
+
+useHead(() => ({
+  link: [
+    { rel: 'canonical', href: canonicalUrl.value },
+  ],
+  script: [
+    {
+      key: 'categories-detail-breadcrumb-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(breadcrumbJsonLd.value),
+    },
+    {
+      key: 'categories-detail-itemlist-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(itemListJsonLd.value),
+    },
+  ],
+}))
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add HTTPS-enforced canonical URL generation to category listing and detail pages and emit link tags
- inject breadcrumb and item list JSON-LD structured data for category navigation

## Testing
- pnpm lint
- pnpm vitest run pages/index.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc36979c88333a3ec2a0dc9c7beea)