### PR TITLE
Normalize canonical URL and enrich category ItemList JSON-LD

### DIFF
--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -506,7 +506,7 @@ const categoryDisplayName = computed(
     category.value?.verticalHomeDescription ??
     siteName.value,
 )
-const canonicalUrl = computed(() => new URL(route.fullPath, requestURL.origin).toString())
+const canonicalUrl = computed(() => new URL(route.path, requestURL.origin).toString())
 const seoTitle = computed(
   () => category.value?.verticalMetaTitle ?? category.value?.verticalHomeTitle ?? siteName.value,
 )
@@ -1286,6 +1286,8 @@ const productListJsonLd = computed(() => {
     '@type': 'ItemList',
     name: seoTitle.value,
     numberOfItems: resultsCount.value,
+    itemListOrder: 'https://schema.org/ItemListUnordered',
+    url: canonicalUrl.value,
     itemListElement: filteredItems,
   }
 })


### PR DESCRIPTION
## Summary
- derive category canonical URLs from the path to avoid query-driven variants
- add itemListOrder and url metadata to the category ItemList JSON-LD for richer SEO output

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dc69cf9e48333b9051d0ceb0233da)