### PR TITLE
Prevent redundant product fetch on category mount

### DIFF
--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -1482,6 +1482,31 @@ const loadingProducts = ref(false)
 const productError = ref<string | null>(null)
 const hasHydrated = ref(false)
 
+const isDefaultQueryState = computed(() => {
+  const hasDefaultFilters = !(manualFilters.value.filters?.length)
+  const hasDefaultSubsets = activeSubsetIds.value.length === 0
+  const hasDefaultSearch = searchTerm.value === ''
+  const hasDefaultPaging =
+    pageNumber.value === 0 && viewMode.value === CATEGORY_DEFAULT_VIEW_MODE
+  const hasDefaultSort = !sortField.value && sortOrder.value === 'desc'
+
+  return (
+    hasDefaultFilters &&
+    hasDefaultSubsets &&
+    hasDefaultSearch &&
+    hasDefaultPaging &&
+    hasDefaultSort
+  )
+})
+
+const isUsingInitialProductsData = computed(() => {
+  if (!initialProductsData.value) {
+    return false
+  }
+
+  return productsData.value === initialProductsData.value && isDefaultQueryState.value
+})
+
 const buildAggregationRequest = (
   options: ProductFieldOptionsResponse | null,
   extraFields: FieldMetadataDto[] = [],
@@ -1718,7 +1743,7 @@ onMounted(async () => {
 
   hasHydrated.value = true
 
-  if (verticalId.value) {
+  if (verticalId.value && !isUsingInitialProductsData.value) {
     await fetchProducts()
   }
 })


### PR DESCRIPTION
## Summary
- add default query state detection to recognize when SSR-provided product data already covers the initial view
- skip the onMounted product fetch when initial data matches the default filters and pagination

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dca27be188333a16b7945b096b8b0)