### PR TITLE
Handle GTIN redirect fallback when slug missing

### DIFF
--- a/frontend/app/pages/[gtin].vue
+++ b/frontend/app/pages/[gtin].vue
@@ -20,13 +20,17 @@ if (!rawGtin) {
 
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
-const targetPath = await resolveGtinRedirectTarget(rawGtin, {
-  fetchProduct: (gtin: string) =>
-    $fetch<ProductDto>(`/api/products/${gtin}`, {
-      headers: requestHeaders,
-    }),
-  createError,
-})
+const targetPath = await resolveGtinRedirectTarget(
+  rawGtin,
+  {
+    fetchProduct: (gtin: string) =>
+      $fetch<ProductDto>(`/api/products/${gtin}`, {
+        headers: requestHeaders,
+      }),
+    createError,
+  },
+  route.path
+)
 
 await navigateTo(targetPath, { replace: true, redirectCode: 301 })
 </script>


### PR DESCRIPTION
## Summary
- allow GTIN redirects to accept the current request path and fallback to the GTIN path when no canonical slug exists
- preserve canonical redirects when slugs are available and pass the route path from the GTIN page
- add unit coverage for slugless products to ensure fallback redirects are returned instead of 404 errors

## Testing
- pnpm vitest run app/utils/_gtin-redirect.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dcdee5ca48333ba70efcce083b1e8)