### PR TITLE
Refine GTIN validation for product routes

### DIFF
--- a/frontend/app/pages/[gtin].vue
+++ b/frontend/app/pages/[gtin].vue
@@ -4,15 +4,18 @@
 
 <script setup lang="ts">
 import type { ProductDto } from '~~/shared/api-client'
-import { extractGtinParam, isValidGtinParam } from '~~/shared/utils/_gtin'
+import {
+  extractRawGtinParam,
+  isValidRawGtin,
+} from '~~/shared/utils/_gtin'
 import { resolveGtinRedirectTarget } from '~/utils/_gtin-redirect'
 
 definePageMeta({
-  validate: (route) => isValidGtinParam(route.params.gtin),
+  validate: (route) => isValidRawGtin(route.params.gtin),
 })
 
 const route = useRoute()
-const rawGtin = extractGtinParam(route.params.gtin)
+const rawGtin = extractRawGtinParam(route.params.gtin)
 
 if (!rawGtin) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })

--- a/frontend/shared/utils/_gtin.spec.ts
+++ b/frontend/shared/utils/_gtin.spec.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractGtinParam, isValidGtinParam } from './_gtin'
+import {
+  extractGtinParam,
+  extractRawGtinParam,
+  isValidGtinParam,
+  isValidRawGtin,
+} from './_gtin'
 
 describe('shared/utils/_gtin', () => {
   describe('isValidGtinParam', () => {
     it('accepts strings with at least six digits', () => {
       expect(isValidGtinParam('123456')).toBe(true)
       expect(isValidGtinParam('9876543210')).toBe(true)
-      expect(isValidGtinParam('123456-some-product')).toBe(true)
     })
 
     it('rejects non-strings and short values', () => {
@@ -15,6 +19,20 @@ describe('shared/utils/_gtin', () => {
       expect(isValidGtinParam('12345')).toBe(false)
       expect(isValidGtinParam('12345a')).toBe(false)
       expect(isValidGtinParam('123456a')).toBe(false)
+      expect(isValidGtinParam('123456-some-product')).toBe(false)
+    })
+  })
+
+  describe('isValidRawGtin', () => {
+    it('accepts only raw numeric GTINs', () => {
+      expect(isValidRawGtin('123456')).toBe(true)
+      expect(isValidRawGtin('9876543210')).toBe(true)
+    })
+
+    it('rejects non-string or slugged values', () => {
+      expect(isValidRawGtin(null)).toBe(false)
+      expect(isValidRawGtin('123')).toBe(false)
+      expect(isValidRawGtin('123456-with-slug')).toBe(false)
     })
   })
 
@@ -34,6 +52,19 @@ describe('shared/utils/_gtin', () => {
       expect(extractGtinParam('123')).toBeNull()
       expect(extractGtinParam(['abc', '12345'])).toBeNull()
       expect(extractGtinParam('123456a')).toBeNull()
+    })
+  })
+
+  describe('extractRawGtinParam', () => {
+    it('returns the GTIN when it is a raw numeric value', () => {
+      expect(extractRawGtinParam('123456')).toBe('123456')
+      expect(extractRawGtinParam(['foo', '654321', '987654'])).toBe('654321')
+    })
+
+    it('rejects slugged or malformed values', () => {
+      expect(extractRawGtinParam('123456-product')).toBeNull()
+      expect(extractRawGtinParam(['abc', '12345'])).toBeNull()
+      expect(extractRawGtinParam(undefined)).toBeNull()
     })
   })
 })

--- a/frontend/shared/utils/_gtin.ts
+++ b/frontend/shared/utils/_gtin.ts
@@ -1,7 +1,8 @@
+const GTIN_ONLY_PATTERN = /^\d{6,}$/
 const GTIN_CAPTURE_PATTERN = /^(\d{6,})(?:$|[-_].*)$/
 
 export const isValidGtinParam = (value: unknown): value is string => {
-  return typeof value === 'string' && GTIN_CAPTURE_PATTERN.test(value)
+  return typeof value === 'string' && GTIN_ONLY_PATTERN.test(value)
 }
 
 export const extractGtinParam = (value: unknown): string | null => {
@@ -24,4 +25,24 @@ export const extractGtinParam = (value: unknown): string | null => {
   }
 
   return null
+}
+
+export const extractRawGtinParam = (value: unknown): string | null => {
+  if (typeof value === 'string' && GTIN_ONLY_PATTERN.test(value)) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === 'string' && GTIN_ONLY_PATTERN.test(item)) {
+        return item
+      }
+    }
+  }
+
+  return null
+}
+
+export const isValidRawGtin = (value: unknown): value is string => {
+  return typeof value === 'string' && GTIN_ONLY_PATTERN.test(value)
 }

--- a/frontend/shared/utils/_product-route.spec.ts
+++ b/frontend/shared/utils/_product-route.spec.ts
@@ -97,6 +97,8 @@ describe('_product-route', () => {
     it('returns null when the route is empty or contains more than three segments', () => {
       expect(matchProductRouteFromSegments([])).toBeNull()
       expect(matchProductRouteFromSegments(['only-one'])).toBeNull()
+      expect(matchProductRouteFromSegments(['123456'])).toBeNull()
+      expect(matchProductRouteFromSegments(['electronique'])).toBeNull()
       expect(
         matchProductRouteFromSegments([
           'too',


### PR DESCRIPTION
## Summary
- add helpers to validate and extract raw numeric GTINs
- restrict the /[gtin] redirect page to numeric-only GTINs so slugged product URLs resolve via the slug route
- extend GTIN and product route tests to cover numeric-only handling and protect category-only paths

## Testing
- pnpm vitest run shared/utils/_gtin.spec.ts shared/utils/_product-route.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ea6abc2d48333bc52bfb431cabc97)