### PR TITLE
Refine product timeline layout and labelling

### DIFF
--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -91,6 +91,12 @@
         </v-card>
 
       </div>
+
+      <v-row v-if="timeline" class="product-attributes__timeline-row" dense>
+        <v-col cols="12">
+          <ProductLifeTimeline :timeline="timeline" />
+        </v-col>
+      </v-row>
     </div>
 
     <div class="product-attributes__block product-attributes__block--detailed">
@@ -108,16 +114,7 @@
         />
       </div>
 
-      <div
-        :class="[
-          'product-attributes__detailed-layout',
-          { 'product-attributes__detailed-layout--with-timeline': Boolean(timeline) },
-        ]"
-      >
-        <div v-if="timeline" class="product-attributes__timeline-column">
-          <ProductLifeTimeline :timeline="timeline" />
-        </div>
-
+      <div class="product-attributes__detailed-layout">
         <div class="product-attributes__details-panel">
           <v-row v-if="filteredGroups.length" class="product-attributes__details-grid" dense>
             <ProductAttributesDetailCard
@@ -762,15 +759,6 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
   gap: 1.5rem;
 }
 
-.product-attributes__timeline-column {
-  flex: 0 0 100%;
-  display: flex;
-}
-
-.product-attributes__timeline-column :deep(.product-life-timeline) {
-  width: 100%;
-}
-
 .product-attributes__details-panel {
   flex: 1;
 }
@@ -800,6 +788,10 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
   background: rgba(var(--v-theme-surface-primary-050), 0.7);
 }
 
+.product-attributes__timeline-row {
+  margin-top: 1.5rem;
+}
+
 @media (min-width: 960px) {
   .product-attributes__main-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
@@ -813,19 +805,6 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
 
   .product-attributes__search {
     max-width: 320px;
-  }
-}
-
-@media (min-width: 1280px) {
-  .product-attributes__detailed-layout--with-timeline {
-    display: grid;
-    grid-template-columns: minmax(240px, 1fr) minmax(0, 3fr);
-    gap: 1.5rem;
-    align-items: flex-start;
-  }
-
-  .product-attributes__details-panel {
-    grid-column: auto;
   }
 }
 </style>

--- a/frontend/app/components/product/ProductLifeTimeline.spec.ts
+++ b/frontend/app/components/product/ProductLifeTimeline.spec.ts
@@ -17,7 +17,7 @@ const i18n = createI18n({
             empty: 'Lifecycle information is not available yet.',
             ariaYear: 'Year {year}',
             sources: {
-              priceHistory: 'Price history',
+              priceHistory: 'Nudger',
               eprel: 'EPREL registry',
               generic: 'Timeline event',
             },
@@ -31,8 +31,8 @@ const i18n = createI18n({
               priceFirstSeenOccasion: 'First second-hand offer',
               priceLastSeenNew: 'Latest new offer',
               priceLastSeenOccasion: 'Latest second-hand offer',
-              eprelOnMarketStart: 'Market start (EPREL)',
-              eprelOnMarketEnd: 'Market end (EPREL)',
+              eprelOnMarketStart: 'Market start',
+              eprelOnMarketEnd: 'Market end',
               eprelOnMarketFirstStart: 'EPREL first entry',
               eprelFirstPublication: 'EPREL first publication',
               eprelLastPublication: 'EPREL last publication',
@@ -135,10 +135,12 @@ describe('ProductLifeTimeline', () => {
     const wrapper = await mountComponent(buildTimeline())
 
     const monthLabels = wrapper.findAll('.product-life-timeline__event-month').map((node) => node.text())
+    const titles = wrapper.findAll('.product-life-timeline__event-title').map((node) => node.text())
 
     expect(monthLabels).toEqual(['Sep', 'Jan', 'Jun'])
+    expect(titles).toContain('Market start')
     expect(wrapper.text()).toContain('First new offer')
-    expect(wrapper.text()).toContain('Market start (EPREL)')
+    expect(wrapper.text()).toContain('Market start')
     expect(wrapper.find('.product-life-timeline--horizontal').exists()).toBe(true)
   })
 

--- a/frontend/app/components/product/ProductLifeTimeline.vue
+++ b/frontend/app/components/product/ProductLifeTimeline.vue
@@ -32,7 +32,7 @@
               class="product-life-timeline__event"
               role="listitem"
             >
-              <v-tooltip location="top" max-width="320">
+              <v-tooltip location="top" max-width="320" content-class="product-life-timeline__tooltip-surface">
                 <template #activator="{ props: tooltipProps }">
                   <button
                     type="button"
@@ -59,6 +59,7 @@
                 </div>
               </v-tooltip>
 
+              <span class="product-life-timeline__event-title">{{ event.label }}</span>
               <span class="product-life-timeline__event-month">{{ event.monthLabel }}</span>
             </div>
           </div>
@@ -146,6 +147,10 @@ const sourceColors: Record<string, string> = {
   EPREL: 'success',
 }
 
+const sourceOverrideByType: Record<string, string> = {
+  EPREL_IMPORTED: 'PRICE_HISTORY',
+}
+
 const monthFormatter = computed(() => new Intl.DateTimeFormat(locale.value, { month: 'short' }))
 const fullDateFormatter = computed(() => new Intl.DateTimeFormat(locale.value, { month: 'long', year: 'numeric' }))
 const eventDescriptionKeys: Record<string, string> = {
@@ -186,9 +191,10 @@ const groupedEvents = computed<TimelineYearGroup[]>(() => {
       const monthLabel = monthFormatter.value.format(date)
       const fullDateLabel = fullDateFormatter.value.format(date)
       const icon = (type && eventIcons[type]) ?? 'mdi-timeline-clock-outline'
-      const color = (source && sourceColors[source]) ?? 'primary'
-      const sourceLabel = source
-        ? t(sourceLabelKeys[source] ?? 'product.attributes.timeline.sources.generic')
+      const resolvedSource = (type && sourceOverrideByType[type]) ?? source
+      const color = (resolvedSource && sourceColors[resolvedSource]) ?? 'primary'
+      const sourceLabel = resolvedSource
+        ? t(sourceLabelKeys[resolvedSource] ?? 'product.attributes.timeline.sources.generic')
         : null
       const year = date.getFullYear()
       const ariaLabel = t('product.attributes.timeline.tooltip.ariaLabel', {
@@ -245,6 +251,7 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   flex-direction: column;
   gap: 1.25rem;
   box-shadow: 0 14px 35px -20px rgba(15, 23, 42, 0.25);
+  width: 100%;
 }
 
 .product-life-timeline__header {
@@ -337,6 +344,7 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   align-items: center;
   position: relative;
   min-width: 42px;
+  text-align: center;
 }
 
 .product-life-timeline__event-point {
@@ -388,11 +396,28 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   font-weight: 600;
 }
 
+.product-life-timeline__event-title {
+  font-size: 0.9rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 600;
+  line-height: 1.2;
+  max-width: 12ch;
+}
+
 .product-life-timeline__tooltip {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   max-width: 300px;
+}
+
+:global(.product-life-timeline__tooltip-surface) {
+  background-color: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-text-neutral-strong));
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35);
+  box-shadow: 0 18px 40px -22px rgba(15, 23, 42, 0.35);
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
 }
 
 .product-life-timeline__tooltip-title {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1678,7 +1678,7 @@
         "empty": "Lifecycle information is not available yet.",
         "ariaYear": "Milestones for {year}",
         "sources": {
-          "priceHistory": "Price history",
+          "priceHistory": "Nudger",
           "eprel": "EPREL registry",
           "generic": "Lifecycle event"
         },
@@ -1692,8 +1692,8 @@
           "priceFirstSeenOccasion": "First second-hand offer",
           "priceLastSeenNew": "Latest new offer",
           "priceLastSeenOccasion": "Latest second-hand offer",
-          "eprelOnMarketStart": "Market start (EPREL)",
-          "eprelOnMarketEnd": "Market end (EPREL)",
+          "eprelOnMarketStart": "Market start",
+          "eprelOnMarketEnd": "Market end",
           "eprelOnMarketFirstStart": "First EU market start",
           "eprelFirstPublication": "First EPREL publication",
           "eprelLastPublication": "Latest EPREL publication",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1678,7 +1678,7 @@
         "empty": "Aucune information sur le cycle de vie n'est disponible pour le moment.",
         "ariaYear": "Événements de l'année {year}",
         "sources": {
-          "priceHistory": "Historique des prix",
+          "priceHistory": "Nudger",
           "eprel": "Registre EPREL",
           "generic": "Événement du cycle de vie"
         },
@@ -1692,8 +1692,8 @@
           "priceFirstSeenOccasion": "Première offre d'occasion",
           "priceLastSeenNew": "Dernière offre neuve",
           "priceLastSeenOccasion": "Dernière offre d'occasion",
-          "eprelOnMarketStart": "Début commercialisation (EPREL)",
-          "eprelOnMarketEnd": "Fin commercialisation (EPREL)",
+          "eprelOnMarketStart": "Début commercialisation",
+          "eprelOnMarketEnd": "Fin commercialisation",
           "eprelOnMarketFirstStart": "Première mise sur le marché UE",
           "eprelFirstPublication": "Première publication EPREL",
           "eprelLastPublication": "Dernière publication EPREL",


### PR DESCRIPTION
## Summary
- move the product lifecycle timeline into the main attributes block with full-width layout adjustments
- add event titles, theme-aware tooltips, and update source mappings to use Nudger where appropriate
- refresh timeline translations and specs to reflect the new labels

## Testing
- pnpm vitest run components/product/ProductLifeTimeline.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0c657bd48333aac73936c517f151)