### PR TITLE
Prevent SSR from setting PWA install cookie

### DIFF
--- a/frontend/app/components/pwa/PwaInstallPrompt.ssr.spec.ts
+++ b/frontend/app/components/pwa/PwaInstallPrompt.ssr.spec.ts
@@ -1,0 +1,36 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const cookiesWithDefaults: string[] = []
+
+describe('PWA install prompt SSR', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    cookiesWithDefaults.length = 0
+  })
+
+  it('does not write the install dismissal cookie during server render', async () => {
+    const originalWindow = globalThis.window
+
+    // @ts-expect-error - window is intentionally unset to emulate SSR
+    globalThis.window = undefined
+
+    mockNuxtImport('useCookie', () => (name: string, options?: { default?: () => boolean }) => {
+      if (options?.default) {
+        cookiesWithDefaults.push(name)
+      }
+
+      return ref(undefined)
+    })
+
+    const { usePwaPrompt } = await import('~~/app/composables/usePwaPrompt')
+
+    usePwaPrompt()
+
+    expect(cookiesWithDefaults).toEqual([])
+
+    // @ts-expect-error - window is restored after SSR emulation
+    globalThis.window = originalWindow
+  })
+})

--- a/frontend/app/composables/usePwaPrompt.ts
+++ b/frontend/app/composables/usePwaPrompt.ts
@@ -23,10 +23,12 @@ export function usePwaPrompt() {
   const installInProgress = useState('pwa-installing', () => false)
   const offlineReady = useState('pwa-offline-ready', () => false)
   const updateAvailable = useState('pwa-update-available', () => false)
-  const installDismissed = useCookie<boolean>(INSTALL_DISMISS_COOKIE, {
-    default: () => false,
+  const installCookieDefaultsAllowed = import.meta.client && typeof window !== 'undefined'
+
+  const installDismissed = useCookie<boolean | undefined>(INSTALL_DISMISS_COOKIE, {
     maxAge: 60 * 60 * 24 * 30, // 30 days
     sameSite: 'lax',
+    ...(installCookieDefaultsAllowed ? { default: () => false } : {}),
   })
 
   const swState: RegisterSWState = import.meta.client


### PR DESCRIPTION
## Summary
- guard the PWA install dismissal cookie so it is only initialised in the browser
- add an SSR-focused test to ensure server renders do not emit a Set-Cookie header for the prompt

## Testing
- pnpm vitest run app/components/pwa/PwaInstallPrompt.ssr.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff5f9cd008333ad7b281c9fabaa34)