### PR TITLE
Simplify impact score criteria configuration

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/VerticalsGenerationService.java
+++ b/api/src/main/java/org/open4goods/api/services/VerticalsGenerationService.java
@@ -25,6 +25,7 @@ import org.open4goods.api.model.VerticalCategoryMapping;
 import org.open4goods.icecat.services.IcecatService;
 import org.open4goods.model.helper.IdHelper;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.ImpactScoreConfig;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.services.evaluation.service.EvaluationService;
@@ -449,12 +450,17 @@ public class VerticalsGenerationService {
 
 			StringBuilder ret = new StringBuilder();
 
-			criterias.entrySet().forEach(score -> {
-				ret.append("  ").append(score.getKey()).append(" : " );
-				// NOTE : Spank me if NPE...
-				ret.append(vConf.getAvailableImpactScoreCriterias().get(score.getKey()).getDescription().get("fr"));
-				ret.append("\n");
-			});
+                        criterias.entrySet().forEach(score -> {
+                                ret.append("  ").append(score.getKey()).append(" : ");
+
+                                Optional.ofNullable(vConf.getAttributesConfig())
+                                        .map(config -> config.getAttributeConfigByKey(score.getKey()))
+                                        .map(AttributeConfig::getScoreDescription)
+                                        .map(description -> description.get("fr"))
+                                        .ifPresentOrElse(ret::append, () -> ret.append(score.getKey()));
+
+                                ret.append("\n");
+                        });
 
 			return ret.toString();
 		}

--- a/api/src/main/java/org/open4goods/api/services/VerticalsGenerationService.java
+++ b/api/src/main/java/org/open4goods/api/services/VerticalsGenerationService.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
@@ -88,8 +88,8 @@ public record VerticalConfigFullDto(
         AttributesConfigDto attributesConfig,
         @Schema(description = "Popular attributes resolved to their full configuration metadata.")
         List<AttributeConfigDto> popularAttributes,
-        @Schema(description = "Impact score criteria available for this vertical with localised metadata.")
-        Map<String, ImpactScoreCriteriaDto> availableImpactScoreCriterias,
+        @Schema(description = "Identifiers of impact score criteria available for this vertical.")
+        List<String> availableImpactScoreCriterias,
         @Schema(description = "Impact score configuration balancing each criterion, with localised texts.")
         ImpactScoreConfigDto impactScoreConfig,
         @Schema(description = "Custom subsets defined for this vertical with localised labels.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -16,7 +16,6 @@ import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.AttributesConfig;
 import org.open4goods.model.vertical.FeatureGroup;
 import org.open4goods.model.vertical.ImpactScoreConfig;
-import org.open4goods.model.vertical.ImpactScoreCriteria;
 import org.open4goods.model.vertical.ProductCategory;
 import org.open4goods.model.vertical.ProductI18nElements;
 import org.open4goods.model.vertical.SiteNaming;
@@ -31,7 +30,6 @@ import org.open4goods.nudgerfrontapi.dto.category.CategoryNavigationDto;
 import org.open4goods.nudgerfrontapi.dto.category.FeatureGroupDto;
 import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
 import org.open4goods.nudgerfrontapi.dto.category.ImpactScoreConfigDto;
-import org.open4goods.nudgerfrontapi.dto.category.ImpactScoreCriteriaDto;
 import org.open4goods.nudgerfrontapi.dto.category.SiteNamingDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
@@ -145,7 +143,7 @@ public class CategoryMappingService {
                 verticalConfig.getResourcesConfig(),
                 mapAttributesConfig(verticalConfig.getAttributesConfig(), domainLanguage),
                 mapPopularAttributes(verticalConfig, domainLanguage),
-                mapImpactScoreCriterias(verticalConfig.getAvailableImpactScoreCriterias(), domainLanguage),
+                defaultList(verticalConfig.getAvailableImpactScoreCriterias()),
                 mapImpactScoreConfig(verticalConfig.getImpactScoreConfig(), domainLanguage),
                 mapVerticalSubsets(verticalConfig.getSubsets(), domainLanguage),
                 mapVerticalSubset(verticalConfig.getBrandsSubset(), domainLanguage),
@@ -452,35 +450,6 @@ public class CategoryMappingService {
                 attributeConfig.getParser(),
                 defaultMap(attributeConfig.getNumericMapping()),
                 defaultMap(attributeConfig.getMappings()));
-    }
-
-    /**
-     * Map impact score criteria definitions keyed by their identifier.
-     */
-    private Map<String, ImpactScoreCriteriaDto> mapImpactScoreCriterias(Map<String, ImpactScoreCriteria> criterias,
-                                                                         DomainLanguage domainLanguage) {
-        if (criterias == null || criterias.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return criterias.entrySet().stream()
-                .filter(entry -> entry.getValue() != null)
-                .collect(Collectors.toMap(Map.Entry::getKey,
-                        entry -> mapImpactScoreCriteria(entry.getValue(), domainLanguage),
-                        (left, right) -> right,
-                        LinkedHashMap::new));
-    }
-
-    /**
-     * Map a single impact score criterion.
-     */
-    private ImpactScoreCriteriaDto mapImpactScoreCriteria(ImpactScoreCriteria criteria, DomainLanguage domainLanguage) {
-        if (criteria == null) {
-            return null;
-        }
-        return new ImpactScoreCriteriaDto(
-                criteria.getKey(),
-                localise(criteria.getTitle(), domainLanguage),
-                localise(criteria.getDescription(), domainLanguage));
     }
 
     /**

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -45,7 +45,6 @@ import org.open4goods.model.resource.ImageInfo;
 import org.open4goods.model.resource.PdfInfo;
 import org.open4goods.model.resource.Resource;
 import org.open4goods.model.review.ReviewGenerationStatus;
-import org.open4goods.model.vertical.ImpactScoreCriteria;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.PageDto;
@@ -1402,20 +1401,23 @@ public class ProductMappingService {
             return null;
         }
 
-        ImpactScoreCriteria criteria = null;
-        if (vConf != null && vConf.getAvailableImpactScoreCriterias() != null) {
-            criteria = vConf.getAvailableImpactScoreCriterias().get(score.getName());
-        }
+        AttributeConfig attributeConfig = vConf == null || vConf.getAttributesConfig() == null
+                ? null
+                : vConf.getAttributesConfig().getAttributeConfigByKey(score.getName());
 
         String description = null;
         String title = null;
-        if (criteria == null) {
-            logger.debug("No ImpactScoreCriteria found for {}", score.getName());
+        if (attributeConfig == null) {
+            // With criteria metadata removed from the configuration, fall back to the score identifier when no attribute metadata exists.
+            logger.debug("No attribute-backed metadata found for score {}", score.getName());
             title = score.getName();
         }
         else {
-            title = criteria.getTitle().i18n(domainLanguage.languageTag());
-            description = criteria.getDescription().i18n(domainLanguage.languageTag());
+            title = localise(attributeConfig.getScoreTitle(), domainLanguage);
+            if (!StringUtils.hasText(title)) {
+                title = localise(attributeConfig.getName(), domainLanguage);
+            }
+            description = localise(attributeConfig.getScoreDescription(), domainLanguage);
         }
 
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -45,6 +45,7 @@ import org.open4goods.model.resource.ImageInfo;
 import org.open4goods.model.resource.PdfInfo;
 import org.open4goods.model.resource.Resource;
 import org.open4goods.model.review.ReviewGenerationStatus;
+import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.PageDto;
@@ -1456,6 +1457,13 @@ public class ProductMappingService {
                 cardinality.getCount(),
                 cardinality.getSum(),
                 cardinality.getValue());
+    }
+
+    /**
+     * Convenience overload to localise string attributes when no display locale is available.
+     */
+    private String localise(Localisable<String, String> localisable, DomainLanguage domainLanguage) {
+        return resolveLocalisedString(localisable, domainLanguage, null);
     }
 
     /**

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -128,7 +128,6 @@ import {
   type AttributeConfigDto,
   type CommercialEvent,
   type FilterRequestDto,
-  type ImpactScoreCriteriaDto,
   type ProductDto,
   type ProductReferenceDto,
   type ProductScoreDto,
@@ -291,16 +290,20 @@ const attributeConfigMap = computed(() => {
 })
 
 const availableImpactCriteriaMap = computed(() => {
-  const criterias = categoryDetail.value?.availableImpactScoreCriterias ?? {}
+  const criterias = categoryDetail.value?.availableImpactScoreCriterias ?? []
 
-  return Object.entries(criterias).reduce((map, [key, criterion]) => {
+  return criterias.reduce((map, key) => {
     const normalizedKey = key?.toString().trim().toUpperCase()
     if (normalizedKey?.length) {
-      map.set(normalizedKey, criterion as ImpactScoreCriteriaDto)
+      const attribute = attributeConfigMap.value.get(normalizedKey)
+      map.set(normalizedKey, {
+        title: attribute?.scoreTitle ?? attribute?.name ?? normalizedKey,
+        description: attribute?.scoreDescription ?? null,
+      })
     }
 
     return map
-  }, new Map<string, ImpactScoreCriteriaDto>())
+  }, new Map<string, { title: string; description: string | null }>())
 })
 
 if (categorySlug) {

--- a/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
+++ b/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
@@ -215,10 +215,7 @@ const categoryFixture = {
       },
     }),
   },
-  availableImpactScoreCriterias: {
-    POWER: { key: 'POWER', title: 'Energy', description: 'Energy consumption.' },
-    REPAIRABILITY: { key: 'REPAIRABILITY', title: 'Repairability', description: 'Repair score.' },
-  },
+  availableImpactScoreCriterias: ['POWER', 'REPAIRABILITY'],
   attributesConfig: {
     configs: [
       { key: 'POWER', name: 'Energy efficiency', icon: 'mdi-flash' },

--- a/frontend/shared/api-client/models/VerticalConfigFullDto.ts
+++ b/frontend/shared/api-client/models/VerticalConfigFullDto.ts
@@ -12,7 +12,6 @@
  * Do not edit the class manually.
  */
 
-import { mapValues } from '../runtime';
 import type { BlogPostDto } from './BlogPostDto';
 import {
     BlogPostDtoFromJSON,
@@ -41,13 +40,6 @@ import {
     VerticalSubsetDtoToJSON,
     VerticalSubsetDtoToJSONTyped,
 } from './VerticalSubsetDto';
-import type { ImpactScoreCriteriaDto } from './ImpactScoreCriteriaDto';
-import {
-    ImpactScoreCriteriaDtoFromJSON,
-    ImpactScoreCriteriaDtoFromJSONTyped,
-    ImpactScoreCriteriaDtoToJSON,
-    ImpactScoreCriteriaDtoToJSONTyped,
-} from './ImpactScoreCriteriaDto';
 import type { AttributesConfigDto } from './AttributesConfigDto';
 import {
     AttributesConfigDtoFromJSON,
@@ -330,11 +322,11 @@ export interface VerticalConfigFullDto {
      */
     popularAttributes?: Array<AttributeConfigDto>;
     /**
-     * Impact score criteria available for this vertical with localised metadata.
-     * @type {{ [key: string]: ImpactScoreCriteriaDto; }}
+     * Identifiers of impact score criteria available for this vertical.
+     * @type {Array<string>}
      * @memberof VerticalConfigFullDto
      */
-    availableImpactScoreCriterias?: { [key: string]: ImpactScoreCriteriaDto; };
+    availableImpactScoreCriterias?: Array<string>;
     /**
      * Impact score configuration balancing each criterion, with localised texts.
      * @type {ImpactScoreConfigDto}
@@ -448,7 +440,7 @@ export function VerticalConfigFullDtoFromJSONTyped(json: any, ignoreDiscriminato
         'resourcesConfig': json['resourcesConfig'] == null ? undefined : ResourcesAggregationConfigFromJSON(json['resourcesConfig']),
         'attributesConfig': json['attributesConfig'] == null ? undefined : AttributesConfigDtoFromJSON(json['attributesConfig']),
         'popularAttributes': json['popularAttributes'] == null ? undefined : ((json['popularAttributes'] as Array<any>).map(AttributeConfigDtoFromJSON)),
-        'availableImpactScoreCriterias': json['availableImpactScoreCriterias'] == null ? undefined : (mapValues(json['availableImpactScoreCriterias'], ImpactScoreCriteriaDtoFromJSON)),
+        'availableImpactScoreCriterias': json['availableImpactScoreCriterias'] == null ? undefined : json['availableImpactScoreCriterias'],
         'impactScoreConfig': json['impactScoreConfig'] == null ? undefined : ImpactScoreConfigDtoFromJSON(json['impactScoreConfig']),
         'subsets': json['subsets'] == null ? undefined : ((json['subsets'] as Array<any>).map(VerticalSubsetDtoFromJSON)),
         'brandsSubset': json['brandsSubset'] == null ? undefined : VerticalSubsetDtoFromJSON(json['brandsSubset']),
@@ -507,7 +499,7 @@ export function VerticalConfigFullDtoToJSONTyped(value?: VerticalConfigFullDto |
         'resourcesConfig': ResourcesAggregationConfigToJSON(value['resourcesConfig']),
         'attributesConfig': AttributesConfigDtoToJSON(value['attributesConfig']),
         'popularAttributes': value['popularAttributes'] == null ? undefined : ((value['popularAttributes'] as Array<any>).map(AttributeConfigDtoToJSON)),
-        'availableImpactScoreCriterias': value['availableImpactScoreCriterias'] == null ? undefined : (mapValues(value['availableImpactScoreCriterias'], ImpactScoreCriteriaDtoToJSON)),
+        'availableImpactScoreCriterias': value['availableImpactScoreCriterias'],
         'impactScoreConfig': ImpactScoreConfigDtoToJSON(value['impactScoreConfig']),
         'subsets': value['subsets'] == null ? undefined : ((value['subsets'] as Array<any>).map(VerticalSubsetDtoToJSON)),
         'brandsSubset': VerticalSubsetDtoToJSON(value['brandsSubset']),

--- a/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
@@ -197,11 +197,13 @@ public class VerticalConfig {
 	@JsonMerge
 	private Map<String, AggregationConfiguration> aggregationConfiguration = new HashMap<>();
 
-	/**
-	 * The scores that are eligible to participate to the impact score construction
-	 */
-	@JsonMerge
-	private Map<String, ImpactScoreCriteria> availableImpactScoreCriterias = new HashMap<>();
+        /**
+         * Keys identifying the scores that are eligible to participate to the impact score construction.
+         * Titles and descriptions were previously embedded here but are now resolved elsewhere to keep the
+         * configuration lightweight and focused on selectable criteria identifiers.
+         */
+        @JsonMerge
+        private List<String> availableImpactScoreCriterias = new ArrayList<>();
 
 	/**
 	 * Configuration relativ to ecoscore computation. Key / values are : scoreName
@@ -856,13 +858,13 @@ public class VerticalConfig {
 		this.generationExcludedFromAttributesMatching = generationExcludedFromAttributesMatching;
 	}
 
-	public Map<String, ImpactScoreCriteria> getAvailableImpactScoreCriterias() {
-		return availableImpactScoreCriterias;
-	}
+        public List<String> getAvailableImpactScoreCriterias() {
+                return availableImpactScoreCriterias;
+        }
 
-	public void setAvailableImpactScoreCriterias(Map<String, ImpactScoreCriteria> availableImpactScoreCriterias) {
-		this.availableImpactScoreCriterias = availableImpactScoreCriterias;
-	}
+        public void setAvailableImpactScoreCriterias(List<String> availableImpactScoreCriterias) {
+                this.availableImpactScoreCriterias = availableImpactScoreCriterias;
+        }
 
 	public Integer getWorseLimit() {
 		return worseLimit;

--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -272,19 +272,24 @@ public class ProductRepository {
 	 */
 	public Map<String,Long> scoresCoverage(VerticalConfig vConf) {
 
-		Map<String, Long> ret = new HashMap<>();
+                Map<String, Long> ret = new HashMap<>();
 
-		vConf.getAvailableImpactScoreCriterias().entrySet().forEach(criteria -> {
+                if (vConf.getAvailableImpactScoreCriterias() == null) {
+                        logger.debug("No available impact score criteria configured for vertical {}", vConf.getId());
+                        return ret;
+                }
 
-			Long count = countMainIndexHavingScore(criteria.getKey(),vConf.getId());
+                vConf.getAvailableImpactScoreCriterias().forEach(criteriaKey -> {
 
-			// TODO(p2, conf) : threshold from conf
-			if (count > 10) {
-				ret.put(criteria.getKey() ,  count);
-			} else {
-				logger.info("Excluded from score mapping : {}", criteria );
-			}
-		});
+                        Long count = countMainIndexHavingScore(criteriaKey,vConf.getId());
+
+                        // TODO(p2, conf) : threshold from conf
+                        if (count > 10) {
+                                ret.put(criteriaKey ,  count);
+                        } else {
+                                logger.info("Excluded from score mapping : {}", criteriaKey );
+                        }
+                });
 
 
 		return ret;

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -113,84 +113,19 @@ subsets:
 
 # The scores that are available to build the impact score
 availableImpactScoreCriterias:
-    CLASSE_ENERGY:
-      key: CLASSE_ENERGY
-      title:
-        fr: "Classe énergétique"
-      description:
-        fr: "La classe énergétique"
-    REPAIRABILITY_INDEX:
-      key: REPAIRABILITY_INDEX
-      title:
-        fr: "Indice de réparabilité"      
-      description:
-        fr: "L'indice de réparabilité de l'objet"
-    WEIGHT:
-      key: WEIGHT
-      title:
-        fr: "Poids de l'objet"      
-      description:
-        fr: "Le poids de l'objet"
-    POWER_CONSUMPTION_TYPICAL:
-      key: POWER_CONSUMPTION_TYPICAL
-      title:
-        fr: "Consommation électrique (en marche)"      
-      description:
-        fr: "La consommation électrique de l'objet en fonctionnement"
-    POWER_CONSUMPTION_OFF:
-      key: POWER_CONSUMPTION_OFF
-      title:
-        fr: "Consommation électrique (arret)"      
-      description:
-        fr: "La consommation électrique à l'arrêt, ou en veille"
-    BRAND_SUSTAINABILITY:
-      key: BRAND_SUSTAINABILITY
-      title:
-        fr: "Evaluation ESG de la marque"      
-      description:
-        fr: "L'évaluation ESG de l'entreprise (filiale ou société mère, suivant la finesse des données) qui fabrique le produit, d'après le score de performance ESG de Sustainalytics"
-    DATA_QUALITY:
-      key: DATA_QUALITY
-      title:
-        fr: "Qualité de la donnée"
-      description:
-        fr: "La qualité de la donnée pour le produit. Quand un facteur manque pour un produit, on lui associe la moyenne de ce facteur pour sa catégorie, mais on dégrade le facteur DATA_QUALITY. Cela permet de pénaliser sans exclure les produits pour lequel un facteur est absent. "
-    DIAGONALE_POUCES:
-      key: DIAGONALE_POUCES
-      title:
-        fr: "Diagonale (en pouces)"
-      description:
-        fr: "La taille de l'écran mesurée en pouces"
-    POWER_CONSUMPTION_STANDBY_NETWORKD:
-      key: POWER_CONSUMPTION_STANDBY_NETWORKD
-      title:
-        fr: "Consommation électrique (arrêt/veille)"
-      description:
-        fr: "La consommation électrique de l'appareil en mode veille ou réseau"
-    POWER_CONSUMPTION_SDR:
-      key: POWER_CONSUMPTION_SDR
-      title:
-        fr: "Consommation électrique (SDR)"
-      description:
-        fr: "La consommation électrique du téléviseur en mode SDR (basse définition)"
-    POWER_CONSUMPTION_HDR:
-      key: POWER_CONSUMPTION_HDR
-      title:
-        fr: "Consommation électrique (HDR)"
-      description:
-        fr: "La consommation électrique du téléviseur en mode HDR (haute définition)"
-    CLASSE_ENERGY_HDR:
-      key: CLASSE_ENERGY_HDR
-      title:
-        fr: "Classe énergétique (HDR)"
-      description:
-        fr: "La classe énergétique du téléviseur en mode HDR"
-    CLASSE_ENERGY_SDR:
-      key: CLASSE_ENERGY_SDR
-      title:
-        fr: "Classe énergétique (SDR)"
-      description:
-        fr: "La classe énergétique du téléviseur en mode SDR"
+    - CLASSE_ENERGY
+    - REPAIRABILITY_INDEX
+    - WEIGHT
+    - POWER_CONSUMPTION_TYPICAL
+    - POWER_CONSUMPTION_OFF
+    - BRAND_SUSTAINABILITY
+    - DATA_QUALITY
+    - DIAGONALE_POUCES
+    - POWER_CONSUMPTION_STANDBY_NETWORKD
+    - POWER_CONSUMPTION_SDR
+    - POWER_CONSUMPTION_HDR
+    - CLASSE_ENERGY_HDR
+    - CLASSE_ENERGY_SDR
               
                 
       

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -89,12 +89,7 @@ impactScoreConfig:
 
 
 availableImpactScoreCriterias:
-  DIAGONALE_POUCES:
-    key: DIAGONALE_POUCES
-    title:
-      fr: "Diagonale (en pouces)"
-    description:
-      fr: "La taille de l'écran mesurée en pouces"
+  - DIAGONALE_POUCES
 
 
 #####################################################################################################################################


### PR DESCRIPTION
## Summary
- switch impact score availability from keyed metadata maps to simple lists across vertical configuration
- update backend services, DTOs, and mappings to resolve titles from attribute metadata and guard missing criteria definitions
- align frontend pages, tests, and generated client types with the new list-based criteria configuration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693005ca88f8833389bfa8a4ce91e3ac)