### PR TITLE
Slow down product price countdown animation

### DIFF
--- a/frontend/app/components/product/ProductHeroPricing.vue
+++ b/frontend/app/components/product/ProductHeroPricing.vue
@@ -501,8 +501,8 @@ const startPriceCountdown = (condition: OfferCondition) => {
     return
   }
 
-  const duration = 1200
-  const easing = (progress: number) => 1 - Math.pow(1 - progress, 3)
+  const duration = 4000
+  const easing = (progress: number) => 1 - Math.pow(1 - progress, 2.6)
   const startedAt = performance.now()
 
   if (animationFrameId.value != null) {


### PR DESCRIPTION
## Summary
- increase the product hero price countdown duration to a smoother 4s
- soften the easing curve to keep the longer animation responsive

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693199b43d4083339b3922b2d10f6eb5)