### PR TITLE
Improve product gallery responsiveness and fallbacks

### DIFF
--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -535,8 +535,10 @@ const galleryItems = computed<ProductGalleryItem[]>(() => {
     .map((item, index) => ({ item, index }))
     .filter(({ item }) => Boolean(item.originalUrl))
     .sort((a, b) => {
-      const groupA = a.item.group?.toLowerCase() ?? ''
-      const groupB = b.item.group?.toLowerCase() ?? ''
+      const normaliseGroup = (value: unknown) => (value == null ? '' : String(value).toLowerCase())
+
+      const groupA = normaliseGroup(a.item.group)
+      const groupB = normaliseGroup(b.item.group)
 
       if (groupA === groupB) {
         return a.index - b.index


### PR DESCRIPTION
## Summary
- adjust the product hero gallery layout to better fit small screens while maintaining aspect ratio
- order gallery media by their group metadata while preserving original ordering within each group
- add client-side image error handling to swap broken images with the shared no-image fallback

## Testing
- pnpm lint *(fails: pnpm not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329143bab08333b9486b16ad478397)