### PR TITLE
Enhance impact details table layout and grouping

### DIFF
--- a/frontend/app/components/product/impact/impact-types.ts
+++ b/frontend/app/components/product/impact/impact-types.ts
@@ -17,6 +17,10 @@ export type ScoreView = {
   description?: string | null
   relativeValue: number | null
   value?: number | null
+  participateInScores?: string[] | null
+  participateInACV?: string[] | null
+  attributeValue?: string | null
+  attributeSuffix?: string | null
   absoluteValue?: string | number | null
   absolute?: ScoreAbsoluteStats | null
   coefficient?: number | null

--- a/frontend/app/pages/[...slug].vue
+++ b/frontend/app/pages/[...slug].vue
@@ -660,6 +660,15 @@ const impactScores = computed(() => {
       ? score.relativ.value
       : null
 
+    const participateInScores = attributeConfig?.participateInScores
+      ? Array.from(attributeConfig.participateInScores)
+      : []
+    const participateInACV = attributeConfig?.participateInACV
+      ? Array.from(attributeConfig.participateInACV)
+      : []
+    const attributeValue = normalizedScoreId ? findIndexedAttributeValue(normalizedScoreId) : null
+    const attributeSuffix = attributeConfig?.suffix ?? null
+
     return {
       id: score.id,
       label: score.name,
@@ -668,6 +677,10 @@ const impactScores = computed(() => {
       relativeValue: isEcoscore ? absoluteScoreValue : relativeScoreValue,
       // For ECOSCORE, value should be the absolute value; for subscores, use relative
       value: isEcoscore ? absoluteScoreValue : relativeScoreValue,
+      participateInScores,
+      participateInACV,
+      attributeValue,
+      attributeSuffix,
       absoluteValue: score.absoluteValue ?? null,
       absolute: score.absolute ?? null,
       coefficient: coefficients[normalizedScoreId] ?? null,

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1899,12 +1899,20 @@
       "valueOutOf": "{value} / {max}",
       "subtitle": "Explore how this product scores across ecological and social criteria.",
       "tableHeaders": {
-        "percent": "Percentile",
-        "ranking": "Rank",
+        "scoreName": "Indicator",
+        "attributeValue": "Attribute value",
+        "scoreValue": "Score",
         "coefficient": "Coefficient",
-        "score": "Indicator",
-        "value": "Value"
+        "lifecycle": "Lifecycle"
       },
+      "lifecycle": {
+        "END_OF_LIFE": "End of life & recycling",
+        "EXTRACTION": "Raw material extraction",
+        "MANUFACTURING": "Manufacturing & assembly",
+        "TRANSPORTATION": "Transport & logistics",
+        "USE": "Product use"
+      },
+      "aggregateScores": {},
       "showDetails": "Show detailed indicators",
       "hideDetails": "Hide detailed indicators",
       "title": "Environmental impact"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1899,12 +1899,20 @@
       "valueOutOf": "{value} / {max}",
       "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
       "tableHeaders": {
-        "percent": "Percentile",
-        "ranking": "Rang",
+        "scoreName": "Indicateur",
+        "attributeValue": "Valeur brute",
+        "scoreValue": "Score",
         "coefficient": "Coefficient",
-        "score": "Indicateur",
-        "value": "Valeur"
+        "lifecycle": "Cycle de vie"
       },
+      "lifecycle": {
+        "END_OF_LIFE": "Fin de vie & recyclage",
+        "EXTRACTION": "Extraction des matières premières",
+        "MANUFACTURING": "Fabrication & assemblage",
+        "TRANSPORTATION": "Transport & logistique",
+        "USE": "Usage du produit"
+      },
+      "aggregateScores": {},
       "showDetails": "Afficher les indicateurs détaillés",
       "hideDetails": "Masquer les indicateurs détaillés",
       "title": "Impact écologique"


### PR DESCRIPTION
## Summary
- add lifecycle chips and attribute value rendering to the product impact details table
- group subscores by participating aggregate scores with collapsible parents
- update score mapping to expose attribute metadata and refresh related translations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932958ea7188333acbf6341d8afb044)