### PR TITLE
Align i18n domain defaults with production hosts

### DIFF
--- a/frontend/docs/internationalisation.md
+++ b/frontend/docs/internationalisation.md
@@ -1,7 +1,7 @@
 # Frontend internationalisation
 
 ## Overview
-The Nuxt 3 frontend determines the active language on every request by inspecting the incoming hostname. This logic is centralised in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) so that both client and server share the same mapping between hostnames, domain language codes (`'en' | 'fr'`), and Nuxt locales (`'en-US' | 'fr-FR'`). The helper now also exposes `buildI18nLocaleDomains()`, allowing [`nuxt.config.ts`](../nuxt.config.ts) to hydrate each locale definition with its canonical domain plus any alternates (e.g. `localhost`) without duplicating configuration. With `differentDomains: true` enabled, the i18n module can reuse the same mapping for host-based locale detection while our plugin keeps SSR and CSR aligned.
+The Nuxt 3 frontend determines the active language on every request by inspecting the incoming hostname. This logic is centralised in [`shared/utils/domain-language.ts`](../shared/utils/domain-language.ts) so that both client and server share the same mapping between hostnames, domain language codes (`'en' | 'fr'`), and Nuxt locales (`'en-US' | 'fr-FR'`). The helper now also exposes `buildI18nLocaleDomains()`, allowing [`nuxt.config.ts`](../nuxt.config.ts) to hydrate each locale definition with its canonical domain plus any alternates (e.g. `localhost`) without duplicating configuration. With `differentDomains: true` enabled, the i18n module can reuse the same mapping for host-based locale detection while our plugin keeps SSR and CSR aligned. The default locale is French (`DEFAULT_DOMAIN_LANGUAGE = 'fr'` / `DEFAULT_NUXT_LOCALE = 'fr-FR'`) to match the live site at `nudger.fr`.
 
 The helper is consumed by:
 
@@ -30,18 +30,18 @@ Top-level routes now expose translated slugs per locale through [`shared/utils/l
 `buildI18nPagesConfig()` exports the same mapping as a structure that Nuxt i18n understands. `nuxt.config.ts` feeds this output to the `pages` option, ensuring the module registers translated aliases and generates `<link rel="alternate">` tags for SEO. Keeping the data in one place guarantees SSR, CSR, and server routes all agree on which slug belongs to which locale.
 
 ## Current hostname mapping
-| Hostname        | Domain language | Nuxt locale | Notes                                     |
-|-----------------|-----------------|-------------|-------------------------------------------|
-| `nudger.com`    | `en`            | `en-US`     | Default English site.                     |
-| `nudger.fr`     | `fr`            | `fr-FR`     | French production domain.                 |
-| `localhost`     | `fr`            | `fr-FR`     | Development override for local browsers.  |
-| `127.0.0.1`     | `en`            | `en-US`     | Development override for English testing. |
+| Hostname        | Domain language | Nuxt locale | Notes                                         |
+|-----------------|-----------------|-------------|-----------------------------------------------|
+| `nudger.fr`     | `fr`            | `fr-FR`     | Default production site and canonical locale. |
+| `nudger.com`    | `en`            | `en-US`     | English production domain.                    |
+| `localhost`     | `fr`            | `fr-FR`     | Development override for local browsers.      |
+| `127.0.0.1`     | `en`            | `en-US`     | Development override for English testing.     |
 
-*IPv6 loopback (`::1`) is intentionally ignored so that dual-stack machines fall back to the default English locale.*
+*IPv6 loopback (`::1`) is intentionally ignored so that dual-stack machines fall back to the default French locale.*
 
 ## How the helper works
 1. **Hostname normalisation** – `normalizeHost` extracts the first value from incoming headers (supporting comma-separated `x-forwarded-host` values), strips the port, and lowercases it so that `LOCALHOST:3000` resolves to `localhost`.
-2. **Domain language resolution** – the hostname is matched against `HOST_DOMAIN_LANGUAGE_MAP`. When no match is found the helper falls back to English (`domainLanguage: 'en'`, `locale: 'en-US'`).
+2. **Domain language resolution** – the hostname is matched against `HOST_DOMAIN_LANGUAGE_MAP`. When no match is found the helper falls back to French (`domainLanguage: 'fr'`, `locale: 'fr-FR'`).
 3. **Locale derivation** – `DOMAIN_LANGUAGE_TO_LOCALE_MAP` provides the Nuxt locale string associated with each domain language.
 4. **Observability** – server callers can enable logging (default behaviour) to warn about unknown hostnames. Client-side consumers typically disable it to avoid console noise.
 5. **Application** – the i18n plugin uses `setLocale` only when the resolved locale differs from the current one. Server routes pass the `domainLanguage` to service factories so outbound API calls carry the correct locale context.
@@ -57,7 +57,7 @@ The mapping lives in [`shared/utils/domain-language.ts`](../shared/utils/domain-
 When introducing a new locale, also register it in `nuxt.config.ts` under the `i18n.locales` array so translations can load correctly.
 
 ## Behaviour on unknown domains
-If the application receives a hostname that is not present in `HOST_DOMAIN_LANGUAGE_MAP`, the request falls back to English (`domainLanguage: 'en'`, `locale: 'en-US'`). Server-side callers log a warning describing the unknown hostname so operators can adjust the mapping. Client-side navigation continues without additional logging to avoid noise in the browser console.
+If the application receives a hostname that is not present in `HOST_DOMAIN_LANGUAGE_MAP`, the request falls back to French (`domainLanguage: 'fr'`, `locale: 'fr-FR'`). Server-side callers log a warning describing the unknown hostname so operators can adjust the mapping. Client-side navigation continues without additional logging to avoid noise in the browser console.
 
 ## Relationship with content bundles
 Locale codes correspond to JSON translation bundles stored under

--- a/frontend/i18n.config.ts
+++ b/frontend/i18n.config.ts
@@ -1,7 +1,7 @@
 export default defineI18nConfig(() => ({
   legacy: false,
-  locale: 'en-US',
-  fallbackLocale: 'en-US',
+  locale: 'fr-FR',
+  fallbackLocale: 'fr-FR',
   availableLocales: ['en-US', 'fr-FR'],
   missingWarn: false,
   fallbackWarn: false,

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -362,7 +362,7 @@ export default defineNuxtConfig({
       },
     },
   i18n: {
-    defaultLocale: 'en-US',
+    defaultLocale: 'fr-FR',
     langDir: '../i18n/locales',
     locales: [
       { code: 'fr-FR', name: 'Français', file: 'fr-FR.ts', ...(localeDomains['fr-FR'] ?? {}) },

--- a/frontend/shared/utils/domain-language.spec.ts
+++ b/frontend/shared/utils/domain-language.spec.ts
@@ -38,8 +38,8 @@ describe('domain-language helpers', () => {
   it('falls back to default mapping when hostname is missing', () => {
     const resolution = getDomainLanguageFromHostname(null)
 
-    expect(resolution.domainLanguage).toBe('en')
-    expect(resolution.locale).toBe('en-US')
+    expect(resolution.domainLanguage).toBe('fr')
+    expect(resolution.locale).toBe('fr-FR')
     expect(resolution.matched).toBe(false)
   })
 })

--- a/frontend/shared/utils/domain-language.ts
+++ b/frontend/shared/utils/domain-language.ts
@@ -1,13 +1,14 @@
 export type DomainLanguage = 'en' | 'fr'
 export type NuxtLocale = 'en-US' | 'fr-FR'
 
-export const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'en'
-export const DEFAULT_NUXT_LOCALE: NuxtLocale = 'en-US'
+export const DEFAULT_DOMAIN_LANGUAGE: DomainLanguage = 'fr'
+export const DEFAULT_NUXT_LOCALE: NuxtLocale = 'fr-FR'
 
 export const HOST_DOMAIN_LANGUAGE_MAP: Record<string, DomainLanguage> = {
   'nudger.fr': 'fr',
   localhost: 'fr',
   'beta.nudger.fr': 'fr',
+  'nudger.com': 'en',
   '127.0.0.1': 'en',
 }
 

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -14,8 +14,8 @@ describe('localized-routes utilities', () => {
   it('normalizes supported locales', () => {
     expect(normalizeLocale('fr-FR')).toBe('fr-FR')
     expect(normalizeLocale('en-US')).toBe('en-US')
-    expect(normalizeLocale('es-ES')).toBe('en-US')
-    expect(normalizeLocale(undefined)).toBe('en-US')
+    expect(normalizeLocale('es-ES')).toBe('fr-FR')
+    expect(normalizeLocale(undefined)).toBe('fr-FR')
   })
 
   it('resolves localized static paths', () => {

--- a/frontend/site.config.ts
+++ b/frontend/site.config.ts
@@ -2,6 +2,7 @@ import { defineSiteConfig } from 'nuxt-site-config'
 
 const urls = {
   fr: 'https://nudger.fr',
+  en: 'https://nudger.com',
 } as const
 
 export default defineSiteConfig({


### PR DESCRIPTION
## Summary
- switch the default domain language/locale to French and map the English production host to nudger.com
- align Nuxt i18n configuration and site URLs with the updated domain mapping
- update internationalisation documentation to reflect the new defaults and hostname notes

## Testing
- `pnpm lint` *(fails: pnpm unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b02e43588333930ce530a5190b25)