### PR TITLE
Fix required attribute exclusion and add tests

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
@@ -311,19 +311,21 @@ public class AttributeRealtimeAggregationService extends AbstractAggregationServ
 
 
 		Set<String> attrKeys = data.getAttributes().getattributesAsStringKeys();
-		if (vConf.getRequiredAttributes() != null && !attrKeys.containsAll(vConf.getRequiredAttributes())) {
+                if (vConf.getRequiredAttributes() != null) {
 
-			Set<String> missing = new HashSet<>(vConf.getRequiredAttributes());
-			missing.retainAll(attrKeys);
+                        Set<String> missing = new HashSet<>(vConf.getRequiredAttributes());
+                        missing.removeAll(attrKeys);
 
-			missing.forEach(e-> {
-				data.getExcludedCauses().add("missing_attr_" + e);
-			});
+                        if (!missing.isEmpty()) {
+                                missing.forEach(e-> {
+                                        data.getExcludedCauses().add("missing_attr_" + e);
+                                });
 
-			dedicatedLogger.info("Excluded because required attributes are missing : {}", data );
-			ret =  true;
+                                dedicatedLogger.info("Excluded because required attributes are missing : {}", data );
+                                ret =  true;
+                        }
 
-		}
+                }
 
 		data.setExcluded(ret);
 

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
@@ -1,0 +1,80 @@
+package org.open4goods.api.services.aggregation.services.realtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.brand.service.BrandService;
+import org.open4goods.icecat.services.IcecatService;
+import org.open4goods.model.attribute.ProductAttribute;
+import org.open4goods.model.attribute.ReferentielKey;
+import org.open4goods.model.eprel.EprelProduct;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AttributeRealtimeAggregationServiceTest {
+
+        private AttributeRealtimeAggregationService service;
+        private VerticalConfig verticalConfig;
+
+        @BeforeEach
+        void setUp() {
+                Logger logger = LoggerFactory.getLogger(AttributeRealtimeAggregationServiceTest.class);
+                BrandService brandService = Mockito.mock(BrandService.class);
+                VerticalsConfigService verticalConfigService = Mockito.mock(VerticalsConfigService.class);
+                IcecatService icecatService = Mockito.mock(IcecatService.class);
+                service = new AttributeRealtimeAggregationService(verticalConfigService, brandService, logger, icecatService);
+
+                verticalConfig = new VerticalConfig();
+                verticalConfig.setRequiredAttributes(Set.of("required_attr"));
+        }
+
+        @Test
+        void updateExcludeStatusDoesNotExcludeWhenRequiredAttributesPresent() throws Exception {
+                Product product = buildBaseProduct();
+                addAttribute(product, "required_attr");
+
+                invokeUpdateExcludeStatus(product);
+
+                assertThat(product.isExcluded()).isFalse();
+                assertThat(product.getExcludedCauses()).isEmpty();
+        }
+
+        @Test
+        void updateExcludeStatusFlagsMissingRequiredAttributes() throws Exception {
+                Product product = buildBaseProduct();
+
+                invokeUpdateExcludeStatus(product);
+
+                assertThat(product.isExcluded()).isTrue();
+                assertThat(product.getExcludedCauses()).containsExactly("missing_attr_required_attr");
+        }
+
+        private Product buildBaseProduct() {
+                Product product = new Product(123L);
+                product.getAttributes().getReferentielAttributes().put(ReferentielKey.BRAND, "Brand");
+                product.getAttributes().getReferentielAttributes().put(ReferentielKey.MODEL, "ModelX");
+                product.setEprelDatas(new EprelProduct());
+                return product;
+        }
+
+        private void addAttribute(Product product, String name) {
+                ProductAttribute attribute = new ProductAttribute();
+                attribute.setName(name);
+                attribute.setValue("value");
+                product.getAttributes().getAll().put(name, attribute);
+        }
+
+        private void invokeUpdateExcludeStatus(Product product) throws Exception {
+                Method method = AttributeRealtimeAggregationService.class.getDeclaredMethod("updateExcludeStatus", Product.class, VerticalConfig.class);
+                method.setAccessible(true);
+                method.invoke(service, product, verticalConfig);
+        }
+}


### PR DESCRIPTION
## Summary
- correct required attribute handling so exclusion only occurs for missing attributes
- add unit tests covering updateExcludeStatus for required attributes

## Testing
- mvn -Dtest=AttributeRealtimeAggregationServiceTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934524ac8f483339ce4fa32a3d8a062)