### PR TITLE
Add nudge tool configuration support for verticals

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolConfigDto.java
@@ -1,0 +1,16 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Frontend representation of the nudge tool configuration.
+ */
+public record NudgeToolConfigDto(
+        @Schema(description = "List of scores highlighted by the nudge tool.")
+        List<NudgeToolScoreDto> scores,
+        @Schema(description = "Subsets reused by the nudge tool.")
+        List<VerticalSubsetDto> subsets
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolScoreDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolScoreDto.java
@@ -1,0 +1,20 @@
+package org.open4goods.nudgerfrontapi.dto.category;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Score definition exposed by the nudge tool.
+ */
+public record NudgeToolScoreDto(
+        @Schema(description = "Identifier of the score used by the nudge tool.", example = "IMPACT_SCORE")
+        String scoreName,
+        @Schema(description = "Minimum value required to feature the score.", example = "70")
+        Double scoreMinValue,
+        @Schema(description = "Material Design icon representing the score.", example = "leaf")
+        String mdiIcon,
+        @Schema(description = "Localised title of the nudge.")
+        String title,
+        @Schema(description = "Localised description for the nudge.")
+        String description
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigDto.java
@@ -38,6 +38,8 @@ public record VerticalConfigDto(
         @Schema(description = "Popular attributes resolved to their full configuration metadata.")
         List<AttributeConfigDto> popularAttributes,
         @Schema(description = "Identifiers of composite scores aggregating score attributes for the vertical.")
-        Set<String> aggregatedScores
+        Set<String> aggregatedScores,
+        @Schema(description = "Configuration supporting the guided nudge tool for this vertical.")
+        NudgeToolConfigDto nudgeToolConfig
 ) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/VerticalConfigFullDto.java
@@ -13,6 +13,7 @@ import org.open4goods.model.vertical.ResourcesAggregationConfig;
 import org.open4goods.model.vertical.ScoringAggregationConfig;
 import org.open4goods.model.vertical.WikiPageConfig;
 import org.open4goods.nudgerfrontapi.dto.blog.BlogPostDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolConfigDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -98,6 +99,8 @@ public record VerticalConfigFullDto(
         ImpactScoreConfigDto impactScoreConfig,
         @Schema(description = "Custom subsets defined for this vertical with localised labels.")
         List<VerticalSubsetDto> subsets,
+        @Schema(description = "Configuration supporting the guided nudge tool for this vertical.")
+        NudgeToolConfigDto nudgeToolConfig,
         @Schema(description = "Subset dedicated to brand exploration with localised labels.")
         VerticalSubsetDto brandsSubset,
         @Schema(description = "Barcode aggregation configuration.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -17,6 +17,8 @@ import org.open4goods.model.vertical.AttributesConfig;
 import org.open4goods.model.vertical.FeatureGroup;
 import org.open4goods.model.vertical.ImpactScoreConfig;
 import org.open4goods.model.vertical.ProductCategory;
+import org.open4goods.model.vertical.NudgeToolConfig;
+import org.open4goods.model.vertical.NudgeToolScore;
 import org.open4goods.model.vertical.ProductI18nElements;
 import org.open4goods.model.vertical.SiteNaming;
 import org.open4goods.model.vertical.VerticalConfig;
@@ -30,6 +32,8 @@ import org.open4goods.nudgerfrontapi.dto.category.CategoryNavigationDto;
 import org.open4goods.nudgerfrontapi.dto.category.FeatureGroupDto;
 import org.open4goods.nudgerfrontapi.dto.category.GoogleCategoryDto;
 import org.open4goods.nudgerfrontapi.dto.category.ImpactScoreConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolScoreDto;
 import org.open4goods.nudgerfrontapi.dto.category.SiteNamingDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
 import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigFullDto;
@@ -90,7 +94,8 @@ public class CategoryMappingService {
                 i18n == null ? null : i18n.getVerticalHomeDescription(),
                 i18n == null ? null : i18n.getVerticalHomeUrl(),
                 mapPopularAttributes(verticalConfig, domainLanguage),
-                defaultSet(verticalConfig.getAggregatedScores()));
+                defaultSet(verticalConfig.getAggregatedScores()),
+                mapNudgeToolConfig(verticalConfig.getNudgeToolConfig(), domainLanguage));
     }
 
     /**
@@ -150,6 +155,7 @@ public class CategoryMappingService {
                 defaultSet(verticalConfig.getAggregatedScores()),
                 mapImpactScoreConfig(verticalConfig.getImpactScoreConfig(), domainLanguage),
                 mapVerticalSubsets(verticalConfig.getSubsets(), domainLanguage),
+                mapNudgeToolConfig(verticalConfig.getNudgeToolConfig(), domainLanguage),
                 mapVerticalSubset(verticalConfig.getBrandsSubset(), domainLanguage),
                 verticalConfig.getBarcodeConfig(),
                 verticalConfig.getRecommandationsConfig(),
@@ -468,6 +474,36 @@ public class CategoryMappingService {
                 localise(impactScoreConfig.getTexts(), domainLanguage),
                 impactScoreConfig.getYamlPrompt(),
                 impactScoreConfig.getAiJsonResponse());
+    }
+
+
+    /**
+     * Map the nudge tool configuration to its DTO representation.
+     */
+    private NudgeToolConfigDto mapNudgeToolConfig(NudgeToolConfig nudgeToolConfig, DomainLanguage domainLanguage) {
+        if (nudgeToolConfig == null) {
+            return null;
+        }
+
+        List<NudgeToolScoreDto> scores = defaultList(nudgeToolConfig.getScores()).stream()
+                .map(score -> mapNudgeToolScore(score, domainLanguage))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        return new NudgeToolConfigDto(scores, mapVerticalSubsets(nudgeToolConfig.getSubsets(), domainLanguage));
+    }
+
+    private NudgeToolScoreDto mapNudgeToolScore(NudgeToolScore score, DomainLanguage domainLanguage) {
+        if (score == null) {
+            return null;
+        }
+
+        return new NudgeToolScoreDto(
+                score.getScoreName(),
+                score.getScoreMinValue(),
+                score.getMdiIcon(),
+                localise(score.getTitle(), domainLanguage),
+                localise(score.getDescription(), domainLanguage));
     }
 
 

--- a/model/src/main/java/org/open4goods/model/vertical/NudgeToolConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/NudgeToolConfig.java
@@ -1,0 +1,54 @@
+package org.open4goods.model.vertical;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+
+/**
+ * Configuration for the nudge tool displayed on vertical pages.
+ * It combines curated score thresholds and reusable subsets to simplify
+ * user discovery.
+ */
+public class NudgeToolConfig {
+
+    @JsonMerge
+    private List<NudgeToolScore> scores = new ArrayList<>();
+
+    @JsonMerge
+    private List<VerticalSubset> subsets = new ArrayList<>();
+
+    public List<NudgeToolScore> getScores() {
+        return scores;
+    }
+
+    public void setScores(List<NudgeToolScore> scores) {
+        this.scores = scores;
+    }
+
+    public List<VerticalSubset> getSubsets() {
+        return subsets;
+    }
+
+    public void setSubsets(List<VerticalSubset> subsets) {
+        this.subsets = subsets;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof NudgeToolConfig)) {
+            return false;
+        }
+        NudgeToolConfig that = (NudgeToolConfig) o;
+        return Objects.equals(scores, that.scores) && Objects.equals(subsets, that.subsets);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scores, subsets);
+    }
+}

--- a/model/src/main/java/org/open4goods/model/vertical/NudgeToolScore.java
+++ b/model/src/main/java/org/open4goods/model/vertical/NudgeToolScore.java
@@ -1,0 +1,76 @@
+package org.open4goods.model.vertical;
+
+import java.util.Objects;
+
+import org.open4goods.model.Localisable;
+
+/**
+ * Describes a score threshold highlighted by the nudge tool.
+ */
+public class NudgeToolScore {
+
+    private String scoreName;
+    private Double scoreMinValue;
+    private String mdiIcon;
+    private Localisable<String, String> title = new Localisable<>();
+    private Localisable<String, String> description = new Localisable<>();
+
+    public String getScoreName() {
+        return scoreName;
+    }
+
+    public void setScoreName(String scoreName) {
+        this.scoreName = scoreName;
+    }
+
+    public Double getScoreMinValue() {
+        return scoreMinValue;
+    }
+
+    public void setScoreMinValue(Double scoreMinValue) {
+        this.scoreMinValue = scoreMinValue;
+    }
+
+    public String getMdiIcon() {
+        return mdiIcon;
+    }
+
+    public void setMdiIcon(String mdiIcon) {
+        this.mdiIcon = mdiIcon;
+    }
+
+    public Localisable<String, String> getTitle() {
+        return title;
+    }
+
+    public void setTitle(Localisable<String, String> title) {
+        this.title = title;
+    }
+
+    public Localisable<String, String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(Localisable<String, String> description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof NudgeToolScore)) {
+            return false;
+        }
+        NudgeToolScore that = (NudgeToolScore) o;
+        return Objects.equals(scoreName, that.scoreName) && Objects.equals(scoreMinValue, that.scoreMinValue)
+                && Objects.equals(mdiIcon, that.mdiIcon) && Objects.equals(title, that.title)
+                && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scoreName, scoreMinValue, mdiIcon, title, description);
+    }
+}

--- a/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/VerticalConfig.java
@@ -217,15 +217,21 @@ public class VerticalConfig {
 	 */
 	private ImpactScoreConfig impactScoreConfig = new ImpactScoreConfig();
 
-	////////////////////
-	// The subsets for this vertical
-	////////////////////
+        ////////////////////
+        // The subsets for this vertical
+        ////////////////////
 
 	/**
 	 * The vertical custom subsets
 	 */
-	@JsonMerge
-	private List<VerticalSubset> subsets = new ArrayList<VerticalSubset>();
+        @JsonMerge
+        private List<VerticalSubset> subsets = new ArrayList<VerticalSubset>();
+
+        /**
+         * The nudge tool configuration displayed to guide user selection.
+         */
+        @JsonMerge
+        private NudgeToolConfig nudgeToolConfig = new NudgeToolConfig();
 
 	/**
 	 * The subset dedicated to brands; Technical, no yaml def needed TODO(p2,
@@ -917,12 +923,20 @@ public class VerticalConfig {
 		return subsets;
 	}
 
-	public void setSubsets(List<VerticalSubset> subsets) {
-		this.subsets = subsets;
-	}
+        public void setSubsets(List<VerticalSubset> subsets) {
+                this.subsets = subsets;
+        }
 
-	public VerticalSubset getBrandsSubset() {
-		return brandsSubset;
+        public NudgeToolConfig getNudgeToolConfig() {
+                return nudgeToolConfig;
+        }
+
+        public void setNudgeToolConfig(NudgeToolConfig nudgeToolConfig) {
+                this.nudgeToolConfig = nudgeToolConfig;
+        }
+
+        public VerticalSubset getBrandsSubset() {
+                return brandsSubset;
 	}
 
 	public void setBrandsSubset(VerticalSubset brandsSubset) {

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -217,7 +217,162 @@ i18n:
    # The image used as a logo
 
 
-          
+nudgeToolConfig:
+  scores:
+    - scoreName: "IMPACT_SCORE"
+      scoreMinValue: 70
+      mdiIcon: "leaf"
+      title:
+        en: "Great eco score"
+        fr: "Excellent score éco"
+      description:
+        en: "Televisions with an eco score of 70 or above."
+        fr: "Téléviseurs avec un score écologique supérieur ou égal à 70."
+    - scoreName: "REPAIRABILITY_INDEX"
+      scoreMinValue: 7
+      mdiIcon: "wrench"
+      title:
+        en: "Repairable choices"
+        fr: "Choix réparables"
+      description:
+        en: "Models with a repairability index of 7 or more."
+        fr: "Modèles dont l'indice de réparabilité est d'au moins 7."
+  subsets:
+################
+# Price
+################
+   - id: "price_lower_500"  # Unique identifier for the subset
+     group: "price"
+     criterias:
+       - field: "price.minPrice.price"
+         operator: "LOWER_THAN"
+         value: "500"
+       - field: "price.minPrice.price"
+         operator: "GREATER_THAN"
+         value: "0"
+     image: "example-image.png"
+     url:
+       en: "low-price"
+       fr: "petits-prix"
+     caption:
+       en: "< 500 €"
+       fr: "< 500 €"
+     title:
+       en: "Affordable TVs"
+       fr: "TV pas chères"
+     description:
+       en: "TVs priced under €500."
+       fr: "Les TV dont le prix est inférieur à 500€."
+
+   - id: "price_500_1000"
+     group: "price"
+     criterias:
+       - field: "price.minPrice.price"
+         operator: "GREATER_THAN"
+         value: "500"
+       - field: "price.minPrice.price"
+         operator: "LOWER_THAN"
+         value: "1000"
+     image: "example-image.png"
+     url:
+       en: "tv-500-1000-euros"
+       fr: "tv-500-1000-euros"
+     caption:
+       en: "500 - 1000 €"
+       fr: "500 - 1000 €"
+     title:
+       en: "Mid-range TVs"
+       fr: "TV milieu de gamme"
+     description:
+       en: "TVs priced between €500 and €1000."
+       fr: "Les TV dont le prix est compris entre 500€ et 1000€."
+
+   - id: "price_greater_1000"
+     group: "price"
+     criterias:
+       - field: "price.minPrice.price"
+         operator: "GREATER_THAN"
+         value: "1000"
+     image: "example-image.png"
+     url:
+       en: "premium-price"
+       fr: "haut-de-gamme"
+     caption:
+       en: "> 1000 €"
+       fr: "> 1000 €"
+     title:
+       en: "Premium TVs"
+       fr: "TV haut de gamme"
+     description:
+       en: "TVs priced over €1000."
+       fr: "Les TV dont le prix est supérieur à 1000€."
+
+################
+# Screen Size
+################
+   - id: "small_screens"
+     group: "screen_size"
+     criterias:
+       - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+         operator: "LOWER_THAN"
+         value: "32"
+     image: "small-screen.png"
+     url:
+       en: "small-screens"
+       fr: "petits-ecrans"
+     caption:
+       en: "Small screens (< 32\")"
+       fr: "Petits écrans (< 32\")"
+     title:
+       en: "Small Screen TVs"
+       fr: "Petits écrans"
+     description:
+       en: "TVs with a screen size smaller than 32 inches."
+       fr: "Les TV avec une taille d'écran inférieure à 32 pouces."
+
+   - id: "medium_screens"
+     group: "screen_size"
+     criterias:
+       - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+         operator: "GREATER_THAN"
+         value: "32"
+       - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+         operator: "LOWER_THAN"
+         value: "55"
+     image: "medium-screen.png"
+     url:
+       en: "medium-screens"
+       fr: "ecrans-moyens"
+     caption:
+       en: "Medium screens (32\" - 55\")"
+       fr: "Écrans moyens (32\" - 55\")"
+     title:
+       en: "Medium Screen TVs"
+       fr: "Écrans moyens"
+     description:
+       en: "TVs with a screen size between 32 and 55 inches."
+       fr: "Les TV avec une taille d'écran comprise entre 32 et 55 pouces."
+
+   - id: "large_screens"
+     group: "screen_size"
+     criterias:
+       - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+         operator: "GREATER_THAN"
+         value: "55"
+     image: "large-screen.png"
+     url:
+       en: "large-screens"
+       fr: "grands-ecrans"
+     caption:
+       en: "Large screens (> 55\")"
+       fr: "Grands écrans (> 55\")"
+     title:
+       en: "Large Screen TVs"
+       fr: "Grands écrans"
+     description:
+       en: "TVs with a screen size greater than 55 inches."
+       fr: "Les TV avec une taille d'écran supérieure à 55 pouces."
+
 subsets:
 ################
 # Price


### PR DESCRIPTION
## Summary
- add nudge tool configuration for the TV vertical including nudge scores and duplicated subsets
- introduce nudge tool domain models and expose them through vertical DTOs with localisation
- map the new configuration in the front API so clients receive the guided selection data

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69359842129483229aca12d6b27e3ea3)