### PR TITLE
Add home page nudge wizard and fix lint issues

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -2,7 +2,7 @@
   <div class="nudge-step-subset">
     <div class="nudge-step-subset__header">
       <div>
-        <div class="nudge-step-subset__eyebrow" v-if="group.mdiIcon || group.title">
+        <div v-if="group.mdiIcon || group.title" class="nudge-step-subset__eyebrow">
           <v-icon v-if="group.mdiIcon" :icon="group.mdiIcon" size="18" class="me-1" />
           <span>{{ group.title }}</span>
         </div>
@@ -30,7 +30,7 @@
           :aria-pressed="modelValue.includes(subset.id ?? '')"
           @click="toggle(subset.id ?? '')"
         >
-          <div class="nudge-step-subset__media" v-if="subset.image">
+          <div v-if="subset.image" class="nudge-step-subset__media">
             <v-img :src="subset.image" height="120" cover />
           </div>
           <div class="nudge-step-subset__body">

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="nudge-wizard" rounded="xl" elevation="3">
-    <div class="nudge-wizard__progress" v-if="loading">
+    <div v-if="loading" class="nudge-wizard__progress">
       <v-progress-linear indeterminate color="primary" rounded bar-height="4" />
     </div>
 
@@ -37,6 +37,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import type { Component } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import {
   buildCategoryHash,
@@ -153,13 +154,15 @@ const hashState = computed<CategoryHashState>(() => ({
 
 const canNavigate = computed(() => Boolean(selectedCategory?.value))
 
-const steps = computed(() => {
-  const sequence: Array<{
-    key: string
-    component: any
-    props: Record<string, unknown>
-    onUpdate?: (...args: any[]) => void
-  }> = []
+type WizardStep = {
+  key: string
+  component: Component
+  props: Record<string, unknown>
+  onUpdate?: (value: unknown) => void
+}
+
+const steps = computed<WizardStep[]>(() => {
+  const sequence: WizardStep[] = []
 
   if (!props.initialCategoryId) {
     sequence.push({

--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -22,21 +22,21 @@
                 v-if="heroMedia.type === 'image'"
                 :src="heroMedia.previewUrl"
                 :alt="heroMedia.alt"
-                class="product-gallery__stage-media"
-                @error="handleImageError"
                 format="webp"
                 :width="heroMedia.width"
                 :height="heroMedia.height"
+                class="product-gallery__stage-media"
+                @error="handleImageError"
               />
               <NuxtImg
                 v-else-if="heroMedia.posterUrl"
                 :src="heroMedia.posterUrl"
                 :alt="heroMedia.alt"
-                class="product-gallery__stage-media"
-                @error="handleImageError"
                 format="webp"
                 :width="heroMedia.width"
                 :height="heroMedia.height"
+                class="product-gallery__stage-media"
+                @error="handleImageError"
               />
               <div v-if="heroMedia.type === 'video'" class="product-gallery__stage-overlay">
                 <v-icon icon="mdi-play-circle-outline" size="56" class="product-gallery__stage-icon" />
@@ -118,11 +118,11 @@
                     <NuxtImg
                       :src="item.thumbnailUrl"
                       :alt="item.alt"
-                      class="product-gallery__thumbnail-image"
-                      @error="handleImageError"
                       format="webp"
                       :width="item.thumbnailWidth"
                       :height="item.thumbnailHeight"
+                      class="product-gallery__thumbnail-image"
+                      @error="handleImageError"
                     />
                     <span
                       v-if="item.type === 'video'"
@@ -161,11 +161,11 @@
           <NuxtImg
             :src="heroFallbackImage"
             :alt="title"
-            class="product-hero__fallback"
-            @error="handleImageError"
             format="webp"
             :width="600"
             :height="600"
+            class="product-hero__fallback"
+            @error="handleImageError"
           />
         </div>
       </template>
@@ -174,11 +174,11 @@
           v-if="heroFallbackImage"
           :src="heroFallbackImage"
           :alt="title"
-          class="product-hero__fallback"
-          @error="handleImageError"
           format="webp"
           :width="600"
           :height="600"
+          class="product-hero__fallback"
+          @error="handleImageError"
         />
       </template>
     </ClientOnly>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -10,6 +10,7 @@ import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
 import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
 import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
+import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
 import type { CategorySuggestionItem, ProductSuggestionItem } from '~/components/search/SearchSuggestField.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useBlog } from '~/composables/blog/useBlog'
@@ -618,6 +619,20 @@ useHead(() => ({
       @select-category="handleCategorySuggestion"
       @select-product="handleProductSuggestion"
     />
+    <section class="home-page__nudge-tool">
+      <v-container class="pa-0 pa-md-6">
+        <v-row class="align-center" :gutter="0">
+          <v-col cols="12" md="4" class="pe-md-6 pb-6 pb-md-0">
+            <p class="home-page__nudge-eyebrow">{{ t('home.nudgeTool.eyebrow') }}</p>
+            <h2 class="home-page__nudge-title">{{ t('home.nudgeTool.title') }}</h2>
+            <p class="home-page__nudge-subtitle">{{ t('home.nudgeTool.subtitle') }}</p>
+          </v-col>
+          <v-col cols="12" md="8">
+            <NudgeToolWizard :verticals="rawCategories" />
+          </v-col>
+        </v-row>
+      </v-container>
+    </section>
     <div class="home-page__sections">
       <HomeProblemsSection :items="problemItems" />
 
@@ -656,6 +671,33 @@ useHead(() => ({
   flex-direction: column
   gap: 0
   background-color: rgb(var(--v-theme-surface-default))
+
+.home-page__nudge-tool
+  background-color: rgb(var(--v-theme-surface-primary-050))
+  padding: clamp(2.5rem, 6vw, 4rem) 0
+
+.home-page__nudge-eyebrow
+  display: inline-flex
+  align-items: center
+  gap: 8px
+  margin: 0 0 8px
+  padding: 6px 12px
+  font-weight: 700
+  color: rgb(var(--v-theme-text-on-accent))
+  background: linear-gradient(90deg, rgba(var(--v-theme-hero-gradient-start), 0.8), rgba(var(--v-theme-hero-gradient-end), 0.9))
+  border-radius: 999px
+  width: fit-content
+
+.home-page__nudge-title
+  margin: 0 0 8px
+  font-size: clamp(1.6rem, 2.5vw, 2rem)
+  color: rgb(var(--v-theme-text-neutral-strong))
+  font-weight: 800
+
+.home-page__nudge-subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-size: clamp(1rem, 1.6vw, 1.1rem)
 
 .home-page__sections
   display: flex

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -70,6 +70,11 @@
         ]
       }
     },
+    "nudgeTool": {
+      "eyebrow": "Personalised guidance",
+      "title": "Try the Nudge tool",
+      "subtitle": "Answer a few quick questions to jump straight to responsible products."
+    },
     "problems": {
       "title": "Too many labels, not enough clarity?",
       "description": "Comparing impact, price and trust sources across dozens of tabs is exhausting. Nudger brings it back to one place.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -70,6 +70,11 @@
         ]
       }
     },
+    "nudgeTool": {
+      "eyebrow": "Guidage personnalisé",
+      "title": "Essayez l'outil Nudge",
+      "subtitle": "Répondez à quelques questions et accédez directement aux produits responsables."
+    },
     "problems": {
       "title": "Trop de labels, pas assez de clarté ?",
       "description": "Comparer impact, prix et fiabilité à travers une multitude d’onglets est épuisant. Nudger rassemble tout au même endroit.",


### PR DESCRIPTION
## Summary
- integrate the NudgeToolWizard on the home page with supporting copy and styling
- clean up lint warnings in nudge tool components and the product hero gallery
- add translations for the new nudge tool section

## Testing
- pnpm lint
- pnpm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367a5e75748333b2ee705c1419edcf)