### PR TITLE
Refine nudge tool wizard navigation

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2199,7 +2199,9 @@
   "nudge-tool": {
     "actions": {
       "continue": "Continue",
-      "seeAll": "See all recommendations"
+      "seeAll": "See all recommendations",
+      "previous": "Previous",
+      "next": "Next"
     },
     "meta": {
       "matches": "{count} products match your choices"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2200,7 +2200,9 @@
   "nudge-tool": {
     "actions": {
       "continue": "Continuer",
-      "seeAll": "Voir toutes les recommandations"
+      "seeAll": "Voir toutes les recommandations",
+      "previous": "Précédent",
+      "next": "Suivant"
     },
     "meta": {
       "matches": "{count} produits correspondent à vos choix"


### PR DESCRIPTION
## Summary
- add a Vuetify stepper header with a filtered-results link and re-ordered wizard steps
- streamline navigation controls with previous/next buttons and multi-select gating
- localize the new navigation labels for both English and French

## Testing
- pnpm lint
- pnpm vitest run NudgeToolWizard --passWithNoTests
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69392f61901083228a4221153ca1bd47)