### PR TITLE
Allow aggregated scores in product filters

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -468,6 +468,7 @@ public class ProductController {
         VerticalConfig config = hasVertical ? verticalsConfigService.getConfigById(normalizedVerticalId) : null;
         ProductFieldOptionsResponse fieldOptions = resolveVerticalFields(config, domainLanguage, globalFields);
         Set<String> allowedFilters = collectAllowedFieldMappings(fieldOptions);
+        augmentWithAggregatedScores(allowedFilters, config);
         Set<String> allowedSorts = collectGlobalSortMappings();
         if (hasVertical) {
             allowedSorts.addAll(allowedFilters);
@@ -486,6 +487,27 @@ public class ProductController {
         addFieldMappings(allowed, fieldOptions.impact());
         addFieldMappings(allowed, fieldOptions.technical());
         return allowed;
+    }
+
+    /**
+     * Add aggregated score mappings derived from the vertical configuration.
+     *
+     * @param target collection of allowed filter mappings to update
+     * @param config vertical configuration supplying aggregated score identifiers
+     */
+    private void augmentWithAggregatedScores(Set<String> target, VerticalConfig config) {
+        LOGGER.info("Entering augmentWithAggregatedScores(targetSize={}, config={})",
+                target != null ? target.size() : 0, config);
+        if (target == null || config == null || config.getAggregatedScores() == null) {
+            return;
+        }
+        for (String score : config.getAggregatedScores()) {
+            if (!StringUtils.hasText(score)) {
+                continue;
+            }
+            String mapping = "scores." + score.trim();
+            target.add(mapping);
+        }
     }
 
     /**

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ProductControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ProductControllerTest.java
@@ -1,0 +1,90 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.model.vertical.AttributeConfig;
+import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.dto.PageDto;
+import org.open4goods.nudgerfrontapi.dto.PageMetaDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.Filter;
+import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
+import org.open4goods.nudgerfrontapi.dto.search.ProductSearchRequestDto;
+import org.open4goods.nudgerfrontapi.dto.search.ProductSearchResponseDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.ProductMappingService;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Unit tests for {@link ProductController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProductControllerTest {
+
+    @Mock
+    private ProductMappingService productMappingService;
+
+    @Mock
+    private VerticalsConfigService verticalsConfigService;
+
+    private ProductController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new ProductController(productMappingService, verticalsConfigService);
+    }
+
+    @Test
+    void aggregatedScoreFiltersArePermitted() {
+        VerticalConfig config = new VerticalConfig();
+        config.setId("electronics");
+
+        AttributeConfig attributeConfig = new AttributeConfig();
+        attributeConfig.setKey("POWER_USAGE");
+        attributeConfig.setAsScore(true);
+        attributeConfig.setParticipateInScores(Set.of("ENERGY_CONSUMPTION"));
+        config.setAttributesConfig(new AttributesConfig(List.of(attributeConfig)));
+
+        when(verticalsConfigService.getConfigById("electronics")).thenReturn(config);
+
+        Filter filter = new Filter("scores.ENERGY_CONSUMPTION", FilterOperator.range, null, 0.0, 100.0);
+        ProductSearchRequestDto searchRequest = new ProductSearchRequestDto(null, null, new FilterRequestDto(List.of(filter)));
+
+        PageDto<ProductDto> page = new PageDto<>(new PageMetaDto(0, 20, 1, 1), List.of());
+        ProductSearchResponseDto responseDto = new ProductSearchResponseDto(page, List.of());
+        when(productMappingService.searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(), any(), any(), any()))
+                .thenReturn(responseDto);
+
+        ResponseEntity<ProductSearchResponseDto> response = controller.products(PageRequest.of(0, 20), Set.of(),
+                "electronics", null, DomainLanguage.fr, Locale.FRANCE, searchRequest);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ArgumentCaptor<FilterRequestDto> filterCaptor = ArgumentCaptor.forClass(FilterRequestDto.class);
+        verify(productMappingService).searchProducts(any(Pageable.class), any(Locale.class), anySet(), any(), any(), any(), any(),
+                filterCaptor.capture());
+
+        assertThat(filterCaptor.getValue().filters()).extracting(Filter::field).contains("scores.ENERGY_CONSUMPTION");
+    }
+}
+


### PR DESCRIPTION
## Summary
- include aggregated score mappings from vertical configuration when building allowed product filters
- add a unit test covering acceptance of scores.ENERGY_CONSUMPTION filter fields

## Testing
- mvn test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69394630c36c8322ba0e3a7020a8e7c0)