### PR TITLE
Refine nudge wizard navigation and hero layout

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -148,14 +148,7 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
           </v-col>
 
           <v-col cols="12" lg="6" class="home-hero__wizard">
-            <v-sheet rounded="xl" elevation="8" class="home-hero__wizard-sheet">
-              <div class="home-hero__wizard-header">
-                <p class="home-hero__nudge-eyebrow">{{ t('home.nudgeTool.eyebrow') }}</p>
-                <h2 class="home-hero__nudge-title">{{ t('home.nudgeTool.title') }}</h2>
-                <p class="home-hero__nudge-subtitle">{{ t('home.nudgeTool.subtitle') }}</p>
-              </div>
-              <NudgeToolWizard :verticals="wizardVerticals" />
-            </v-sheet>
+            <NudgeToolWizard :verticals="wizardVerticals" />
           </v-col>
         </v-row>
       </div>
@@ -244,43 +237,6 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 .home-hero__wizard
   display: flex
   align-items: stretch
-
-.home-hero__wizard-sheet
-  width: 100%
-  display: flex
-  flex-direction: column
-  gap: 1.5rem
-  padding: clamp(1rem, 2.8vw, 1.5rem)
-  background: rgba(var(--v-theme-surface-glass-strong), 0.96)
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6)
-
-.home-hero__wizard-header
-  display: flex
-  flex-direction: column
-  gap: 0.4rem
-
-.home-hero__nudge-eyebrow
-  display: inline-flex
-  align-items: center
-  gap: 8px
-  margin: 0
-  padding: 6px 12px
-  font-weight: 700
-  color: rgb(var(--v-theme-text-on-accent))
-  background: linear-gradient(90deg, rgba(var(--v-theme-hero-gradient-start), 0.9), rgba(var(--v-theme-hero-gradient-end), 0.95))
-  border-radius: 999px
-  width: fit-content
-
-.home-hero__nudge-title
-  margin: 0
-  font-size: clamp(1.5rem, 2.4vw, 1.85rem)
-  color: rgb(var(--v-theme-text-neutral-strong))
-  font-weight: 800
-
-.home-hero__nudge-subtitle
-  margin: 0
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  font-size: clamp(1rem, 1.4vw, 1.05rem)
 
 @media (max-width: 959px)
   .home-hero

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -31,7 +31,7 @@
           @click="toggle(score.scoreName ?? '')"
         >
           <div class="nudge-step-scores__icon">
-            <v-icon :icon="score.mdiIcon ?? 'mdi-leaf'" size="28" />
+            <v-icon :icon="getScoreIcon(score)" size="28" />
           </div>
           <div class="nudge-step-scores__content">
             <p class="nudge-step-scores__name">{{ score.title }}</p>
@@ -55,6 +55,8 @@ const emit = defineEmits<{ (event: 'update:modelValue', value: string[]): void; 
 
 const selectedNames = computed(() => props.modelValue)
 const hasSelection = computed(() => selectedNames.value.length > 0)
+
+const getScoreIcon = (score: NudgeToolScoreDto) => score.mdiIcon ?? 'mdi-leaf'
 
 const toggle = (scoreName: string) => {
   const next = new Set(selectedNames.value)

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -187,7 +187,7 @@ const hashState = computed<CategoryHashState>(() => ({
 const defaultStepIcons = {
   category: 'mdi-shape-outline',
   scores: 'mdi-star-check-outline',
-  condition: 'mdi-tune-vertical',
+  condition: 'mdi-recycle-variant',
   subset: 'mdi-tune-variant',
   recommendations: 'mdi-lightbulb-on-outline',
 }
@@ -312,7 +312,11 @@ const goToPrevious = () => {
   const index = steps.value.findIndex((step) => step.key === activeStepKey.value)
   const previousStep = steps.value[index - 1]
   if (previousStep) {
-    activeStepKey.value = previousStep.key
+    if (previousStep.key === 'category') {
+      resetForCategorySelection()
+    } else {
+      activeStepKey.value = previousStep.key
+    }
   }
 }
 
@@ -438,13 +442,30 @@ const stepperItems = computed(() =>
   })),
 )
 
-const showStepper = computed(() => Boolean(selectedCategoryId.value))
+const showStepper = computed(
+  () => activeStepKey.value !== 'category' && Boolean(selectedCategoryId.value),
+)
 
 const onStepClick = (value: string | number) => {
   const targetKey = String(value)
+  if (targetKey === 'category') {
+    resetForCategorySelection()
+    return
+  }
+
   if (steps.value.some((step) => step.key === targetKey)) {
     activeStepKey.value = targetKey
   }
+}
+
+const resetForCategorySelection = () => {
+  selectedCategoryId.value = null
+  selectedScores.value = []
+  activeSubsetIds.value = []
+  condition.value = 'any'
+  recommendations.value = []
+  totalMatches.value = 0
+  activeStepKey.value = 'category'
 }
 
 onMounted(async () => {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -67,11 +67,6 @@
         ]
       }
     },
-    "nudgeTool": {
-      "eyebrow": "Personalised guidance",
-      "title": "Try the Nudge tool",
-      "subtitle": "Answer a few quick questions to jump straight to responsible products."
-    },
     "problems": {
       "title": "Too many labels, not enough clarity?",
       "description": "Comparing impact, price and trust sources across dozens of tabs is exhausting. Nudger brings it back to one place.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -67,11 +67,6 @@
         ]
       }
     },
-    "nudgeTool": {
-      "eyebrow": "Guidage personnalisé",
-      "title": "Essayez l'outil Nudge",
-      "subtitle": "Répondez à quelques questions et accédez directement aux produits responsables."
-    },
     "problems": {
       "title": "Trop de labels, pas assez de clarté ?",
       "description": "Comparer impact, prix et fiabilité à travers une multitude d’onglets est épuisant. Nudger rassemble tout au même endroit.",


### PR DESCRIPTION
## Summary
- Hide and reset the nudge wizard stepper when selecting a category, enable step navigation via clicks, and update the condition icon
- Ensure score cards use configured mdi icons and keep score selection flow intact
- Remove the hero card wrapper around the nudge wizard and drop unused i18n strings

## Testing
- pnpm lint
- pnpm vitest run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939476ce1708322815950031bc67a84)