### PR TITLE
feat: extract hero education card component

### DIFF
--- a/frontend/app/components/domains/opensource/OpensourceHero.vue
+++ b/frontend/app/components/domains/opensource/OpensourceHero.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import HeroEducationCard from '~/components/shared/ui/HeroEducationCard.vue'
 import TextContent from '~/components/domains/content/TextContent.vue'
 
 interface HeroCta {
@@ -19,8 +20,8 @@ interface HeroInfoCardItem {
 
 interface HeroInfoCard {
   icon: string
-  highlight?: string
-  description?: string
+  title: string
+  bodyHtml?: string
   items: HeroInfoCardItem[]
 }
 
@@ -44,60 +45,50 @@ withDefaults(
 <template>
   <HeroSurface class="opensource-hero" aria-labelledby="opensource-hero-title" variant="prism">
     <v-container class="py-16 position-relative">
-        <v-row class="align-center" :no-gutters="false" justify="space-between">
-          <v-col cols="12" md="7" class="d-flex flex-column gap-4">
+      <v-row class="align-center" :no-gutters="false" justify="space-between">
+        <v-col cols="12" md="7" class="d-flex flex-column gap-4">
+          <div class="hero-headline">
+            <h1 id="opensource-hero-title" class="hero-title">
+              <span class="fw-light">{{ title }}</span>
+            </h1>
+            <p class="hero-subtitle">{{ subtitle }}</p>
+          </div>
 
-            <div class="hero-headline">
-              <h1 id="opensource-hero-title" class="hero-title">
-                <span class="fw-light">{{ title }}</span>
-              </h1>
-              <p class="hero-subtitle">{{ subtitle }}</p>
-            </div>
+          <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
 
-            <TextContent :bloc-id="descriptionBlocId" :ipsum-length="220" />
+          <div class="hero-ctas" role="group" :aria-label="ctaGroupLabel">
+            <v-btn
+              v-for="cta in ctas"
+              :key="cta.href"
+              :href="cta.href"
+              :aria-label="cta.ariaLabel"
+              :color="cta.color ?? 'primary'"
+              :variant="cta.variant ?? 'flat'"
+              :target="cta.target"
+              :rel="cta.rel"
+              size="large"
+              class="me-3 mb-3"
+              append-icon="mdi-arrow-top-right"
+            >
+              <template v-if="cta.icon" #prepend>
+                <v-icon :icon="cta.icon" aria-hidden="true" />
+              </template>
+              {{ cta.label }}
+            </v-btn>
+          </div>
+        </v-col>
 
-            <div class="hero-ctas" role="group" :aria-label="ctaGroupLabel">
-              <v-btn
-                v-for="cta in ctas"
-                :key="cta.href"
-                :href="cta.href"
-                :aria-label="cta.ariaLabel"
-                :color="cta.color ?? 'primary'"
-                :variant="cta.variant ?? 'flat'"
-                :target="cta.target"
-                :rel="cta.rel"
-                size="large"
-                class="me-3 mb-3"
-                append-icon="mdi-arrow-top-right"
-              >
-                <template v-if="cta.icon" #prepend>
-                  <v-icon :icon="cta.icon" aria-hidden="true" />
-                </template>
-                {{ cta.label }}
-              </v-btn>
-            </div>
-          </v-col>
-
-          <v-col cols="12" md="5" class="mt-10 mt-md-0">
-            <v-card v-if="infoCard" class="hero-card" elevation="12" rounded="xl" aria-hidden="true">
-              <div class="hero-card-content">
-                <v-icon :icon="infoCard.icon" class="hero-card-icon" size="64" />
-                <p class="hero-card-text">
-                  <span v-if="infoCard.highlight" class="fw-medium">{{ infoCard.highlight }}</span>
-                  <span v-if="infoCard.description">{{ infoCard.description }}</span>
-                </p>
-                <v-divider class="my-4" />
-                <ul class="hero-card-list">
-                  <li v-for="(item, index) in infoCard.items" :key="index">
-                    <v-icon v-if="item.icon" :icon="item.icon" size="small" />
-                    <span>{{ item.text }}</span>
-                  </li>
-                </ul>
-              </div>
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
+        <v-col cols="12" md="5" class="mt-10 mt-md-0">
+          <HeroEducationCard
+            v-if="infoCard"
+            :icon="infoCard.icon"
+            :title="infoCard.title"
+            :body-html="infoCard.bodyHtml"
+            :items="infoCard.items"
+          />
+        </v-col>
+      </v-row>
+    </v-container>
   </HeroSurface>
 </template>
 
@@ -132,45 +123,4 @@ withDefaults(
   display: flex
   flex-wrap: wrap
   gap: 0.75rem
-
-.hero-card
-  background: rgba(var(--v-theme-surface-glass), 0.9)
-  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
-  backdrop-filter: blur(18px)
-
-.hero-card-content
-  padding: clamp(1.5rem, 3vw, 2.5rem)
-  display: flex
-  flex-direction: column
-  gap: 1.5rem
-  color: rgba(var(--v-theme-text-neutral-strong), 0.95)
-
-.hero-card-icon
-  align-self: flex-start
-  color: rgba(var(--v-theme-accent-primary-highlight), 0.85)
-
-.hero-card-text
-  font-size: 1rem
-  margin: 0
-
-.hero-card-text .fw-medium
-  margin-right: 0.25rem
-  
-.hero-card-list
-  list-style: none
-  padding: 0
-  margin: 0
-  display: flex
-  flex-direction: column
-  gap: 0.75rem
-
-.hero-card-list li
-  display: flex
-  align-items: center
-  gap: 0.75rem
-  font-size: 0.95rem
-  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
-
-.hero-card-list li .v-icon
-  color: rgba(var(--v-theme-accent-supporting), 0.9)
 </style>

--- a/frontend/app/components/shared/ui/HeroEducationCard.spec.ts
+++ b/frontend/app/components/shared/ui/HeroEducationCard.spec.ts
@@ -1,0 +1,89 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import HeroEducationCard from './HeroEducationCard.vue'
+
+const stubs = {
+  VCard: defineComponent({
+    name: 'VCardStub',
+    setup(_, { slots, attrs }) {
+      return () =>
+        h(
+          'div',
+          {
+            ...attrs,
+            'data-testid': 'hero-education-card',
+          },
+          slots.default?.(),
+        )
+    },
+  }),
+  VIcon: defineComponent({
+    name: 'VIconStub',
+    props: {
+      icon: {
+        type: String,
+        required: false,
+      },
+      size: {
+        type: [String, Number],
+        default: undefined,
+      },
+    },
+    setup(props) {
+      return () =>
+        h('span', {
+          'data-testid': 'hero-education-card-icon',
+          'data-icon': props.icon,
+          'data-size': props.size,
+        })
+    },
+  }),
+  VDivider: defineComponent({
+    name: 'VDividerStub',
+    setup(_, { attrs }) {
+      return () => h('hr', { ...attrs, 'data-testid': 'hero-education-card-divider' })
+    },
+  }),
+}
+
+describe('HeroEducationCard', () => {
+  it('renders the title, icon and body HTML content', () => {
+    const wrapper = mount(HeroEducationCard, {
+      props: {
+        icon: 'mdi-school-outline',
+        title: 'What is open source?',
+        bodyHtml: '<strong>Open4goods</strong> grows with everyone.',
+      },
+      global: {
+        stubs,
+      },
+    })
+
+    expect(wrapper.find('.hero-education-card__title').text()).toBe('What is open source?')
+    expect(wrapper.find('[data-testid="hero-education-card-icon"]').attributes('data-icon')).toBe('mdi-school-outline')
+    expect(wrapper.find('.hero-education-card__body').html()).toContain('<strong>Open4goods</strong>')
+  })
+
+  it('renders list items with their optional icons', () => {
+    const wrapper = mount(HeroEducationCard, {
+      props: {
+        icon: 'mdi-school-outline',
+        title: 'List example',
+        items: [
+          { icon: 'mdi-check', text: 'First item' },
+          { text: 'Second item' },
+        ],
+      },
+      global: {
+        stubs,
+      },
+    })
+
+    const listItems = wrapper.findAll('.hero-education-card__list li')
+    expect(listItems).toHaveLength(2)
+    expect(listItems[0].find('[data-testid="hero-education-card-icon"]').attributes('data-icon')).toBe('mdi-check')
+    expect(listItems[1].find('[data-testid="hero-education-card-icon"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="hero-education-card-divider"]').exists()).toBe(true)
+  })
+})

--- a/frontend/app/components/shared/ui/HeroEducationCard.vue
+++ b/frontend/app/components/shared/ui/HeroEducationCard.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+interface HeroEducationCardItem {
+  icon?: string
+  text: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    icon: string
+    title: string
+    bodyHtml?: string
+    items?: HeroEducationCardItem[]
+  }>(),
+  {
+    items: () => [],
+  },
+)
+</script>
+
+<template>
+  <v-card class="hero-education-card" elevation="12" rounded="xl" aria-hidden="true">
+    <div class="hero-education-card__header">
+      <v-icon :icon="props.icon" class="hero-education-card__icon" size="64" />
+      <h2 class="hero-education-card__title">{{ props.title }}</h2>
+    </div>
+
+    <p
+      v-if="props.bodyHtml"
+      class="hero-education-card__body"
+      v-html="props.bodyHtml"
+    />
+
+    <v-divider v-if="props.items?.length" class="my-4" />
+
+    <ul v-if="props.items?.length" class="hero-education-card__list">
+      <li v-for="(item, index) in props.items" :key="index">
+        <v-icon v-if="item.icon" :icon="item.icon" size="small" />
+        <span>{{ item.text }}</span>
+      </li>
+    </ul>
+  </v-card>
+</template>
+
+<style scoped lang="sass">
+.hero-education-card
+  background: rgba(var(--v-theme-surface-glass), 0.9)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+  backdrop-filter: blur(18px)
+  color: rgba(var(--v-theme-text-neutral-strong), 0.95)
+  padding: clamp(1.5rem, 3vw, 2.5rem)
+
+.hero-education-card__header
+  display: flex
+  align-items: center
+  gap: 1rem
+  margin-bottom: 1rem
+
+.hero-education-card__icon
+  color: rgba(var(--v-theme-accent-primary-highlight), 0.85)
+
+.hero-education-card__title
+  font-size: clamp(1.5rem, 4vw, 2rem)
+  margin: 0
+  line-height: 1.2
+
+.hero-education-card__body
+  font-size: 1rem
+  margin: 0
+  line-height: 1.6
+
+.hero-education-card__list
+  list-style: none
+  padding: 0
+  margin: 0
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.hero-education-card__list li
+  display: flex
+  align-items: center
+  gap: 0.75rem
+  font-size: 0.95rem
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.hero-education-card__list li .v-icon
+  color: rgba(var(--v-theme-accent-supporting), 0.9)
+</style>

--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -94,8 +94,8 @@ interface ContactCtaDisplay {
 
 interface HeroInfoCardDisplay {
   icon: string
-  highlight?: string
-  description?: string
+  title: string
+  bodyHtml?: string
   items: { icon?: string; text: string }[]
 }
 
@@ -141,8 +141,8 @@ const heroCtaGroupLabel = computed(() => String(t('opensource.hero.ctaGroupLabel
 
 const heroInfoCard = computed<HeroInfoCardDisplay>(() => ({
   icon: 'mdi-source-branch',
-  highlight: String(t('opensource.hero.infoCard.highlight')),
-  description: String(t('opensource.hero.infoCard.description')),
+  title: String(t('opensource.hero.infoCard.title')),
+  bodyHtml: `<strong>${String(t('opensource.hero.infoCard.highlight'))}</strong> ${String(t('opensource.hero.infoCard.description'))}`,
   items: [
     {
       icon: 'mdi-checkbox-marked-circle-outline',

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1363,6 +1363,7 @@
     "hero": {
       "ctaGroupLabel": "Primary hero actions",
       "infoCard": {
+        "title": "What is open source?",
         "description": "grows with everyone. Every pull request, issue or piece of feedback makes the platform more transparent.",
         "highlight": "Open4goods",
         "items": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1363,8 +1363,9 @@
     "hero": {
       "ctaGroupLabel": "Appels à action principaux",
       "infoCard": {
+        "title": "C'est quoi l'Open Source ?",
         "description": "L’Open Source désigne des logiciels dont le fonctionnement est ouvert et accessible à tous. Chacun peut les utiliser librement, les modifier et les partager. L’idée centrale est le partage du savoir et la collaboration.",
-        "highlight": "",
+        "highlight": "Open4goods",
         "items": {
           "collaborativeReviews": "Contributions",
           "openLicenses": "Code publié sous licence GPL",


### PR DESCRIPTION
## Summary
- add a reusable HeroEducationCard component for hero sections
- refactor the Open Source hero to consume the shared education card and updated i18n strings
- cover the new component with unit tests

## Testing
- pnpm vitest run app/components/shared/ui/HeroEducationCard.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69394973bca883229fbaa0ef1757df4d)