### PR TITLE
Adjust nudge wizard layout sizing

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -237,6 +237,8 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 .home-hero__wizard
   display: flex
   align-items: stretch
+  width: 100%
+  align-self: stretch
 
 @media (max-width: 959px)
   .home-hero

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -483,6 +483,11 @@ onMounted(async () => {
 .nudge-wizard {
   position: relative;
   padding: 16px;
+  width: 100%;
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 
   &__header {
     display: flex;
@@ -510,6 +515,9 @@ onMounted(async () => {
 
   &__window {
     min-height: 420px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
   }
 
   &__footer {


### PR DESCRIPTION
## Summary
- expand the nudge wizard card to use the full column width and flex layout so its steps stretch evenly
- stretch the home hero wizard column to fill its grid span for consistent alignment

## Testing
- pnpm lint (warnings in an unrelated component)
- pnpm test (fails/cancelled: vitest run remained queued)
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396a8cd68483228d0dbb11aabbadee)