### PR TITLE
Add opendata hero education card and license link improvements

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataDatasetHighlights.vue
+++ b/frontend/app/components/domains/opendata/OpendataDatasetHighlights.vue
@@ -15,11 +15,28 @@ interface DatasetCard {
   href: string
 }
 
-defineProps<{
+const props = defineProps<{
   title: string
   subtitle?: string
   cards: DatasetCard[]
 }>()
+
+const handleSubtitleClick = (event: MouseEvent) => {
+  if (!import.meta.client || !props.subtitle) {
+    return
+  }
+
+  const anchor = (event.target as HTMLElement | null)?.closest('[data-scroll-target]')
+  const targetSelector = anchor?.getAttribute('data-scroll-target')
+
+  if (anchor && targetSelector) {
+    const target = document.querySelector(targetSelector)
+    if (target instanceof HTMLElement) {
+      event.preventDefault()
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+}
 </script>
 
 <template>
@@ -31,6 +48,7 @@ defineProps<{
         <p
           v-if="subtitle"
           class="opendata-datasets__subtitle subtitle-text"
+          @click="handleSubtitleClick"
           v-html="subtitle"
         ></p>
         <!-- eslint-enable vue/no-v-html -->

--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import HeroEducationCard from '~/components/shared/ui/HeroEducationCard.vue'
+
 interface HeroCta {
   label: string
   href: string
@@ -8,16 +10,30 @@ interface HeroCta {
   appendIcon?: string
 }
 
+interface HeroEducationCardItem {
+  icon?: string
+  text: string
+}
+
+interface HeroEducationCardProps {
+  icon: string
+  title: string
+  bodyHtml?: string
+  items?: HeroEducationCardItem[]
+}
+
 const props = withDefaults(
   defineProps<{
     eyebrow?: string
     title: string
     subtitle: string
     primaryCta?: HeroCta
+    educationCard?: HeroEducationCardProps
   }>(),
   {
     eyebrow: undefined,
     primaryCta: undefined,
+    educationCard: undefined,
   },
 )
 
@@ -35,6 +51,23 @@ const handlePrimaryClick = (event: MouseEvent) => {
     }
   }
 }
+
+const handleSubtitleClick = (event: MouseEvent) => {
+  if (!import.meta.client) {
+    return
+  }
+
+  const anchor = (event.target as HTMLElement | null)?.closest('[data-scroll-target]')
+  const targetSelector = anchor?.getAttribute('data-scroll-target')
+
+  if (anchor && targetSelector) {
+    const target = document.querySelector(targetSelector)
+    if (target instanceof HTMLElement) {
+      event.preventDefault()
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+}
 </script>
 
 <template>
@@ -46,7 +79,7 @@ const handlePrimaryClick = (event: MouseEvent) => {
             <span v-if="eyebrow" class="opendata-hero__eyebrow" role="text">{{ eyebrow }}</span>
             <h1 id="opendata-hero-heading" class="opendata-hero__title">{{ title }}</h1>
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <p class="opendata-hero__subtitle" v-html="subtitle" />
+            <p class="opendata-hero__subtitle" @click="handleSubtitleClick" v-html="subtitle" />
           </div>
 
 
@@ -73,6 +106,15 @@ const handlePrimaryClick = (event: MouseEvent) => {
             <div class="opendata-hero__glow-ring opendata-hero__glow-ring--secondary" />
               <span v-for="index in 6" :key="index" />
           </div>
+
+          <HeroEducationCard
+            v-if="educationCard"
+            class="opendata-hero__education-card"
+            :icon="educationCard.icon"
+            :title="educationCard.title"
+            :body-html="educationCard.bodyHtml"
+            :items="educationCard.items"
+          />
         </v-col>
       </v-row>
     </v-container>
@@ -121,6 +163,7 @@ const handlePrimaryClick = (event: MouseEvent) => {
   display: flex
   justify-content: center
   align-items: center
+  position: relative
 
 .opendata-hero__glow
   position: relative
@@ -139,12 +182,25 @@ const handlePrimaryClick = (event: MouseEvent) => {
   border-color: rgba(var(--v-theme-accent-supporting), 0.3)
   box-shadow: 0 0 40px rgba(var(--v-theme-accent-supporting), 0.22)
 
+.opendata-hero__education-card
+  width: 100%
+  max-width: 420px
+  position: relative
+  z-index: 1
+  margin-top: clamp(1rem, 3vw, 2rem)
+  box-shadow: 0 20px 60px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
 
 @media (max-width: 959px)
   .opendata-hero__visual
     margin-top: 2rem
+    align-items: stretch
 
   .opendata-hero__glow
     width: 240px
+    margin-inline: auto
+
+  .opendata-hero__education-card
+    max-width: none
 </style>
 

--- a/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
+++ b/frontend/app/components/domains/opendata/OpendataLicenseSection.vue
@@ -1,21 +1,32 @@
 <script setup lang="ts">
-defineProps<{
-  title: string
-  description: string
-  licenseLabel: string
-  licenseUrl: string
-  licenseAriaLabel: string
-}>()
+withDefaults(
+  defineProps<{
+    title: string
+    description: string
+    licenseLabel: string
+    licenseUrl: string
+    licenseAriaLabel: string
+    licenseId?: string
+  }>(),
+  {
+    licenseId: 'opendata-odbl-license',
+  },
+)
 </script>
 
 <template>
-  <section class="opendata-license" aria-labelledby="opendata-license-heading">
+  <section
+    :id="licenseId"
+    class="opendata-license"
+    aria-labelledby="opendata-license-heading"
+  >
     <v-container max-width="lg">
       <v-card class="opendata-license__card" elevation="4" rounded="xl">
         <div class="opendata-license__content">
           <div class="opendata-license__text">
             <h2 id="opendata-license-heading" class="opendata-license__title">{{ title }}</h2>
-            <p class="opendata-license__description">{{ description }}</p>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <p class="opendata-license__description" v-html="description" />
           </div>
           <div class="opendata-license__cta">
             <v-btn

--- a/frontend/app/components/shared/ui/HeroEducationCard.vue
+++ b/frontend/app/components/shared/ui/HeroEducationCard.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
     items?: HeroEducationCardItem[]
   }>(),
   {
+    bodyHtml: undefined,
     items: () => [],
   },
 )
@@ -24,11 +25,13 @@ const props = withDefaults(
       <h2 class="hero-education-card__title">{{ props.title }}</h2>
     </div>
 
+    <!-- eslint-disable vue/no-v-html -->
     <p
       v-if="props.bodyHtml"
       class="hero-education-card__body"
       v-html="props.bodyHtml"
     />
+    <!-- eslint-enable vue/no-v-html -->
 
     <v-divider v-if="props.items?.length" class="my-4" />
 

--- a/frontend/app/pages/opendata/index.vue
+++ b/frontend/app/pages/opendata/index.vue
@@ -3,7 +3,8 @@
     <OpendataHero
       :eyebrow="t('opendata.hero.eyebrow')"
       :title="t('opendata.hero.title')"
-      :subtitle="t('opendata.hero.subtitle')"
+      :subtitle="heroSubtitle"
+      :education-card="educationCard"
       description-bloc-id="webpages:opendata:hero-overview"
       :primary-cta="heroPrimaryCta"
     />
@@ -36,7 +37,7 @@
     <OpendataDatasetHighlights
       id="datasets"
       :title="t('opendata.datasets.title')"
-      :subtitle="t('opendata.datasets.subtitle')"
+      :subtitle="datasetsSubtitle"
       :cards="datasetCards"
     />
 
@@ -46,6 +47,7 @@
       :license-label="t('opendata.license.cta.label')"
       :license-aria-label="t('opendata.license.cta.ariaLabel')"
       :license-url="t('opendata.license.cta.href')"
+      :license-id="licenseSectionId"
     />
 
     <OpendataFaqSection
@@ -85,12 +87,16 @@ const { t, locale } = useI18n()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+const licenseSectionId = 'opendata-odbl-license'
 
 const { data, pending, error, refresh } = await useAsyncData<OpenDataOverviewDto>('opendata-overview', () =>
   $fetch<OpenDataOverviewDto>('/api/opendata', {
     headers: requestHeaders,
   }),
 )
+
+const heroSubtitle = computed(() => String(t('opendata.hero.subtitle', { licenseId: licenseSectionId })))
+const datasetsSubtitle = computed(() => String(t('opendata.datasets.subtitle', { licenseId: licenseSectionId })))
 
 const formatProductCount = (count?: string | number | null) => {
   if (count == null || count === '') {
@@ -214,6 +220,12 @@ const heroPrimaryCta = computed(() => ({
   ariaLabel: String(t('opendata.hero.primaryCta.ariaLabel')),
   href: '#datasets',
   appendIcon: 'mdi-arrow-down',
+}))
+
+const educationCard = computed(() => ({
+  icon: 'mdi-database-check-outline',
+  title: String(t('opendata.hero.educationCard.title')),
+  bodyHtml: String(t('opendata.hero.educationCard.description')),
 }))
 
 const canonicalUrl = computed(

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1261,7 +1261,7 @@
           "title": "ISBN dataset overview"
         }
       },
-      "subtitle": "Pick the export that matches your project. Both are updated weekly and delivered under the Open Database Licence.",
+      "subtitle": "Pick the export that matches your project. Both are updated weekly and delivered under the Open Database Licence (<a href=\"#{licenseId}\" data-scroll-target=\"#{licenseId}\">ODbL</a>).",
       "title": "Two complementary datasets"
     },
     "errors": {
@@ -1295,6 +1295,10 @@
       "primaryCta": {
         "ariaLabel": "Scroll to the open data datasets section",
         "label": "Explore the datasets"
+      },
+      "educationCard": {
+        "description": "Open data refers to information that organisations make freely available so anyone can consult, use or reuse it. The goal is to promote transparency and knowledge, better understand the world around us, and enable citizens, nonprofits or companies to create new ideas and useful services.",
+        "title": "Open data... what?"
       },
       "subtitle": "Download GTIN and ISBN datasets maintained by Nudger to build your own analyses, services and research.",
       "title": "Transparent product data for responsible commerce"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1261,7 +1261,7 @@
           "title": "Chiffres clés du dataset ISBN"
         }
       },
-      "subtitle": "Les deux exports sont mis à jour chaque semaine et publiés sous licence ODbL.",
+      "subtitle": "Les deux exports sont mis à jour chaque semaine et publiés sous licence <a href=\"#{licenseId}\" data-scroll-target=\"#{licenseId}\">ODbL</a>.",
       "title": "Deux jeux de données"
     },
     "errors": {
@@ -1295,6 +1295,10 @@
       "primaryCta": {
         "ariaLabel": "Faire défiler jusqu'à la section des jeux de données Open Data",
         "label": "Découvre nos jeux de données"
+      },
+      "educationCard": {
+        "description": "L’open data, ou « données ouvertes », désigne des informations rendues disponibles librement par des organismes pour que chacun puisse les consulter, les utiliser et les réutiliser. L’objectif est de favoriser la transparence et la connaissance, de mieux comprendre le monde qui nous entoure et de permettre à des citoyens, associations ou entreprises de créer de nouvelles idées et services utiles.",
+        "title": "Open Da... Quoi ?"
       },
       "subtitle": "Nous sommes des geeks généreux et partageurs. Pas de secrets chez nous.<br/> Nos données produits ? Open bar. Nos bases ? Téléchargeables.",
       "title": "Open Data"


### PR DESCRIPTION
## Summary
- add the shared HeroEducationCard to the opendata hero with smooth scrolling for in-page anchors
- allow HTML descriptions in the ODbL license card and wire subtitles to scroll to the license section
- localize new education card copy and make the datasets subtitle include a clickable ODbL anchor

## Testing
- pnpm lint
- pnpm vitest run app/components/shared/ui/HeroEducationCard.spec.ts
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396a29e4608322812ac215732ab1ad)