### PR TITLE
Refine nudge wizard stepper and score filters

### DIFF
--- a/frontend/app/utils/_nudge-tool-filters.spec.ts
+++ b/frontend/app/utils/_nudge-tool-filters.spec.ts
@@ -32,14 +32,14 @@ describe('nudge tool filters', () => {
     )
 
     expect(filters).toEqual([
-      { field: 'scores.REPAIRABILITY', operator: 'range', min: 6 },
+      { field: 'scores.REPAIRABILITY.value', operator: 'range', min: 6 },
     ])
   })
 
   it('merges base, condition, score and subset filters without duplicates', () => {
     const baseFilters: Filter[] = [{ field: 'price.minPrice.productState', operator: 'term', terms: ['NEW'] }]
     const conditionFilter: Filter = { field: 'price.minPrice.productState', operator: 'term', terms: ['NEW'] }
-    const scoreFilters: Filter[] = [{ field: 'scores.IMPACT', operator: 'range', min: 50 }]
+    const scoreFilters: Filter[] = [{ field: 'scores.IMPACT.value', operator: 'range', min: 50 }]
     const subsetFilters: Filter[] = [{ field: 'attributes.indexed.SIZE', operator: 'range', max: 40 }]
 
     const request = buildNudgeFilterRequest(baseFilters, conditionFilter, scoreFilters, subsetFilters)
@@ -47,7 +47,7 @@ describe('nudge tool filters', () => {
     expect(request).toEqual({
       filters: [
         { field: 'price.minPrice.productState', operator: 'term', terms: ['NEW'] },
-        { field: 'scores.IMPACT', operator: 'range', min: 50 },
+        { field: 'scores.IMPACT.value', operator: 'range', min: 50 },
         { field: 'attributes.indexed.SIZE', operator: 'range', max: 40 },
       ],
     })

--- a/frontend/app/utils/_nudge-tool-filters.ts
+++ b/frontend/app/utils/_nudge-tool-filters.ts
@@ -36,7 +36,7 @@ export const buildScoreFilters = (
       }
 
       return {
-        field: `scores.${name}`,
+        field: `scores.${name}.value`,
         operator: 'range',
         min: matchedScore.scoreMinValue,
       } satisfies Filter


### PR DESCRIPTION
## Summary
- move category selection outside the stepper while keeping navigation and swipe within the wizard steps
- adjust navigation guards for the stepper sequence and swipe handling
- emit score filters against `scores.{name}.value` and update related tests

## Testing
- pnpm vitest run utils/_nudge-tool-filters.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69397ef2ff848322b486245dbb3eefe6)