### PR TITLE
Improve nudge tool filtering interactions

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -12,13 +12,13 @@
       >
         <v-card
           class="nudge-step-condition__card"
-          :elevation="modelValue === option.value ? 8 : 2"
-          :color="modelValue === option.value ? 'primary' : undefined"
-          :variant="modelValue === option.value ? 'elevated' : 'tonal'"
+          :elevation="isSelected(option.value) ? 8 : 2"
+          :color="isSelected(option.value) ? 'primary' : undefined"
+          :variant="isSelected(option.value) ? 'elevated' : 'tonal'"
           rounded="xl"
           role="button"
-          :aria-pressed="(modelValue === option.value).toString()"
-          @click="() => emit('update:modelValue', option.value)"
+          :aria-pressed="isSelected(option.value).toString()"
+          @click="() => toggleOption(option.value)"
         >
           <v-icon :icon="option.icon" size="32" class="mb-2" />
           <p class="nudge-step-condition__label">{{ option.label }}</p>
@@ -31,25 +31,30 @@
 <script setup lang="ts">
 import type { ProductConditionChoice } from '~/utils/_nudge-tool-filters'
 
-defineProps<{
-  modelValue: ProductConditionChoice
+const props = defineProps<{
+  modelValue: ProductConditionChoice[]
 }>()
 
-const emit = defineEmits<{ (event: 'update:modelValue', value: ProductConditionChoice): void }>()
+const emit = defineEmits<{ (event: 'update:modelValue', value: ProductConditionChoice[]): void }>()
+
+const { t } = useI18n()
 
 const options: Array<{ value: ProductConditionChoice; label: string; icon: string }> = [
-  { value: 'new', label: useI18n().t('nudge-tool.steps.condition.options.new'), icon: 'mdi-star-outline' },
-  {
-    value: 'occasion',
-    label: useI18n().t('nudge-tool.steps.condition.options.occasion'),
-    icon: 'mdi-recycle-variant',
-  },
-  {
-    value: 'any',
-    label: useI18n().t('nudge-tool.steps.condition.options.any'),
-    icon: 'mdi-sync',
-  },
+  { value: 'new', label: t('nudge-tool.steps.condition.options.new'), icon: 'mdi-star-outline' },
+  { value: 'occasion', label: t('nudge-tool.steps.condition.options.occasion'), icon: 'mdi-recycle-variant' },
 ]
+
+const isSelected = (choice: ProductConditionChoice) => {
+  return props.modelValue.includes(choice)
+}
+
+const toggleOption = (choice: ProductConditionChoice) => {
+  const nextSelection = isSelected(choice)
+    ? props.modelValue.filter((entry) => entry !== choice)
+    : [...props.modelValue, choice]
+
+  emit('update:modelValue', nextSelection)
+}
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/utils/_nudge-tool-filters.spec.ts
+++ b/frontend/app/utils/_nudge-tool-filters.spec.ts
@@ -6,19 +6,27 @@ import {
   buildConditionFilter,
   buildNudgeFilterRequest,
   buildScoreFilters,
-  type ProductConditionChoice,
+  type ProductConditionSelection,
 } from './_nudge-tool-filters'
 
 describe('nudge tool filters', () => {
   it('builds condition filters according to the choice', () => {
-    const cases: Record<ProductConditionChoice, Filter | null> = {
-      any: null,
+    const cases: Record<string, Filter | null> = {
+      none: null,
       new: { field: 'price.conditions', operator: 'term', terms: ['NEW'] },
       occasion: { field: 'price.conditions', operator: 'term', terms: ['OCCASION'] },
+      multi: { field: 'price.conditions', operator: 'term', terms: ['NEW', 'OCCASION'] },
     }
 
     Object.entries(cases).forEach(([choice, expected]) => {
-      expect(buildConditionFilter(choice as ProductConditionChoice)).toEqual(expected)
+      const selection: ProductConditionSelection =
+        choice === 'none'
+          ? []
+          : choice === 'multi'
+            ? ['new', 'occasion']
+            : [choice as ProductConditionSelection[number]]
+
+      expect(buildConditionFilter(selection)).toEqual(expected)
     })
   })
 

--- a/frontend/app/utils/_nudge-tool-filters.ts
+++ b/frontend/app/utils/_nudge-tool-filters.ts
@@ -2,21 +2,22 @@ import type { Filter, FilterRequestDto, NudgeToolScoreDto } from '~~/shared/api-
 
 import { mergeFiltersWithoutDuplicates } from './_subset-to-filters'
 
-export type ProductConditionChoice = 'new' | 'occasion' | 'any'
+export type ProductConditionChoice = 'new' | 'occasion'
+export type ProductConditionSelection = ProductConditionChoice[]
 
 const PRODUCT_STATE_FIELD = 'price.conditions'
 
-export const buildConditionFilter = (choice: ProductConditionChoice): Filter | null => {
-  if (choice === 'any') {
+export const buildConditionFilter = (choices: ProductConditionSelection): Filter | null => {
+  if (!choices.length) {
     return null
   }
 
-  const value = choice === 'new' ? 'NEW' : 'OCCASION'
+  const terms = Array.from(new Set(choices.map((choice) => (choice === 'new' ? 'NEW' : 'OCCASION'))))
 
   return {
     field: PRODUCT_STATE_FIELD,
     operator: 'term',
-    terms: [value],
+    terms,
   }
 }
 

--- a/frontend/app/utils/_subset-to-filters.ts
+++ b/frontend/app/utils/_subset-to-filters.ts
@@ -125,14 +125,105 @@ export const getRemainingSubsetFilters = (
   return convertSubsetCriteriaToFilters(subset).filter((_, index) => index !== removedIndex)
 }
 
+const buildGroupKey = (subset: VerticalSubsetDto): string => {
+  return subset.group ?? subset.id ?? 'ungrouped'
+}
+
+const groupFiltersByField = (filters: Filter[]): Map<string, Filter[]> => {
+  const buckets = new Map<string, Filter[]>()
+
+  filters.forEach((filter) => {
+    if (!filter.field || !filter.operator) {
+      return
+    }
+
+    const key = `${filter.field ?? ''}|${filter.operator}`
+    const bucket = buckets.get(key) ?? []
+    bucket.push(filter)
+    buckets.set(key, bucket)
+  })
+
+  return buckets
+}
+
+const mergeTermFilters = (field: string, filters: Filter[]): Filter | null => {
+  const terms = filters.flatMap((filter) => normalizeTerms(filter.terms))
+  if (!terms.length) {
+    return null
+  }
+
+  return { field, operator: 'term', terms: Array.from(new Set(terms)) }
+}
+
+const mergeRangeFilters = (field: string, filters: Filter[]): Filter | null => {
+  const minValues = filters
+    .map((filter) => filter.min)
+    .filter((value): value is number => typeof value === 'number')
+  const maxValues = filters
+    .map((filter) => filter.max)
+    .filter((value): value is number => typeof value === 'number')
+
+  const merged: Filter = { field, operator: 'range' }
+
+  if (minValues.length) {
+    merged.min = Math.min(...minValues)
+  }
+
+  if (maxValues.length) {
+    merged.max = Math.max(...maxValues)
+  }
+
+  if (merged.min != null && merged.max != null && merged.min > merged.max) {
+    return null
+  }
+
+  if (merged.min == null && merged.max == null) {
+    return null
+  }
+
+  return merged
+}
+
+const mergeGroupFilters = (filters: Filter[]): Filter[] => {
+  const groupedByField = groupFiltersByField(filters)
+
+  return Array.from(groupedByField.entries())
+    .map(([, entries]) => {
+      const operator = entries[0]?.operator
+      const field = entries[0]?.field ?? ''
+
+      if (operator === 'term') {
+        return mergeTermFilters(field, entries)
+      }
+
+      if (operator === 'range') {
+        return mergeRangeFilters(field, entries)
+      }
+
+      return null
+    })
+    .filter((filter): filter is Filter => Boolean(filter))
+}
+
 export const buildFilterRequestFromSubsets = (
   subsets: VerticalSubsetDto[],
   activeSubsetIds: string[],
 ): FilterRequestDto => {
-  const filters = activeSubsetIds.flatMap((subsetId) => {
+  const groups = new Map<string, Filter[]>()
+
+  activeSubsetIds.forEach((subsetId) => {
     const subset = subsets.find((candidate) => candidate.id === subsetId)
-    return subset ? convertSubsetCriteriaToFilters(subset) : []
+    if (!subset) {
+      return
+    }
+
+    const groupKey = buildGroupKey(subset)
+    const current = groups.get(groupKey) ?? []
+    const filters = convertSubsetCriteriaToFilters(subset)
+    groups.set(groupKey, [...current, ...filters])
   })
 
-  return filters.length ? { filters } : {}
+  const mergedFilters = Array.from(groups.values()).flatMap((filters) => mergeGroupFilters(filters))
+
+  return mergedFilters.length ? { filters: mergedFilters } : {}
 }


### PR DESCRIPTION
## Summary
- add animated match counter and hide matches on the category step
- convert condition step to multi-select and adjust navigation gating
- apply OR semantics to subset group filters and expand tests

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939947c0d508322bcc9489a277c3ba7)