### PR TITLE
Support conjunctive filter groups

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -712,7 +712,8 @@ public class ProductController {
                 return Validation.error(sanitizedFilters.error());
             }
             if (sanitizedFilters.value() != null && !sanitizedFilters.value().isEmpty()) {
-                sanitizedGroups.add(new FilterRequestDto.FilterGroup(List.copyOf(sanitizedFilters.value())));
+                sanitizedGroups.add(new FilterRequestDto.FilterGroup(List.copyOf(sanitizedFilters.value()),
+                        group.combinationOperator()));
             }
         }
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
@@ -524,7 +524,15 @@ public class SearchService {
                     if (clause == null) {
                         continue;
                     }
-                    groupCriteria = groupCriteria == null ? clause : groupCriteria.or(clause);
+                    if (groupCriteria == null) {
+                        groupCriteria = clause;
+                    }
+                    else {
+                        groupCriteria = switch (group.combinationOperator()) {
+                        case and -> groupCriteria.and(clause);
+                        case or -> groupCriteria.or(clause);
+                        };
+                    }
                 }
                 if (groupCriteria != null) {
                     combined = combined.and(groupCriteria);


### PR DESCRIPTION
## Summary
- add a combination operator to filter groups to allow OR or AND semantics in the request schema
- ensure ProductController sanitisation and SearchService honour the chosen operator when building criteria
- cover conjunctive price subset handling with new unit test

## Testing
- mvn --offline -pl front-api -am test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a91448dac8322885b4c321af816ac)