### PR TITLE
Adjust nudge wizard navigation and UI

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepRecommendations.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepRecommendations.vue
@@ -5,9 +5,6 @@
         <h2 class="nudge-step-recos__title">{{ $t('nudge-tool.steps.recommendations.title') }}</h2>
         <p class="nudge-step-recos__subtitle">{{ $t('nudge-tool.steps.recommendations.subtitle') }}</p>
       </div>
-      <v-btn color="primary" :disabled="!canNavigate" @click="emit('see-all')">
-        {{ $t('nudge-tool.actions.seeAll') }}
-      </v-btn>
     </div>
 
     <div v-if="loading" class="py-4">
@@ -42,9 +39,6 @@ const props = defineProps<{
   loading: boolean
 }>()
 
-const emit = defineEmits<{ (event: 'see-all'): void }>()
-
-const canNavigate = computed(() => props.totalCount > 0)
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Summary
- clear nudge wizard selection state when returning to the category step and add link icon to matches button
- allow progressing past the ecological priorities step without selection and hide step titles on mobile viewports
- remove the recommendations footer CTA from the proposals step

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9134ac48832298fdbd9f32e8f32c)