### PR TITLE
Preserve distinct filter groups

### DIFF
--- a/frontend/app/utils/_merge-filter-requests.ts
+++ b/frontend/app/utils/_merge-filter-requests.ts
@@ -1,18 +1,29 @@
-import type { FilterRequestDto } from '~~/shared/api-client'
+import type { FilterGroup, FilterRequestDto } from '~~/shared/api-client'
 
 export const mergeFilterRequests = (
   primary?: FilterRequestDto,
   secondary?: FilterRequestDto,
 ): FilterRequestDto | undefined => {
   const filters = [...(primary?.filters ?? []), ...(secondary?.filters ?? [])]
-  const mergedMust = [...(primary?.filterGroups ?? []), ...(secondary?.filterGroups ?? [])]
-    .flatMap((group) => group.must ?? group.filters ?? [])
-  const mergedShould = [...(primary?.filterGroups ?? []), ...(secondary?.filterGroups ?? [])]
-    .flatMap((group) => group.should ?? [])
+  const filterGroups = [...(primary?.filterGroups ?? []), ...(secondary?.filterGroups ?? [])]
+    .map((group) => {
+      const mustClauses = [...(group.must ?? group.filters ?? [])].filter(Boolean)
+      const shouldClauses = [...(group.should ?? [])].filter(Boolean)
 
-  const filterGroups = mergedMust.length || mergedShould.length
-    ? [{ ...(mergedMust.length ? { must: mergedMust } : {}), ...(mergedShould.length ? { should: mergedShould } : {}) }]
-    : []
+      const normalized: FilterGroup | null = mustClauses.length || shouldClauses.length
+        ? {
+            ...(mustClauses.length ? { must: mustClauses } : {}),
+            ...(shouldClauses.length ? { should: shouldClauses } : {}),
+          }
+        : null
+
+      return normalized
+    })
+    .filter((group): group is FilterGroup => Boolean(group))
+    .filter((group, index, self) => {
+      const signature = JSON.stringify(group)
+      return self.findIndex((candidate) => JSON.stringify(candidate) === signature) === index
+    })
 
   if (!filters.length && !filterGroups.length) {
     return undefined

--- a/frontend/app/utils/_nudge-tool-filters.spec.ts
+++ b/frontend/app/utils/_nudge-tool-filters.spec.ts
@@ -60,4 +60,21 @@ describe('nudge tool filters', () => {
       filterGroups: [{ must: [{ field: 'attributes.indexed.SIZE', operator: 'range', max: 40 }], should: [] }],
     })
   })
+
+  it('preserves multiple subset filter groups', () => {
+    const request = buildNudgeFilterRequest(
+      [],
+      null,
+      [],
+      [
+        { must: [{ field: 'price.min', operator: 'range', max: 500 }], should: [] },
+        { should: [{ field: 'scores.ECOSCORE.value', operator: 'range', min: 2 }], must: [] },
+      ],
+    )
+
+    expect(request.filterGroups).toEqual([
+      { must: [{ field: 'price.min', operator: 'range', max: 500 }], should: [] },
+      { should: [{ field: 'scores.ECOSCORE.value', operator: 'range', min: 2 }], must: [] },
+    ])
+  })
 })

--- a/frontend/app/utils/_subset-to-filters.spec.ts
+++ b/frontend/app/utils/_subset-to-filters.spec.ts
@@ -64,17 +64,13 @@ describe('_subset-to-filters helpers', () => {
 
     expect(request).toEqual({
       filterGroups: [
-        {
-          must: [
-            { field: 'price.conditions', operator: 'term', terms: ['NEW'] },
-            { field: 'price.conditions', operator: 'term', terms: ['OCCASION'] },
-          ],
-        },
+        { must: [{ field: 'price.conditions', operator: 'term', terms: ['NEW'] }] },
+        { must: [{ field: 'price.conditions', operator: 'term', terms: ['OCCASION'] }] },
       ],
     })
   })
 
-  it('combines compatible range filters by widening the bounds', () => {
+  it('keeps each range subset in its own filter group', () => {
     const subsets: VerticalSubsetDto[] = [
       {
         id: 'mid-range',
@@ -90,12 +86,12 @@ describe('_subset-to-filters helpers', () => {
 
     const request = buildFilterRequestFromSubsets(subsets, ['mid-range', 'entry'])
 
-    expect(request.filterGroups?.[0]?.must).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ field: 'price.min', operator: 'range', max: 800 }),
-        expect.objectContaining({ field: 'price.min', operator: 'range', max: 500 }),
-      ]),
-    )
+    expect(request).toEqual({
+      filterGroups: [
+        { must: [{ field: 'price.min', operator: 'range', max: 800 }] },
+        { must: [{ field: 'price.min', operator: 'range', max: 500 }] },
+      ],
+    })
   })
 
   it('drops conflicting range filters when they cannot be merged safely', () => {
@@ -114,11 +110,11 @@ describe('_subset-to-filters helpers', () => {
 
     const request = buildFilterRequestFromSubsets(subsets, ['budget', 'premium'])
 
-    expect(request.filterGroups?.[0]?.must).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ field: 'price.min', operator: 'range', max: 500 }),
-        expect.objectContaining({ field: 'price.min', operator: 'range', min: 1000 }),
-      ]),
-    )
+    expect(request).toEqual({
+      filterGroups: [
+        { must: [{ field: 'price.min', operator: 'range', max: 500 }] },
+        { must: [{ field: 'price.min', operator: 'range', min: 1000 }] },
+      ],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- keep filter groups separate when merging filter requests to retain OR semantics
- build subset-based filter requests as independent groups and expand related unit coverage
- ensure nudge wizard preserves multiple subset filter groups in merged requests

## Testing
- pnpm lint
- pnpm vitest run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bc562fe348322aec1650c018013cc)