### PR TITLE
Align subset filter union behaviour across frontend and API

### DIFF
--- a/frontend/app/utils/_subset-to-filters.spec.ts
+++ b/frontend/app/utils/_subset-to-filters.spec.ts
@@ -64,13 +64,15 @@ describe('_subset-to-filters helpers', () => {
 
     expect(request).toEqual({
       filterGroups: [
-        { must: [{ field: 'price.conditions', operator: 'term', terms: ['NEW'] }] },
-        { must: [{ field: 'price.conditions', operator: 'term', terms: ['OCCASION'] }] },
+        { should: [
+          { field: 'price.conditions', operator: 'term', terms: ['NEW'] },
+          { field: 'price.conditions', operator: 'term', terms: ['OCCASION'] },
+        ] },
       ],
     })
   })
 
-  it('keeps each range subset in its own filter group', () => {
+  it('unions range subsets within their shared group', () => {
     const subsets: VerticalSubsetDto[] = [
       {
         id: 'mid-range',
@@ -88,13 +90,15 @@ describe('_subset-to-filters helpers', () => {
 
     expect(request).toEqual({
       filterGroups: [
-        { must: [{ field: 'price.min', operator: 'range', max: 800 }] },
-        { must: [{ field: 'price.min', operator: 'range', max: 500 }] },
+        { should: [
+          { field: 'price.min', operator: 'range', max: 800 },
+          { field: 'price.min', operator: 'range', max: 500 },
+        ] },
       ],
     })
   })
 
-  it('drops conflicting range filters when they cannot be merged safely', () => {
+  it('keeps disjoint range boundaries as independent options', () => {
     const subsets: VerticalSubsetDto[] = [
       {
         id: 'budget',
@@ -112,8 +116,10 @@ describe('_subset-to-filters helpers', () => {
 
     expect(request).toEqual({
       filterGroups: [
-        { must: [{ field: 'price.min', operator: 'range', max: 500 }] },
-        { must: [{ field: 'price.min', operator: 'range', min: 1000 }] },
+        { should: [
+          { field: 'price.min', operator: 'range', max: 500 },
+          { field: 'price.min', operator: 'range', min: 1000 },
+        ] },
       ],
     })
   })


### PR DESCRIPTION
## Summary
- normalize subset filters to merge range and term bounds and emit OR-capable filter groups when multiple subsets are active
- adjust SearchService grouped filter handling so should clauses form alternative branches alongside mandatory criteria
- refresh unit tests around subset filter construction and grouped criteria semantics

## Testing
- pnpm vitest run app/utils/_subset-to-filters.spec.ts
- pnpm lint
- mvn --offline -pl front-api -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bd2ebfa388322b0bde435e6b4e7bd)