### PR TITLE
Revamp nudge category step slider

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="nudge-step-category">
+	<v-row justify="center" class="mt-2" >
+    <h2 class="align-center nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
+    </v-row>
     <div class="nudge-step-category__header">
-      <h2 class="nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
 
       <div class="nudge-step-category__subtitle-row">
         <div class="nudge-step-category__step" :aria-label="$t('nudge-tool.steps.category.step', { step: 1 })">

--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -1,28 +1,61 @@
 <template>
   <div class="nudge-step-category">
-    <h2 class="nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
-    <p class="nudge-step-category__subtitle">
-      {{ $t('nudge-tool.steps.category.subtitle') }}
-    </p>
+    <div class="nudge-step-category__header">
+      <div class="nudge-step-category__step" :aria-label="$t('nudge-tool.steps.category.step', { step: 1 })">
+        <v-avatar color="surface-primary-080" size="40" rounded="lg">
+          <v-icon icon="mdi-numeric-1-circle" color="accent-primary-highlight" size="26" />
+        </v-avatar>
+      </div>
 
-    <v-row dense>
-      <v-col
+      <div class="nudge-step-category__titles">
+        <h2 class="nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
+        <p class="nudge-step-category__subtitle">
+          {{ $t('nudge-tool.steps.category.subtitle') }}
+        </p>
+      </div>
+    </div>
+
+    <v-slide-group
+      v-model="selected"
+      class="nudge-step-category__slider"
+      show-arrows
+      center-active
+      mandatory
+    >
+      <template #prev="{ props: prevArrowProps }">
+        <v-btn
+          v-bind="prevArrowProps"
+          class="nudge-step-category__arrow"
+          icon="mdi-chevron-left"
+          variant="flat"
+          :aria-label="$t('nudge-tool.actions.previous')"
+        />
+      </template>
+
+      <template #next="{ props: nextArrowProps }">
+        <v-btn
+          v-bind="nextArrowProps"
+          class="nudge-step-category__arrow"
+          icon="mdi-chevron-right"
+          variant="flat"
+          :aria-label="$t('nudge-tool.actions.next')"
+        />
+      </template>
+
+      <v-slide-group-item
         v-for="category in categories"
         :key="category.id"
-        cols="6"
-        sm="4"
-        md="3"
+        :value="category.id ?? ''"
       >
         <v-card
           class="nudge-step-category__card"
-          :elevation="selectedCategoryId === category.id ? 6 : 2"
-          :color="selectedCategoryId === category.id ? 'primary' : undefined"
-          :variant="selectedCategoryId === category.id ? 'elevated' : 'tonal'"
+          :class="{ 'nudge-step-category__card--selected': selected === category.id }"
+          :elevation="selected === category.id ? 8 : 2"
           rounded="xl"
-        role="button"
-        :aria-pressed="(selectedCategoryId === category.id).toString()"
-        @click="() => emit('select', category.id ?? '')"
-      >
+          role="button"
+          :aria-pressed="(selected === category.id).toString()"
+          @click="() => emit('select', category.id ?? '')"
+        >
           <div class="nudge-step-category__image">
             <v-img
               :src="category.imageSmall"
@@ -46,44 +79,108 @@
           </div>
           <p class="nudge-step-category__name">{{ category.verticalHomeTitle ?? category.id }}</p>
         </v-card>
-      </v-col>
-    </v-row>
+      </v-slide-group-item>
+    </v-slide-group>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { VerticalConfigDto } from '~~/shared/api-client'
 
-defineProps<{
+const props = defineProps<{
   categories: VerticalConfigDto[]
   selectedCategoryId?: string | null
 }>()
 
 const emit = defineEmits<{ (event: 'select', categoryId: string): void }>()
+
+const selected = ref<string | null>(props.selectedCategoryId ?? null)
+
+watch(
+  () => props.selectedCategoryId,
+  (value) => {
+    selected.value = value ?? null
+  },
+)
+
+watch(
+  selected,
+  (value) => {
+    if (value) {
+      emit('select', value)
+    }
+  },
+  { immediate: true },
+)
 </script>
 
 <style scoped lang="scss">
 .nudge-step-category {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    text-align: center;
+  }
+
+  &__step {
+    display: flex;
+    align-items: center;
+  }
+
+  &__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
   &__title {
     font-size: 1.5rem;
     font-weight: 700;
-    margin-bottom: 4px;
+    margin: 0;
   }
 
   &__subtitle {
     color: rgb(var(--v-theme-text-neutral-secondary));
-    margin-bottom: 16px;
+    margin: 0;
+  }
+
+  &__slider {
+    display: flex;
+    align-items: center;
+    padding-inline: 8px;
+    gap: 8px;
+  }
+
+  &__arrow {
+    background: rgb(var(--v-theme-surface-primary-080));
+    color: rgb(var(--v-theme-accent-primary-highlight));
+    box-shadow: none;
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
   }
 
   &__card {
     text-align: center;
-    padding: 16px;
+    padding: 16px 14px;
     height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: 8px;
+    min-width: 160px;
+    background: rgb(var(--v-theme-surface-default));
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+
+    &--selected {
+      border-color: rgb(var(--v-theme-accent-primary-highlight));
+      box-shadow: 0 10px 25px -12px rgba(var(--v-theme-shadow-primary-600), 0.5);
+    }
   }
 
   &__image {

--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="nudge-step-category">
     <div class="nudge-step-category__header">
-      <div class="nudge-step-category__step" :aria-label="$t('nudge-tool.steps.category.step', { step: 1 })">
-        <v-avatar color="surface-primary-080" size="40" rounded="lg">
-          <v-icon icon="mdi-numeric-1-circle" color="accent-primary-highlight" size="26" />
-        </v-avatar>
-      </div>
+      <h2 class="nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
 
-      <div class="nudge-step-category__titles">
-        <h2 class="nudge-step-category__title">{{ $t('nudge-tool.steps.category.title') }}</h2>
+      <div class="nudge-step-category__subtitle-row">
+        <div class="nudge-step-category__step" :aria-label="$t('nudge-tool.steps.category.step', { step: 1 })">
+          <v-avatar color="surface-primary-080" size="36" rounded="lg">
+            <v-icon icon="mdi-numeric-1-circle" color="accent-primary-highlight" size="22" />
+          </v-avatar>
+        </div>
+
         <p class="nudge-step-category__subtitle">
           {{ $t('nudge-tool.steps.category.subtitle') }}
         </p>
@@ -118,14 +119,14 @@ watch(
 .nudge-step-category {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 
   &__header {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
-    text-align: center;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    text-align: left;
   }
 
   &__step {
@@ -133,16 +134,16 @@ watch(
     align-items: center;
   }
 
-  &__titles {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
   &__title {
     font-size: 1.5rem;
     font-weight: 700;
     margin: 0;
+  }
+
+  &__subtitle-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
   }
 
   &__subtitle {
@@ -152,9 +153,19 @@ watch(
 
   &__slider {
     display: flex;
-    align-items: center;
-    padding-inline: 8px;
-    gap: 8px;
+    align-items: stretch;
+    padding-inline: 4px;
+    gap: 10px;
+
+    :deep(.v-slide-group__container) {
+      align-items: stretch;
+    }
+
+    :deep(.v-slide-group__content) {
+      justify-content: center;
+      gap: 12px;
+      padding-block: 4px;
+    }
   }
 
   &__arrow {
@@ -167,7 +178,7 @@ watch(
   &__card {
     text-align: center;
     padding: 16px 14px;
-    height: 100%;
+    height: auto;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -584,7 +584,6 @@ onMounted(async () => {
   }
 
   &__window {
-    min-height: 420px;
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/frontend/app/components/shared/hero/HeroSurface.vue
+++ b/frontend/app/components/shared/hero/HeroSurface.vue
@@ -16,8 +16,8 @@ const props = withDefaults(
   }>(),
   {
     tag: 'section',
-    //variant: 'aurora',
-    //bleed: false,
+    variant: 'aurora',
+    bleed: false,
   },
 )
 

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2204,8 +2204,9 @@
     },
     "steps": {
       "category": {
-        "title": "Choose a category",
-        "subtitle": "Pick the type of product you want to browse"
+        "title": "Nudger guides you, step by step.",
+        "subtitle": "Choose a category",
+        "step": "Step {step}"
       },
       "condition": {
         "title": "Product condition",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2205,8 +2205,9 @@
     },
     "steps": {
       "category": {
-        "title": "Choisis une catégorie",
-        "subtitle": "Nudger te guide, pas à pas."
+        "title": "Nudger te guide, pas à pas.",
+        "subtitle": "Choisis une catégorie",
+        "step": "Étape {step}"
       },
       "condition": {
         "title": "Neuf ou occasion ?",


### PR DESCRIPTION
## Summary
- Restyled the nudge category step header with a numbered icon and updated localized copy.
- Switched category selection to a single-row slide group with themed navigation arrows and refreshed card styling.
- Added translation keys for the new step label and set default hero surface props to satisfy linting.

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d3fcee9f0832b9f4dadcd4cb0e8fa)