### PR TITLE
Align Nudger theme with light palette

### DIFF
--- a/frontend/app/assets/sass/base/_fonts.sass
+++ b/frontend/app/assets/sass/base/_fonts.sass
@@ -84,7 +84,7 @@ $font-files: (
   --font-family-signature: #{$font-family-signature}
 
 // Thème spécifique (ex : nudger)
-.v-theme--nudger
+.v-theme--light
   --font-family-base: #{$font-family-primary}
 
 html, body

--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -14,12 +14,12 @@
 
 // custom pour element nudger
 
-.v-theme--nudger
+.v-theme--light
     .v-main
         top: 0!important
         --v-layout-top: 0!important
 
-.v-theme--nudger
+.v-theme--light
     .main-menu-app-bar
         .v-list
             background: transparent!important

--- a/frontend/app/components/shared/footers/TheMainFooter.vue
+++ b/frontend/app/components/shared/footers/TheMainFooter.vue
@@ -22,7 +22,7 @@
     border-top: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
     box-shadow: 0 -18px 48px rgba(var(--v-theme-shadow-primary-600), 0.22);
   }
-  .v-theme--nudger.main-footer {
+  .v-theme--light.main-footer {
     background: #0083A4!important;
   }
 

--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -8,18 +8,18 @@
     rounded="pill"
     :data-testid="testId"
   >
-    <v-tooltip :text="lightTooltip" location="bottom">
+    <v-tooltip :text="nudgerTooltip" location="bottom">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
           :value="'light'"
-          :aria-label="lightAriaLabel"
+          :aria-label="nudgerAriaLabel"
           :data-testid="`${testId}-light`"
           :size="size"
           icon
           variant="plain"
         >
-          <v-icon icon="mdi-white-balance-sunny" />
+          <v-icon icon="mdi-gradient-horizontal" />
         </v-btn>
       </template>
     </v-tooltip>
@@ -36,22 +36,6 @@
           variant="plain"
         >
           <v-icon icon="mdi-weather-night" />
-        </v-btn>
-      </template>
-    </v-tooltip>
-
-    <v-tooltip :text="nudgerTooltip" location="bottom">
-      <template #activator="{ props: tooltipProps }">
-        <v-btn
-          v-bind="tooltipProps"
-          :value="'nudger'"
-          :aria-label="nudgerAriaLabel"
-          :data-testid="`${testId}-nudger`"
-          :size="size"
-          icon
-          variant="plain"
-        >
-          <v-icon icon="mdi-gradient-horizontal" />
         </v-btn>
       </template>
     </v-tooltip>
@@ -82,7 +66,7 @@ const props = withDefaults(
 const { t } = useI18n()
 const theme = useTheme()
 const preferredDark = usePreferredDark()
-const themeCookie = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
+const themeCookie = useCookie<string | null>(THEME_PREFERENCE_KEY, {
   sameSite: 'lax',
   path: '/',
   watch: false,
@@ -123,10 +107,8 @@ const selectedTheme = computed<ThemeName>({
   set: (value) => applyTheme(value),
 })
 
-const lightTooltip = computed(() => t('siteIdentity.menu.theme.lightTooltip'))
 const darkTooltip = computed(() => t('siteIdentity.menu.theme.darkTooltip'))
 const nudgerTooltip = computed(() => t('siteIdentity.menu.theme.nudgerTooltip'))
-const lightAriaLabel = computed(() => t('siteIdentity.menu.theme.lightAriaLabel'))
 const darkAriaLabel = computed(() => t('siteIdentity.menu.theme.darkAriaLabel'))
 const nudgerAriaLabel = computed(() => t('siteIdentity.menu.theme.nudgerAriaLabel'))
 

--- a/frontend/app/plugins/vuetify-theme.ts
+++ b/frontend/app/plugins/vuetify-theme.ts
@@ -44,7 +44,7 @@ const themePlugin = defineNuxtPlugin({
   enforce: 'pre',
   setup(nuxt) {
     const nuxtApp = nuxt as NuxtApp
-    const storedPreference = useCookie<ThemeName | null>(THEME_PREFERENCE_KEY, {
+    const storedPreference = useCookie<string | null>(THEME_PREFERENCE_KEY, {
       sameSite: 'lax',
       path: '/',
       watch: false,

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -223,13 +223,10 @@ export default defineNuxtConfig({
           defaultTheme: 'light',
           themes: {
             light: {
-              colors: vuetifyPalettes.light,
+              colors: vuetifyPalettes.nudger,
             },
             dark: {
               colors: vuetifyPalettes.dark,
-            },
-            nudger: {
-              colors: vuetifyPalettes.nudger,
             },
           },
         },

--- a/frontend/shared/constants/theme.ts
+++ b/frontend/shared/constants/theme.ts
@@ -1,4 +1,4 @@
-export const THEME_NAMES = ['light', 'dark', 'nudger'] as const
+export const THEME_NAMES = ['light', 'dark'] as const
 
 export type ThemeName = (typeof THEME_NAMES)[number]
 
@@ -8,8 +8,10 @@ export const resolveThemeName = (
   value: string | null | undefined,
   fallback: ThemeName = 'light',
 ): ThemeName => {
-  if (value && (THEME_NAMES as readonly string[]).includes(value)) {
-    return value as ThemeName
+  const normalizedValue = value === 'nudger' ? 'light' : value
+
+  if (normalizedValue && (THEME_NAMES as readonly string[]).includes(normalizedValue)) {
+    return normalizedValue as ThemeName
   }
 
   return fallback


### PR DESCRIPTION
## Summary
- map the Vuetify light theme to the Nudger palette and remove the extra theme entry
- normalize theme constants and toggle logic to prefer light/dark while treating legacy `nudger` as light
- retarget Nudger-specific styles to the light theme class

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d43b547f0832b9bfac9e952a59785)