### PR TITLE
Add nudger theme toggle option

### DIFF
--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -12,14 +12,30 @@
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
-          :value="'light'"
+          :value="'nudger'"
           :aria-label="nudgerAriaLabel"
-          :data-testid="`${testId}-light`"
+          :data-testid="`${testId}-nudger`"
           :size="size"
           icon
           variant="plain"
         >
           <v-icon icon="mdi-gradient-horizontal" />
+        </v-btn>
+      </template>
+    </v-tooltip>
+
+    <v-tooltip :text="lightTooltip" location="bottom">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          :value="'light'"
+          :aria-label="lightAriaLabel"
+          :data-testid="`${testId}-light`"
+          :size="size"
+          icon
+          variant="plain"
+        >
+          <v-icon icon="mdi-white-balance-sunny" />
         </v-btn>
       </template>
     </v-tooltip>
@@ -107,8 +123,10 @@ const selectedTheme = computed<ThemeName>({
   set: (value) => applyTheme(value),
 })
 
+const lightTooltip = computed(() => t('siteIdentity.menu.theme.lightTooltip'))
 const darkTooltip = computed(() => t('siteIdentity.menu.theme.darkTooltip'))
 const nudgerTooltip = computed(() => t('siteIdentity.menu.theme.nudgerTooltip'))
+const lightAriaLabel = computed(() => t('siteIdentity.menu.theme.lightAriaLabel'))
 const darkAriaLabel = computed(() => t('siteIdentity.menu.theme.darkAriaLabel'))
 const nudgerAriaLabel = computed(() => t('siteIdentity.menu.theme.nudgerAriaLabel'))
 

--- a/frontend/shared/constants/theme.ts
+++ b/frontend/shared/constants/theme.ts
@@ -1,4 +1,4 @@
-export const THEME_NAMES = ['light', 'dark'] as const
+export const THEME_NAMES = ['light', 'dark', 'nudger'] as const
 
 export type ThemeName = (typeof THEME_NAMES)[number]
 
@@ -8,10 +8,8 @@ export const resolveThemeName = (
   value: string | null | undefined,
   fallback: ThemeName = 'light',
 ): ThemeName => {
-  const normalizedValue = value === 'nudger' ? 'light' : value
-
-  if (normalizedValue && (THEME_NAMES as readonly string[]).includes(normalizedValue)) {
-    return normalizedValue as ThemeName
+  if (value && (THEME_NAMES as readonly string[]).includes(value)) {
+    return value as ThemeName
   }
 
   return fallback


### PR DESCRIPTION
## Summary
- add a dedicated Nudger toggle option with proper labeling and data-test ids
- allow theme preference resolution to include the Nudger palette

## Testing
- pnpm test --run app/components/shared/menus/menus-auth.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d7bdb755c832bb0010d106e40b8fc)