### PR TITLE
Refactor font mixin to use named if arguments

### DIFF
--- a/frontend/app/assets/sass/base/_fonts.sass
+++ b/frontend/app/assets/sass/base/_fonts.sass
@@ -40,7 +40,11 @@ $font-files: (
   $format: 'truetype'
 )
   // Résolution du nom de fichier AVANT le bloc @font-face
-  $resolved-file: if($file-name, $file-name, '#{$name}-#{map.get($file-map, $weight)}')
+  $resolved-file: if(
+    condition: $file-name,
+    then: $file-name,
+    else: '#{$name}-#{map.get($file-map, $weight)}'
+  )
 
   @if $file-name == null and $style == italic
     $resolved-file: '#{$resolved-file}Italic'


### PR DESCRIPTION
## Summary
- replace the deprecated positional `if()` usage in the font-face mixin with named arguments to silence Sass warnings
- keep the existing filename resolution logic for custom names and generated names

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fd5668300832bae9b8346bd704ffa)