### PR TITLE
Revamp nudge tool score selection cards

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -27,28 +27,36 @@
         .theme-toggle
             background-color: transparent!important
 
-    .card__nudger 
-        background: #ffffff!important
-        border-radius: 30px!important
-        padding: 1.25rem!important
+.card__nudger
+    background: rgb(var(--v-theme-surface-default))!important
+    border: 1px solid rgba(var(--v-theme-primary), 0.08)!important
+    border-radius: 30px!important
+    padding: 1.25rem!important
+    color: rgb(var(--v-theme-text-neutral-strong))
+    box-shadow: 0 10px 26px rgba(var(--v-theme-primary), 0.06)
+    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease
 
-        &--border
-            border: 1px solid rgb(var(--v-theme-primary))!important
+    &:hover
+        box-shadow: 0 18px 42px rgba(var(--v-theme-primary), 0.12)
+        transform: translateY(-1px)
 
-        &--radius_bottom-right_50px
-            border-bottom-right-radius: 50px!important
+    &--border
+        border: 1px solid rgba(var(--v-theme-primary), 0.2)!important
 
-        &--radius_top-right_0
-            border-top-right-radius: 0!important
+    &--radius_bottom-right_50px
+        border-bottom-right-radius: 50px!important
 
-    .home-hero__subtitle
-        font-size: clamp(1.05rem, 2.6vw, 1.35rem)
-        color: rgb(var(--v-theme-text-neutral-strong))
-        text-align: center
-        font-weight: bolder
-        text-transform: uppercase
-        margin: 0 0 1.25rem 0
+    &--radius_top-right_0
+        border-top-right-radius: 0!important
 
-    .nudger_degrade-defaut
-        background-image: linear-gradient(to left, rgb(var(--v-theme-primary)), rgb(var(--v-theme-secondary)))!important
-        color: #ffffff!important
+.home-hero__subtitle
+    font-size: clamp(1.05rem, 2.6vw, 1.35rem)
+    color: rgb(var(--v-theme-text-neutral-strong))
+    text-align: center
+    font-weight: bolder
+    text-transform: uppercase
+    margin: 0 0 1.25rem 0
+
+.nudger_degrade-defaut
+    background-image: linear-gradient(to left, rgb(var(--v-theme-primary)), rgb(var(--v-theme-secondary)))!important
+    color: #ffffff!important

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -3,7 +3,6 @@
     <div class="nudge-step-scores__header">
       <div>
         <h2 class="nudge-step-scores__title">{{ $t('nudge-tool.steps.scores.title') }}</h2>
-        <p class="nudge-step-scores__subtitle">{{ $t('nudge-tool.steps.scores.subtitle') }}</p>
       </div>
 
     </div>
@@ -15,23 +14,31 @@
         cols="12"
         sm="6"
       >
-        <v-card
-          class="nudge-step-scores__card"
-          :elevation="selectedNames.includes(score.scoreName ?? '') ? 6 : 2"
-          :variant="selectedNames.includes(score.scoreName ?? '') ? 'elevated' : 'tonal'"
-          rounded="xl"
-          role="button"
-          :aria-pressed="selectedNames.includes(score.scoreName ?? '')"
-          @click="toggle(score.scoreName ?? '')"
+        <v-tooltip
+          location="top"
+          :text="score.description"
+          :disabled="!score.description"
         >
-          <div class="nudge-step-scores__icon">
-            <v-icon :icon="getScoreIcon(score)" size="28" />
-          </div>
-          <div class="nudge-step-scores__content">
-            <p class="nudge-step-scores__name">{{ score.title }}</p>
-            <p class="nudge-step-scores__description">{{ score.description }}</p>
-          </div>
-        </v-card>
+          <template #activator="{ props: activatorProps }">
+            <v-card
+              v-bind="activatorProps"
+              class="nudge-step-scores__card card__nudger"
+              :class="{ 'nudge-step-scores__card--selected': selectedNames.includes(score.scoreName ?? '') }"
+              :variant="selectedNames.includes(score.scoreName ?? '') ? 'elevated' : 'flat'"
+              rounded="xl"
+              role="button"
+              :aria-pressed="selectedNames.includes(score.scoreName ?? '')"
+              @click="toggle(score.scoreName ?? '')"
+            >
+              <div class="nudge-step-scores__icon">
+                <v-icon :icon="getScoreIcon(score)" size="28" />
+              </div>
+              <div class="nudge-step-scores__content">
+                <p class="nudge-step-scores__name">{{ score.title }}</p>
+              </div>
+            </v-card>
+          </template>
+        </v-tooltip>
       </v-col>
     </v-row>
   </div>
@@ -81,17 +88,20 @@ const toggle = (scoreName: string) => {
     margin: 0;
   }
 
-  &__subtitle {
-    margin: 0;
-    color: rgb(var(--v-theme-text-neutral-secondary));
-  }
-
   &__card {
     display: flex;
     gap: 12px;
     padding: 16px;
     height: 100%;
     align-items: center;
+    cursor: pointer;
+    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+
+    &--selected {
+      border: 1px solid rgba(var(--v-theme-primary), 0.3) !important;
+      box-shadow: 0 14px 38px rgba(var(--v-theme-primary), 0.12);
+      transform: translateY(-2px);
+    }
   }
 
   &__icon {
@@ -107,11 +117,6 @@ const toggle = (scoreName: string) => {
   &__name {
     margin: 0;
     font-weight: 700;
-  }
-
-  &__description {
-    margin: 2px 0 0;
-    color: rgb(var(--v-theme-text-neutral-secondary));
   }
 }
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2218,8 +2218,8 @@
         }
       },
       "scores": {
-        "title": "Ecological priorities",
-        "subtitle": "Select the eco topics that matter most"
+        "title": "Your ecological priorities",
+        "subtitle": ""
       },
       "recommendations": {
         "title": "Our picks for you",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2219,8 +2219,8 @@
         }
       },
       "scores": {
-        "title": "Priorités écologiques",
-        "subtitle": "Qu'est ce compte pour toi ?"
+        "title": "Tes priorités écologiques",
+        "subtitle": ""
       },
       "recommendations": {
         "title": "Nos propositions",


### PR DESCRIPTION
## Summary
- restyle nudge tool score cards with the shared card__nudger surface and tooltip-only descriptions
- adjust score header copy and translations to highlight user-focused ecological priorities
- generalize card__nudger styles for consistent rendering across themes

## Testing
- pnpm lint
- pnpm test -- --run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fd9513cd0832b8d80bc334eabb427)