### PR TITLE
Refine nudge tool option cards

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -40,6 +40,26 @@
         box-shadow: 0 18px 42px rgba(var(--v-theme-primary), 0.12)
         transform: translateY(-1px)
 
+.nudge-option-card
+    background: rgb(var(--v-theme-surface-default))!important
+    border: 1px solid rgba(var(--v-theme-primary), 0.08)!important
+    border-radius: 24px!important
+    padding: 16px!important
+    color: rgb(var(--v-theme-text-neutral-strong))
+    box-shadow: 0 6px 20px rgba(var(--v-theme-primary), 0.05)
+    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease
+    text-align: center
+    cursor: pointer
+
+    &:hover
+        box-shadow: 0 14px 38px rgba(var(--v-theme-primary), 0.12)
+        transform: translateY(-1px)
+
+    &--selected
+        background: rgba(var(--v-theme-primary), 0.08)!important
+        border-color: rgba(var(--v-theme-primary), 0.3)!important
+        box-shadow: 0 18px 42px rgba(var(--v-theme-primary), 0.14)
+
     &--border
         border: 1px solid rgba(var(--v-theme-primary), 0.2)!important
 

--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -1,22 +1,24 @@
 <template>
   <div class="nudge-step-condition">
 
-    <h2 class="nudge-step-condition__title"><v-icon icon="mdi-numeric-3-circle" color="accent-primary-highlight" size="30" /> {{ $t('nudge-tool.steps.condition.title') }}</h2>
+    <h2 class="nudge-step-condition__title">
+      <v-icon icon="mdi-numeric-3-circle" color="accent-primary-highlight" size="30" />
+      {{ $t('nudge-tool.steps.condition.title') }}
+    </h2>
     <p class="nudge-step-condition__subtitle">{{ $t('nudge-tool.steps.condition.subtitle') }}</p>
 
-    <v-row dense>
+    <v-row dense class="nudge-step-condition__row" justify="center">
       <v-col
         v-for="option in options"
         :key="option.value"
         cols="12"
         sm="4"
+        class="d-flex"
       >
         <v-card
-          class="nudge-step-condition__card"
-          :elevation="isSelected(option.value) ? 8 : 2"
-          :color="isSelected(option.value) ? 'primary' : undefined"
-          :variant="isSelected(option.value) ? 'elevated' : 'tonal'"
-          rounded="xl"
+          class="nudge-step-condition__card nudge-option-card"
+          :class="{ 'nudge-option-card--selected': isSelected(option.value) }"
+          rounded="lg"
           role="button"
           :aria-pressed="isSelected(option.value).toString()"
           @click="() => toggleOption(option.value)"
@@ -71,9 +73,16 @@ const toggleOption = (choice: ProductConditionChoice) => {
     margin-bottom: 16px;
   }
 
+  &__row {
+    row-gap: 12px;
+  }
+
   &__card {
-    padding: 16px;
-    text-align: center;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
   }
 
   &__label {

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -2,7 +2,10 @@
   <div class="nudge-step-scores">
     <div class="nudge-step-scores__header">
       <div>
-	      <h2 class="nudge-step-scores__title"> <v-icon icon="mdi-numeric-2-circle" color="accent-primary-highlight" size="30" /> {{ $t('nudge-tool.steps.scores.title') }}</h2>
+        <h2 class="nudge-step-scores__title">
+          <v-icon icon="mdi-numeric-2-circle" color="accent-primary-highlight" size="30" />
+          {{ $t('nudge-tool.steps.scores.title') }}
+        </h2>
       </div>
 
     </div>
@@ -22,10 +25,9 @@
           <template #activator="{ props: activatorProps }">
             <v-card
               v-bind="activatorProps"
-              class="nudge-step-scores__card card__nudger"
-              :class="{ 'nudge-step-scores__card--selected': selectedNames.includes(score.scoreName ?? '') }"
-              :variant="selectedNames.includes(score.scoreName ?? '') ? 'elevated' : 'flat'"
-              rounded="xl"
+              class="nudge-step-scores__card nudge-option-card"
+              :class="{ 'nudge-option-card--selected': selectedNames.includes(score.scoreName ?? '') }"
+              rounded="lg"
               role="button"
               :aria-pressed="selectedNames.includes(score.scoreName ?? '')"
               @click="toggle(score.scoreName ?? '')"
@@ -91,17 +93,8 @@ const toggle = (scoreName: string) => {
   &__card {
     display: flex;
     gap: 12px;
-    padding: 16px;
     height: 100%;
     align-items: center;
-    cursor: pointer;
-    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
-
-    &--selected {
-      border: 1px solid rgba(var(--v-theme-primary), 0.3) !important;
-      box-shadow: 0 14px 38px rgba(var(--v-theme-primary), 0.12);
-      transform: translateY(-2px);
-    }
   }
 
   &__icon {

--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="nudge-step-subset">
     <div class="nudge-step-subset__header">
-      <div>
-        <div v-if="group.mdiIcon || group.title" class="nudge-step-subset__eyebrow">
-          <v-icon v-if="group.mdiIcon" :icon="group.mdiIcon" size="18" class="me-1" />
-          <span>{{ group.title }}</span>
-        </div>
-        <p class="nudge-step-subset__description">{{ group.description }}</p>
-      </div>
-
+      <h2 class="nudge-step-subset__title">
+        <v-icon
+          :icon="`mdi-numeric-${stepNumber}-circle`"
+          color="accent-primary-highlight"
+          size="30"
+        />
+        {{ group.title }}
+      </h2>
+      <p v-if="group.description" class="nudge-step-subset__description">{{ group.description }}</p>
     </div>
 
     <v-row dense>
@@ -18,24 +19,28 @@
         cols="12"
         sm="6"
       >
-        <v-card
-          class="nudge-step-subset__card"
-          :elevation="modelValue.includes(subset.id ?? '') ? 6 : 2"
-          :variant="modelValue.includes(subset.id ?? '') ? 'elevated' : 'tonal'"
-          rounded="xl"
-          role="button"
-          :aria-pressed="modelValue.includes(subset.id ?? '')"
-          @click="toggle(subset.id ?? '')"
+        <v-tooltip
+          location="top"
+          :text="subset.description"
+          :disabled="!subset.description"
         >
-          <div v-if="subset.image" class="nudge-step-subset__media">
-            <v-img :src="subset.image" height="120" cover />
-          </div>
-          <div class="nudge-step-subset__body">
-            <p class="nudge-step-subset__title">{{ subset.title }}</p>
-            <p class="nudge-step-subset__caption">{{ subset.caption }}</p>
-            <p class="nudge-step-subset__description">{{ subset.description }}</p>
-          </div>
-        </v-card>
+          <template #activator="{ props: activatorProps }">
+            <v-card
+              v-bind="activatorProps"
+              class="nudge-step-subset__card nudge-option-card"
+              :class="{ 'nudge-option-card--selected': modelValue.includes(subset.id ?? '') }"
+              rounded="lg"
+              role="button"
+              :aria-pressed="modelValue.includes(subset.id ?? '')"
+              @click="toggle(subset.id ?? '')"
+            >
+              <div class="nudge-step-subset__body">
+                <p class="nudge-step-subset__name">{{ subset.title }}</p>
+                <p v-if="subset.caption" class="nudge-step-subset__caption">{{ subset.caption }}</p>
+              </div>
+            </v-card>
+          </template>
+        </v-tooltip>
       </v-col>
     </v-row>
   </div>
@@ -48,6 +53,7 @@ const props = defineProps<{
   group: NudgeToolSubsetGroupDto
   subsets: VerticalSubsetDto[]
   modelValue: string[]
+  stepNumber: number
 }>()
 
 const emit = defineEmits<{ (event: 'update:modelValue', value: string[]): void; (event: 'continue'): void }>()
@@ -76,28 +82,25 @@ const toggle = (subsetId: string) => {
     margin-bottom: 16px;
   }
 
-  &__eyebrow {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+  &__title {
+    font-size: 1.5rem;
     font-weight: 700;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   &__description {
-    margin: 4px 0 0;
+    margin: 0;
     color: rgb(var(--v-theme-text-neutral-secondary));
   }
 
   &__card {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    align-items: center;
     height: 100%;
-  }
-
-  &__media {
-    border-radius: 12px;
-    overflow: hidden;
   }
 
   &__body {
@@ -107,7 +110,7 @@ const toggle = (subsetId: string) => {
     gap: 4px;
   }
 
-  &__title {
+  &__name {
     margin: 0;
     font-weight: 700;
   }

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -258,6 +258,8 @@ const steps = computed<WizardStep[]>(() => {
     },
   })
 
+  let subsetStepNumber = 4
+
   subsetGroups.value.forEach((group) => {
     const subsets = groupedSubsets.value[group.id ?? ''] ?? []
     if (!subsets.length) {
@@ -268,9 +270,11 @@ const steps = computed<WizardStep[]>(() => {
       key: `group-${group.id}`,
       component: NudgeToolStepSubsetGroup,
       title: group.title ?? '',
-      props: { group, subsets, modelValue: activeSubsetIds.value },
+      props: { group, subsets, modelValue: activeSubsetIds.value, stepNumber: subsetStepNumber },
       onUpdate: (value: string[]) => (activeSubsetIds.value = value),
     })
+
+    subsetStepNumber += 1
   })
 
   sequence.push({
@@ -457,14 +461,6 @@ const navigateToCategoryPage = () => {
   void router.push({ path: `/${slug}`, hash })
 }
 
-const getStepGroupSelection = (key: string) => {
-  const groupId = key.replace('group-', '')
-  const subsets = groupedSubsets.value[groupId] ?? []
-  const subsetIds = subsets.map((subset) => subset.id)
-
-  return activeSubsetIds.value.filter((subsetId) => subsetIds.includes(subsetId))
-}
-
 const hasPreviousStep = computed(() => {
   const index = steps.value.findIndex((step) => step.key === activeStepKey.value)
   return index > 0
@@ -479,37 +475,9 @@ const hasNextStep = computed(() => {
   return index >= 0 && index < steps.value.length - 1
 })
 
-const isMultiSelectStep = computed(
-  () => activeStepKey.value === 'condition' || activeStepKey.value.startsWith('group-'),
-)
-
-const hasSelectionForStep = computed(() => {
-  if (activeStepKey.value === 'scores') {
-    return selectedScores.value.length > 0
-  }
-
-  if (activeStepKey.value === 'condition') {
-    return condition.value.length > 0
-  }
-
-  if (activeStepKey.value.startsWith('group-')) {
-    return getStepGroupSelection(activeStepKey.value).length > 0
-  }
-
-  if (activeStepKey.value === 'category') {
-    return Boolean(selectedCategoryId.value)
-  }
-
-  return true
-})
-
 const isNextDisabled = computed(() => {
   if (activeStepKey.value === 'category') {
     return !selectedCategoryId.value
-  }
-
-  if (isMultiSelectStep.value) {
-    return !hasSelectionForStep.value
   }
 
   return false


### PR DESCRIPTION
## Summary
- unify shared option card styling across nudge wizard steps
- keep navigation enabled for condition and subset steps while aligning condition card layout
- simplify subset group cards with numeric headers, tooltips, and consistent selection visuals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe7710244832b977e5e9275ac7003)