### PR TITLE
Improve home hero parallax and loading state

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-
 import { computed, onMounted, ref, toRefs } from 'vue'
 import { useTheme } from 'vuetify'
 import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
@@ -14,7 +13,6 @@ type HeroHelperItem = {
   label: string
 }
 
-const heroBackgroundSrc = '/images/home/home-hero_background.webp'
 const isHeroImageLoaded = ref(false)
 const heroReadyFallbackDelayMs = 900
 
@@ -97,24 +95,23 @@ const heroHelperItems = computed<HeroHelperItem[]>(() => {
 
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundSrc = computed(() => {
-const isDarkMode = Boolean(theme.global.current.value.dark)
-const lightImage = props.heroImageLight || '/images/home/home-hero_background.webp'
-const darkImage = props.heroImageDark || '/images/home/hero-placeholder.svg'
+  const isDarkMode = Boolean(theme.global.current.value.dark)
+  const lightImage = props.heroImageLight || '/images/home/home-hero_background.webp'
+  const darkImage = props.heroImageDark || '/images/home/hero-placeholder.svg'
 
-  
+  return isDarkMode ? darkImage : lightImage
+})
+
 const handleHeroImageLoad = () => {
   isHeroImageLoaded.value = true
 }
 
-return isDarkMode ? darkImage : lightImage
-  
 onMounted(() => {
   window.setTimeout(() => {
     if (!isHeroImageLoaded.value) {
       isHeroImageLoaded.value = true
     }
   }, heroReadyFallbackDelayMs)
-
 })
 
 const handleSubmit = () => {
@@ -133,7 +130,6 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 <template>
   <HeroSurface tag="section" class="home-hero" aria-labelledby="home-hero-title" variant="aurora" :bleed="true">
     <div class="home-hero__background" aria-hidden="true">
-
       <v-fade-transition>
         <div v-if="showHeroSkeleton" class="home-hero__background-loader">
           <v-skeleton-loader type="image" class="home-hero__background-skeleton" />
@@ -149,9 +145,6 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
       >
         <div class="home-hero__background-overlay" />
       </v-parallax>
-
-
-
     </div>
     <v-container fluid class="home-hero__container">
       <div class="home-hero__inner">
@@ -300,12 +293,42 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     align-items: center
     text-align: center
 
+  .home-hero__eyebrow-block
+    display: inline-flex
+    flex-direction: column
+    gap: clamp(0.5rem, 1.5vw, 0.75rem)
+    padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
+    align-items: flex-start
+
   .home-hero__eyebrow
     font-weight: 600
     letter-spacing: 0.08em
     text-transform: uppercase
     color: rgba(var(--v-theme-hero-gradient-end), 0.9)
     margin: 0
+
+  .home-hero__icon-wrapper
+    width: clamp(88px, 18vw, 136px)
+    height: clamp(88px, 18vw, 136px)
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45)
+    box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+    backdrop-filter: blur(8px)
+
+  .home-hero__icon
+    border-radius: inherit
+    width: 100%
+    height: 100%
+    transition: transform 250ms ease, filter 250ms ease
+    filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
+
+  .home-hero__icon--fade
+    animation: home-hero-fade-up 900ms ease-out both
+
+  .home-hero__icon--scale
+    animation: home-hero-scale-in 800ms ease-out both
+
+  .home-hero__icon--pulse
+    animation: home-hero-pulse 1200ms ease-in-out both
 
   .home-hero__title
     font-size: clamp(2.2rem, 5vw, 3.8rem)
@@ -431,6 +454,36 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     white-space: nowrap
     border: 0
 
+  @keyframes home-hero-fade-up
+    from
+      opacity: 0
+      transform: translateY(12px) scale(0.98)
+    to
+      opacity: 1
+      transform: translateY(0) scale(1)
+
+  @keyframes home-hero-scale-in
+    from
+      opacity: 0
+      transform: scale(0.9)
+    55%
+      opacity: 1
+      transform: scale(1.02)
+    to
+      transform: scale(1)
+
+  @keyframes home-hero-pulse
+    0%
+      transform: scale(0.92)
+      opacity: 0
+    35%
+      transform: scale(1.04)
+      opacity: 1
+    70%
+      transform: scale(0.98)
+    100%
+      transform: scale(1)
+
   @media (max-width: 959px)
     .home-hero
       min-height: clamp(520px, 68dvh, 760px)
@@ -470,5 +523,4 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     .home-hero__panel
       max-width: 980px
       margin-inline: auto
-
 </style>

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
+import { computed, onMounted, ref, toRefs } from 'vue'
 import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
 import SearchSuggestField, {
   type CategorySuggestionItem,
@@ -11,6 +11,10 @@ type HeroHelperItem = {
   icon: string
   label: string
 }
+
+const heroBackgroundSrc = '/images/home/home-hero_background.webp'
+const isHeroImageLoaded = ref(false)
+const heroReadyFallbackDelayMs = 900
 
 const props = defineProps<{
   searchQuery: string
@@ -86,6 +90,20 @@ const heroHelperItems = computed<HeroHelperItem[]>(() => {
   ]
 })
 
+const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
+
+const handleHeroImageLoad = () => {
+  isHeroImageLoaded.value = true
+}
+
+onMounted(() => {
+  window.setTimeout(() => {
+    if (!isHeroImageLoaded.value) {
+      isHeroImageLoaded.value = true
+    }
+  }, heroReadyFallbackDelayMs)
+})
+
 const handleSubmit = () => {
   emit('submit')
 }
@@ -102,82 +120,84 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 <template>
   <HeroSurface tag="section" class="home-hero" aria-labelledby="home-hero-title" variant="aurora" :bleed="true">
     <div class="home-hero__background" aria-hidden="true">
-      <v-img
-        class="home-hero__background-image"
-        src="/images/home/home-hero_background.webp"
-        alt=""
-        cover
-      />
+      <v-fade-transition>
+        <div v-if="showHeroSkeleton" class="home-hero__background-loader">
+          <v-skeleton-loader type="image" class="home-hero__background-skeleton" />
+        </div>
+      </v-fade-transition>
+      <v-parallax
+        class="home-hero__parallax"
+        :src="heroBackgroundSrc"
+        height="100%"
+        scale="1.08"
+        eager
+        @load="handleHeroImageLoad"
+      >
+        <div class="home-hero__background-overlay" />
+      </v-parallax>
     </div>
     <v-container fluid class="home-hero__container">
       <div class="home-hero__inner">
         <v-row class="home-hero__layout" align="stretch" justify="center">
           <v-col cols="12" class="home-hero__content">
-            <h1 id="home-hero-title" class="home-hero__title">
-              {{ t('home.hero.title') }}
-            </h1>
+            <v-slide-y-transition mode="out-in">
+              <h1 id="home-hero-title" class="home-hero__title">
+                {{ t('home.hero.title') }}
+              </h1>
+            </v-slide-y-transition>
           </v-col>
         </v-row>
         <v-row justify="center">
-          <v-col cols="12" lg="6" class="home-hero__wizard">
-            <NudgeToolWizard :verticals="wizardVerticals" />
+          <v-col cols="12" lg="10" xl="8">
+            <v-sheet class="home-hero__panel" color="transparent" elevation="0">
+              <div class="home-hero__panel-grid">
+                <div class="home-hero__panel-block">
+                  <NudgeToolWizard :verticals="wizardVerticals" />
+                </div>
+                <div class="home-hero__panel-block">
+                  <form class="home-hero__search" role="search" @submit.prevent="handleSubmit">
+                    <SearchSuggestField
+                      :model-value="searchQueryValue"
+                      class="home-hero__search-input"
+                      :label="t('home.hero.search.label')"
+                      :placeholder="t('home.hero.search.placeholder')"
+                      :aria-label="t('home.hero.search.ariaLabel')"
+                      :min-chars="minSuggestionQueryLength"
+                      @update:model-value="updateSearchQuery"
+                      @submit="handleSubmit"
+                      @select-category="handleCategorySelect"
+                      @select-product="handleProductSelect"
+                    >
+                      <template #append-inner>
+                        <v-btn
+                          class="home-hero__search-submit nudger_degrade-defaut"
+                          icon="mdi-arrow-right"
+                          variant="flat"
+                          color="primary"
+                          size="small"
+                          type="submit"
+                          :aria-label="t('home.hero.search.cta')"
+                        />
+                      </template>
+                    </SearchSuggestField>
+                  </form>
+                  <div class="home-hero__context">
+                    <p class="home-hero__subtitle">{{ t('home.hero.subtitle') }}</p>
+                    <div class="home-hero__helper-row">
+                      <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+                      <ul v-if="heroHelperItems.length" class="home-hero__helpers">
+                        <li v-for="(item, index) in heroHelperItems" :key="`hero-helper-${index}`" class="home-hero__helper">
+                          <span class="home-hero__helper-icon" aria-hidden="true">{{ item.icon }}</span>
+                          <span class="home-hero__helper-text">{{ item.label }}</span>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </v-sheet>
           </v-col>
         </v-row>
-
-
-        <v-row justify="center">
-         <v-col cols="12" lg="6" class="home-hero__content">
-			<form class="home-hero__search" role="search" @submit.prevent="handleSubmit">
-                <SearchSuggestField
-                  :model-value="searchQueryValue"
-                  class="home-hero__search-input"
-                  :label="t('home.hero.search.label')"
-                  :placeholder="t('home.hero.search.placeholder')"
-                  :aria-label="t('home.hero.search.ariaLabel')"
-                  :min-chars="minSuggestionQueryLength"
-                  @update:model-value="updateSearchQuery"
-                  @submit="handleSubmit"
-                  @select-category="handleCategorySelect"
-                  @select-product="handleProductSelect"
-                >
-                  <template #append-inner>
-                    <v-btn
-                      class="home-hero__search-submit nudger_degrade-defaut"
-                      icon="mdi-arrow-right"
-                      variant="flat"
-                      color="primary"
-                      size="small"
-                      type="submit"
-                      :aria-label="t('home.hero.search.cta')"
-                    />
-                  </template>
-                </SearchSuggestField>
-              </form>
-          </v-col>
-        </v-row>
-
-        <v-row justify="center">
-          <v-col cols="12" lg="6" class="home-hero__content">
-            <div class="card__nudger">
-              <p class="home-hero__subtitle">{{ t('home.hero.subtitle') }}</p>
-
-              <v-row class="mt-5" align="center">
-                <v-col cols="12" lg="4">
-                  <p class="mt-4 ms-6 home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
-                </v-col>
-                <v-col cols="12" lg="8">
-                  <ul v-if="heroHelperItems.length" class="ms-8 home-hero__helpers">
-                    <li v-for="(item, index) in heroHelperItems" :key="`hero-helper-${index}`" class="home-hero__helper">
-                      <span class="home-hero__helper-icon" aria-hidden="true">{{ item.icon }}</span>
-                      <span class="home-hero__helper-text">{{ item.label }}</span>
-                    </li>
-                  </ul>
-                </v-col>
-              </v-row>
-            </div>
-          </v-col>
-        </v-row>
-
       </div>
     </v-container>
   </HeroSurface>
@@ -187,8 +207,8 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
   .home-hero
     position: relative
     overflow: hidden
-    min-height: clamp(520px, 70dvh, 840px)
-    padding-block: clamp(2.5rem, 7vw, 4.5rem)
+    min-height: clamp(560px, 70dvh, 860px)
+    padding-block: clamp(2.5rem, 7vw, 4.75rem)
 
   .home-hero__background
     position: absolute
@@ -196,30 +216,45 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     z-index: 0
     pointer-events: none
 
-  .home-hero__background-image
-    height: 100%
-    width: 100%
-    opacity: 0.95
+  .home-hero__background-loader
+    position: absolute
+    inset: 0
+    z-index: 0
+    display: flex
+    align-items: center
+    justify-content: center
+    background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.12), rgba(var(--v-theme-hero-gradient-end), 0.18))
 
-  .home-hero__background :deep(img)
+  .home-hero__background-skeleton
+    width: 100%
+    height: 100%
+    opacity: 0.45
+
+  .home-hero__parallax
+    position: absolute
+    inset: 0
+    width: 100%
+    height: 100%
+    opacity: 0.98
+
+  .home-hero__background :deep(.v-img__img)
     object-fit: cover
 
-  .home-hero__background::after
-    content: ''
+  .home-hero__background-overlay
     position: absolute
     inset: 0
     background: radial-gradient(
-        circle at 20% 20%,
-        rgba(var(--v-theme-hero-gradient-start), 0.18),
-        transparent 35%
+        circle at 16% 24%,
+        rgba(var(--v-theme-hero-gradient-start), 0.22),
+        transparent 32%
       ), radial-gradient(
-        circle at 80% 10%,
-        rgba(var(--v-theme-hero-gradient-end), 0.16),
-        transparent 40%
+        circle at 78% 12%,
+        rgba(var(--v-theme-hero-gradient-end), 0.24),
+        transparent 36%
       ), linear-gradient(
         180deg,
-        rgba(var(--v-theme-surface-default), 0) 0%,
-        rgba(var(--v-theme-surface-default), 0.15) 40%,
+        rgba(var(--v-theme-surface-default), 0.1) 0%,
+        rgba(var(--v-theme-surface-default), 0.15) 35%,
         rgba(var(--v-theme-surface-default), 0.65) 100%
       )
     pointer-events: none
@@ -245,6 +280,8 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     display: flex
     flex-direction: column
     gap: 1.5rem
+    align-items: center
+    text-align: center
 
   .home-hero__eyebrow
     font-weight: 600
@@ -258,7 +295,6 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     line-height: 1.05
     margin: 0
     color: #ffffff
-    text-align: center
     text-shadow: rgb(var(--v-theme-primary)) 1px 0 10px
 
   .home-hero__search
@@ -273,6 +309,36 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 
   .home-hero__search-submit
     box-shadow: none
+
+  .home-hero__panel
+    backdrop-filter: blur(10px)
+    background: rgba(var(--v-theme-surface-glass), 0.82)
+    border-radius: clamp(1.5rem, 4vw, 2rem)
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+    box-shadow: 0 18px 40px rgba(var(--v-theme-shadow-primary-600), 0.16)
+    padding: clamp(1.5rem, 4vw, 2.5rem)
+
+  .home-hero__panel-grid
+    display: grid
+    gap: clamp(1.25rem, 3vw, 1.75rem)
+    grid-template-columns: 1fr
+
+  .home-hero__panel-block
+    display: flex
+    flex-direction: column
+    gap: clamp(1.25rem, 2vw, 1.75rem)
+
+  .home-hero__context
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+    text-align: left
+
+  .home-hero__helper-row
+    display: grid
+    gap: 0.75rem
+    grid-template-columns: auto 1fr
+    align-items: center
 
   .home-hero__helpers
     margin: 0
@@ -294,6 +360,13 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 
   .home-hero__helper-text
     line-height: 1.35
+
+  .home-hero__subtitle
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  .home-hero__wizard
+    width: 100%
 
   .home-hero__media
     display: flex
@@ -343,8 +416,14 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 
   @media (max-width: 959px)
     .home-hero
-      min-height: clamp(480px, 68dvh, 720px)
-      padding-block: clamp(2rem, 10vw, 3.75rem)
+      min-height: clamp(520px, 68dvh, 760px)
+      padding-block: clamp(2rem, 10vw, 4rem)
+
+    .home-hero__panel
+      padding: clamp(1.25rem, 5vw, 2rem)
+
+    .home-hero__panel-grid
+      gap: clamp(1rem, 3vw, 1.5rem)
 
     .home-hero__media
       order: 1
@@ -358,5 +437,21 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 
     .home-hero__video
       transform: scale(1.15)
+
+  @media (min-width: 960px)
+    .home-hero__panel-grid
+      grid-template-columns: 1fr
+
+    .home-hero__helper-row
+      grid-template-columns: auto 1fr
+
+  @media (min-width: 1280px)
+    .home-hero__panel-grid
+      grid-template-columns: 1fr
+
+  @media (min-width: 1440px)
+    .home-hero__panel
+      max-width: 980px
+      margin-inline: auto
 
 </style>


### PR DESCRIPTION
## Summary
- add Vuetify parallax background with gradient overlay and lightweight skeleton to stabilise SSR rendering
- reorganise hero layout into a glassmorphic panel with smoother transitions for title and inputs
- refine spacing and helper alignment for consistent mobile-first hero presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694010d038e8832b843720774a08944d)