### PR TITLE
Add theme-aware hero background image

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, toRefs } from 'vue'
+import { useTheme } from 'vuetify'
 import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
 import SearchSuggestField, {
   type CategorySuggestionItem,
@@ -16,6 +17,8 @@ const props = defineProps<{
   searchQuery: string
   minSuggestionQueryLength: number
   verticals?: VerticalConfigDto[]
+  heroImageLight?: string
+  heroImageDark?: string
 }>()
 
 const emit = defineEmits<{
@@ -26,6 +29,7 @@ const emit = defineEmits<{
 }>()
 
 const { t, tm } = useI18n()
+const theme = useTheme()
 
 const searchQueryValue = computed(() => props.searchQuery)
 
@@ -86,6 +90,15 @@ const heroHelperItems = computed<HeroHelperItem[]>(() => {
   ]
 })
 
+const heroBackgroundSrc = computed(() => {
+  const isDarkMode = Boolean(theme.global.current.value.dark)
+
+  const lightImage = props.heroImageLight || '/images/home/home-hero_background.webp'
+  const darkImage = props.heroImageDark || '/images/home/hero-placeholder.svg'
+
+  return isDarkMode ? darkImage : lightImage
+})
+
 const handleSubmit = () => {
   emit('submit')
 }
@@ -104,7 +117,7 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     <div class="home-hero__background" aria-hidden="true">
       <v-img
         class="home-hero__background-image"
-        src="/images/home/home-hero_background.webp"
+        :src="heroBackgroundSrc"
         alt=""
         cover
       />


### PR DESCRIPTION
## Summary
- make the home hero background image react to the active Vuetify theme with light/dark fallbacks
- allow optional light and dark hero image overrides while defaulting to the existing light asset and a placeholder for dark mode

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694013c51a08832b93a67f17958af80b)