### PR TITLE
Add animated PWA icon to home hero section

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -1,0 +1,93 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import HomeHeroSection from './HomeHeroSection.vue'
+
+const messages: Record<string, string> = {
+  'home.hero.eyebrow': 'notre comparateur',
+  'home.hero.title': 'Réconcilier écologie et pouvoir d\'achat',
+  'home.hero.subtitle': 'Gagne du temps. Choisis librement.',
+  'home.hero.search.label': 'Tu sais déjà ce que tu cherches ?',
+  'home.hero.search.placeholder': 'Recherchez un produit ou une catégorie',
+  'home.hero.search.ariaLabel': 'Rechercher un produit responsable',
+  'home.hero.search.cta': 'NUDGER',
+  'home.hero.iconAlt': 'Icône du lanceur PWA Nudger',
+}
+
+const helperItems = [
+  { icon: '🌿', label: 'Une évaluation écologique et environnementale unique' },
+]
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key,
+    tm: (key: string) => (key === 'home.hero.search.helpers' ? helperItems : []),
+  }),
+}))
+
+const createStub = (tag: string, className = '') =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () => h(tag, { class: [className, attrs.class], ...attrs }, slots.default ? slots.default() : [])
+    },
+  })
+
+const VImgStub = defineComponent({
+  name: 'VImgStub',
+  setup(_, { slots, attrs }) {
+    return () => h('img', { class: ['v-img-stub', attrs.class], ...attrs }, slots.default ? slots.default() : [])
+  },
+})
+
+const mountComponent = async () =>
+  mountSuspended(HomeHeroSection, {
+    props: {
+      searchQuery: '',
+      minSuggestionQueryLength: 2,
+    },
+    global: {
+      stubs: {
+        HeroSurface: createStub('section'),
+        NudgeToolWizard: createStub('div', 'nudge-tool-wizard-stub'),
+        SearchSuggestField: createStub('div', 'search-suggest-field-stub'),
+        VContainer: createStub('div'),
+        VRow: createStub('div'),
+        VCol: createStub('div'),
+        VAvatar: createStub('div'),
+        VImg: VImgStub,
+        VBtn: createStub('button'),
+      },
+    },
+  })
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('HomeHeroSection', () => {
+  it('renders the eyebrow copy without trailing punctuation and shows the launcher icon', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.1)
+
+    const wrapper = await mountComponent()
+    const eyebrow = wrapper.find('.home-hero__eyebrow')
+    const icon = wrapper.find('.home-hero__icon')
+
+    expect(eyebrow.text()).toBe(messages['home.hero.eyebrow'])
+    expect(icon.attributes('src')).toBe('/pwa-assets/icons/android/android-launchericon-512-512.png')
+    expect(icon.attributes('alt')).toBe(messages['home.hero.iconAlt'])
+
+    await wrapper.unmount()
+  })
+
+  it('applies a random animation class from the configured list', async () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.95)
+
+    const wrapper = await mountComponent()
+    const icon = wrapper.find('.home-hero__icon')
+
+    expect(icon.classes()).toContain('home-hero__icon--pulse')
+
+    await wrapper.unmount()
+  })
+})

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRefs } from 'vue'
+import { computed, ref, toRefs } from 'vue'
 import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
 import SearchSuggestField, {
   type CategorySuggestionItem,
@@ -11,6 +11,14 @@ type HeroHelperItem = {
   icon: string
   label: string
 }
+
+const ICON_ANIMATIONS = [
+  'home-hero__icon--fade',
+  'home-hero__icon--scale',
+  'home-hero__icon--pulse',
+] as const
+
+type IconAnimationClass = (typeof ICON_ANIMATIONS)[number]
 
 const props = defineProps<{
   searchQuery: string
@@ -31,6 +39,14 @@ const searchQueryValue = computed(() => props.searchQuery)
 
 const { minSuggestionQueryLength } = toRefs(props)
 const wizardVerticals = computed(() => props.verticals ?? [])
+
+const selectIconAnimationClass = (): IconAnimationClass => {
+  const randomIndex = Math.floor(Math.random() * ICON_ANIMATIONS.length)
+
+  return ICON_ANIMATIONS[randomIndex]
+}
+
+const iconAnimationClass = ref<IconAnimationClass>(selectIconAnimationClass())
 
 const updateSearchQuery = (value: string) => {
   emit('update:searchQuery', value)
@@ -163,7 +179,18 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
 
               <v-row class="mt-5" align="center">
                 <v-col cols="12" lg="4">
-                  <p class="mt-4 ms-6 home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+                  <div class="home-hero__eyebrow-block">
+                    <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+                    <v-avatar class="home-hero__icon-wrapper" color="surface-glass-strong" size="128">
+                      <v-img
+                        class="home-hero__icon"
+                        src="/pwa-assets/icons/android/android-launchericon-512-512.png"
+                        :alt="t('home.hero.iconAlt')"
+                        cover
+                        :class="iconAnimationClass"
+                      />
+                    </v-avatar>
+                  </div>
                 </v-col>
                 <v-col cols="12" lg="8">
                   <ul v-if="heroHelperItems.length" class="ms-8 home-hero__helpers">
@@ -246,12 +273,42 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     flex-direction: column
     gap: 1.5rem
 
+  .home-hero__eyebrow-block
+    display: inline-flex
+    flex-direction: column
+    gap: clamp(0.5rem, 1.5vw, 0.75rem)
+    padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
+    align-items: flex-start
+
   .home-hero__eyebrow
     font-weight: 600
     letter-spacing: 0.08em
     text-transform: uppercase
     color: rgba(var(--v-theme-hero-gradient-end), 0.9)
     margin: 0
+
+  .home-hero__icon-wrapper
+    width: clamp(88px, 18vw, 136px)
+    height: clamp(88px, 18vw, 136px)
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45)
+    box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+    backdrop-filter: blur(8px)
+
+  .home-hero__icon
+    border-radius: inherit
+    width: 100%
+    height: 100%
+    transition: transform 250ms ease, filter 250ms ease
+    filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
+
+  .home-hero__icon--fade
+    animation: home-hero-fade-up 900ms ease-out both
+
+  .home-hero__icon--scale
+    animation: home-hero-scale-in 800ms ease-out both
+
+  .home-hero__icon--pulse
+    animation: home-hero-pulse 1200ms ease-in-out both
 
   .home-hero__title
     font-size: clamp(2.2rem, 5vw, 3.8rem)
@@ -340,6 +397,36 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     clip: rect(0, 0, 0, 0)
     white-space: nowrap
     border: 0
+
+  @keyframes home-hero-fade-up
+    from
+      opacity: 0
+      transform: translateY(12px) scale(0.98)
+    to
+      opacity: 1
+      transform: translateY(0) scale(1)
+
+  @keyframes home-hero-scale-in
+    from
+      opacity: 0
+      transform: scale(0.9)
+    55%
+      opacity: 1
+      transform: scale(1.02)
+    to
+      transform: scale(1)
+
+  @keyframes home-hero-pulse
+    0%
+      transform: scale(0.92)
+      opacity: 0
+    35%
+      transform: scale(1.04)
+      opacity: 1
+    70%
+      transform: scale(0.98)
+    100%
+      transform: scale(1)
 
   @media (max-width: 959px)
     .home-hero

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -44,6 +44,7 @@
       "eyebrow": "Responsible shopping",
       "title": "Responsible choices aren’t a luxury",
       "subtitle": "Save time, stay true to your values. Compare effortlessly, choose freely.",
+      "iconAlt": "Nudger PWA launcher icon",
       "imageAlt": "Illustration of the Nudger comparison experience with product cards and impact charts.",
       "search": {
         "label": "Search for a product",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -41,9 +41,10 @@
       "imageAlt": "Illustration du tableau de bord Nudger présentant des scores d’impact et des prix."
     },
     "hero": {
-      "eyebrow": "notre comparateur :",
+      "eyebrow": "notre comparateur",
       "title": "Réconcilier écologie et pouvoir d'achat",
       "subtitle": "Gagne du temps. Choisis librement.",
+      "iconAlt": "Icône du lanceur PWA Nudger",
       "imageAlt": "Illustration d’un comparateur Nudger affichant des cartes produits et des graphiques d’impact.",
       "search": {
         "label": "Tu sais déjà ce que tu cherches ?",


### PR DESCRIPTION
## Summary
- update the home hero eyebrow copy and add a PWA launcher icon with a randomized animation
- add localized alt text for the new icon in both French and English resources
- cover the hero updates with a focused unit test for the eyebrow copy, icon, and animation class

## Testing
- pnpm lint
- pnpm test *(fails: components/shared/menus/menus-auth.spec.ts – missing [data-testid="hero-theme-toggle-nudger"] selector in existing suite)*
- pnpm vitest run HomeHeroSection
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694010ebbe98832b9ddbe49e898479fd)