### PR TITLE
Add hero helper logo beneath eyebrow

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -93,6 +93,14 @@ const heroHelperItems = computed<HeroHelperItem[]>(() => {
   ]
 })
 
+const heroIconAlt = computed(() => String(t('home.hero.iconAlt')).trim())
+const heroIconSrc = '/pwa-assets/icons/android/android-launchericon-512-512.png'
+const heroIconAnimationOptions = ['home-hero__icon--fade', 'home-hero__icon--scale', 'home-hero__icon--pulse'] as const
+const heroIconAnimation = ref(
+  heroIconAnimationOptions[Math.floor(Math.random() * heroIconAnimationOptions.length)] || heroIconAnimationOptions[0],
+)
+const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
+
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundSrc = computed(() => {
   const isDarkMode = Boolean(theme.global.current.value.dark)
@@ -194,7 +202,17 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
                   <div class="home-hero__context">
                     <p class="home-hero__subtitle">{{ t('home.hero.subtitle') }}</p>
                     <div class="home-hero__helper-row">
-                      <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+                      <div class="home-hero__eyebrow-block">
+                        <p class="home-hero__eyebrow">{{ t('home.hero.eyebrow') }}</p>
+                        <div v-if="showHeroIcon" class="home-hero__icon-wrapper">
+                          <img
+                            :src="heroIconSrc"
+                            :alt="heroIconAlt"
+                            :class="['home-hero__icon', heroIconAnimation]"
+                            loading="lazy"
+                          />
+                        </div>
+                      </div>
                       <ul v-if="heroHelperItems.length" class="home-hero__helpers">
                         <li v-for="(item, index) in heroHelperItems" :key="`hero-helper-${index}`" class="home-hero__helper">
                           <span class="home-hero__helper-icon" aria-hidden="true">{{ item.icon }}</span>


### PR DESCRIPTION
## Summary
- render the hero logo beneath the eyebrow in the helper row with existing styling and i18n alt text
- add randomized animation selection and consistent launcher icon source for the hero logo

## Testing
- pnpm lint
- pnpm test components/home/sections/HomeHeroSection.spec.ts components/shared/menus/menus-auth.spec.ts *(fails: menus-auth.spec.ts cannot find data-testid "hero-theme-toggle-nudger" in TheHeroMenu)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940495b6cec832ba2bb718c03deb1e6)