### PR TITLE
Fix dark theme backgrounds for navigation and footer

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -28,7 +28,7 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 <style lang="sass" scoped>
 .main-menu-app-bar
   color: rgb(var(--v-theme-text-neutral-strong))
-  background-color: #ffffff!important
+  background-color: rgb(var(--v-theme-surface-default))
   border-radius: 0 0 40px 40px
   box-shadow: 0 16px 28px rgba(var(--v-theme-shadow-primary-600), 0.12);
 

--- a/frontend/app/components/shared/footers/TheMainFooter.vue
+++ b/frontend/app/components/shared/footers/TheMainFooter.vue
@@ -26,6 +26,14 @@
     background: #0083A4!important;
   }
 
+  .v-theme--dark.main-footer {
+    background: linear-gradient(
+        135deg,
+        rgba(var(--v-theme-surface-default), 0.96) 0%,
+        rgba(var(--v-theme-surface-muted-contrast), 0.96) 100%
+      ) !important;
+  }
+
   .main-footer :deep(a) {
     color: inherit;
   }


### PR DESCRIPTION
## Summary
- adjust the home hero navigation bar to use the themed surface color so dark mode renders correctly
- add a dark theme gradient override for the shared footer to avoid the light background in dark mode

## Testing
- pnpm lint
- pnpm test *(fails: existing suites such as HomeHeroSection and menus-auth reported missing elements; test run interrupted after failures)*
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694049437874832b99b9ac438a98ea49)