### PR TITLE
Adjust theme toggles for two-theme setup

### DIFF
--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -460,14 +460,6 @@ describe('Shared menu authentication controls', () => {
     expect(storedThemePreference.value).toBe('dark')
     expect(themeName.value).toBe('dark')
 
-    const nudgerToggle = heroWrapper.get('[data-testid="hero-theme-toggle-nudger"]')
-
-    await nudgerToggle.trigger('click')
-    await flushPromises()
-
-    expect(storedThemePreference.value).toBe('nudger')
-    expect(themeName.value).toBe('nudger')
-
     const mobileWrapper = await mountSuspended(TheMobileMenu)
 
     expect(mobileWrapper.find('[data-testid="mobile-theme-toggle"]').exists()).toBe(true)

--- a/frontend/shared/constants/theme.ts
+++ b/frontend/shared/constants/theme.ts
@@ -1,4 +1,4 @@
-export const THEME_NAMES = ['light', 'dark', 'nudger'] as const
+export const THEME_NAMES = ['light', 'dark'] as const
 
 export type ThemeName = (typeof THEME_NAMES)[number]
 


### PR DESCRIPTION
## Summary
- limit supported theme names to light and dark
- update menu authentication test expectations to match the two-theme toggle

## Testing
- pnpm vitest run components/shared/menus/menus-auth.spec.ts --config vitest.config.mts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69406e9d2208832b8b573cc00b67fce1)