### PR TITLE
Add parallax sections to home page layout

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -144,16 +144,15 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
           <v-skeleton-loader type="image" class="home-hero__background-skeleton" />
         </div>
       </v-fade-transition>
-      <v-parallax
-        class="home-hero__parallax"
+      <v-img
+        class="home-hero__background-media"
         :src="heroBackgroundSrc"
-        height="100%"
-        scale="1.08"
+        cover
         eager
         @load="handleHeroImageLoad"
       >
         <div class="home-hero__background-overlay" />
-      </v-parallax>
+      </v-img>
     </div>
     <v-container fluid class="home-hero__container">
       <div class="home-hero__inner">
@@ -270,18 +269,12 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
     height: 100%
     opacity: 0.45
 
-  .home-hero__parallax
+  .home-hero__background-media
     position: absolute
     inset: 0
     width: 100%
     height: 100%
     opacity: 0.98
-    min-height: 100%
-
-  .home-hero__background :deep(.v-img__img)
-    width: 100%
-    object-fit: cover
-    min-height: 100%
 
   .home-hero__background-overlay
     position: absolute

--- a/frontend/app/components/shared/ui/ParallaxSection.vue
+++ b/frontend/app/components/shared/ui/ParallaxSection.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { computed, type CSSProperties } from 'vue'
+import { usePreferredReducedMotion, useWindowScroll } from '@vueuse/core'
+import { useDisplay, useTheme } from 'vuetify'
+
+const props = withDefaults(
+  defineProps<{
+    id?: string
+    ariaLabel?: string
+    backgroundLight?: string
+    backgroundDark?: string
+    overlayColor?: string
+    overlayOpacity?: number
+    minHeight?: string
+    paddingY?: string
+    parallaxAmount?: number
+    disableParallaxBelow?: number
+    maxWidth?: string
+    contentAlign?: 'start' | 'center'
+    enableAplats?: boolean
+    aplatSvg?: string
+  }>(),
+  {
+    id: undefined,
+    ariaLabel: undefined,
+    backgroundLight: undefined,
+    backgroundDark: undefined,
+    overlayColor: 'rgb(var(--v-theme-surface-default))',
+    overlayOpacity: 0.42,
+    minHeight: '75vh',
+    paddingY: 'clamp(3rem, 8vw, 5.5rem)',
+    parallaxAmount: 0.18,
+    disableParallaxBelow: 960,
+    maxWidth: '1180px',
+    contentAlign: 'start',
+    enableAplats: false,
+    aplatSvg: '/images/home/parallax-aplats.svg',
+  },
+)
+
+const theme = useTheme()
+const prefersReducedMotion = usePreferredReducedMotion()
+const display = useDisplay()
+const { y } = useWindowScroll()
+
+const isDark = computed(() => Boolean(theme.global.current.value.dark))
+
+const backgroundImage = computed(() => {
+  if (isDark.value && props.backgroundDark) {
+    return props.backgroundDark
+  }
+
+  if (!isDark.value && props.backgroundLight) {
+    return props.backgroundLight
+  }
+
+  return props.backgroundDark ?? props.backgroundLight ?? ''
+})
+
+const isBelowBreakpoint = computed(
+  () => props.disableParallaxBelow > 0 && display.width.value < props.disableParallaxBelow,
+)
+
+const parallaxEnabled = computed(
+  () =>
+    import.meta.client &&
+    !isBelowBreakpoint.value &&
+    prefersReducedMotion.value === 'no-preference' &&
+    props.parallaxAmount > 0,
+)
+
+const parallaxOffset = computed(() =>
+  parallaxEnabled.value ? `${-y.value * props.parallaxAmount}px` : '0px',
+)
+
+const mediaStyles = computed<CSSProperties>(() => ({
+  '--parallax-image': backgroundImage.value ? `url('${backgroundImage.value}')` : 'none',
+  '--parallax-overlay-color': props.overlayColor,
+  '--parallax-overlay-opacity': props.overlayOpacity,
+  '--parallax-offset': parallaxOffset.value,
+  minHeight: props.minHeight,
+}))
+
+const contentStyles = computed<CSSProperties>(() => ({
+  paddingBlock: props.paddingY,
+}))
+
+const innerStyles = computed<CSSProperties>(() => ({
+  maxWidth: props.maxWidth,
+  margin: '0 auto',
+}))
+
+const contentAlignClass = computed(() =>
+  props.contentAlign === 'center' ? 'parallax-section__inner--center' : 'parallax-section__inner--start',
+)
+</script>
+
+<template>
+  <section :id="props.id" class="parallax-section" :aria-label="ariaLabel">
+    <div class="parallax-section__media" :style="mediaStyles" aria-hidden="true">
+      <div class="parallax-section__image" />
+      <div class="parallax-section__overlay" />
+      <div v-if="enableAplats" class="parallax-section__aplats">
+        <slot name="aplats">
+          <img
+            class="parallax-section__aplat-image"
+            :src="aplatSvg"
+            alt=""
+            loading="lazy"
+            decoding="async"
+          />
+        </slot>
+      </div>
+    </div>
+    <div class="parallax-section__content" :style="contentStyles">
+      <v-container fluid class="parallax-section__container">
+        <div class="parallax-section__inner" :class="contentAlignClass" :style="innerStyles">
+          <slot />
+        </div>
+      </v-container>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="sass">
+  .parallax-section
+    position: relative
+    overflow: hidden
+    background-color: rgb(var(--v-theme-surface-default))
+
+  .parallax-section__media
+    position: absolute
+    inset: 0
+    width: 100%
+    height: 100%
+    pointer-events: none
+
+  .parallax-section__image
+    position: absolute
+    inset: -10%
+    background-image: var(--parallax-image)
+    background-size: cover
+    background-repeat: no-repeat
+    background-position: center center
+    transform: translate3d(0, var(--parallax-offset), 0)
+    transition: transform 160ms ease-out
+    filter: saturate(1.05)
+
+  .parallax-section__overlay
+    position: absolute
+    inset: 0
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--parallax-overlay-color) 12%, transparent) 0%,
+      color-mix(in srgb, var(--parallax-overlay-color) 65%, transparent) 42%,
+      color-mix(in srgb, var(--parallax-overlay-color) 82%, transparent) 100%
+    )
+    mix-blend-mode: multiply
+    opacity: var(--parallax-overlay-opacity)
+
+  .parallax-section__aplats
+    position: absolute
+    inset: 0
+    display: flex
+    align-items: center
+    justify-content: center
+    opacity: 0.45
+    filter: drop-shadow(0 20px 45px rgba(var(--v-theme-shadow-primary-600), 0.22))
+
+  .parallax-section__aplat-image
+    max-width: min(100%, 1024px)
+    width: 90%
+    height: auto
+
+  .parallax-section__content
+    position: relative
+    z-index: 1
+
+  .parallax-section__container
+    padding-inline: clamp(1.5rem, 5vw, 4rem)
+
+  .parallax-section__inner
+    display: flex
+    flex-direction: column
+    gap: clamp(1.5rem, 4vw, 2.5rem)
+
+  .parallax-section__inner--center
+    align-items: center
+    text-align: center
+
+  .parallax-section__inner--start
+    align-items: stretch
+
+  :deep(.home-section)
+    background: transparent
+    box-shadow: none
+
+  :deep(.home-section__container)
+    padding-inline: 0
+
+  @media (max-width: 959px)
+    .parallax-section__image
+      transform: none !important
+
+    .parallax-section__overlay
+      opacity: calc(var(--parallax-overlay-opacity) + 0.08)
+</style>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -10,6 +10,7 @@ import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
 import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
 import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
+import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
 import type { CategorySuggestionItem, ProductSuggestionItem } from '~/components/search/SearchSuggestField.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useBlog } from '~/composables/blog/useBlog'
@@ -34,6 +35,42 @@ const { categories: rawCategories, fetchCategories } = useCategories()
 const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
 
 const BLOG_ARTICLES_LIMIT = 4
+
+const heroBackgrounds = computed(() => ({
+  light: '/images/home/hero-full-viewport-light.jpg',
+  dark: '/images/home/hero-full-viewport-dark.jpg',
+}))
+
+const parallaxBackgrounds = computed(() => ({
+  essentials: {
+    light: '/images/home/parallax-essentials-light.jpg',
+    dark: '/images/home/parallax-essentials-dark.jpg',
+    overlay: 0.62,
+    parallaxAmount: 0.16,
+    ariaLabel: String(t('home.parallax.essentials.ariaLabel')),
+  },
+  features: {
+    light: '/images/home/parallax-features-light.jpg',
+    dark: '/images/home/parallax-features-dark.jpg',
+    overlay: 0.55,
+    parallaxAmount: 0.12,
+    ariaLabel: String(t('home.parallax.features.ariaLabel')),
+  },
+  knowledge: {
+    light: '/images/home/parallax-knowledge-light.jpg',
+    dark: '/images/home/parallax-knowledge-dark.jpg',
+    overlay: 0.5,
+    parallaxAmount: 0.1,
+    ariaLabel: String(t('home.parallax.knowledge.ariaLabel')),
+  },
+  cta: {
+    light: '/images/home/parallax-cta-light.jpg',
+    dark: '/images/home/parallax-cta-dark.jpg',
+    overlay: 0.48,
+    parallaxAmount: 0.08,
+    ariaLabel: String(t('home.parallax.cta.ariaLabel')),
+  },
+}))
 
 const toSafeString = (value: unknown) => {
   if (typeof value === 'string') {
@@ -496,35 +533,87 @@ useHead(() => ({
       v-model:search-query="searchQuery"
       :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
       :verticals="rawCategories"
+      :hero-image-light="heroBackgrounds.light"
+      :hero-image-dark="heroBackgrounds.dark"
       @submit="handleSearchSubmit"
       @select-category="handleCategorySuggestion"
       @select-product="handleProductSuggestion"
     />
     <div class="home-page__sections">
-      <HomeProblemsSection :items="problemItems" />
+      <ParallaxSection
+        id="home-essentials"
+        class="home-page__parallax"
+        :background-light="parallaxBackgrounds.essentials.light"
+        :background-dark="parallaxBackgrounds.essentials.dark"
+        :overlay-opacity="parallaxBackgrounds.essentials.overlay"
+        :parallax-amount="parallaxBackgrounds.essentials.parallaxAmount"
+        :aria-label="parallaxBackgrounds.essentials.ariaLabel"
+        :enable-aplats="true"
+      >
+        <div class="home-page__stack">
+          <HomeProblemsSection :items="problemItems" />
 
-      <HomeSolutionSection :benefits="solutionBenefits" />
+          <HomeSolutionSection :benefits="solutionBenefits" />
+        </div>
+      </ParallaxSection>
 
-      <HomeFeaturesSection :features="featureCards" />
+      <ParallaxSection
+        id="home-features"
+        class="home-page__parallax home-page__parallax--centered"
+        :background-light="parallaxBackgrounds.features.light"
+        :background-dark="parallaxBackgrounds.features.dark"
+        :overlay-opacity="parallaxBackgrounds.features.overlay"
+        :parallax-amount="parallaxBackgrounds.features.parallaxAmount"
+        :aria-label="parallaxBackgrounds.features.ariaLabel"
+        content-align="center"
+      >
+        <HomeFeaturesSection :features="featureCards" />
+      </ParallaxSection>
 
-      <HomeBlogSection
-        :loading="blogLoading"
-        :featured-item="featuredBlogItem"
-        :secondary-items="secondaryBlogItems"
-      />
+      <ParallaxSection
+        id="home-knowledge"
+        class="home-page__parallax"
+        :background-light="parallaxBackgrounds.knowledge.light"
+        :background-dark="parallaxBackgrounds.knowledge.dark"
+        :overlay-opacity="parallaxBackgrounds.knowledge.overlay"
+        :parallax-amount="parallaxBackgrounds.knowledge.parallaxAmount"
+        :aria-label="parallaxBackgrounds.knowledge.ariaLabel"
+        :enable-aplats="true"
+      >
+        <div class="home-page__stack home-page__stack--two-columns">
+          <HomeBlogSection
+            :loading="blogLoading"
+            :featured-item="featuredBlogItem"
+            :secondary-items="secondaryBlogItems"
+          />
 
-      <HomeObjectionsSection :items="objectionItems" />
+          <HomeObjectionsSection :items="objectionItems" />
+        </div>
+      </ParallaxSection>
 
-      <HomeFaqSection :items="faqPanels" />
+      <ParallaxSection
+        id="home-cta"
+        class="home-page__parallax home-page__parallax--centered"
+        :background-light="parallaxBackgrounds.cta.light"
+        :background-dark="parallaxBackgrounds.cta.dark"
+        :overlay-opacity="parallaxBackgrounds.cta.overlay"
+        :parallax-amount="parallaxBackgrounds.cta.parallaxAmount"
+        :aria-label="parallaxBackgrounds.cta.ariaLabel"
+        content-align="center"
+      >
+        <div class="home-page__stack home-page__stack--compact">
+          <HomeFaqSection :items="faqPanels" />
 
-      <HomeCtaSection
-        v-model:search-query="searchQuery"
-        :categories-landing-url="categoriesLandingUrl"
-        :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
-        @submit="handleSearchSubmit"
-        @select-category="handleCategorySuggestion"
-        @select-product="handleProductSuggestion"
-      />
+          <HomeCtaSection
+            v-model:search-query="searchQuery"
+            :categories-landing-url="categoriesLandingUrl"
+            :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
+            @submit="handleSearchSubmit"
+            @select-category="handleCategorySuggestion"
+            @select-product="handleProductSuggestion"
+          />
+        </div>
+      </ParallaxSection>
     </div>
   </div>
 </template>
@@ -542,7 +631,32 @@ useHead(() => ({
   .home-page__sections
     display: flex
     flex-direction: column
-    gap: clamp(1.5rem, 3.5vw, 2.5rem)
+    gap: clamp(1.5rem, 3.5vw, 2.25rem)
     padding-top: var(--cat-overlap)
-    background: rgb(var(--v-theme-surface-default))
+    background: transparent
+
+  .home-page__parallax
+    border-radius: clamp(1.25rem, 3vw, 1.85rem)
+    box-shadow: 0 22px 48px rgba(var(--v-theme-shadow-primary-600), 0.12)
+    overflow: hidden
+
+  .home-page__parallax--centered :deep(.home-section)
+    text-align: center
+
+  .home-page__stack
+    display: flex
+    flex-direction: column
+    gap: clamp(1.5rem, 4vw, 2.25rem)
+
+  .home-page__stack--two-columns
+    display: grid
+    grid-template-columns: 1fr
+    gap: clamp(1.5rem, 4vw, 2.25rem)
+
+  .home-page__stack--compact
+    gap: clamp(1.25rem, 3vw, 2rem)
+
+  @media (min-width: 1100px)
+    .home-page__stack--two-columns
+      grid-template-columns: repeat(2, 1fr)
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -68,6 +68,20 @@
         ]
       }
     },
+    "parallax": {
+      "essentials": {
+        "ariaLabel": "Decorative background for the challenges and solutions section"
+      },
+      "features": {
+        "ariaLabel": "Decorative background for the key features section"
+      },
+      "knowledge": {
+        "ariaLabel": "Decorative background for community stories and objections"
+      },
+      "cta": {
+        "ariaLabel": "Decorative background for the FAQ and call to action"
+      }
+    },
     "problems": {
       "title": "Too many labels, not enough clarity?",
       "description": "Comparing impact, price and trust sources across dozens of tabs is exhausting. Nudger brings it back to one place.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -68,6 +68,20 @@
         ]
       }
     },
+    "parallax": {
+      "essentials": {
+        "ariaLabel": "Fond décoratif pour la section problèmes et solutions"
+      },
+      "features": {
+        "ariaLabel": "Fond décoratif pour la section des fonctionnalités clés"
+      },
+      "knowledge": {
+        "ariaLabel": "Fond décoratif pour les articles et les objections"
+      },
+      "cta": {
+        "ariaLabel": "Fond décoratif pour la FAQ et l’appel à l’action"
+      }
+    },
     "problems": {
       "title": "Trop de labels, pas assez de clarté ?",
       "description": "Comparer impact, prix et fiabilité à travers une multitude d’onglets est épuisant. Nudger rassemble tout au même endroit.",

--- a/frontend/public/images/home/parallax-aplats.svg
+++ b/frontend/public/images/home/parallax-aplats.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="bubbleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="rgba(33,150,243,0.28)" />
+      <stop offset="100%" stop-color="rgba(34,197,94,0.18)" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.35)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="800" fill="none" />
+  <g opacity="0.62">
+    <circle cx="220" cy="260" r="180" fill="url(#bubbleGradient)" />
+    <circle cx="940" cy="200" r="220" fill="url(#bubbleGradient)" />
+    <circle cx="640" cy="560" r="260" fill="url(#bubbleGradient)" />
+  </g>
+  <g opacity="0.45">
+    <circle cx="220" cy="260" r="110" fill="url(#glow)" />
+    <circle cx="940" cy="200" r="130" fill="url(#glow)" />
+    <circle cx="640" cy="560" r="170" fill="url(#glow)" />
+  </g>
+  <g stroke="rgba(255,255,255,0.4)" stroke-width="4" fill="none" opacity="0.5">
+    <path d="M180 460 C 260 520 360 520 420 460" />
+    <path d="M760 320 C 820 380 900 390 960 340" />
+    <path d="M520 620 C 600 680 720 700 820 640" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable `ParallaxSection` component with motion-safe parallax behavior, overlays, and optional decorative aplats
- refactor the home page to wrap problem/solution, features, blog/objections, and CTA/FAQ blocks in themed parallax backgrounds while disabling hero parallax
- introduce localized aria labels for parallax backgrounds and provide a simple SVG aplat asset for future background layering

## Testing
- pnpm lint
- pnpm vitest run pages/index.spec.ts
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69407ed315c8832bad5fbef1c305853b)