### PR TITLE
Add ESG attribute support to TV vertical

### DIFF
--- a/verticals/src/main/resources/attributes/ESG.yml
+++ b/verticals/src/main/resources/attributes/ESG.yml
@@ -1,0 +1,16 @@
+key: "ESG"
+betterIs: "GREATER"
+faIcon: "mdi-scale-balance"
+name:
+  default: "ESG score"
+  fr: "Score ESG"
+asScore: true
+scoreTitle:
+  default: "ESG performance"
+  fr: "Performance ESG"
+scoreDescription:
+  default: "Composite score reflecting environmental, social, and governance practices."
+  fr: "Score composite reflétant les pratiques environnementales, sociales et de gouvernance."
+scoreUtility:
+  default: "Highlights brands with robust ESG commitments contributing to lower lifecycle risks."
+  fr: "Met en avant les marques avec des engagements ESG solides, réduisant les risques sur le cycle de vie."

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -665,6 +665,7 @@ attributesConfig:
     - key: "POWER_CONSUMPTION_STANDBY_NETWORKD"
     - key: "POWER_CONSUMPTION_SDR"
     - key: "POWER_CONSUMPTION_HDR"
+    - key: "ESG"
     - key: "CLASSE_ENERGY_HDR"
     - key: "CLASSE_ENERGY_SDR"
 ##############################################################################
@@ -799,6 +800,5 @@ matchingCategories:
      - "HIGH-TECH | HIGH-TECH>TV - CINEMA>TELEVISEURS - TELEVISIONS - TV>TV PANASONIC | TV - CINEMA | TELEVISEURS - TELEVISIONS - TV"
      - "HIGH-TECH | HIGH-TECH>MARQUES HIGH-TECH>TCL>TV MINI LED TCL>TV MINI LED 4K TCL | MARQUES HIGH-TECH | TCL"
      - "HIGH TECH | HIGH-TECH > TV - CINEMA > TELEVISEURS - TELEVISIONS - TV > TV LG | TV - CINEMA | TELEVISEURS - TELEVISIONS - TV"
-
 
 


### PR DESCRIPTION
## Summary
- add an ESG attribute definition with score metadata for ESG performance
- register ESG attribute in the TV vertical attribute configuration so impact score references resolve

## Testing
- mvn --offline test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b2bf840c832284a510e04751563a)