### PR TITLE
Add reusable rounded card component and showcase

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -57,6 +57,7 @@ const mountComponent = async () =>
         VAvatar: createStub('div'),
         VImg: VImgStub,
         VBtn: createStub('button'),
+        RoundedCornerCard: createStub('div', 'rounded-corner-card-stub'),
       },
     },
   })

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -7,7 +7,7 @@ import SearchSuggestField, {
   type ProductSuggestionItem,
 } from '~/components/search/SearchSuggestField.vue'
 import type { VerticalConfigDto } from '~~/shared/api-client'
-import CardSecondary from '~/components/shared/cards/CardSecondary.vue'
+import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
 import { useHeroBackgroundAsset } from '~~/app/composables/useThemedAsset'
 
 type HeroHelperItem = {
@@ -209,7 +209,20 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
                       </template>
                     </SearchSuggestField>
                   </form>
-                  <CardSecondary class="home-hero__context-card" surface="strong" accent-corner="bottom-right">
+                  <RoundedCornerCard
+                    class="home-hero__context-card"
+                    surface="strong"
+                    accent-corner="bottom-right"
+                    corner-variant="text"
+                    corner-size="lg"
+                    rounded="lg"
+                    :selectable="false"
+                    :elevation="10"
+                    :hover-elevation="14"
+                    :corner-label="t('home.hero.context.cornerLabel')"
+                    :corner-tooltip="t('home.hero.context.cornerTooltip')"
+                    :aria-label="t('home.hero.context.ariaLabel')"
+                  >
                     <div class="home-hero__context">
                       <p class="home-hero__subtitle">{{ t('home.hero.subtitle') }}</p>
                       <div class="home-hero__helper-row">
@@ -236,7 +249,7 @@ const handleProductSelect = (payload: ProductSuggestionItem) => {
                         </ul>
                       </div>
                     </div>
-                  </CardSecondary>
+                  </RoundedCornerCard>
                 </div>
               </div>
             </v-sheet>

--- a/frontend/app/components/home/sections/HomeRoundedCardShowcase.vue
+++ b/frontend/app/components/home/sections/HomeRoundedCardShowcase.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { AccentCorner } from '~/components/shared/cards/RoundedCornerCard.vue'
+import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
+
+type CornerSize = 'sm' | 'md' | 'lg'
+type CornerVariant = 'icon' | 'text' | 'custom' | 'none'
+type RoundedSize = 'sm' | 'md' | 'lg'
+type SurfaceTone = 'glass' | 'strong'
+
+type ShowcaseCard = {
+  id: string
+  eyebrow: string
+  title: string
+  subtitle: string
+  accentCorner: AccentCorner
+  cornerVariant: CornerVariant
+  cornerSize: CornerSize
+  rounded: RoundedSize
+  surface: SurfaceTone
+  cornerLabel?: string
+  cornerIcon?: string
+  tooltip: string
+  bullets: string[]
+  selected: boolean
+  selectable?: boolean
+  ariaLabel: string
+}
+
+const { t, tm } = useI18n()
+
+const cardState = ref<Record<string, boolean>>({
+  impact: true,
+  text: false,
+  compact: false,
+  custom: false,
+  dual: true,
+})
+
+const customScore = 72
+const customScoreLabel = computed(() => t('home.roundedCards.samples.custom.progressLabel', { value: customScore }))
+
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter((entry): entry is string => entry.length > 0)
+}
+
+const cards = computed<ShowcaseCard[]>(() => [
+  {
+    id: 'impact',
+    eyebrow: t('home.roundedCards.samples.impact.eyebrow'),
+    title: t('home.roundedCards.samples.impact.title'),
+    subtitle: t('home.roundedCards.samples.impact.subtitle'),
+    accentCorner: 'bottom-right',
+    cornerVariant: 'icon',
+    cornerSize: 'lg',
+    rounded: 'lg',
+    surface: 'strong',
+    tooltip: t('home.roundedCards.samples.impact.tooltip'),
+    bullets: toStringArray(tm('home.roundedCards.samples.impact.bullets')),
+    selected: cardState.value.impact,
+    ariaLabel: `${t('home.roundedCards.ariaLabel')} - ${t('home.roundedCards.samples.impact.title')}`,
+  },
+  {
+    id: 'text',
+    eyebrow: t('home.roundedCards.samples.text.eyebrow'),
+    title: t('home.roundedCards.samples.text.title'),
+    subtitle: t('home.roundedCards.samples.text.subtitle'),
+    accentCorner: 'top-right',
+    cornerVariant: 'text',
+    cornerSize: 'md',
+    rounded: 'md',
+    surface: 'glass',
+    cornerLabel: t('home.roundedCards.samples.text.cornerLabel'),
+    cornerIcon: 'mdi-star-four-points-outline',
+    tooltip: t('home.roundedCards.samples.text.tooltip'),
+    bullets: toStringArray(tm('home.roundedCards.samples.text.bullets')),
+    selected: cardState.value.text,
+    ariaLabel: `${t('home.roundedCards.ariaLabel')} - ${t('home.roundedCards.samples.text.title')}`,
+  },
+  {
+    id: 'compact',
+    eyebrow: t('home.roundedCards.samples.compact.eyebrow'),
+    title: t('home.roundedCards.samples.compact.title'),
+    subtitle: t('home.roundedCards.samples.compact.subtitle'),
+    accentCorner: 'top-left',
+    cornerVariant: 'icon',
+    cornerSize: 'sm',
+    rounded: 'sm',
+    surface: 'glass',
+    tooltip: t('home.roundedCards.samples.compact.tooltip'),
+    bullets: toStringArray(tm('home.roundedCards.samples.compact.bullets')),
+    selected: cardState.value.compact,
+    ariaLabel: `${t('home.roundedCards.ariaLabel')} - ${t('home.roundedCards.samples.compact.title')}`,
+  },
+  {
+    id: 'custom',
+    eyebrow: t('home.roundedCards.samples.custom.eyebrow'),
+    title: t('home.roundedCards.samples.custom.title'),
+    subtitle: t('home.roundedCards.samples.custom.subtitle'),
+    accentCorner: 'bottom-left',
+    cornerVariant: 'custom',
+    cornerSize: 'md',
+    rounded: 'md',
+    surface: 'strong',
+    tooltip: t('home.roundedCards.samples.custom.tooltip'),
+    bullets: toStringArray(tm('home.roundedCards.samples.custom.bullets')),
+    selected: cardState.value.custom,
+    ariaLabel: `${t('home.roundedCards.ariaLabel')} - ${t('home.roundedCards.samples.custom.title')}`,
+  },
+  {
+    id: 'dual',
+    eyebrow: t('home.roundedCards.samples.dual.eyebrow'),
+    title: t('home.roundedCards.samples.dual.title'),
+    subtitle: t('home.roundedCards.samples.dual.subtitle'),
+    accentCorner: 'bottom-right',
+    cornerVariant: 'text',
+    cornerSize: 'md',
+    rounded: 'md',
+    surface: 'glass',
+    cornerLabel: t('home.roundedCards.samples.dual.cornerLabel'),
+    tooltip: t('home.roundedCards.samples.dual.tooltip'),
+    bullets: toStringArray(tm('home.roundedCards.samples.dual.bullets')),
+    selected: cardState.value.dual,
+    ariaLabel: `${t('home.roundedCards.ariaLabel')} - ${t('home.roundedCards.samples.dual.title')}`,
+  },
+])
+
+const updateSelected = (id: string, value: boolean) => {
+  cardState.value = {
+    ...cardState.value,
+    [id]: value,
+  }
+}
+</script>
+
+<template>
+  <section class="home-card-showcase" aria-labelledby="home-card-showcase-title">
+    <v-container fluid class="home-card-showcase__container">
+      <div class="home-card-showcase__header">
+        <p class="home-card-showcase__eyebrow">{{ t('home.roundedCards.eyebrow') }}</p>
+        <h2 id="home-card-showcase-title" class="home-card-showcase__title">{{ t('home.roundedCards.title') }}</h2>
+        <p class="home-card-showcase__subtitle">{{ t('home.roundedCards.subtitle') }}</p>
+      </div>
+
+      <v-row class="home-card-showcase__grid" align="stretch" justify="center" dense>
+        <v-col v-for="card in cards" :key="card.id" cols="12" md="6" lg="4">
+          <RoundedCornerCard
+            class="home-card-showcase__card"
+            :eyebrow="card.eyebrow"
+            :title="card.title"
+            :subtitle="card.subtitle"
+            :accent-corner="card.accentCorner"
+            :corner-size="card.cornerSize"
+            :corner-variant="card.cornerVariant"
+            :corner-label="card.cornerLabel"
+            :corner-icon="card.cornerIcon"
+            :corner-tooltip="card.tooltip"
+            :rounded="card.rounded"
+            :surface="card.surface"
+            :selected="card.selected"
+            :selectable="card.selectable ?? true"
+            :hover-elevation="14"
+            :elevation="9"
+            :aria-label="card.ariaLabel"
+            @update:selected="(value) => updateSelected(card.id, value)"
+          >
+            <ul v-if="card.bullets.length" class="home-card-showcase__bullets">
+              <li v-for="(bullet, index) in card.bullets" :key="`${card.id}-bullet-${index}`">
+                {{ bullet }}
+              </li>
+            </ul>
+
+            <template v-if="card.id === 'custom'" #corner>
+              <div class="home-card-showcase__corner-meter">
+                <v-progress-circular
+                  :model-value="customScore"
+                  size="44"
+                  width="5"
+                  color="accent-supporting"
+                  rotate="-90"
+                  :title="customScoreLabel"
+                >
+                  <span class="home-card-showcase__corner-meter-text">{{ customScoreLabel }}</span>
+                </v-progress-circular>
+              </div>
+            </template>
+
+            <template v-if="card.id === 'dual'" #actions>
+              <v-btn color="primary" variant="tonal" size="small">
+                {{ t('home.cta.button') }}
+              </v-btn>
+              <v-btn variant="text" size="small" color="text-neutral-secondary">
+                {{ t('home.roundedCards.samples.dual.tooltip') }}
+              </v-btn>
+            </template>
+          </RoundedCornerCard>
+        </v-col>
+      </v-row>
+    </v-container>
+  </section>
+</template>
+
+<style scoped lang="sass">
+  .home-card-showcase
+    padding: clamp(1.5rem, 5vw, 2.75rem) clamp(1.25rem, 6vw, 3.5rem)
+    background: linear-gradient(140deg, rgba(var(--v-theme-surface-ice-050), 0.8), rgba(var(--v-theme-surface-muted), 0.9))
+    border-radius: clamp(1.5rem, 4vw, 2.5rem)
+    box-shadow: 0 18px 42px rgba(var(--v-theme-shadow-primary-600), 0.12)
+
+  .home-card-showcase__container
+    max-width: 1260px
+    margin: 0 auto
+
+  .home-card-showcase__header
+    text-align: center
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+    margin-bottom: clamp(1.25rem, 4vw, 2rem)
+
+  .home-card-showcase__eyebrow
+    margin: 0
+    font-weight: 700
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgba(var(--v-theme-hero-gradient-start), 0.9)
+
+  .home-card-showcase__title
+    margin: 0
+    font-size: clamp(1.6rem, 4vw, 2.1rem)
+    line-height: 1.2
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  .home-card-showcase__subtitle
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    max-width: 780px
+    align-self: center
+    line-height: 1.4
+
+  .home-card-showcase__grid
+    --v-gutter-x: clamp(1rem, 3vw, 1.5rem)
+    --v-gutter-y: clamp(1rem, 3vw, 1.5rem)
+
+  .home-card-showcase__card
+    height: 100%
+
+  .home-card-showcase__bullets
+    margin: 0
+    padding-inline-start: 1rem
+    display: grid
+    gap: 0.35rem
+    color: rgb(var(--v-theme-text-neutral-strong))
+    line-height: 1.4
+
+  .home-card-showcase__bullets li
+    margin: 0
+
+  .home-card-showcase__corner-meter
+    display: grid
+    place-items: center
+    color: rgb(var(--v-theme-text-on-accent))
+
+  .home-card-showcase__corner-meter-text
+    font-weight: 800
+    font-size: 0.85rem
+
+  @media (max-width: 960px)
+    .home-card-showcase
+      padding: clamp(1.2rem, 5vw, 2rem)
+      border-radius: clamp(1.1rem, 3vw, 1.6rem)
+
+    .home-card-showcase__title
+      font-size: clamp(1.45rem, 5vw, 1.8rem)
+
+    .home-card-showcase__subtitle
+      font-size: 0.95rem
+
+  @media (min-width: 1280px)
+    .home-card-showcase__grid
+      --v-gutter-y: 1.75rem
+      --v-gutter-x: 1.75rem
+
+    .home-card-showcase__card
+      transform-origin: center
+
+      &:hover
+        transform: translateY(-2px)
+
+</style>

--- a/frontend/app/components/shared/cards/RoundedCornerCard.spec.ts
+++ b/frontend/app/components/shared/cards/RoundedCornerCard.spec.ts
@@ -1,0 +1,63 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import RoundedCornerCard from './RoundedCornerCard.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    tm: () => [],
+  }),
+}))
+
+const createStub = (tag: string, className = '') =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () => h(tag, { class: [className, attrs.class], ...attrs }, slots.default ? slots.default() : [])
+    },
+  })
+
+const mountComponent = (props = {}) =>
+  mountSuspended(RoundedCornerCard, {
+    props: {
+      title: 'Sample',
+      subtitle: 'Subtitle',
+      ...props,
+    },
+    global: {
+      stubs: {
+        VCard: createStub('div', 'v-card-stub'),
+        VIcon: createStub('div', 'v-icon-stub'),
+        VImg: createStub('img', 'v-img-stub'),
+        VProgressCircular: createStub('div', 'v-progress-circular-stub'),
+        VBtn: createStub('button', 'v-btn-stub'),
+      },
+    },
+  })
+
+describe('RoundedCornerCard', () => {
+  it('renders a text corner variant when configured', async () => {
+    const wrapper = await mountComponent({
+      cornerVariant: 'text',
+      cornerLabel: 'Fresh',
+    })
+
+    expect(wrapper.find('.rounded-card__corner-label').text()).toContain('Fresh')
+    await wrapper.unmount()
+  })
+
+  it('emits selection events when clicked', async () => {
+    const wrapper = await mountComponent({
+      cornerVariant: 'icon',
+      selected: false,
+    })
+
+    await wrapper.trigger('click')
+
+    expect(wrapper.emitted('update:selected')?.[0]).toEqual([true])
+    expect(wrapper.emitted('select')?.[0]).toEqual([true])
+
+    await wrapper.unmount()
+  })
+})

--- a/frontend/app/components/shared/cards/RoundedCornerCard.vue
+++ b/frontend/app/components/shared/cards/RoundedCornerCard.vue
@@ -1,0 +1,424 @@
+<script setup lang="ts">
+import { computed, ref, useSlots } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+export type CornerSize = 'sm' | 'md' | 'lg'
+export type CornerVariant = 'icon' | 'text' | 'custom' | 'none'
+export type AccentCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
+export type SurfaceTone = 'glass' | 'strong'
+export type RoundedSize = 'sm' | 'md' | 'lg'
+
+const cornerSizeTokens: Record<CornerSize, string> = {
+  sm: '46px',
+  md: '58px',
+  lg: '72px',
+}
+
+const roundedSizeTokens: Record<RoundedSize, string> = {
+  sm: '14px',
+  md: '18px',
+  lg: '24px',
+}
+
+const props = withDefaults(
+  defineProps<{
+    title?: string
+    subtitle?: string
+    eyebrow?: string
+    accentCorner?: AccentCorner
+    cornerSize?: CornerSize
+    cornerVariant?: CornerVariant
+    cornerLabel?: string
+    cornerIcon?: string
+    selected?: boolean
+    selectable?: boolean
+    selectedIcon?: string
+    unselectedIcon?: string
+    rounded?: RoundedSize
+    surface?: SurfaceTone
+    elevation?: number
+    hoverElevation?: number
+    ariaLabel?: string
+    disabled?: boolean
+    cornerTooltip?: string
+  }>(),
+  {
+    title: '',
+    subtitle: '',
+    eyebrow: '',
+    accentCorner: 'bottom-right',
+    cornerSize: 'md',
+    cornerVariant: 'icon',
+    cornerLabel: '',
+    cornerIcon: '',
+    selected: false,
+    selectable: true,
+    selectedIcon: '/icons/rounded-card-selected.svg',
+    unselectedIcon: '/icons/rounded-card-unselected.svg',
+    rounded: 'md',
+    surface: 'glass',
+    elevation: 8,
+    hoverElevation: 12,
+    ariaLabel: '',
+    disabled: false,
+    cornerTooltip: '',
+  },
+)
+
+type RoundedCornerCardEmits = {
+  (event: 'update:selected' | 'select', value: boolean): void
+  (event: 'click', value: MouseEvent): void
+}
+
+const emit = defineEmits<RoundedCornerCardEmits>()
+
+const slots = useSlots()
+const { t } = useI18n()
+
+const isInteractive = computed(() => props.selectable && !props.disabled)
+const tabIndex = computed(() => (props.disabled ? -1 : 0))
+const ariaPressed = computed(() => (isInteractive.value ? String(props.selected) : undefined))
+const ariaDisabled = computed(() => (props.disabled ? 'true' : undefined))
+
+const surfaceClass = computed(() => `rounded-card--surface-${props.surface}`)
+const cornerClass = computed(() => `rounded-card--corner-${props.accentCorner}`)
+const roundedClass = computed(() => `rounded-card--rounded-${props.rounded}`)
+
+const sizeStyles = computed(() => ({
+  '--rounded-card-corner-size': cornerSizeTokens[props.cornerSize],
+  '--rounded-card-radius': roundedSizeTokens[props.rounded],
+}))
+
+const hasCornerSlot = computed(() => Boolean(slots.corner))
+const resolvedCornerVariant = computed<CornerVariant>(() => {
+  if (props.cornerVariant === 'custom' && !hasCornerSlot.value) {
+    return 'icon'
+  }
+
+  return props.cornerVariant
+})
+
+const resolvedCornerLabel = computed(() => {
+  if (props.cornerLabel) {
+    return props.cornerLabel
+  }
+
+  return props.selected ? t('shared.roundedCard.cornerSelected') : t('shared.roundedCard.cornerIdle')
+})
+
+const cornerTooltip = computed(() => {
+  if (props.cornerTooltip) {
+    return props.cornerTooltip
+  }
+
+  return props.selected ? t('shared.roundedCard.tooltipSelected') : t('shared.roundedCard.tooltipIdle')
+})
+
+const resolvedIcon = computed(() => (props.selected ? props.selectedIcon : props.unselectedIcon))
+
+const hoverState = ref(false)
+const isHovered = computed({
+  get: () => hoverState.value,
+  set: (value: boolean) => {
+    hoverState.value = value
+  },
+})
+const elevationValue = computed(() => (isHovered.value ? props.hoverElevation : props.elevation))
+
+const handleSelect = (event: MouseEvent | KeyboardEvent) => {
+  emit('click', event as MouseEvent)
+
+  if (!isInteractive.value) {
+    return
+  }
+
+  const nextValue = !props.selected
+  emit('update:selected', nextValue)
+  emit('select', nextValue)
+}
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    handleSelect(event)
+  }
+}
+
+const cardAriaLabel = computed(() => props.ariaLabel || props.title || props.subtitle || undefined)
+
+const hasHeader = computed(() => Boolean(props.title || props.subtitle || props.eyebrow || slots.header))
+</script>
+
+<template>
+  <v-card
+    class="rounded-card"
+    :class="[
+      surfaceClass,
+      cornerClass,
+      roundedClass,
+      {
+        'rounded-card--selected': selected,
+        'rounded-card--clickable': isInteractive,
+        'rounded-card--disabled': disabled,
+      },
+    ]"
+    variant="elevated"
+    :elevation="elevationValue"
+    :style="sizeStyles"
+    :tabindex="tabIndex"
+    :role="isInteractive ? 'button' : 'group'"
+    :aria-pressed="ariaPressed"
+    :aria-disabled="ariaDisabled"
+    :aria-label="cardAriaLabel"
+    :ripple="isInteractive"
+    @click="handleSelect"
+    @keydown="handleKeyDown"
+    @mouseenter="isHovered = true"
+    @mouseleave="isHovered = false"
+    @focusin="isHovered = true"
+    @focusout="isHovered = false"
+  >
+    <div class="rounded-card__corner" :class="[`rounded-card__corner--${resolvedCornerVariant}`]" :title="cornerTooltip">
+      <div v-if="resolvedCornerVariant === 'icon'" class="rounded-card__corner-indicator" aria-hidden="true">
+        <v-icon v-if="resolvedIcon?.startsWith('mdi-')" :icon="resolvedIcon" size="26" />
+        <v-img v-else-if="resolvedIcon" :src="resolvedIcon" :alt="cornerTooltip" eager cover />
+      </div>
+      <div v-else-if="resolvedCornerVariant === 'text'" class="rounded-card__corner-label">
+        <v-icon v-if="cornerIcon" :icon="cornerIcon" size="18" />
+        <span>{{ resolvedCornerLabel }}</span>
+      </div>
+      <div v-else-if="resolvedCornerVariant === 'custom'" class="rounded-card__corner-custom">
+        <slot name="corner" />
+      </div>
+    </div>
+
+    <div class="rounded-card__body">
+      <header v-if="hasHeader" class="rounded-card__header">
+        <slot name="header">
+          <p v-if="eyebrow" class="rounded-card__eyebrow">{{ eyebrow }}</p>
+          <p v-if="title" class="rounded-card__title">{{ title }}</p>
+          <p v-if="subtitle" class="rounded-card__subtitle">{{ subtitle }}</p>
+        </slot>
+      </header>
+
+      <div class="rounded-card__content">
+        <slot />
+      </div>
+
+      <footer v-if="$slots.actions" class="rounded-card__actions">
+        <slot name="actions" />
+      </footer>
+    </div>
+  </v-card>
+</template>
+
+<style scoped lang="scss">
+.rounded-card {
+  --rounded-card-border: rgba(var(--v-theme-border-primary-strong), 0.7);
+  --rounded-card-highlight-main: rgba(var(--v-theme-hero-gradient-start), 0.38);
+  --rounded-card-highlight-alt: rgba(var(--v-theme-hero-gradient-end), 0.32);
+  --rounded-card-text: rgb(var(--v-theme-text-neutral-strong));
+  --rounded-card-bg: rgba(var(--v-theme-surface-glass), 0.96);
+  --rounded-card-corner-size: 58px;
+  --rounded-card-radius: 18px;
+
+  position: relative;
+  display: flex;
+  padding: clamp(1rem, 3vw, 1.5rem) clamp(1.1rem, 3vw, 1.6rem);
+  border-radius: var(--rounded-card-radius);
+  border: 1px solid var(--rounded-card-border);
+  background: var(--rounded-card-bg);
+  color: var(--rounded-card-text);
+  overflow: hidden;
+  transition: box-shadow 180ms ease, transform 180ms ease, border-color 180ms ease;
+
+  &--surface-strong {
+    --rounded-card-bg: rgba(var(--v-theme-surface-glass-strong), 0.98);
+  }
+
+  &--selected {
+    --rounded-card-border: rgba(var(--v-theme-accent-supporting), 0.75);
+    box-shadow: 0 16px 36px rgba(var(--v-theme-shadow-primary-600), 0.2);
+  }
+
+  &--clickable:not(&--disabled) {
+    cursor: pointer;
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 42px rgba(var(--v-theme-shadow-primary-600), 0.16);
+    }
+  }
+
+  &--disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 22% 18%, rgba(var(--v-theme-surface-primary-080), 0.5), transparent 40%),
+      radial-gradient(circle at 80% 80%, rgba(var(--v-theme-surface-primary-100), 0.45), transparent 40%);
+    opacity: 0.85;
+    pointer-events: none;
+  }
+
+  &__body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(0.7rem, 1.8vw, 0.95rem);
+    z-index: 1;
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  &__eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: rgba(var(--v-theme-hero-gradient-end), 0.85);
+  }
+
+  &__title {
+    margin: 0;
+    font-weight: 700;
+    font-size: 1.15rem;
+    line-height: 1.25;
+  }
+
+  &__subtitle {
+    margin: 0;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+    line-height: 1.35;
+    font-weight: 500;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__actions {
+    margin-top: 0.35rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  &__corner {
+    position: absolute;
+    width: var(--rounded-card-corner-size);
+    height: var(--rounded-card-corner-size);
+    background: linear-gradient(135deg, var(--rounded-card-highlight-main), rgba(var(--v-theme-accent-supporting), 0.38));
+    border: 1px solid var(--rounded-card-border);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: rgb(var(--v-theme-text-on-accent));
+    overflow: hidden;
+    z-index: 2;
+    transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+    backdrop-filter: blur(6px);
+
+    &--icon {
+      padding: 0.35rem;
+    }
+
+    &--text {
+      padding: 0.45rem 0.65rem;
+    }
+
+    &--custom {
+      padding: 0.3rem;
+    }
+
+    &--none {
+      display: none;
+    }
+  }
+
+  &__corner-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__corner-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 700;
+    font-size: 0.85rem;
+  }
+
+  &__corner-custom {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+  }
+
+  &--corner-bottom-right &__corner {
+    bottom: 0;
+    right: 0;
+    border-radius: 54% 0 0 0;
+  }
+
+  &--corner-bottom-left &__corner {
+    bottom: 0;
+    left: 0;
+    border-radius: 0 54% 0 0;
+  }
+
+  &--corner-top-right &__corner {
+    top: 0;
+    right: 0;
+    border-radius: 0 0 0 54%;
+  }
+
+  &--corner-top-left &__corner {
+    top: 0;
+    left: 0;
+    border-radius: 0 0 54% 0;
+  }
+
+  &--rounded-sm {
+    --rounded-card-radius: 14px;
+  }
+
+  &--rounded-md {
+    --rounded-card-radius: 18px;
+  }
+
+  &--rounded-lg {
+    --rounded-card-radius: 24px;
+  }
+}
+
+@media (max-width: 600px) {
+  .rounded-card {
+    padding: clamp(0.9rem, 3vw, 1.2rem);
+  }
+
+  .rounded-card__title {
+    font-size: 1.05rem;
+  }
+
+  .rounded-card__corner {
+    --rounded-card-corner-size: 52px;
+  }
+}
+</style>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -10,6 +10,7 @@ import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
 import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
 import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
+import HomeRoundedCardShowcase from '~/components/home/sections/HomeRoundedCardShowcase.vue'
 import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
 import type { CategorySuggestionItem, ProductSuggestionItem } from '~/components/search/SearchSuggestField.vue'
 import { useCategories } from '~/composables/categories/useCategories'
@@ -628,6 +629,8 @@ useHead(() => ({
           />
         </div>
       </ParallaxSection>
+
+      <HomeRoundedCardShowcase class="home-page__card-showcase" />
     </div>
   </div>
 </template>
@@ -673,4 +676,7 @@ useHead(() => ({
   @media (min-width: 1100px)
     .home-page__stack--two-columns
       grid-template-columns: repeat(2, 1fr)
+
+  .home-page__card-showcase
+    margin-top: clamp(1rem, 3vw, 1.5rem)
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -61,14 +61,19 @@
             "icon": "🏷️",
             "label": "The best prices on the market"
           },
-          {
-            "icon": "🛡️",
-            "label": "Independent comparator, open-source software and open data"
-          }
-        ]
+      {
+        "icon": "🛡️",
+        "label": "Independent comparator, open-source software and open data"
       }
+    ]
     },
-    "parallax": {
+    "context": {
+      "cornerLabel": "Impact digest",
+      "cornerTooltip": "Key highlights from Nudger’s methodology",
+      "ariaLabel": "Hero context card summarising Nudger’s promise"
+    }
+  },
+  "parallax": {
       "essentials": {
         "ariaLabel": "Decorative background for the challenges and solutions section"
       },
@@ -247,12 +252,86 @@
         }
       }
     },
+    "roundedCards": {
+      "eyebrow": "Design system",
+      "title": "Rounded corner cards",
+      "subtitle": "One reusable card for hero highlights, feature grids, and pickers with selectable corners.",
+      "ariaLabel": "Rounded card showcase grid",
+      "samples": {
+        "impact": {
+          "eyebrow": "Icon · bottom-right · large",
+          "title": "Impact-first state",
+          "subtitle": "Selected badge with large rounded corner and elevated glass surface.",
+          "tooltip": "Toggle the selected indicator",
+          "bullets": [
+            "Built-in selected/unselected SVGs",
+            "Hover and keyboard focus elevate the card",
+            "Fits dense hero layouts"
+          ]
+        },
+        "text": {
+          "eyebrow": "Text · top-right · medium",
+          "title": "Text badge corner",
+          "subtitle": "Swap the corner icon for a text pill with optional icon.",
+          "tooltip": "Corner text badge",
+          "cornerLabel": "Fresh data",
+          "bullets": [
+            "Use `cornerVariant=text` with an optional icon",
+            "Ideal for badges like \"beta\" or \"new\"",
+            "Keeps the corner highlight subtle"
+          ]
+        },
+        "compact": {
+          "eyebrow": "Icon · top-left · small",
+          "title": "Compact selector",
+          "subtitle": "Small corner radius with unselected state by default.",
+          "tooltip": "Mark this compact card as selected",
+          "bullets": [
+            "Smaller corner footprint for tight grids",
+            "Uses the unselected SVG until toggled",
+            "Keyboard and click both flip the state"
+          ]
+        },
+        "custom": {
+          "eyebrow": "Custom slot · bottom-left · medium",
+          "title": "Slot anything in the corner",
+          "subtitle": "Inject avatars, progress rings, or KPIs into the highlighted corner.",
+          "tooltip": "Custom corner content",
+          "progressLabel": "{value}% impact readiness",
+          "bullets": [
+            "Provide content via the `corner` slot",
+            "Blend text, icons, or charts",
+            "Keeps the rounded mask and gradient"
+          ]
+        },
+        "dual": {
+          "eyebrow": "Text + icon · bottom-right · medium",
+          "title": "Mixed content card",
+          "subtitle": "Textual badge with supporting icon and elevated actions.",
+          "tooltip": "Toggle this mixed badge card",
+          "cornerLabel": "Priority",
+          "bullets": [
+            "Demonstrates rounded size medium",
+            "Shows action slot usage",
+            "Great for CTA or selection flows"
+          ]
+        }
+      }
+    },
     "cta": {
       "title": "Ready to buy better without overspending?",
       "subtitle": "Restart a search or explore the analysed offers.",
       "button": "Start a search",
       "searchSubmit": "Launch search",
       "browseTaxonomy": "Explore categories"
+    }
+  },
+  "shared": {
+    "roundedCard": {
+      "tooltipSelected": "Card selected",
+      "tooltipIdle": "Mark this card as selected",
+      "cornerSelected": "Selected",
+      "cornerIdle": "Available"
     }
   },
   "categories": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -66,6 +66,11 @@
             "label": "Sans se faire avoir sur les prix"
           }
         ]
+      },
+      "context": {
+        "cornerLabel": "Résumé impact",
+        "cornerTooltip": "Les points forts de la méthodologie Nudger",
+        "ariaLabel": "Carte contexte du héros présentant la promesse Nudger"
       }
     },
     "parallax": {
@@ -247,12 +252,86 @@
         }
       }
     },
+    "roundedCards": {
+      "eyebrow": "Design system",
+      "title": "Cartes à coins arrondis",
+      "subtitle": "Une seule carte réutilisable pour les blocs héros, grilles de fonctionnalités et sélecteurs à coins accentués.",
+      "ariaLabel": "Grille de démonstration des cartes arrondies",
+      "samples": {
+        "impact": {
+          "eyebrow": "Icône · bas droite · large",
+          "title": "État sélectionné",
+          "subtitle": "Badge sélection avec grand angle arrondi et surface glass.",
+          "tooltip": "Basculer l'indicateur sélectionné",
+          "bullets": [
+            "Icônes sélection/non sélection intégrées",
+            "Survol et focus clavier augmentent le relief",
+            "S'intègre aux mises en page denses du héros"
+          ]
+        },
+        "text": {
+          "eyebrow": "Texte · haut droite · moyen",
+          "title": "Coin texte",
+          "subtitle": "Remplacez l'icône par un badge texte avec icône optionnelle.",
+          "tooltip": "Badge texte du coin",
+          "cornerLabel": "Données fraîches",
+          "bullets": [
+            "Utilisez `cornerVariant=text` avec icône optionnelle",
+            "Parfait pour les badges « beta » ou « new »",
+            "Accent discret côté arrondi"
+          ]
+        },
+        "compact": {
+          "eyebrow": "Icône · haut gauche · petit",
+          "title": "Sélecteur compact",
+          "subtitle": "Petit rayon d'angle avec état non sélectionné par défaut.",
+          "tooltip": "Marquer cette carte compacte comme sélectionnée",
+          "bullets": [
+            "Empreinte réduite pour les grilles serrées",
+            "Utilise le SVG non sélectionné jusqu'à clic",
+            "Clavier et clic inversent l'état"
+          ]
+        },
+        "custom": {
+          "eyebrow": "Slot custom · bas gauche · moyen",
+          "title": "Contenu sur-mesure",
+          "subtitle": "Injectez avatars, anneaux de progression ou KPIs dans le coin.",
+          "tooltip": "Contenu custom du coin",
+          "progressLabel": "{value}% de préparation impact",
+          "bullets": [
+            "Alimentez via le slot `corner`",
+            "Mélangez texte, icônes ou graphiques",
+            "Conserve le masque et le dégradé arrondi"
+          ]
+        },
+        "dual": {
+          "eyebrow": "Texte + icône · bas droite · moyen",
+          "title": "Carte mixte",
+          "subtitle": "Badge textuel avec icône et zone d'actions.",
+          "tooltip": "Basculer cette carte mixte",
+          "cornerLabel": "Priorité",
+          "bullets": [
+            "Montre le rayon moyen",
+            "Illustre le slot actions",
+            "Adaptée aux CTA ou sélections"
+          ]
+        }
+      }
+    },
     "cta": {
       "title": "Prêt à acheter mieux sans vous ruiner ?",
       "subtitle": "Relancez une recherche ou découvrez les offres analysées.",
       "button": "Lancer une recherche",
       "searchSubmit": "Lancer la recherche",
       "browseTaxonomy": "Explorer les catégories"
+    }
+  },
+  "shared": {
+    "roundedCard": {
+      "tooltipSelected": "Carte sélectionnée",
+      "tooltipIdle": "Marquer cette carte comme sélectionnée",
+      "cornerSelected": "Sélectionné",
+      "cornerIdle": "Disponible"
     }
   },
   "categories": {

--- a/frontend/public/icons/rounded-card-selected.svg
+++ b/frontend/public/icons/rounded-card-selected.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="rounded-selected" x1="14" y1="10" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="currentColor" stop-opacity="0.9" />
+      <stop offset="1" stop-color="currentColor" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="18" fill="url(#rounded-selected)" />
+  <path
+    d="M26.5 32.75L31.25 37.5L38.5 27.5"
+    stroke="#fff"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/frontend/public/icons/rounded-card-unselected.svg
+++ b/frontend/public/icons/rounded-card-unselected.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="6" width="52" height="52" rx="18" stroke="currentColor" stroke-width="3" opacity="0.75" />
+  <path
+    d="M22 32H42"
+    stroke="currentColor"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    opacity="0.6"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- create a reusable rounded-corner card component with size variants, selectable state handling, and slot-based corner content
- update the home hero context card to use the new component and add translations for the new variants and tooltips
- add a rounded card showcase section on the homepage with sample variants, icons, and unit coverage

## Testing
- pnpm --offline lint
- pnpm --offline test
- pnpm --offline build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b6a470c88322b609c01aabb5f03e)