### PR TITLE
Refine nudge tool selection cards

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -41,24 +41,28 @@
         transform: translateY(-1px)
 
 .nudge-option-card
-    background: rgb(var(--v-theme-surface-default))!important
-    border: 1px solid rgba(var(--v-theme-primary), 0.08)!important
+    @extend .card__nudger
+    padding: 16px 18px!important
     border-radius: 24px!important
-    padding: 16px!important
-    color: rgb(var(--v-theme-text-neutral-strong))
-    box-shadow: 0 6px 20px rgba(var(--v-theme-primary), 0.05)
-    transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease
-    text-align: center
+    box-shadow: 0 8px 22px rgba(var(--v-theme-primary), 0.08)
+    transition: box-shadow 0.22s ease, transform 0.22s ease, border-color 0.22s ease, background-color 0.22s ease
+    text-align: left
     cursor: pointer
+    position: relative
 
     &:hover
-        box-shadow: 0 14px 38px rgba(var(--v-theme-primary), 0.12)
-        transform: translateY(-1px)
+        box-shadow: 0 16px 36px rgba(var(--v-theme-primary), 0.14)
+        transform: translateY(-2px)
 
     &--selected
         background: rgba(var(--v-theme-primary), 0.08)!important
-        border-color: rgba(var(--v-theme-primary), 0.3)!important
-        box-shadow: 0 18px 42px rgba(var(--v-theme-primary), 0.14)
+        border-color: rgba(var(--v-theme-primary), 0.32)!important
+        box-shadow: 0 20px 44px rgba(var(--v-theme-primary), 0.16)
+
+    &--flat
+        box-shadow: none
+        background: rgb(var(--v-theme-surface-default))!important
+        border-color: rgba(var(--v-theme-primary), 0.1)!important
 
     &--border
         border: 1px solid rgba(var(--v-theme-primary), 0.2)!important

--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -57,11 +57,11 @@
         :value="category.id ?? ''"
       >
         <v-card
-          class="nudge-step-category__card"
+          class="nudge-step-category__card nudge-option-card nudge-option-card--flat"
           :class="{
-            'nudge-step-category__card--selected': selected === category.id,
+            'nudge-option-card--selected': selected === category.id,
           }"
-          :elevation="selected === category.id ? 8 : 2"
+          variant="flat"
           rounded="xl"
           role="button"
           :aria-pressed="(selected === category.id).toString()"
@@ -197,13 +197,7 @@ watch(
     justify-content: center;
     gap: 8px;
     min-width: 160px;
-    background: rgb(var(--v-theme-surface-default));
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
-
-    &--selected {
-      border-color: rgb(var(--v-theme-accent-primary-highlight));
-      box-shadow: 0 10px 25px -12px rgba(var(--v-theme-shadow-primary-600), 0.5);
-    }
+    box-shadow: none;
   }
 
   &__image {

--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -22,13 +22,23 @@
       >
         <v-card
           class="nudge-step-condition__card nudge-option-card"
-          :class="{ 'nudge-option-card--selected': isSelected(option.value) }"
+          :class="{
+            'nudge-option-card--selected': isSelected(option.value),
+          }"
           rounded="lg"
           role="button"
           :aria-pressed="isSelected(option.value).toString()"
           @click="() => toggleOption(option.value)"
         >
-          <v-icon :icon="option.icon" size="32" class="mb-2" />
+          <div class="nudge-step-condition__icon-wrapper">
+            <v-icon :icon="option.icon" size="26" />
+            <v-icon
+              v-if="isSelected(option.value)"
+              icon="mdi-check-circle"
+              size="18"
+              class="nudge-step-condition__check"
+            />
+          </div>
           <p class="nudge-step-condition__label">{{ option.label }}</p>
         </v-card>
       </v-col>
@@ -99,14 +109,36 @@ const toggleOption = (choice: ProductConditionChoice) => {
   &__card {
     width: 100%;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
+    justify-content: space-between;
+    padding: 14px 16px;
   }
 
   &__label {
     margin: 0;
     font-weight: 600;
+    flex: 1;
+  }
+
+  &__icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: rgba(var(--v-theme-primary), 0.08);
+    color: rgb(var(--v-theme-primary));
+    position: relative;
+  }
+
+  &__check {
+    position: absolute;
+    right: -6px;
+    top: -6px;
+    color: rgb(var(--v-theme-primary));
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -13,7 +13,7 @@
       </div>
     </div>
 
-    <v-row dense>
+    <v-row dense class="nudge-step-scores__grid">
       <v-col v-for="score in scores" :key="score.scoreName" cols="12" sm="6">
         <v-tooltip
           location="top"
@@ -25,20 +25,32 @@
               v-bind="activatorProps"
               class="nudge-step-scores__card nudge-option-card"
               :class="{
-                'nudge-option-card--selected': selectedNames.includes(
+                'nudge-option-card--selected': isSelected(score.scoreName),
+                'nudge-step-scores__card--selected': isSelected(
                   score.scoreName ?? ''
                 ),
               }"
               rounded="lg"
               role="button"
-              :aria-pressed="selectedNames.includes(score.scoreName ?? '')"
+              :aria-pressed="isSelected(score.scoreName).toString()"
               @click="toggle(score.scoreName ?? '')"
             >
-              <div class="nudge-step-scores__icon">
-                <v-icon :icon="getScoreIcon(score)" size="28" />
-              </div>
-              <div class="nudge-step-scores__content">
-                <p class="nudge-step-scores__name">{{ score.title }}</p>
+              <div class="nudge-step-scores__top-row">
+                <div class="nudge-step-scores__titles">
+                  <p class="nudge-step-scores__name">{{ score.title }}</p>
+                  <p v-if="score.caption" class="nudge-step-scores__caption">
+                    {{ score.caption }}
+                  </p>
+                </div>
+                <div class="nudge-step-scores__icon-wrapper">
+                  <v-icon :icon="getScoreIcon(score)" size="28" />
+                  <v-icon
+                    v-if="isSelected(score.scoreName)"
+                    icon="mdi-check-circle"
+                    size="18"
+                    class="nudge-step-scores__check"
+                  />
+                </div>
               </div>
             </v-card>
           </template>
@@ -64,6 +76,9 @@ const emit = defineEmits<{
 const selectedNames = computed(() => props.modelValue)
 
 const getScoreIcon = (score: NudgeToolScoreDto) => score.mdiIcon ?? 'mdi-leaf'
+
+const isSelected = (scoreName?: string | null) =>
+  scoreName ? selectedNames.value.includes(scoreName) : false
 
 const toggle = (scoreName: string) => {
   const next = new Set(selectedNames.value)
@@ -95,26 +110,66 @@ const toggle = (scoreName: string) => {
     margin: 0;
   }
 
-  &__card {
-    display: flex;
-    gap: 12px;
-    height: 100%;
-    align-items: center;
+  &__grid {
+    row-gap: 12px;
   }
 
-  &__icon {
-    width: 48px;
-    height: 48px;
-    border-radius: 12px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(var(--v-theme-primary), 0.08);
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    height: 100%;
+    border-radius: 22px;
+    padding: 14px 16px;
+    position: relative;
+  }
+
+  &__card--selected {
+    background: rgba(var(--v-theme-primary), 0.08) !important;
+  }
+
+  &__top-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
   }
 
   &__name {
     margin: 0;
     font-weight: 700;
+    line-height: 1.4;
+  }
+
+  &__caption {
+    margin: 0;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+    font-size: 0.95rem;
+  }
+
+  &__icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: rgba(var(--v-theme-primary), 0.08);
+    position: relative;
+    color: rgb(var(--v-theme-primary));
+  }
+
+  &__check {
+    position: absolute;
+    right: -6px;
+    top: -6px;
+    color: rgb(var(--v-theme-primary));
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -26,20 +26,29 @@
               v-bind="activatorProps"
               class="nudge-step-subset__card nudge-option-card"
               :class="{
-                'nudge-option-card--selected': modelValue.includes(
-                  subset.id ?? ''
-                ),
+                'nudge-option-card--selected': isSelected(subset.id),
               }"
               rounded="lg"
               role="button"
-              :aria-pressed="modelValue.includes(subset.id ?? '')"
+              :aria-pressed="isSelected(subset.id).toString()"
               @click="toggle(subset.id ?? '')"
             >
               <div class="nudge-step-subset__body">
-                <p class="nudge-step-subset__name">{{ subset.title }}</p>
-                <p v-if="subset.caption" class="nudge-step-subset__caption">
-                  {{ subset.caption }}
-                </p>
+                <div class="nudge-step-subset__text">
+                  <p class="nudge-step-subset__name">{{ subset.title }}</p>
+                  <p v-if="subset.caption" class="nudge-step-subset__caption">
+                    {{ subset.caption }}
+                  </p>
+                </div>
+                <div class="nudge-step-subset__icon-wrapper">
+                  <v-icon :icon="getSubsetIcon(subset)" size="24" />
+                  <v-icon
+                    v-if="isSelected(subset.id)"
+                    icon="mdi-check-circle"
+                    size="18"
+                    class="nudge-step-subset__check"
+                  />
+                </div>
               </div>
             </v-card>
           </template>
@@ -66,6 +75,12 @@ const emit = defineEmits<{
   (event: 'update:modelValue', value: string[]): void
   (event: 'continue'): void
 }>()
+
+const isSelected = (subsetId?: string | null) =>
+  subsetId ? props.modelValue.includes(subsetId) : false
+
+const getSubsetIcon = (subset: VerticalSubsetDto) =>
+  subset.mdiIcon ?? 'mdi-sprout'
 
 const toggle = (subsetId: string) => {
   const next = new Set(props.modelValue)
@@ -108,15 +123,22 @@ const toggle = (subsetId: string) => {
   &__card {
     display: flex;
     flex-direction: column;
-    align-items: center;
     height: 100%;
+    padding: 14px 16px;
   }
 
   &__body {
-    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__text {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    flex: 1;
   }
 
   &__name {
@@ -127,6 +149,25 @@ const toggle = (subsetId: string) => {
   &__caption {
     margin: 0;
     color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__icon-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: rgba(var(--v-theme-primary), 0.08);
+    color: rgb(var(--v-theme-primary));
+    position: relative;
+  }
+
+  &__check {
+    position: absolute;
+    right: -6px;
+    top: -6px;
+    color: rgb(var(--v-theme-primary));
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- align nudge tool steps to the shared nudger rounded card styling, including flat category tiles
- restyle score, condition, and subset selections with top-right icons and linear inline layouts for consistency
- refine the shared nudge option card styles for selected/flat states to keep interactions uniform

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941082af42c83228b34c51ca0bcbf6b)