### PR TITLE
Improve nudge wizard height stabilization and category visuals

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -206,7 +206,7 @@ watch(
     aspect-ratio: 1 / 1;
     border-radius: 12px;
     overflow: hidden;
-    background: rgba(var(--v-theme-primary), 0.08);
+    background: transparent;
   }
 
   &__img {
@@ -217,7 +217,7 @@ watch(
     display: grid;
     place-items: center;
     height: 100%;
-    background: rgba(var(--v-theme-primary), 0.06);
+    background: transparent;
     color: rgb(var(--v-theme-primary));
   }
 


### PR DESCRIPTION
## Summary
- integrate the category selection fully into the wizard steps and auto-skip to the first content step when an initial category is provided
- stabilize the wizard container with tracked min-heights for the window content so height only shrinks on the category screen and grows for other steps
- make category cards flat by removing the background behind thumbnails

## Testing
- pnpm lint (warnings about existing v-html usage)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d62c397c83228501f388959f7cbd)