### PR TITLE
Use themed parallax assets for home sections

### DIFF
--- a/frontend/app/assets/themes/dark/parallax/parallax-background-1-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-1-1.svg
@@ -1,0 +1,174 @@
+<!-- Save as: hero-parallax.svg  |  Height fixed at 800, responsive width -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="800" viewBox="0 0 1440 800" preserveAspectRatio="xMidYMid slice">
+  <title>Parallax Glass Tech Background</title>
+
+  <defs>
+    <!-- Core palette (from your tokens) -->
+    <!-- hero-gradient-start: #1E3A8A | mid: #1D4ED8 | end: #166534 -->
+    <!-- accent-primary-highlight: #38BDF8 | accent-supporting: #22C55E | shadow-primary-600: #3B82F6 -->
+
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#000000"></stop>
+      <stop offset="0.35" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#1E3A8A" stop-opacity="0.85"></stop>
+      <stop offset="0.72" stop-color="#1D4ED8" stop-opacity="0.55"></stop>
+      <stop offset="1" stop-color="#166534" stop-opacity="0.35"></stop>
+    </linearGradient>
+
+    <radialGradient id="glowBlue" cx="35%" cy="35%" r="60%">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.55"></stop>
+      <stop offset="0.45" stop-color="#3B82F6" stop-opacity="0.22"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowGreen" cx="78%" cy="55%" r="65%">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.38"></stop>
+      <stop offset="0.55" stop-color="#166534" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowIce" cx="55%" cy="10%" r="60%">
+      <stop offset="0" stop-color="#64B5F6" stop-opacity="0.35"></stop>
+      <stop offset="0.55" stop-color="#1D4ED8" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Subtle grid -->
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 H 0 V 48" fill="none" stroke="#90CAF9" stroke-opacity="0.10" stroke-width="1"></path>
+      <path d="M 24 0 V 48 M 0 24 H 48" fill="none" stroke="#90CAF9" stroke-opacity="0.06" stroke-width="1"></path>
+    </pattern>
+
+    <!-- Scanlines -->
+    <pattern id="scanlines" width="6" height="6" patternUnits="userSpaceOnUse">
+      <rect width="6" height="1" y="0" fill="#FFFFFF" opacity="0.06"></rect>
+    </pattern>
+
+    <!-- Noise overlay -->
+    <filter id="noise" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"></feTurbulence>
+      <feColorMatrix type="matrix" values="
+        1 0 0 0 0
+        0 1 0 0 0
+        0 0 1 0 0
+        0 0 0 0.12 0"></feColorMatrix>
+    </filter>
+
+    <!-- Soft glow -->
+    <filter id="softGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="18" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="
+        1 0 0 0 0
+        0 1 0 0 0
+        0 0 1 0 0
+        0 0 0 0.9 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Glass card feel -->
+    <filter id="glass" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur"></feGaussianBlur>
+      <feSpecularLighting in="blur" surfaceScale="2" specularConstant="0.35" specularExponent="24" lighting-color="#FFFFFF" result="spec">
+        <feDistantLight azimuth="220" elevation="35"></feDistantLight>
+      </feSpecularLighting>
+      <feComposite in="spec" in2="SourceAlpha" operator="in" result="specIn"></feComposite>
+      <feMerge>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+        <feMergeNode in="specIn"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="50%" cy="50%" r="70%">
+      <stop offset="55%" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="100%" stop-color="#000000" stop-opacity="0.78"></stop>
+    </radialGradient>
+
+    <!-- “Circuit” stroke gradient -->
+    <linearGradient id="circuitGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.9"></stop>
+      <stop offset="0.5" stop-color="#90CAF9" stop-opacity="0.55"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.8"></stop>
+    </linearGradient>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1440" height="800" fill="#000000"></rect>
+
+  <!-- LAYER 0: background gradient + large glows -->
+  <g id="layer0" data-depth="0.06">
+    <rect width="1440" height="800" fill="url(#bgGrad)"></rect>
+    <ellipse cx="520" cy="280" rx="640" ry="460" fill="url(#glowBlue)"></ellipse>
+    <ellipse cx="1120" cy="470" rx="760" ry="520" fill="url(#glowGreen)"></ellipse>
+    <ellipse cx="820" cy="120" rx="640" ry="360" fill="url(#glowIce)"></ellipse>
+  </g>
+
+  <!-- LAYER 1: blurred “nebula” blobs (parallax friendly) -->
+  <g id="layer1" data-depth="0.12" filter="url(#softGlow)" style="mix-blend-mode:screen">
+    <path d="M190,610 C280,500 460,520 560,430 C680,320 610,210 760,170 C930,125 980,250 1100,310 C1240,380 1360,360 1440,300 L1440,800 L0,800 Z" fill="#1D4ED8" opacity="0.14"></path>
+    <path d="M0,520 C140,470 280,520 420,470 C600,405 640,290 820,260 C1010,225 1080,340 1230,390 C1320,420 1380,400 1440,360 L1440,800 L0,800 Z" fill="#22C55E" opacity="0.10"></path>
+    <path d="M0,240 C160,190 290,230 430,190 C620,130 700,40 880,60 C1070,80 1160,170 1320,210 C1390,228 1420,220 1440,210 L1440,0 L0,0 Z" fill="#38BDF8" opacity="0.10"></path>
+  </g>
+
+  <!-- LAYER 2: grid + scanlines + noise -->
+  <g id="layer2" data-depth="0.18">
+    <rect width="1440" height="800" fill="url(#grid)" opacity="0.65"></rect>
+    <rect width="1440" height="800" fill="url(#scanlines)" opacity="0.25"></rect>
+    <rect width="1440" height="800" filter="url(#noise)" opacity="0.55"></rect>
+  </g>
+
+  <!-- LAYER 3: circuits + particles -->
+  <g id="layer3" data-depth="0.28" opacity="0.95">
+    <g fill="none" stroke="url(#circuitGrad)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.55">
+      <path d="M120 560 H420 Q460 560 460 520 V420 Q460 380 500 380 H680"></path>
+      <path d="M220 220 H520 Q560 220 560 260 V310 Q560 350 600 350 H820 Q860 350 860 310 V250"></path>
+      <path d="M860 520 H1040 Q1100 520 1100 460 V360 Q1100 320 1140 320 H1320"></path>
+      <path d="M980 160 H1140 Q1180 160 1180 200 V260 Q1180 300 1220 300 H1340"></path>
+      <path d="M80 360 H240 Q300 360 300 300 V240 Q300 200 340 200 H420"></path>
+    </g>
+
+    <!-- Nodes -->
+    <g opacity="0.75" style="mix-blend-mode:screen">
+      <circle cx="460" cy="520" r="5" fill="#38BDF8"></circle>
+      <circle cx="560" cy="260" r="5" fill="#90CAF9"></circle>
+      <circle cx="1100" cy="460" r="5" fill="#22C55E"></circle>
+      <circle cx="1180" cy="200" r="5" fill="#64B5F6"></circle>
+      <circle cx="300" cy="300" r="5" fill="#3B82F6"></circle>
+      <circle cx="680" cy="380" r="4" fill="#38BDF8"></circle>
+      <circle cx="1320" cy="320" r="4" fill="#22C55E"></circle>
+      <circle cx="860" cy="250" r="4" fill="#90CAF9"></circle>
+    </g>
+
+    <!-- Floating particles -->
+    <g opacity="0.55">
+      <circle cx="180" cy="120" r="2" fill="#CBD5F5"></circle>
+      <circle cx="260" cy="640" r="2" fill="#CBD5F5"></circle>
+      <circle cx="720" cy="690" r="2" fill="#CBD5F5"></circle>
+      <circle cx="1180" cy="110" r="2" fill="#CBD5F5"></circle>
+      <circle cx="1320" cy="610" r="2" fill="#CBD5F5"></circle>
+      <circle cx="980" cy="420" r="2" fill="#CBD5F5"></circle>
+    </g>
+  </g>
+
+  <!-- LAYER 4: glassmorphism cards (optional depth elements) -->
+  <g id="layer4" data-depth="0.38">
+    <g filter="url(#glass)" opacity="0.92">
+      <rect x="120" y="120" width="420" height="170" rx="22" fill="#1E293B" fill-opacity="0.42" stroke="#90CAF9" stroke-opacity="0.22"></rect>
+      <rect x="860" y="480" width="460" height="190" rx="24" fill="#111827" fill-opacity="0.40" stroke="#38BDF8" stroke-opacity="0.20"></rect>
+      <rect x="560" y="310" width="320" height="140" rx="22" fill="#0F172A" fill-opacity="0.42" stroke="#22C55E" stroke-opacity="0.16"></rect>
+    </g>
+
+    <!-- Card highlights -->
+    <g opacity="0.35" style="mix-blend-mode:screen">
+      <path d="M150 150 H500" stroke="#38BDF8" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M590 340 H850" stroke="#64B5F6" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M890 510 H1280" stroke="#22C55E" stroke-width="2" stroke-linecap="round"></path>
+    </g>
+  </g>
+
+  <!-- Vignette for focus -->
+  <rect width="1440" height="800" fill="url(#vignette)"></rect>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-2-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-2-1.svg
@@ -1,0 +1,142 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Abstract dark tech parallax background">
+  <defs>
+    <!-- Core background -->
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0F172A"></stop>
+      <stop offset="0.45" stop-color="#1E293B"></stop>
+      <stop offset="1" stop-color="#0B1220"></stop>
+    </linearGradient>
+
+    <!-- Hero-ish sweep -->
+    <linearGradient id="heroSweep" x1="1600" y1="0" x2="200" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1E3A8A" stop-opacity="0.55"></stop>
+      <stop offset="0.55" stop-color="#1D4ED8" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#166534" stop-opacity="0.25"></stop>
+    </linearGradient>
+
+    <!-- Glow fills -->
+    <radialGradient id="glowBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 240) rotate(110) scale(520 520)">
+      <stop stop-color="#38BDF8" stop-opacity="0.95"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 620) rotate(25) scale(560 460)">
+      <stop stop-color="#22C55E" stop-opacity="0.75"></stop>
+      <stop offset="0.55" stop-color="#22C55E" stop-opacity="0.25"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowViolet" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(340 180) rotate(15) scale(520 420)">
+      <stop stop-color="#82B1FF" stop-opacity="0.60"></stop>
+      <stop offset="0.6" stop-color="#90CAF9" stop-opacity="0.20"></stop>
+      <stop offset="1" stop-color="#82B1FF" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Grid / dots -->
+    <pattern id="grid" width="90" height="90" patternUnits="userSpaceOnUse">
+      <path d="M90 0H0V90" fill="none" stroke="#94A3B8" stroke-opacity="0.08" stroke-width="1"></path>
+      <path d="M0 45H90M45 0V90" fill="none" stroke="#CBD5F5" stroke-opacity="0.04" stroke-width="1"></path>
+    </pattern>
+
+    <pattern id="dots" width="34" height="34" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.2" fill="#F8FAFC" opacity="0.08"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(900 520)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.55"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur40" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="40"></feGaussianBlur>
+    </filter>
+
+    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.85 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glass" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="6" result="bg"></feGaussianBlur>
+      <feColorMatrix in="bg" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.35 0" result="m"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="m"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Subtle grain -->
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.18 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1600" height="800" fill="url(#bg)"></rect>
+  <rect width="1600" height="800" fill="url(#heroSweep)" opacity="0.85"></rect>
+
+  <!-- Layer: far back (slow parallax) -->
+  <g id="parallax-back">
+    <rect width="1600" height="800" fill="url(#grid)"></rect>
+    <rect width="1600" height="800" fill="url(#dots)" opacity="0.55"></rect>
+    <path d="M-40 610C190 520 320 540 560 610C820 688 1020 720 1300 640C1460 594 1560 530 1680 460" stroke="#CBD5F5" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M-60 260C160 210 320 250 540 300C780 360 960 330 1220 250C1400 195 1540 130 1700 90" stroke="#94A3B8" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Layer: mid (medium parallax) -->
+  <g id="parallax-mid" filter="url(#glow)">
+    <ellipse cx="1180" cy="240" rx="520" ry="360" fill="url(#glowBlue)" opacity="0.85"></ellipse>
+    <ellipse cx="520" cy="620" rx="560" ry="380" fill="url(#glowGreen)" opacity="0.75"></ellipse>
+    <ellipse cx="340" cy="180" rx="520" ry="360" fill="url(#glowViolet)" opacity="0.70"></ellipse>
+
+    <!-- “Circuit” strokes -->
+    <path d="M220 520H520C560 520 590 490 590 450V320C590 280 620 250 660 250H860" stroke="#38BDF8" stroke-opacity="0.35" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 560H1230C1270 560 1300 530 1300 490V360C1300 320 1330 290 1370 290H1500" stroke="#22C55E" stroke-opacity="0.28" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M860 250L910 250M590 320L640 320M1300 360L1355 360" stroke="#F8FAFC" stroke-opacity="0.20" stroke-width="3" stroke-linecap="round"></path>
+    <circle cx="520" cy="520" r="5.5" fill="#38BDF8" opacity="0.75"></circle>
+    <circle cx="590" cy="320" r="5.5" fill="#60A5FA" opacity="0.75"></circle>
+    <circle cx="1300" cy="560" r="5.5" fill="#22C55E" opacity="0.70"></circle>
+  </g>
+
+  <!-- Layer: front (faster parallax) -->
+  <g id="parallax-front" filter="url(#glass)">
+    <!-- Glass panels -->
+    <g opacity="0.75">
+      <path d="M1040 120C1040 102 1054 88 1072 88H1462C1480 88 1494 102 1494 120V310C1494 328 1480 342 1462 342H1072C1054 342 1040 328 1040 310V120Z" fill="#1E293B" fill-opacity="0.35" stroke="#CBD5F5" stroke-opacity="0.12"></path>
+      <path d="M120 420C120 402 134 388 152 388H620C638 388 652 402 652 420V660C652 678 638 692 620 692H152C134 692 120 678 120 660V420Z" fill="#111827" fill-opacity="0.30" stroke="#CBD5F5" stroke-opacity="0.10"></path>
+    </g>
+
+    <!-- Angular shards -->
+    <path d="M980 120L1120 80L1180 210L1040 250Z" fill="#38BDF8" fill-opacity="0.10"></path>
+    <path d="M300 320L520 260L590 360L370 430Z" fill="#82B1FF" fill-opacity="0.10"></path>
+    <path d="M1260 520L1500 480L1540 610L1300 660Z" fill="#22C55E" fill-opacity="0.10"></path>
+
+    <!-- Highlight lines -->
+    <path d="M152 430H610" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M1072 126H1462" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-3-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-3-1.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Abstract dark tech parallax background variant">
+  <defs>
+    <!-- Background -->
+    <linearGradient id="bg2" x1="0" y1="0" x2="1600" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.45" stop-color="#111827"></stop>
+      <stop offset="1" stop-color="#0F172A"></stop>
+    </linearGradient>
+
+    <!-- Diagonal atmosphere -->
+    <linearGradient id="atm2" x1="0" y1="760" x2="1600" y2="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#166534" stop-opacity="0.22"></stop>
+      <stop offset="0.5" stop-color="#1D4ED8" stop-opacity="0.30"></stop>
+      <stop offset="1" stop-color="#1E3A8A" stop-opacity="0.40"></stop>
+    </linearGradient>
+
+    <!-- Glows -->
+    <radialGradient id="gCyan2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 220) rotate(110) scale(560 520)">
+      <stop stop-color="#38BDF8" stop-opacity="0.95"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="gGreen2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 520) rotate(25) scale(640 520)">
+      <stop stop-color="#22C55E" stop-opacity="0.70"></stop>
+      <stop offset="0.6" stop-color="#22C55E" stop-opacity="0.22"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="gBlue2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1380 640) rotate(-20) scale(520 420)">
+      <stop stop-color="#82B1FF" stop-opacity="0.55"></stop>
+      <stop offset="0.6" stop-color="#90CAF9" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#82B1FF" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Subtle mesh gradient band -->
+    <linearGradient id="meshBand" x1="200" y1="140" x2="1400" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.10"></stop>
+      <stop offset="0.5" stop-color="#1D4ED8" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.10"></stop>
+    </linearGradient>
+
+    <!-- Patterns -->
+    <pattern id="thinGrid2" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M80 0H0V80" fill="none" stroke="#CBD5F5" stroke-opacity="0.06" stroke-width="1"></path>
+    </pattern>
+
+    <pattern id="microDots2" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="14" cy="18" r="0.9" fill="#F8FAFC" opacity="0.05"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vig2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(940 560)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur32" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="32"></feGaussianBlur>
+    </filter>
+
+    <filter id="softGlow2" x="-60%" y="-60%" width="220%" height="220%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.75 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glass2" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="7" result="bg"></feGaussianBlur>
+      <feColorMatrix in="bg" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.33 0" result="m"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="m"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain2" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1600" height="800" fill="url(#bg2)"></rect>
+  <rect width="1600" height="800" fill="url(#atm2)"></rect>
+
+  <!-- Layer: back (slow) -->
+  <g id="parallax-back">
+    <rect width="1600" height="800" fill="url(#thinGrid2)" opacity="0.85"></rect>
+    <rect width="1600" height="800" fill="url(#microDots2)" opacity="0.8"></rect>
+
+    <!-- Wide blurred wave band -->
+    <path d="M-40 560C180 470 350 500 560 560C820 635 1060 650 1320 560C1500 495 1620 420 1700 350" stroke="#94A3B8" stroke-opacity="0.10" stroke-width="18" filter="url(#blur32)"></path>
+  </g>
+
+  <!-- Layer: mid (medium) -->
+  <g id="parallax-mid" filter="url(#softGlow2)">
+    <ellipse cx="980" cy="220" rx="560" ry="380" fill="url(#gCyan2)" opacity="0.9"></ellipse>
+    <ellipse cx="520" cy="520" rx="640" ry="420" fill="url(#gGreen2)" opacity="0.8"></ellipse>
+    <ellipse cx="1380" cy="640" rx="520" ry="360" fill="url(#gBlue2)" opacity="0.75"></ellipse>
+
+    <!-- Mesh ribbon -->
+    <path d="M200 150C420 80 620 120 820 210C1010 295 1180 330 1400 280V410C1180 470 1020 450 820 360C620 265 420 230 200 300Z" fill="url(#meshBand)"></path>
+
+    <!-- “Constellation” nodes + links -->
+    <g opacity="0.75">
+      <path d="M360 250L520 320L700 240L890 310L1040 230" stroke="#38BDF8" stroke-opacity="0.28" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M520 520L680 460L860 520L1040 450L1220 520" stroke="#22C55E" stroke-opacity="0.22" stroke-width="2" stroke-linecap="round"></path>
+      <circle cx="360" cy="250" r="5.5" fill="#60A5FA" opacity="0.7"></circle>
+      <circle cx="520" cy="320" r="5.5" fill="#38BDF8" opacity="0.75"></circle>
+      <circle cx="700" cy="240" r="5.5" fill="#82B1FF" opacity="0.65"></circle>
+      <circle cx="890" cy="310" r="5.5" fill="#38BDF8" opacity="0.7"></circle>
+      <circle cx="1040" cy="230" r="5.5" fill="#60A5FA" opacity="0.7"></circle>
+
+      <circle cx="520" cy="520" r="5.5" fill="#22C55E" opacity="0.7"></circle>
+      <circle cx="680" cy="460" r="5.5" fill="#81C784" opacity="0.7"></circle>
+      <circle cx="860" cy="520" r="5.5" fill="#22C55E" opacity="0.7"></circle>
+      <circle cx="1040" cy="450" r="5.5" fill="#38BDF8" opacity="0.55"></circle>
+      <circle cx="1220" cy="520" r="5.5" fill="#22C55E" opacity="0.7"></circle>
+    </g>
+  </g>
+
+  <!-- Layer: front (fast) -->
+  <g id="parallax-front" filter="url(#glass2)">
+    <!-- Glass arc panel -->
+    <path d="M1000 110C1120 70 1290 85 1445 140C1505 162 1540 215 1540 280V318C1540 356 1510 386 1472 386H1030C992 386 960 356 960 318V230C960 175 972 134 1000 110Z" fill="#1E293B" fill-opacity="0.32" stroke="#CBD5F5" stroke-opacity="0.11"></path>
+
+    <!-- Lower glass slab -->
+    <path d="M110 520C110 488 136 462 168 462H650C682 462 708 488 708 520V675C708 707 682 733 650 733H168C136 733 110 707 110 675V520Z" fill="#111827" fill-opacity="0.28" stroke="#CBD5F5" stroke-opacity="0.10"></path>
+
+    <!-- Angular shards / highlights -->
+    <path d="M1060 160L1260 110L1320 220L1120 270Z" fill="#38BDF8" fill-opacity="0.11"></path>
+    <path d="M220 420L420 360L500 470L300 530Z" fill="#22C55E" fill-opacity="0.09"></path>
+    <path d="M1260 560L1500 520L1545 640L1300 690Z" fill="#82B1FF" fill-opacity="0.09"></path>
+
+    <path d="M168 505H650" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M1030 160H1472" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vig2)"></rect>
+  <g filter="url(#grain2)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-1-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-1-1.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with rising bubbles on the left">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Gentle ambient wash (keeps everything unified) -->
+    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.12"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.06"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Left-side bubble glow -->
+    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.22"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + highlight -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.32"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.38"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.18"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture / dots -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.55 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient2)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Left lane glow (so bubbles feel integrated) -->
+  <g id="parallax-back">
+    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
+    <!-- faint upward current -->
+    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#38BDF8" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Large bubbles -->
+    <g transform="translate(150 650)">
+      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
+      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(230 520)">
+      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(170 400)">
+      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
+      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(260 270)">
+      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
+      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(190 140)">
+      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
+      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (more “motion”) -->
+    <g opacity="0.75">
+      <g transform="translate(110 720)">
+        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(270 610)">
+        </g></g></g></svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-2-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-2-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising in the middle">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Center column glow -->
+    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.20"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Center column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
+    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(720 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(865 600)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(790 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(905 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(770 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(840 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (adds motion) -->
+    <g opacity="0.75">
+      <g transform="translate(690 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(925 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(720 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(950 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(700 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(930 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(735 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(905 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Very subtle tech accents (kept unified) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="1345" cy="320" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="1282" cy="513" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-3-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-3-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising on the right">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Right column glow -->
+    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.09"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Right column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
+    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(1375 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1235 610)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1310 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1195 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1330 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1250 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles -->
+    <g opacity="0.75">
+      <g transform="translate(1410 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1175 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1395 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1160 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1400 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1170 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1370 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1190 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Subtle tech accents on left (balances composition) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="335" cy="340" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="282" cy="528" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-1-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-1-1.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with rising bubbles on the left">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Gentle ambient wash (keeps everything unified) -->
+    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.12"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.06"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Left-side bubble glow -->
+    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.22"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + highlight -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.32"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.38"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.18"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture / dots -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.55 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient2)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Left lane glow (so bubbles feel integrated) -->
+  <g id="parallax-back">
+    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
+    <!-- faint upward current -->
+    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#38BDF8" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Large bubbles -->
+    <g transform="translate(150 650)">
+      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
+      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(230 520)">
+      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(170 400)">
+      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
+      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(260 270)">
+      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
+      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(190 140)">
+      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
+      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (more “motion”) -->
+    <g opacity="0.75">
+      <g transform="translate(110 720)">
+        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(270 610)">
+        </g></g></g></svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-2-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-2-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising in the middle">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Center column glow -->
+    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.20"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Center column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
+    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(720 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(865 600)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(790 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(905 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(770 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(840 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (adds motion) -->
+    <g opacity="0.75">
+      <g transform="translate(690 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(925 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(720 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(950 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(700 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(930 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(735 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(905 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Very subtle tech accents (kept unified) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="1345" cy="320" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="1282" cy="513" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-3-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-3-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising on the right">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0B1220"></stop>
+      <stop offset="0.55" stop-color="#0F172A"></stop>
+      <stop offset="1" stop-color="#111827"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Right column glow -->
+    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.09"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Right column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
+    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(1375 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1235 610)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1310 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1195 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1330 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1250 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles -->
+    <g opacity="0.75">
+      <g transform="translate(1410 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1175 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1395 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1160 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1400 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1170 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1370 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1190 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Subtle tech accents on left (balances composition) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="335" cy="340" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="282" cy="528" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-1-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-1-1.svg
@@ -1,0 +1,174 @@
+<!-- Save as: hero-parallax.svg  |  Height fixed at 800, responsive width -->
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="800" viewBox="0 0 1440 800" preserveAspectRatio="xMidYMid slice">
+  <title>Parallax Glass Tech Background</title>
+
+  <defs>
+    <!-- Core palette (from your tokens) -->
+    <!-- hero-gradient-start: #2F54C3 | mid: #4C82F3 | end: #2BA66D -->
+    <!-- accent-primary-highlight: #30B2F6 | accent-supporting: #30D17A | shadow-primary-600: #5D9CFF -->
+
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#F8FAFC"></stop>
+      <stop offset="0.35" stop-color="#EEF3FC"></stop>
+      <stop offset="0.55" stop-color="#2F54C3" stop-opacity="0.85"></stop>
+      <stop offset="0.72" stop-color="#4C82F3" stop-opacity="0.55"></stop>
+      <stop offset="1" stop-color="#2BA66D" stop-opacity="0.35"></stop>
+    </linearGradient>
+
+    <radialGradient id="glowBlue" cx="35%" cy="35%" r="60%">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.55"></stop>
+      <stop offset="0.45" stop-color="#5D9CFF" stop-opacity="0.22"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowGreen" cx="78%" cy="55%" r="65%">
+      <stop offset="0" stop-color="#30D17A" stop-opacity="0.38"></stop>
+      <stop offset="0.55" stop-color="#2BA66D" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowIce" cx="55%" cy="10%" r="60%">
+      <stop offset="0" stop-color="#9CC9FF" stop-opacity="0.35"></stop>
+      <stop offset="0.55" stop-color="#4C82F3" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Subtle grid -->
+    <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 H 0 V 48" fill="none" stroke="#C7E2FF" stroke-opacity="0.10" stroke-width="1"></path>
+      <path d="M 24 0 V 48 M 0 24 H 48" fill="none" stroke="#C7E2FF" stroke-opacity="0.06" stroke-width="1"></path>
+    </pattern>
+
+    <!-- Scanlines -->
+    <pattern id="scanlines" width="6" height="6" patternUnits="userSpaceOnUse">
+      <rect width="6" height="1" y="0" fill="#FFFFFF" opacity="0.06"></rect>
+    </pattern>
+
+    <!-- Noise overlay -->
+    <filter id="noise" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"></feTurbulence>
+      <feColorMatrix type="matrix" values="
+        1 0 0 0 0
+        0 1 0 0 0
+        0 0 1 0 0
+        0 0 0 0.12 0"></feColorMatrix>
+    </filter>
+
+    <!-- Soft glow -->
+    <filter id="softGlow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="18" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="
+        1 0 0 0 0
+        0 1 0 0 0
+        0 0 1 0 0
+        0 0 0 0.9 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Glass card feel -->
+    <filter id="glass" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur"></feGaussianBlur>
+      <feSpecularLighting in="blur" surfaceScale="2" specularConstant="0.35" specularExponent="24" lighting-color="#FFFFFF" result="spec">
+        <feDistantLight azimuth="220" elevation="35"></feDistantLight>
+      </feSpecularLighting>
+      <feComposite in="spec" in2="SourceAlpha" operator="in" result="specIn"></feComposite>
+      <feMerge>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+        <feMergeNode in="specIn"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="50%" cy="50%" r="70%">
+      <stop offset="55%" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="100%" stop-color="#F8FAFC" stop-opacity="0.78"></stop>
+    </radialGradient>
+
+    <!-- “Circuit” stroke gradient -->
+    <linearGradient id="circuitGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.9"></stop>
+      <stop offset="0.5" stop-color="#C7E2FF" stop-opacity="0.55"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.8"></stop>
+    </linearGradient>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1440" height="800" fill="#F8FAFC"></rect>
+
+  <!-- LAYER 0: background gradient + large glows -->
+  <g id="layer0" data-depth="0.06">
+    <rect width="1440" height="800" fill="url(#bgGrad)"></rect>
+    <ellipse cx="520" cy="280" rx="640" ry="460" fill="url(#glowBlue)"></ellipse>
+    <ellipse cx="1120" cy="470" rx="760" ry="520" fill="url(#glowGreen)"></ellipse>
+    <ellipse cx="820" cy="120" rx="640" ry="360" fill="url(#glowIce)"></ellipse>
+  </g>
+
+  <!-- LAYER 1: blurred “nebula” blobs (parallax friendly) -->
+  <g id="layer1" data-depth="0.12" filter="url(#softGlow)" style="mix-blend-mode:screen">
+    <path d="M190,610 C280,500 460,520 560,430 C680,320 610,210 760,170 C930,125 980,250 1100,310 C1240,380 1360,360 1440,300 L1440,800 L0,800 Z" fill="#4C82F3" opacity="0.14"></path>
+    <path d="M0,520 C140,470 280,520 420,470 C600,405 640,290 820,260 C1010,225 1080,340 1230,390 C1320,420 1380,400 1440,360 L1440,800 L0,800 Z" fill="#30D17A" opacity="0.10"></path>
+    <path d="M0,240 C160,190 290,230 430,190 C620,130 700,40 880,60 C1070,80 1160,170 1320,210 C1390,228 1420,220 1440,210 L1440,0 L0,0 Z" fill="#30B2F6" opacity="0.10"></path>
+  </g>
+
+  <!-- LAYER 2: grid + scanlines + noise -->
+  <g id="layer2" data-depth="0.18">
+    <rect width="1440" height="800" fill="url(#grid)" opacity="0.65"></rect>
+    <rect width="1440" height="800" fill="url(#scanlines)" opacity="0.25"></rect>
+    <rect width="1440" height="800" filter="url(#noise)" opacity="0.55"></rect>
+  </g>
+
+  <!-- LAYER 3: circuits + particles -->
+  <g id="layer3" data-depth="0.28" opacity="0.95">
+    <g fill="none" stroke="url(#circuitGrad)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" opacity="0.55">
+      <path d="M120 560 H420 Q460 560 460 520 V420 Q460 380 500 380 H680"></path>
+      <path d="M220 220 H520 Q560 220 560 260 V310 Q560 350 600 350 H820 Q860 350 860 310 V250"></path>
+      <path d="M860 520 H1040 Q1100 520 1100 460 V360 Q1100 320 1140 320 H1320"></path>
+      <path d="M980 160 H1140 Q1180 160 1180 200 V260 Q1180 300 1220 300 H1340"></path>
+      <path d="M80 360 H240 Q300 360 300 300 V240 Q300 200 340 200 H420"></path>
+    </g>
+
+    <!-- Nodes -->
+    <g opacity="0.75" style="mix-blend-mode:screen">
+      <circle cx="460" cy="520" r="5" fill="#30B2F6"></circle>
+      <circle cx="560" cy="260" r="5" fill="#C7E2FF"></circle>
+      <circle cx="1100" cy="460" r="5" fill="#30D17A"></circle>
+      <circle cx="1180" cy="200" r="5" fill="#9CC9FF"></circle>
+      <circle cx="300" cy="300" r="5" fill="#5D9CFF"></circle>
+      <circle cx="680" cy="380" r="4" fill="#30B2F6"></circle>
+      <circle cx="1320" cy="320" r="4" fill="#30D17A"></circle>
+      <circle cx="860" cy="250" r="4" fill="#C7E2FF"></circle>
+    </g>
+
+    <!-- Floating particles -->
+    <g opacity="0.55">
+      <circle cx="180" cy="120" r="2" fill="#E4EBFF"></circle>
+      <circle cx="260" cy="640" r="2" fill="#E4EBFF"></circle>
+      <circle cx="720" cy="690" r="2" fill="#E4EBFF"></circle>
+      <circle cx="1180" cy="110" r="2" fill="#E4EBFF"></circle>
+      <circle cx="1320" cy="610" r="2" fill="#E4EBFF"></circle>
+      <circle cx="980" cy="420" r="2" fill="#E4EBFF"></circle>
+    </g>
+  </g>
+
+  <!-- LAYER 4: glassmorphism cards (optional depth elements) -->
+  <g id="layer4" data-depth="0.38">
+    <g filter="url(#glass)" opacity="0.92">
+      <rect x="120" y="120" width="420" height="170" rx="22" fill="#DFE7F4" fill-opacity="0.42" stroke="#C7E2FF" stroke-opacity="0.22"></rect>
+      <rect x="860" y="480" width="460" height="190" rx="24" fill="#E4E7EF" fill-opacity="0.40" stroke="#30B2F6" stroke-opacity="0.20"></rect>
+      <rect x="560" y="310" width="320" height="140" rx="22" fill="#F4F7FC" fill-opacity="0.42" stroke="#30D17A" stroke-opacity="0.16"></rect>
+    </g>
+
+    <!-- Card highlights -->
+    <g opacity="0.35" style="mix-blend-mode:screen">
+      <path d="M150 150 H500" stroke="#30B2F6" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M590 340 H850" stroke="#9CC9FF" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M890 510 H1280" stroke="#30D17A" stroke-width="2" stroke-linecap="round"></path>
+    </g>
+  </g>
+
+  <!-- Vignette for focus -->
+  <rect width="1440" height="800" fill="url(#vignette)"></rect>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-2-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-2-1.svg
@@ -1,0 +1,142 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Abstract dark tech parallax background">
+  <defs>
+    <!-- Core background -->
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F4F7FC"></stop>
+      <stop offset="0.45" stop-color="#DFE7F4"></stop>
+      <stop offset="1" stop-color="#EEF3FC"></stop>
+    </linearGradient>
+
+    <!-- Hero-ish sweep -->
+    <linearGradient id="heroSweep" x1="1600" y1="0" x2="200" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2F54C3" stop-opacity="0.55"></stop>
+      <stop offset="0.55" stop-color="#4C82F3" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#2BA66D" stop-opacity="0.25"></stop>
+    </linearGradient>
+
+    <!-- Glow fills -->
+    <radialGradient id="glowBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 240) rotate(110) scale(520 520)">
+      <stop stop-color="#30B2F6" stop-opacity="0.95"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 620) rotate(25) scale(560 460)">
+      <stop stop-color="#30D17A" stop-opacity="0.75"></stop>
+      <stop offset="0.55" stop-color="#30D17A" stop-opacity="0.25"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="glowViolet" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(340 180) rotate(15) scale(520 420)">
+      <stop stop-color="#A7C4FF" stop-opacity="0.60"></stop>
+      <stop offset="0.6" stop-color="#C7E2FF" stop-opacity="0.20"></stop>
+      <stop offset="1" stop-color="#A7C4FF" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Grid / dots -->
+    <pattern id="grid" width="90" height="90" patternUnits="userSpaceOnUse">
+      <path d="M90 0H0V90" fill="none" stroke="#CBD5E1" stroke-opacity="0.08" stroke-width="1"></path>
+      <path d="M0 45H90M45 0V90" fill="none" stroke="#E4EBFF" stroke-opacity="0.04" stroke-width="1"></path>
+    </pattern>
+
+    <pattern id="dots" width="34" height="34" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.2" fill="#F8FAFC" opacity="0.08"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(900 520)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.55"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur40" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="40"></feGaussianBlur>
+    </filter>
+
+    <filter id="glow" x="-60%" y="-60%" width="220%" height="220%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.85 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glass" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="6" result="bg"></feGaussianBlur>
+      <feColorMatrix in="bg" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.35 0" result="m"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="m"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <!-- Subtle grain -->
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.18 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1600" height="800" fill="url(#bg)"></rect>
+  <rect width="1600" height="800" fill="url(#heroSweep)" opacity="0.85"></rect>
+
+  <!-- Layer: far back (slow parallax) -->
+  <g id="parallax-back">
+    <rect width="1600" height="800" fill="url(#grid)"></rect>
+    <rect width="1600" height="800" fill="url(#dots)" opacity="0.55"></rect>
+    <path d="M-40 610C190 520 320 540 560 610C820 688 1020 720 1300 640C1460 594 1560 530 1680 460" stroke="#E4EBFF" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M-60 260C160 210 320 250 540 300C780 360 960 330 1220 250C1400 195 1540 130 1700 90" stroke="#CBD5E1" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Layer: mid (medium parallax) -->
+  <g id="parallax-mid" filter="url(#glow)">
+    <ellipse cx="1180" cy="240" rx="520" ry="360" fill="url(#glowBlue)" opacity="0.85"></ellipse>
+    <ellipse cx="520" cy="620" rx="560" ry="380" fill="url(#glowGreen)" opacity="0.75"></ellipse>
+    <ellipse cx="340" cy="180" rx="520" ry="360" fill="url(#glowViolet)" opacity="0.70"></ellipse>
+
+    <!-- “Circuit” strokes -->
+    <path d="M220 520H520C560 520 590 490 590 450V320C590 280 620 250 660 250H860" stroke="#30B2F6" stroke-opacity="0.35" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 560H1230C1270 560 1300 530 1300 490V360C1300 320 1330 290 1370 290H1500" stroke="#30D17A" stroke-opacity="0.28" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M860 250L910 250M590 320L640 320M1300 360L1355 360" stroke="#F8FAFC" stroke-opacity="0.20" stroke-width="3" stroke-linecap="round"></path>
+    <circle cx="520" cy="520" r="5.5" fill="#30B2F6" opacity="0.75"></circle>
+    <circle cx="590" cy="320" r="5.5" fill="#8BC4FF" opacity="0.75"></circle>
+    <circle cx="1300" cy="560" r="5.5" fill="#30D17A" opacity="0.70"></circle>
+  </g>
+
+  <!-- Layer: front (faster parallax) -->
+  <g id="parallax-front" filter="url(#glass)">
+    <!-- Glass panels -->
+    <g opacity="0.75">
+      <path d="M1040 120C1040 102 1054 88 1072 88H1462C1480 88 1494 102 1494 120V310C1494 328 1480 342 1462 342H1072C1054 342 1040 328 1040 310V120Z" fill="#DFE7F4" fill-opacity="0.35" stroke="#E4EBFF" stroke-opacity="0.12"></path>
+      <path d="M120 420C120 402 134 388 152 388H620C638 388 652 402 652 420V660C652 678 638 692 620 692H152C134 692 120 678 120 660V420Z" fill="#E4E7EF" fill-opacity="0.30" stroke="#E4EBFF" stroke-opacity="0.10"></path>
+    </g>
+
+    <!-- Angular shards -->
+    <path d="M980 120L1120 80L1180 210L1040 250Z" fill="#30B2F6" fill-opacity="0.10"></path>
+    <path d="M300 320L520 260L590 360L370 430Z" fill="#A7C4FF" fill-opacity="0.10"></path>
+    <path d="M1260 520L1500 480L1540 610L1300 660Z" fill="#30D17A" fill-opacity="0.10"></path>
+
+    <!-- Highlight lines -->
+    <path d="M152 430H610" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M1072 126H1462" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-3-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-3-1.svg
@@ -1,0 +1,160 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Abstract dark tech parallax background variant">
+  <defs>
+    <!-- Background -->
+    <linearGradient id="bg2" x1="0" y1="0" x2="1600" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EEF3FC"></stop>
+      <stop offset="0.45" stop-color="#E4E7EF"></stop>
+      <stop offset="1" stop-color="#F4F7FC"></stop>
+    </linearGradient>
+
+    <!-- Diagonal atmosphere -->
+    <linearGradient id="atm2" x1="0" y1="760" x2="1600" y2="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2BA66D" stop-opacity="0.22"></stop>
+      <stop offset="0.5" stop-color="#4C82F3" stop-opacity="0.30"></stop>
+      <stop offset="1" stop-color="#2F54C3" stop-opacity="0.40"></stop>
+    </linearGradient>
+
+    <!-- Glows -->
+    <radialGradient id="gCyan2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 220) rotate(110) scale(560 520)">
+      <stop stop-color="#30B2F6" stop-opacity="0.95"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.35"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="gGreen2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(520 520) rotate(25) scale(640 520)">
+      <stop stop-color="#30D17A" stop-opacity="0.70"></stop>
+      <stop offset="0.6" stop-color="#30D17A" stop-opacity="0.22"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="gBlue2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1380 640) rotate(-20) scale(520 420)">
+      <stop stop-color="#A7C4FF" stop-opacity="0.55"></stop>
+      <stop offset="0.6" stop-color="#C7E2FF" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#A7C4FF" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Subtle mesh gradient band -->
+    <linearGradient id="meshBand" x1="200" y1="140" x2="1400" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.10"></stop>
+      <stop offset="0.5" stop-color="#4C82F3" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.10"></stop>
+    </linearGradient>
+
+    <!-- Patterns -->
+    <pattern id="thinGrid2" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M80 0H0V80" fill="none" stroke="#E4EBFF" stroke-opacity="0.06" stroke-width="1"></path>
+    </pattern>
+
+    <pattern id="microDots2" width="28" height="28" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="14" cy="18" r="0.9" fill="#F8FAFC" opacity="0.05"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vig2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(940 560)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur32" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="32"></feGaussianBlur>
+    </filter>
+
+    <filter id="softGlow2" x="-60%" y="-60%" width="220%" height="220%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="16" result="b"></feGaussianBlur>
+      <feColorMatrix in="b" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.75 0" result="g"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="g"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glass2" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="7" result="bg"></feGaussianBlur>
+      <feColorMatrix in="bg" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.33 0" result="m"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="m"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain2" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Base -->
+  <rect width="1600" height="800" fill="url(#bg2)"></rect>
+  <rect width="1600" height="800" fill="url(#atm2)"></rect>
+
+  <!-- Layer: back (slow) -->
+  <g id="parallax-back">
+    <rect width="1600" height="800" fill="url(#thinGrid2)" opacity="0.85"></rect>
+    <rect width="1600" height="800" fill="url(#microDots2)" opacity="0.8"></rect>
+
+    <!-- Wide blurred wave band -->
+    <path d="M-40 560C180 470 350 500 560 560C820 635 1060 650 1320 560C1500 495 1620 420 1700 350" stroke="#CBD5E1" stroke-opacity="0.10" stroke-width="18" filter="url(#blur32)"></path>
+  </g>
+
+  <!-- Layer: mid (medium) -->
+  <g id="parallax-mid" filter="url(#softGlow2)">
+    <ellipse cx="980" cy="220" rx="560" ry="380" fill="url(#gCyan2)" opacity="0.9"></ellipse>
+    <ellipse cx="520" cy="520" rx="640" ry="420" fill="url(#gGreen2)" opacity="0.8"></ellipse>
+    <ellipse cx="1380" cy="640" rx="520" ry="360" fill="url(#gBlue2)" opacity="0.75"></ellipse>
+
+    <!-- Mesh ribbon -->
+    <path d="M200 150C420 80 620 120 820 210C1010 295 1180 330 1400 280V410C1180 470 1020 450 820 360C620 265 420 230 200 300Z" fill="url(#meshBand)"></path>
+
+    <!-- “Constellation” nodes + links -->
+    <g opacity="0.75">
+      <path d="M360 250L520 320L700 240L890 310L1040 230" stroke="#30B2F6" stroke-opacity="0.28" stroke-width="2" stroke-linecap="round"></path>
+      <path d="M520 520L680 460L860 520L1040 450L1220 520" stroke="#30D17A" stroke-opacity="0.22" stroke-width="2" stroke-linecap="round"></path>
+      <circle cx="360" cy="250" r="5.5" fill="#8BC4FF" opacity="0.7"></circle>
+      <circle cx="520" cy="320" r="5.5" fill="#30B2F6" opacity="0.75"></circle>
+      <circle cx="700" cy="240" r="5.5" fill="#A7C4FF" opacity="0.65"></circle>
+      <circle cx="890" cy="310" r="5.5" fill="#30B2F6" opacity="0.7"></circle>
+      <circle cx="1040" cy="230" r="5.5" fill="#8BC4FF" opacity="0.7"></circle>
+
+      <circle cx="520" cy="520" r="5.5" fill="#30D17A" opacity="0.7"></circle>
+      <circle cx="680" cy="460" r="5.5" fill="#81C784" opacity="0.7"></circle>
+      <circle cx="860" cy="520" r="5.5" fill="#30D17A" opacity="0.7"></circle>
+      <circle cx="1040" cy="450" r="5.5" fill="#30B2F6" opacity="0.55"></circle>
+      <circle cx="1220" cy="520" r="5.5" fill="#30D17A" opacity="0.7"></circle>
+    </g>
+  </g>
+
+  <!-- Layer: front (fast) -->
+  <g id="parallax-front" filter="url(#glass2)">
+    <!-- Glass arc panel -->
+    <path d="M1000 110C1120 70 1290 85 1445 140C1505 162 1540 215 1540 280V318C1540 356 1510 386 1472 386H1030C992 386 960 356 960 318V230C960 175 972 134 1000 110Z" fill="#DFE7F4" fill-opacity="0.32" stroke="#E4EBFF" stroke-opacity="0.11"></path>
+
+    <!-- Lower glass slab -->
+    <path d="M110 520C110 488 136 462 168 462H650C682 462 708 488 708 520V675C708 707 682 733 650 733H168C136 733 110 707 110 675V520Z" fill="#E4E7EF" fill-opacity="0.28" stroke="#E4EBFF" stroke-opacity="0.10"></path>
+
+    <!-- Angular shards / highlights -->
+    <path d="M1060 160L1260 110L1320 220L1120 270Z" fill="#30B2F6" fill-opacity="0.11"></path>
+    <path d="M220 420L420 360L500 470L300 530Z" fill="#30D17A" fill-opacity="0.09"></path>
+    <path d="M1260 560L1500 520L1545 640L1300 690Z" fill="#A7C4FF" fill-opacity="0.09"></path>
+
+    <path d="M168 505H650" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+    <path d="M1030 160H1472" stroke="#F8FAFC" stroke-opacity="0.10" stroke-width="2"></path>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vig2)"></rect>
+  <g filter="url(#grain2)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-1-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-1-1.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with rising bubbles on the left">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EEF3FC"></stop>
+      <stop offset="0.55" stop-color="#F4F7FC"></stop>
+      <stop offset="1" stop-color="#E4E7EF"></stop>
+    </linearGradient>
+
+    <!-- Gentle ambient wash (keeps everything unified) -->
+    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
+      <stop offset="0" stop-color="#4C82F3" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#2F54C3" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#4C82F3" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#30D17A" stop-opacity="0.12"></stop>
+      <stop offset="0.7" stop-color="#30D17A" stop-opacity="0.06"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Left-side bubble glow -->
+    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.22"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + highlight -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
+      <stop offset="0.35" stop-color="#30B2F6" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#E4EBFF" stop-opacity="0.32"></stop>
+      <stop offset="0.55" stop-color="#30B2F6" stop-opacity="0.38"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.18"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture / dots -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.55 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient)"></rect>
+  <rect width="1600" height="800" fill="url(#ambient2)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Left lane glow (so bubbles feel integrated) -->
+  <g id="parallax-back">
+    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
+    <!-- faint upward current -->
+    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#30B2F6" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Large bubbles -->
+    <g transform="translate(150 650)">
+      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
+      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(230 520)">
+      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(170 400)">
+      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
+      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(260 270)">
+      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
+      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(190 140)">
+      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
+      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (more “motion”) -->
+    <g opacity="0.75">
+      <g transform="translate(110 720)">
+        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(270 610)">
+        </g></g></g></svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-2-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-2-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising in the middle">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EEF3FC"></stop>
+      <stop offset="0.55" stop-color="#F4F7FC"></stop>
+      <stop offset="1" stop-color="#E4E7EF"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#4C82F3" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#2F54C3" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#4C82F3" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#30D17A" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#30D17A" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Center column glow -->
+    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.20"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#30B2F6" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#E4EBFF" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#30B2F6" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Center column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
+    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#30B2F6" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(720 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(865 600)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(790 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(905 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(770 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(840 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (adds motion) -->
+    <g opacity="0.75">
+      <g transform="translate(690 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(925 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(720 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(950 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(700 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(930 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(735 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(905 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Very subtle tech accents (kept unified) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#8BC4FF" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#30D17A" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="1345" cy="320" r="5" fill="#30B2F6" opacity="0.30"></circle>
+    <circle cx="1282" cy="513" r="5" fill="#30D17A" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-3-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-3-1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising on the right">
+  <defs>
+    <!-- Unified base background -->
+    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EEF3FC"></stop>
+      <stop offset="0.55" stop-color="#F4F7FC"></stop>
+      <stop offset="1" stop-color="#E4E7EF"></stop>
+    </linearGradient>
+
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#4C82F3" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#2F54C3" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#4C82F3" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#30D17A" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#30D17A" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Right column glow -->
+    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.09"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#30B2F6" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#E4EBFF" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#30B2F6" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Unified background -->
+  <rect width="1600" height="800" fill="url(#base)"></rect>
+  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
+  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
+  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+
+  <!-- Right column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
+    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#30B2F6" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(1375 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1235 610)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1310 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1195 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1330 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1250 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles -->
+    <g opacity="0.75">
+      <g transform="translate(1410 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1175 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1395 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1160 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1400 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1170 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1370 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1190 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Subtle tech accents on left (balances composition) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#8BC4FF" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#30D17A" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="335" cy="340" r="5" fill="#30B2F6" opacity="0.30"></circle>
+    <circle cx="282" cy="528" r="5" fill="#30D17A" opacity="0.26"></circle>
+  </g>
+
+  <!-- Vignette + grain -->
+  <rect width="1600" height="800" fill="url(#vignette)"></rect>
+  <g filter="url(#grain)">
+    <rect width="1600" height="800" fill="transparent"></rect>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-1-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-1-1.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Transparent parallax background with rising bubbles on the left">
+  <defs>
+    <!-- Gentle ambient wash (keeps everything unified) -->
+    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
+      <stop offset="0" stop-color="#4C82F3" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#2F54C3" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#4C82F3" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#30D17A" stop-opacity="0.12"></stop>
+      <stop offset="0.7" stop-color="#30D17A" stop-opacity="0.06"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Left-side bubble glow -->
+    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
+      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.22"></stop>
+      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + highlight -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
+      <stop offset="0.35" stop-color="#30B2F6" stop-opacity="0.18"></stop>
+      <stop offset="1" stop-color="#30B2F6" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#E4EBFF" stop-opacity="0.32"></stop>
+      <stop offset="0.55" stop-color="#30B2F6" stop-opacity="0.38"></stop>
+      <stop offset="1" stop-color="#30D17A" stop-opacity="0.18"></stop>
+    </linearGradient>
+
+    <!-- Subtle texture / dots -->
+    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
+      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    </pattern>
+
+    <!-- Soft vignette -->
+    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
+      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    </radialGradient>
+
+    <!-- Filters -->
+    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.55 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
+      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0 0
+                0 0 0 0.16 0" result="a"></feColorMatrix>
+      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    </filter>
+  </defs>
+
+  <!-- Left lane glow (so bubbles feel integrated) -->
+  <g id="parallax-back">
+    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
+    <!-- faint upward current -->
+    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#30B2F6" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Large bubbles -->
+    <g transform="translate(150 650)">
+      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
+      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(230 520)">
+      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(170 400)">
+      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
+      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(260 270)">
+      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
+      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(190 140)">
+      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
+      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (more “motion”) -->
+    <g opacity="0.75">
+      <g transform="translate(110 720)">
+        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(270 610)">
+        <circle cx="0" cy="0" r="5" fill="none" stroke="url(#bubbleStroke)" stroke-width="1" opacity="0.6"></circle>
+      </g>
+      <g transform="translate(180 80)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)" opacity="0.6"></circle>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-2-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-2-1.svg
@@ -1,0 +1,151 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Transparent parallax background with bubbles rising in the middle">
+  <defs>
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Center column glow -->
+    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.20"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.10"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Center column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
+    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(720 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(865 600)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(790 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(905 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(770 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(840 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles (adds motion) -->
+    <g opacity="0.75">
+      <g transform="translate(690 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(925 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(720 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(950 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(700 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(930 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(735 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(905 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Very subtle tech accents (kept unified) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="1345" cy="320" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="1282" cy="513" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-3-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-3-1.svg
@@ -1,0 +1,151 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" fill="none" role="img" aria-label="Transparent parallax background with bubbles rising on the right">
+  <defs>
+    <!-- Ambient washes -->
+    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
+      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
+      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
+      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
+      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Right column glow -->
+    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
+      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.18"></stop>
+      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.09"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
+    </radialGradient>
+
+    <!-- Bubble fill + stroke -->
+    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
+      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
+    </radialGradient>
+
+    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
+      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
+      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    </linearGradient>
+
+    <!-- Filters -->
+    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    </filter>
+
+    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
+      <feMerge>
+        <feMergeNode in="b"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
+      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
+                0 1 0 0 0
+                0 0 1 0 0
+                0 0 0 0.52 0" result="ga"></feColorMatrix>
+      <feMerge>
+        <feMergeNode in="ga"></feMergeNode>
+        <feMergeNode in="SourceGraphic"></feMergeNode>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Right column glow + “current” -->
+  <g id="parallax-back">
+    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
+    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  </g>
+
+  <!-- Bubble column (move this group for parallax) -->
+  <g id="parallax-bubbles" filter="url(#glow)">
+    <!-- Big / medium bubbles -->
+    <g transform="translate(1375 675)">
+      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
+      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
+      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1235 610)">
+      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
+      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
+      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1310 470)">
+      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
+      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
+      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1195 350)">
+      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
+      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1330 210)">
+      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
+      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <g transform="translate(1250 95)">
+      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
+      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    </g>
+
+    <!-- Small bubbles -->
+    <g opacity="0.75">
+      <g transform="translate(1410 735)">
+        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1175 700)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1395 560)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1160 510)">
+        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1400 360)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1170 280)">
+        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1370 125)">
+        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
+      </g>
+      <g transform="translate(1190 60)">
+        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
+        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
+      </g>
+    </g>
+  </g>
+
+  <!-- Subtle tech accents on left (balances composition) -->
+  <g id="parallax-front" opacity="0.9">
+    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
+    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
+    <circle cx="335" cy="340" r="5" fill="#38BDF8" opacity="0.30"></circle>
+    <circle cx="282" cy="528" r="5" fill="#22C55E" opacity="0.26"></circle>
+  </g>
+</svg>

--- a/frontend/app/components/home/sections/HomeFeaturesSection.vue
+++ b/frontend/app/components/home/sections/HomeFeaturesSection.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
+import { useThemedAsset } from '~/composables/useThemedAsset'
 
 type FeatureCard = {
   icon: string
@@ -12,14 +14,21 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+
+const parallaxBackground = useThemedAsset(
+  'parallax/parallax-background-bubbles-transparent-1-1.svg'
+)
+
+const backgrounds = computed(() =>
+  parallaxBackground.value ? [parallaxBackground.value] : []
+)
 </script>
 
 <template>
   <ParallaxSection
     class="home-features"
     aria-label="home-features-title"
-    :background-light="'/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg'"
-    :background-dark="'/assets/themes/dark/parallax/parallax-background-bubbles-1.svg'"
+    :backgrounds="backgrounds"
     :parallax-amount="0.12"
   >
     <div class="home-features__inner">

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
+import { useThemedAsset } from '~/composables/useThemedAsset'
 
 type SolutionBenefit = {
   emoji: string
@@ -16,6 +17,14 @@ const { t } = useI18n()
 
 const sectionTitle = computed(() => t('home.solution.title'))
 const sectionDescription = computed(() => t('home.solution.description'))
+
+const parallaxBackground = useThemedAsset(
+  'parallax/parallax-background-bubbles-transparent-1-1.svg'
+)
+
+const backgrounds = computed(() =>
+  parallaxBackground.value ? [parallaxBackground.value] : []
+)
 </script>
 
 <template>
@@ -23,8 +32,7 @@ const sectionDescription = computed(() => t('home.solution.description'))
     id="home-solution"
     class="home-solution"
     aria-label="home-solution-title"
-    :background-light="'/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg'"
-    :background-dark="'/assets/themes/dark/parallax/parallax-background-bubbles-1.svg'"
+    :backgrounds="backgrounds"
     :parallax-amount="0.16"
   >
     <div class="home-solution__inner">

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -56,22 +56,22 @@ type ParallaxSectionId =
 
 const parallaxAssetPaths: Record<ParallaxSectionId, string[]> = {
   essentials: [
-    'parallax/parallax-background-1.svg',
-    'parallax/parallax-background-bubbles-1.svg',
+    'parallax/parallax-background-1-1.svg',
+    'parallax/parallax-background-bubbles-1-1.svg',
   ],
   features: [
-    'parallax/parallax-background-2.svg',
-    'parallax/parallax-background-bubbles-2.svg',
+    'parallax/parallax-background-2-1.svg',
+    'parallax/parallax-background-bubbles-2-1.svg',
   ],
   blog: [
-    'parallax/parallax-background-3.svg',
-    'parallax/parallax-background-bubbles-3.svg',
+    'parallax/parallax-background-3-1.svg',
+    'parallax/parallax-background-bubbles-3-1.svg',
   ],
   objections: [
-    'parallax/parallax-background-1.svg',
-    'parallax/parallax-background-bubbles-1.svg',
+    'parallax/parallax-background-1-1.svg',
+    'parallax/parallax-background-bubbles-1-1.svg',
   ],
-  cta: ['parallax/parallax-background-2.svg'],
+  cta: ['parallax/parallax-background-2-1.svg'],
 }
 
 const parallaxAssets = Object.fromEntries(


### PR DESCRIPTION
## Summary
- add light and dark parallax asset variants with the new `*-1` naming
- point home page parallax layers to the updated themed asset filenames
- use themed parallax backgrounds for the features and solution sections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694277f6b9508322a716566354b1875c)