### PR TITLE
Improve home hero helper links and layout

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -15,7 +15,14 @@ const messages: Record<string, string> = {
 }
 
 const helperItems = [
-  { icon: '🌿', label: 'Une évaluation écologique et environnementale unique' },
+  {
+    icon: '🌿',
+    label: 'Une évaluation écologique et environnementale unique',
+    segments: [
+      { text: 'Une évaluation écologique', to: '/impact-score' },
+      { text: ' et environnementale unique' },
+    ],
+  },
 ]
 
 vi.mock('vue-i18n', () => ({
@@ -51,6 +58,23 @@ const VImgStub = defineComponent({
   },
 })
 
+const NuxtLinkStub = defineComponent({
+  name: 'NuxtLinkStub',
+  setup(_, { slots, attrs }) {
+    return () =>
+      h(
+        'a',
+        {
+          class: attrs.class,
+          href:
+            (attrs as { to?: string; href?: string }).to ??
+            (attrs as { href?: string }).href,
+        },
+        slots.default ? slots.default() : []
+      )
+  },
+})
+
 const mountComponent = async () =>
   mountSuspended(HomeHeroSection, {
     props: {
@@ -69,6 +93,7 @@ const mountComponent = async () =>
         VImg: VImgStub,
         VBtn: createStub('button'),
         RoundedCornerCard: createStub('div', 'rounded-corner-card-stub'),
+        NuxtLink: NuxtLinkStub,
       },
     },
   })
@@ -101,6 +126,18 @@ describe('HomeHeroSection', () => {
     const icon = wrapper.find('.home-hero__icon')
 
     expect(icon.classes()).toContain('home-hero__icon--pulse')
+
+    await wrapper.unmount()
+  })
+
+  it('renders helper text with linked segments', async () => {
+    const wrapper = await mountComponent()
+    const helperText = wrapper.find('.home-hero__helper-text')
+    const helperLink = helperText.find('.home-hero__helper-link')
+
+    expect(helperText.text()).toContain(helperItems[0].label)
+    expect(helperLink.exists()).toBe(true)
+    expect(helperLink.attributes('href')).toBe('/impact-score')
 
     await wrapper.unmount()
   })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -55,7 +55,11 @@
         "helpers": [
           {
             "icon": "🌿",
-            "label": "A unique ecological and environmental assessment"
+            "label": "A unique ecological and environmental assessment",
+            "segments": [
+              { "text": "A unique ecological assessment", "to": "/impact-score" },
+              { "text": " and environmental review" }
+            ]
           },
           {
             "icon": "🏷️",
@@ -63,7 +67,13 @@
           },
           {
             "icon": "🛡️",
-            "label": "Independent comparator, open-source software and open data"
+            "label": "Independent comparator, open-source software and open data",
+            "segments": [
+              { "text": "Independent comparator, " },
+              { "text": "open-source software", "to": "/opensource" },
+              { "text": " and " },
+              { "text": "open data", "to": "/opendata" }
+            ]
           }
         ]
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -55,11 +55,21 @@
         "helpers": [
           {
             "icon": "🌿",
-            "label": "Une évaluation écologique et environnementale unique"
+            "label": "Une évaluation écologique et environnementale unique",
+            "segments": [
+              { "text": "Une évaluation écologique", "to": "/impact-score" },
+              { "text": " et environnementale unique" }
+            ]
           },
           {
             "icon": "🛡️",
-            "label": "100% indépendant, logiciel libre et données ouvertes"
+            "label": "100% indépendant, logiciel libre et données ouvertes",
+            "segments": [
+              { "text": "100% indépendant, " },
+              { "text": "logiciel libre", "to": "/opensource" },
+              { "text": " et " },
+              { "text": "données ouvertes", "to": "/opendata" }
+            ]
           },
           {
             "icon": "🏷️",


### PR DESCRIPTION
## Summary
- reduce the home hero PWA icon size, tweak helper spacing, and remove the bottom-right accent corner
- add linked helper segments for impact score, open source, and open data with updated i18n entries
- adjust the HomeHeroSection unit test to cover linked helper rendering

## Testing
- pnpm lint
- pnpm vitest run app/components/home/sections/HomeHeroSection.spec.ts
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942878f329483229d1f5df48c34b5d7)