### PR TITLE
Add seasonal parallax packs and gapless section controls

### DIFF
--- a/frontend/app/components/shared/ui/ParallaxSection.vue
+++ b/frontend/app/components/shared/ui/ParallaxSection.vue
@@ -12,14 +12,16 @@ const props = withDefaults(
     backgroundDark?: string
     overlayColor?: string
     overlayOpacity?: number
-    minHeight?: string
-    paddingY?: string
+    minHeight?: string | null
+    paddingY?: string | null
+    containerPadding?: string | null
     parallaxAmount?: number
     disableParallaxBelow?: number
     maxWidth?: string
     contentAlign?: 'start' | 'center'
     enableAplats?: boolean
     aplatSvg?: string
+    gapless?: boolean
   }>(),
   {
     id: undefined,
@@ -31,12 +33,14 @@ const props = withDefaults(
     overlayOpacity: 0.42,
     minHeight: '75vh',
     paddingY: 'clamp(3rem, 8vw, 5.5rem)',
+    containerPadding: 'clamp(1.5rem, 5vw, 4rem)',
     parallaxAmount: 0.18,
     disableParallaxBelow: 960,
     maxWidth: '1180px',
     contentAlign: 'start',
     enableAplats: false,
     aplatSvg: '/images/home/parallax-aplats.svg',
+    gapless: false,
   }
 )
 
@@ -112,11 +116,13 @@ const mediaStyles = computed<CSSProperties>(() => ({
   '--parallax-overlay-color': props.overlayColor,
   '--parallax-overlay-opacity': props.overlayOpacity,
   '--parallax-offset': parallaxOffset.value,
-  minHeight: props.minHeight,
+  minHeight: props.gapless ? 'auto' : props.minHeight || undefined,
 }))
 
 const contentStyles = computed<CSSProperties>(() => ({
-  paddingBlock: props.paddingY,
+  paddingBlock: props.gapless
+    ? props.paddingY ?? '0'
+    : props.paddingY || undefined,
 }))
 
 const innerStyles = computed<CSSProperties>(() => ({
@@ -129,10 +135,21 @@ const contentAlignClass = computed(() =>
     ? 'parallax-section__inner--center'
     : 'parallax-section__inner--start'
 )
+
+const containerPaddingStyle = computed<CSSProperties>(() => ({
+  paddingInline: props.gapless
+    ? props.containerPadding ?? '0'
+    : props.containerPadding || undefined,
+}))
 </script>
 
 <template>
-  <section :id="props.id" class="parallax-section" :aria-label="ariaLabel">
+  <section
+    :id="props.id"
+    class="parallax-section"
+    :class="{ 'parallax-section--gapless': gapless }"
+    :aria-label="ariaLabel"
+  >
     <div
       class="parallax-section__media"
       :style="mediaStyles"
@@ -153,7 +170,11 @@ const contentAlignClass = computed(() =>
       </div>
     </div>
     <div class="parallax-section__content" :style="contentStyles">
-      <v-container fluid class="parallax-section__container">
+      <v-container
+        fluid
+        class="parallax-section__container"
+        :style="containerPaddingStyle"
+      >
         <div
           class="parallax-section__inner"
           :class="contentAlignClass"
@@ -241,6 +262,18 @@ const contentAlignClass = computed(() =>
 
 :deep(.home-section__container)
   padding-inline: 0
+
+.parallax-section--gapless
+  background-color: transparent
+
+.parallax-section--gapless .parallax-section__content
+  padding-block: 0 !important
+
+.parallax-section--gapless .parallax-section__container
+  padding-inline: 0
+
+.parallax-section--gapless .parallax-section__inner
+  gap: clamp(1rem, 2.5vw, 1.75rem)
 
 @media (max-width: 959px)
   .parallax-section__image

--- a/frontend/app/composables/useSeasonalParallaxPack.ts
+++ b/frontend/app/composables/useSeasonalParallaxPack.ts
@@ -1,0 +1,6 @@
+import { computed } from 'vue'
+
+import { resolveActiveParallaxPack } from '~~/config/theme/seasons'
+
+export const useSeasonalParallaxPack = () =>
+  computed(() => resolveActiveParallaxPack())

--- a/frontend/app/composables/useThemedParallaxBackgrounds.ts
+++ b/frontend/app/composables/useThemedParallaxBackgrounds.ts
@@ -1,0 +1,81 @@
+import { computed, unref, type MaybeRef } from 'vue'
+import { useTheme } from 'vuetify'
+
+import {
+  PARALLAX_SECTION_KEYS,
+  DEFAULT_PARALLAX_PACK,
+  THEME_ASSETS_FALLBACK,
+  parallaxPacks,
+  type ParallaxPackConfig,
+  type ParallaxPackName,
+  type ParallaxSectionKey,
+} from '~~/config/theme/assets'
+import { resolveThemeName, type ThemeName } from '~~/shared/constants/theme'
+import { resolveThemedAssetUrl } from './useThemedAsset'
+
+const resolvePackForTheme = (
+  packName: ParallaxPackName,
+  themeName: ThemeName,
+  fallbackPackName: ParallaxPackName = DEFAULT_PARALLAX_PACK
+): ParallaxPackConfig => {
+  const themePack = parallaxPacks[themeName]?.[packName]
+  const commonPack = parallaxPacks.common?.[packName]
+  const fallbackPack = parallaxPacks[THEME_ASSETS_FALLBACK]?.[packName]
+
+  if (themePack || commonPack || fallbackPack) {
+    return themePack ?? commonPack ?? fallbackPack ?? {}
+  }
+
+  if (fallbackPackName !== packName) {
+    return resolvePackForTheme(fallbackPackName, themeName, fallbackPackName)
+  }
+
+  return {}
+}
+
+const resolveParallaxLayers = (
+  assets: string[] | undefined,
+  themeName: ThemeName
+) => {
+  if (!assets?.length) {
+    return []
+  }
+
+  return assets
+    .map(asset => resolveThemedAssetUrl(asset, themeName))
+    .filter((resolved): resolved is string => Boolean(resolved))
+}
+
+export const useThemedParallaxBackgrounds = (
+  packName: MaybeRef<ParallaxPackName>,
+  dynamicOverrides?: MaybeRef<Partial<Record<ParallaxSectionKey, string[]>>>
+) => {
+  const theme = useTheme()
+
+  const themeName = computed<ThemeName>(() =>
+    resolveThemeName(theme.global.name.value, THEME_ASSETS_FALLBACK)
+  )
+
+  return computed<Record<ParallaxSectionKey, string[]>>(() => {
+    const activePackName = unref(packName)
+    const overrides = unref(dynamicOverrides)
+    const packConfig = resolvePackForTheme(activePackName, themeName.value)
+    const fallbackPack =
+      activePackName === DEFAULT_PARALLAX_PACK
+        ? packConfig
+        : resolvePackForTheme(DEFAULT_PARALLAX_PACK, themeName.value)
+
+    return PARALLAX_SECTION_KEYS.reduce<Record<ParallaxSectionKey, string[]>>(
+      (acc, section) => {
+        const assets =
+          overrides?.[section] ?? packConfig[section] ?? fallbackPack[section]
+
+        return {
+          ...acc,
+          [section]: resolveParallaxLayers(assets, themeName.value),
+        }
+      },
+      {} as Record<ParallaxSectionKey, string[]>
+    )
+  })
+}

--- a/frontend/config/theme/assets.ts
+++ b/frontend/config/theme/assets.ts
@@ -14,6 +14,23 @@ export type ThemeAssetKey = (typeof THEME_ASSET_KEYS)[number]
 
 export type ThemeAssetConfig = Partial<Record<ThemeAssetKey, string>>
 
+export const PARALLAX_SECTION_KEYS = [
+  'essentials',
+  'features',
+  'blog',
+  'objections',
+  'cta',
+] as const
+
+export const PARALLAX_PACK_NAMES = ['default', 'sdg'] as const
+
+export type ParallaxSectionKey = (typeof PARALLAX_SECTION_KEYS)[number]
+export type ParallaxPackName = (typeof PARALLAX_PACK_NAMES)[number]
+
+export const DEFAULT_PARALLAX_PACK: ParallaxPackName = 'default'
+
+export type ParallaxPackConfig = Partial<Record<ParallaxSectionKey, string[]>>
+
 export const themeAssets: Record<ThemeName | 'common', ThemeAssetConfig> = {
   light: {
     logo: 'logo.png',
@@ -32,5 +49,34 @@ export const themeAssets: Record<ThemeName | 'common', ThemeAssetConfig> = {
   common: {
     heroBackground: 'hero-background.svg',
     illustration: 'illustration-generic.svg',
+  },
+}
+
+export const parallaxPacks: Record<
+  ThemeName | 'common',
+  Partial<Record<ParallaxPackName, ParallaxPackConfig>>
+> = {
+  light: {
+    default: {
+      essentials: ['parallax/parallax-background-bubbles-1.svg'],
+      features: ['parallax/parallax-background-bubbles-2.svg'],
+      blog: ['parallax/parallax-background-bubbles-3.svg'],
+      objections: ['parallax/parallax-background-bubbles-1.svg'],
+      cta: ['parallax/parallax-background-bubbles-2.svg'],
+    },
+    sdg: {},
+  },
+  dark: {
+    default: {
+      essentials: ['parallax/parallax-background-bubbles-1.svg'],
+      features: ['parallax/parallax-background-bubbles-2.svg'],
+      blog: ['parallax/parallax-background-bubbles-3.svg'],
+      objections: ['parallax/parallax-background-bubbles-1.svg'],
+      cta: ['parallax/parallax-background-bubbles-2.svg'],
+    },
+    sdg: {},
+  },
+  common: {
+    sdg: {},
   },
 }

--- a/frontend/config/theme/assets.ts
+++ b/frontend/config/theme/assets.ts
@@ -22,7 +22,7 @@ export const PARALLAX_SECTION_KEYS = [
   'cta',
 ] as const
 
-export const PARALLAX_PACK_NAMES = ['default', 'sdg'] as const
+export const PARALLAX_PACK_NAMES = ['default', 'sdg', 'christmas'] as const
 
 export type ParallaxSectionKey = (typeof PARALLAX_SECTION_KEYS)[number]
 export type ParallaxPackName = (typeof PARALLAX_PACK_NAMES)[number]
@@ -58,25 +58,47 @@ export const parallaxPacks: Record<
 > = {
   light: {
     default: {
+      essentials: ['parallax/parallax-background-1.svg'],
+      features: ['parallax/parallax-background-2.svg'],
+      blog: ['parallax/parallax-background-3.svg'],
+      objections: ['parallax/parallax-background-1.svg'],
+      cta: ['parallax/parallax-background-2.svg'],
+    },
+    sdg: {},
+    christmas: {
       essentials: ['parallax/parallax-background-bubbles-1.svg'],
       features: ['parallax/parallax-background-bubbles-2.svg'],
       blog: ['parallax/parallax-background-bubbles-3.svg'],
       objections: ['parallax/parallax-background-bubbles-1.svg'],
       cta: ['parallax/parallax-background-bubbles-2.svg'],
     },
-    sdg: {},
   },
   dark: {
     default: {
+      essentials: ['parallax/parallax-background-1.svg'],
+      features: ['parallax/parallax-background-2.svg'],
+      blog: ['parallax/parallax-background-3.svg'],
+      objections: ['parallax/parallax-background-1.svg'],
+      cta: ['parallax/parallax-background-2.svg'],
+    },
+    sdg: {},
+    christmas: {
       essentials: ['parallax/parallax-background-bubbles-1.svg'],
       features: ['parallax/parallax-background-bubbles-2.svg'],
       blog: ['parallax/parallax-background-bubbles-3.svg'],
       objections: ['parallax/parallax-background-bubbles-1.svg'],
       cta: ['parallax/parallax-background-bubbles-2.svg'],
     },
-    sdg: {},
   },
   common: {
+    default: {
+      essentials: ['parallax/parallax-background-1.svg'],
+      features: ['parallax/parallax-background-2.svg'],
+      blog: ['parallax/parallax-background-3.svg'],
+      objections: ['parallax/parallax-background-1.svg'],
+      cta: ['parallax/parallax-background-2.svg'],
+    },
     sdg: {},
+    christmas: {},
   },
 }

--- a/frontend/config/theme/seasons.spec.ts
+++ b/frontend/config/theme/seasons.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveActiveParallaxPack } from './seasons'
+
+describe('resolveActiveParallaxPack', () => {
+  it('returns default pack when no window matches', () => {
+    const date = new Date(Date.UTC(2024, 6, 1))
+
+    expect(resolveActiveParallaxPack(date)).toBe('default')
+  })
+
+  it('prefers SDG campaign window in spring', () => {
+    const date = new Date(Date.UTC(2024, 3, 20))
+
+    expect(resolveActiveParallaxPack(date)).toBe('sdg')
+  })
+
+  it('activates christmas pack within the festive window', () => {
+    const date = new Date(Date.UTC(2024, 11, 15))
+
+    expect(resolveActiveParallaxPack(date)).toBe('christmas')
+  })
+
+  it('falls back to winter pack before christmas window', () => {
+    const date = new Date(Date.UTC(2024, 10, 30))
+
+    expect(resolveActiveParallaxPack(date)).toBe('default')
+  })
+
+  it('keeps winter pack active after the new year', () => {
+    const date = new Date(Date.UTC(2025, 0, 10))
+
+    expect(resolveActiveParallaxPack(date)).toBe('default')
+  })
+})

--- a/frontend/config/theme/seasons.ts
+++ b/frontend/config/theme/seasons.ts
@@ -17,6 +17,13 @@ export const seasonalParallaxSchedule: SeasonalParallaxWindow[] = [
     description: 'Earth Day activation and SDG storytelling',
   },
   {
+    id: 'christmas',
+    start: '12-10',
+    end: '12-27',
+    pack: 'christmas',
+    description: 'Festive bubble backgrounds for the holiday season',
+  },
+  {
     id: 'winter-highlights',
     start: '12-01',
     end: '01-15',

--- a/frontend/config/theme/seasons.ts
+++ b/frontend/config/theme/seasons.ts
@@ -1,0 +1,59 @@
+import { DEFAULT_PARALLAX_PACK, type ParallaxPackName } from './assets'
+
+export type SeasonalParallaxWindow = {
+  id: string
+  start: string
+  end: string
+  pack: ParallaxPackName
+  description?: string
+}
+
+export const seasonalParallaxSchedule: SeasonalParallaxWindow[] = [
+  {
+    id: 'sdg-campaign',
+    start: '04-15',
+    end: '05-02',
+    pack: 'sdg',
+    description: 'Earth Day activation and SDG storytelling',
+  },
+  {
+    id: 'winter-highlights',
+    start: '12-01',
+    end: '01-15',
+    pack: 'default',
+    description: 'Winter friendly visuals without SDG overlays',
+  },
+]
+
+const parseMonthDay = (value: string, year: number) => {
+  const [month, day] = value.split('-').map(part => Number.parseInt(part, 10))
+
+  return new Date(Date.UTC(year, Math.max(0, month - 1), Math.max(1, day)))
+}
+
+const isDateWithinWindow = (
+  date: Date,
+  window: SeasonalParallaxWindow
+): boolean => {
+  const currentYear = date.getUTCFullYear()
+  const start = parseMonthDay(window.start, currentYear)
+  const end = parseMonthDay(window.end, currentYear)
+  const normalizedEnd = end < start ? parseMonthDay(window.end, currentYear + 1) : end
+
+  const inSameYear = date >= start && date <= normalizedEnd
+  const inSpanningYear = date <= normalizedEnd && end < start
+
+  return inSameYear || inSpanningYear
+}
+
+export const resolveActiveParallaxPack = (date: Date = new Date()): ParallaxPackName => {
+  const window = seasonalParallaxSchedule.find(candidate =>
+    isDateWithinWindow(date, candidate)
+  )
+
+  if (window) {
+    return window.pack
+  }
+
+  return DEFAULT_PARALLAX_PACK
+}


### PR DESCRIPTION
## Summary
- add a dedicated parallax pack registry and seasonal schedule to resolve themed backgrounds
- introduce composables to pick the active seasonal pack and expand themed asset resolution with fallbacks
- extend ParallaxSection options and tighten homepage spacing for smoother background transitions

## Testing
- pnpm lint *(fails: existing v-html warnings and an unrelated `no-explicit-any` lint error)*
- pnpm test *(fails: Vitest run hung on queued files and was cancelled)*
- pnpm generate


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e8ed1318832287f07556498464c9)