### PR TITLE
Enhance share intent resolution with async selection

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -147,6 +147,11 @@ const selectedCategory = computed(
     null
 )
 
+const resolveCategoryIcon = (category: VerticalCategoryDto | null) => {
+  const candidate = (category as Record<string, unknown> | null)?.icon
+  return typeof candidate === 'string' ? candidate : undefined
+}
+
 const nudgeConfig = computed(() => selectedCategory.value?.nudgeToolConfig)
 
 const subsetGroups = computed<NudgeToolSubsetGroupDto[]>(() => {
@@ -527,7 +532,7 @@ const categorySummary = computed(() => {
       selectedCategory.value.id ??
       '',
     image: selectedCategory.value.imageSmall,
-    icon: (selectedCategory.value as any).icon ?? 'mdi-tag', // Fallback or explicit cast if typing is missing
+    icon: resolveCategoryIcon(selectedCategory.value) ?? 'mdi-tag',
     alt:
       selectedCategory.value.verticalHomeTitle ??
       selectedCategory.value.id ??

--- a/frontend/app/pages/share-target.vue
+++ b/frontend/app/pages/share-target.vue
@@ -1,0 +1,611 @@
+<template>
+  <div class="share-target-page">
+    <v-container class="py-8 py-md-12">
+      <v-row justify="center">
+        <v-col cols="12" md="10" lg="8">
+          <v-sheet class="share-target-page__hero" rounded="xl" elevation="6">
+            <div class="share-target-page__badge">{{ $t('share.landing.badge') }}</div>
+            <h1 class="share-target-page__title">{{ pageTitle }}</h1>
+            <p class="share-target-page__subtitle">
+              {{ $t('share.landing.subtitle') }}
+            </p>
+            <div v-if="sharedUrl" class="share-target-page__origin">
+              <v-icon size="18" color="accent-supporting" class="me-1">mdi-link</v-icon>
+              <span class="share-target-page__origin-label">
+                {{ $t('share.landing.originUrl', { url: sharedUrl }) }}
+              </span>
+            </div>
+          </v-sheet>
+
+          <v-alert
+            v-if="isTimeout"
+            type="warning"
+            variant="tonal"
+            class="mt-6"
+            :text="$t('share.landing.timeout')"
+            border="start"
+          />
+
+          <v-alert
+            v-if="errorMessage"
+            type="error"
+            variant="tonal"
+            class="mt-6"
+            :text="errorMessage"
+            border="start"
+          />
+
+          <v-skeleton-loader
+            v-else-if="pending && !isTimeout"
+            class="mt-6"
+            type="card-avatar, article"
+          />
+
+          <div v-else-if="hasMultipleResults" class="share-target-page__grid mt-6">
+            <div class="share-target-page__grid-header">
+              <h2 class="text-h5 mb-1">{{ $t('share.selection.title') }}</h2>
+              <p class="text-body-2 mb-0 text-medium-emphasis">
+                {{ $t('share.selection.subtitle') }}
+              </p>
+            </div>
+            <v-row dense>
+              <v-col
+                v-for="productItem in products"
+                :key="productItem.gtin ?? productItem.slug ?? productItem.fullSlug"
+                cols="12"
+                md="6"
+              >
+                <v-card class="share-target-page__card" elevation="4">
+                  <v-card-text>
+                    <div class="share-target-page__pill share-target-page__pill--muted">
+                      {{ originLabel }}
+                    </div>
+                    <div class="d-flex align-center mb-3">
+                      <v-avatar size="64" class="me-3" color="surface-glass">
+                        <v-img
+                          v-if="productItem.resources?.images?.[0]?.url"
+                          :src="productItem.resources.images[0]?.url"
+                          :alt="productItem.identity?.bestName || productItem.base?.bestName"
+                          cover
+                        />
+                        <v-icon v-else size="32" color="primary">mdi-image-outline</v-icon>
+                      </v-avatar>
+                      <div class="flex-grow-1">
+                        <div class="share-target-page__product-title">
+                          {{ productItem.identity?.bestName || productItem.base?.bestName || $t('share.card.untitled') }}
+                        </div>
+                        <p class="share-target-page__brand">
+                          {{ productItem.identity?.brand || productItem.identity?.model }}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div class="share-target-page__metrics mb-4">
+                      <div class="share-target-page__metric">
+                        <span class="share-target-page__metric-label">{{
+                          $t('share.card.ecoScoreLabel')
+                        }}</span>
+                        <ImpactScore
+                          v-if="resolveImpact(productItem) != null"
+                          :score="resolveImpact(productItem)"
+                          :show-value="true"
+                        />
+                        <span v-else class="share-target-page__metric-placeholder">{{
+                          $t('share.card.missingEcoScore')
+                        }}</span>
+                      </div>
+
+                      <div class="share-target-page__metric">
+                        <span class="share-target-page__metric-label">{{
+                          $t('share.card.bestPriceLabel')
+                        }}</span>
+                        <div
+                          v-if="resolveProductPrice(productItem)"
+                          class="share-target-page__price"
+                        >
+                          <v-icon size="18" class="me-2" color="accent-supporting">
+                            mdi-tag-multiple
+                          </v-icon>
+                          <span>{{ resolveProductPrice(productItem) }}</span>
+                        </div>
+                        <span v-else class="share-target-page__metric-placeholder">{{
+                          $t('share.card.missingPrice')
+                        }}</span>
+                      </div>
+                    </div>
+
+                    <div class="share-target-page__actions">
+                      <v-btn
+                        color="primary"
+                        size="large"
+                        :to="resolveProductLink(productItem)"
+                        variant="flat"
+                      >
+                        {{ $t('share.card.viewProduct') }}
+                      </v-btn>
+                      <v-btn
+                        color="secondary"
+                        size="large"
+                        variant="outlined"
+                        :to="fallbackSearchLink"
+                      >
+                        {{ $t('share.card.searchMore') }}
+                      </v-btn>
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-col>
+            </v-row>
+          </div>
+
+          <v-card v-else-if="resolution?.primary" class="share-target-page__card" elevation="8">
+            <v-card-text>
+              <v-row align="center" no-gutters class="share-target-page__card-body">
+                <v-col cols="12" md="4" class="pe-md-6 mb-4 mb-md-0">
+                  <v-sheet class="share-target-page__image-wrapper" rounded="lg" color="surface-glass">
+                    <v-img
+                      v-if="productImage"
+                      :src="productImage"
+                      :alt="productTitle"
+                      cover
+                      height="220"
+                      class="rounded-lg"
+                    />
+                    <div v-else class="share-target-page__image-fallback">
+                      <v-icon size="56" color="primary">mdi-image-search</v-icon>
+                      <span>{{ $t('share.card.noImage') }}</span>
+                    </div>
+                  </v-sheet>
+                </v-col>
+
+                <v-col cols="12" md="8">
+                  <div class="share-target-page__pill">{{ originLabel }}</div>
+                  <h2 class="share-target-page__product-title">{{ productTitle }}</h2>
+                  <p v-if="brandLabel" class="share-target-page__brand">{{ brandLabel }}</p>
+
+                  <div class="share-target-page__metrics">
+                    <div class="share-target-page__metric">
+                      <span class="share-target-page__metric-label">{{
+                        $t('share.card.ecoScoreLabel')
+                      }}</span>
+                      <ImpactScore
+                        v-if="impactScore != null"
+                        :score="impactScore"
+                        :show-value="true"
+                      />
+                      <span v-else class="share-target-page__metric-placeholder">{{
+                        $t('share.card.missingEcoScore')
+                      }}</span>
+                    </div>
+
+                    <div class="share-target-page__metric">
+                      <span class="share-target-page__metric-label">{{
+                        $t('share.card.bestPriceLabel')
+                      }}</span>
+                      <div v-if="bestPrice" class="share-target-page__price">
+                        <v-icon size="18" class="me-2" color="accent-supporting">mdi-tag-multiple</v-icon>
+                        <span>{{ bestPrice }}</span>
+                      </div>
+                      <span v-else class="share-target-page__metric-placeholder">{{
+                        $t('share.card.missingPrice')
+                      }}</span>
+                    </div>
+                  </div>
+
+                  <div class="share-target-page__actions">
+                    <v-btn
+                      color="primary"
+                      size="large"
+                      :to="productLink"
+                      variant="flat"
+                    >
+                      {{ $t('share.card.viewProduct') }}
+                    </v-btn>
+                    <v-btn
+                      color="secondary"
+                      size="large"
+                      variant="outlined"
+                      :to="fallbackSearchLink"
+                    >
+                      {{ $t('share.card.searchMore') }}
+                    </v-btn>
+                  </div>
+                </v-col>
+              </v-row>
+            </v-card-text>
+          </v-card>
+
+          <v-card v-else class="share-target-page__card" elevation="2">
+            <v-card-text class="text-center">
+              <v-icon size="52" color="primary" class="mb-2">mdi-magnify</v-icon>
+              <h2 class="text-h5 mb-2">{{ $t('share.empty.title') }}</h2>
+              <p class="text-body-1 mb-4">{{ emptyHelper }}</p>
+              <v-btn color="primary" :to="fallbackSearchLink">{{
+                $t('share.empty.cta')
+              }}</v-btn>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useSeoMeta } from '#imports'
+import { useI18n } from 'vue-i18n'
+import type { ProductDto } from '~~/shared/api-client'
+import { extractGtinParam } from '~~/shared/utils/_gtin'
+import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
+import { formatBestPrice } from '~/utils/_product-pricing'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+
+definePageMeta({
+  layout: 'default',
+})
+
+const route = useRoute()
+const requestURL = useRequestURL()
+const { t, n } = useI18n()
+
+const gtinParam = computed(() =>
+  extractGtinParam(typeof route.query.gtin === 'string' ? route.query.gtin : null)
+)
+const searchQuery = computed(() =>
+  typeof route.query.q === 'string' && route.query.q.trim().length
+    ? route.query.q.trim().slice(0, 160)
+    : null
+)
+const sharedUrl = computed(() =>
+  typeof route.query.url === 'string' && route.query.url.trim().length
+    ? route.query.url.trim()
+    : null
+)
+const sharedTitle = computed(() =>
+  typeof route.query.title === 'string' ? route.query.title.trim() : null
+)
+const sharedText = computed(() =>
+  typeof route.query.text === 'string' ? route.query.text.trim() : null
+)
+
+const resolutionKey = computed(
+  () =>
+    `share-resolution-${gtinParam.value ?? searchQuery.value ?? sharedUrl.value ?? 'empty'}`
+)
+
+const slaTimerMs = 4000
+const timedOut = ref(false)
+let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+
+const { data: resolution, pending, error } = await useAsyncData<{
+  status: 'resolved' | 'empty' | 'error' | 'timeout'
+  products: ProductDto[]
+  primary: ProductDto | null
+  origin: {
+    gtin: string | null
+    query: string | null
+    url: string | null
+    title: string | null
+    text: string | null
+  }
+}>(() => resolutionKey.value, async () =>
+  $fetch('/api/share/resolution', {
+    query: {
+      gtin: gtinParam.value ?? undefined,
+      q: searchQuery.value ?? undefined,
+      url: sharedUrl.value ?? undefined,
+      title: sharedTitle.value ?? undefined,
+      text: sharedText.value ?? undefined,
+    },
+  })
+)
+
+const startTimeout = () => {
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
+  timedOut.value = false
+  timeoutHandle = setTimeout(() => {
+    timedOut.value = true
+  }, slaTimerMs)
+}
+
+onMounted(() => {
+  startTimeout()
+})
+
+onBeforeUnmount(() => {
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
+})
+
+watch(pending, value => {
+  if (value) {
+    startTimeout()
+  } else if (timeoutHandle) {
+    clearTimeout(timeoutHandle)
+  }
+})
+
+watch(resolution, value => {
+  if (value?.status === 'resolved') {
+    timedOut.value = false
+  }
+})
+
+const pageTitle = computed(() => t('share.landing.title'))
+const productTitle = computed(() => {
+  const entity = resolution.value?.primary
+  if (!entity) {
+    return t('share.card.untitled')
+  }
+
+  return (
+    entity.identity?.bestName ||
+    entity.base?.bestName ||
+    entity.names?.h1Title ||
+    entity.identity?.model ||
+    entity.identity?.brand ||
+    t('share.card.untitled')
+  )
+})
+
+const brandLabel = computed(() => {
+  const entity = resolution.value?.primary
+  const brand = entity?.identity?.brand?.trim()
+  const model = entity?.identity?.model?.trim()
+
+  if (!brand && !model) {
+    return ''
+  }
+
+  return [brand, model].filter(Boolean).join(' • ')
+})
+
+const impactScore = computed(() =>
+  resolution.value?.primary ? resolvePrimaryImpactScore(resolution.value.primary) : null
+)
+const bestPrice = computed(() =>
+  resolution.value?.primary ? formatBestPrice(resolution.value.primary, t, n) : null
+)
+
+const productImage = computed(() => {
+  const images = resolution.value?.primary?.resources?.images ?? []
+  return images.length ? images[0]?.url ?? null : null
+})
+
+const originLabel = computed(() =>
+  gtinParam.value
+    ? t('share.card.sourceGtin', { gtin: gtinParam.value })
+    : resolution.value?.origin?.query
+      ? t('share.card.sourceQuery', { query: resolution.value.origin.query })
+      : sharedUrl.value
+        ? t('share.card.sourceUrl', { url: sharedUrl.value })
+        : t('share.card.sourceUnknown')
+)
+
+const fallbackSearchLink = computed(() =>
+  resolution.value?.origin?.query
+    ? `/search?q=${encodeURIComponent(resolution.value.origin.query)}`
+    : '/search'
+)
+
+const productLink = computed(() => {
+  const slug = resolution.value?.primary?.fullSlug || resolution.value?.primary?.slug
+  return slug || fallbackSearchLink.value
+})
+
+const emptyHelper = computed(() =>
+  resolution.value?.origin?.query
+    ? t('share.empty.withQuery', { query: resolution.value.origin.query })
+    : t('share.empty.helper')
+)
+
+const errorMessage = computed(() =>
+  error.value ? t('share.errors.resolution') : null
+)
+
+const hasMultipleResults = computed(
+  () => (resolution.value?.products?.length ?? 0) > 1
+)
+const products = computed(() => resolution.value?.products ?? [])
+const isTimeout = computed(
+  () => timedOut.value || resolution.value?.status === 'timeout'
+)
+
+const resolveProductLink = (product: ProductDto) =>
+  product.fullSlug || product.slug || fallbackSearchLink.value
+
+const resolveProductPrice = (product: ProductDto) => formatBestPrice(product, t, n)
+const resolveImpact = (product: ProductDto) => resolvePrimaryImpactScore(product)
+
+useSeoMeta({
+  title: pageTitle,
+  description: () => t('share.landing.description'),
+  ogTitle: pageTitle,
+  ogDescription: () => t('share.landing.description'),
+  ogUrl: requestURL.href,
+})
+
+useHead({
+  link: [
+    {
+      rel: 'canonical',
+      href: `${requestURL.origin}${requestURL.pathname}${requestURL.search}`,
+    },
+  ],
+})
+</script>
+
+<style scoped>
+.share-target-page {
+  background: radial-gradient(
+      circle at 20% 20%,
+      rgba(var(--v-theme-hero-gradient-start), 0.08),
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(var(--v-theme-hero-gradient-end), 0.08),
+      transparent 35%
+    ),
+    rgb(var(--v-theme-surface-default));
+}
+
+.share-target-page__hero {
+  background: linear-gradient(135deg, rgba(var(--v-theme-hero-gradient-start), 0.14), rgba(var(--v-theme-hero-gradient-end), 0.16));
+  padding: 1.5rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.5);
+}
+
+.share-target-page__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-hero-gradient-start), 0.16);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  margin-bottom: 0.5rem;
+}
+
+.share-target-page__title {
+  font-size: clamp(1.6rem, 2vw + 1rem, 2.3rem);
+  margin: 0;
+  font-weight: 700;
+}
+
+.share-target-page__subtitle {
+  margin: 0.4rem 0 0;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  font-size: 1.05rem;
+}
+
+.share-target-page__origin {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(var(--v-theme-surface-glass), 0.6);
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  font-weight: 600;
+}
+
+.share-target-page__origin-label {
+  word-break: break-all;
+}
+
+.share-target-page__card {
+  margin-top: 1.5rem;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.5);
+  background: linear-gradient(180deg, rgba(var(--v-theme-surface-glass), 0.9), rgba(var(--v-theme-surface-default), 0.98));
+}
+
+.share-target-page__card-body {
+  gap: 1rem;
+}
+
+.share-target-page__image-wrapper {
+  background: rgba(var(--v-theme-surface-glass), 0.6);
+  border: 1px dashed rgba(var(--v-theme-border-primary-strong), 0.6);
+  padding: 0.75rem;
+}
+
+.share-target-page__image-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  padding: 2rem 1rem;
+}
+
+.share-target-page__pill {
+  display: inline-flex;
+  padding: 0.35rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(var(--v-theme-hero-gradient-end), 0.12);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.share-target-page__product-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.share-target-page__brand {
+  margin: 0.35rem 0 0.75rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.share-target-page__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+}
+
+.share-target-page__metric-label {
+  display: inline-block;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  margin-bottom: 0.35rem;
+}
+
+.share-target-page__metric-placeholder {
+  color: rgb(var(--v-theme-text-neutral-soft));
+}
+
+.share-target-page__price {
+  display: inline-flex;
+  align-items: center;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.share-target-page__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.share-target-page__grid-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.share-target-page__grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.share-target-page__pill--muted {
+  background: rgba(var(--v-theme-surface-glass), 0.8);
+}
+
+@media (max-width: 960px) {
+  .share-target-page__hero {
+    padding: 1.25rem;
+  }
+
+  .share-target-page__card-body {
+    gap: 0.5rem;
+  }
+}
+</style>

--- a/frontend/app/public/site.webmanifest
+++ b/frontend/app/public/site.webmanifest
@@ -137,5 +137,25 @@
   ],
   "edge_side_panel": {
     "preferred_width": 480
+  },
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "file",
+          "accept": [
+            "image/*",
+            "text/plain",
+            "text/html"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2338,6 +2338,43 @@
       "dismiss": "Dismiss"
     }
   },
+  "share": {
+    "card": {
+      "bestPriceLabel": "Best price",
+      "ecoScoreLabel": "Eco-score",
+      "missingEcoScore": "We are still calculating this score",
+      "missingPrice": "Price unavailable",
+      "noImage": "No image found",
+      "searchMore": "See more results",
+      "sourceGtin": "Resolved from GTIN {gtin}",
+      "sourceUrl": "Resolved from shared URL",
+      "sourceQuery": "Resolved from search \"{query}\"",
+      "sourceUnknown": "Shared link",
+      "untitled": "Untitled product",
+      "viewProduct": "Open full product"
+    },
+    "empty": {
+      "cta": "Open search",
+      "helper": "Share a product name or barcode to get an instant preview.",
+      "title": "Nothing to preview yet",
+      "withQuery": "No result matched \"{query}\" yet, but you can browse all results."
+    },
+    "errors": {
+      "resolution": "We could not resolve this shared link. Please try again."
+    },
+    "landing": {
+      "badge": "Shared with Nudger",
+      "description": "Preview the eco-score and best offers for shared products, then jump into the full experience.",
+      "originUrl": "Shared URL: {url}",
+      "subtitle": "We used the shared link or text to resolve your product. Open the full page or explore more results.",
+      "timeout": "We are still resolving this link. Results may take longer than expected—try again or open search directly.",
+      "title": "Quick preview of your shared product"
+    },
+    "selection": {
+      "subtitle": "We found several possible matches. Pick the product you want to inspect.",
+      "title": "Multiple matches found"
+    }
+  },
   "nudge-tool": {
     "actions": {
       "continue": "Continue",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2326,6 +2326,43 @@
       "dismiss": "Fermer"
     }
   },
+  "share": {
+    "card": {
+      "bestPriceLabel": "Meilleur prix",
+      "ecoScoreLabel": "Éco-score",
+      "missingEcoScore": "Le score est en cours de calcul",
+      "missingPrice": "Prix non disponible",
+      "noImage": "Aucune image trouvée",
+      "searchMore": "Voir plus de résultats",
+      "sourceGtin": "Résolu depuis le GTIN {gtin}",
+      "sourceUrl": "Résolu depuis l’URL partagée",
+      "sourceQuery": "Résolu depuis la recherche \"{query}\"",
+      "sourceUnknown": "Lien partagé",
+      "untitled": "Produit sans titre",
+      "viewProduct": "Ouvrir la fiche complète"
+    },
+    "empty": {
+      "cta": "Ouvrir la recherche",
+      "helper": "Partage un nom de produit ou un code-barres pour afficher un aperçu immédiat.",
+      "title": "Pas encore d’aperçu",
+      "withQuery": "Aucun résultat ne correspond encore à \"{query}\". Parcours les résultats disponibles."
+    },
+    "errors": {
+      "resolution": "Impossible de résoudre ce lien partagé. Merci de réessayer."
+    },
+    "landing": {
+      "badge": "Partagé avec Nudger",
+      "description": "Aperçu des éco-scores et des meilleures offres du produit partagé avant d’ouvrir la fiche complète.",
+      "originUrl": "URL partagée : {url}",
+      "subtitle": "Nous avons analysé le lien ou le texte partagé. Ouvre la fiche complète ou explore plus de résultats.",
+      "timeout": "La résolution prend plus de temps que prévu. Réessaie ou lance une recherche directe.",
+      "title": "Aperçu rapide du produit partagé"
+    },
+    "selection": {
+      "subtitle": "Plusieurs correspondances sont possibles. Choisis le produit à inspecter.",
+      "title": "Plusieurs résultats trouvés"
+    }
+  },
   "nudge-tool": {
     "actions": {
       "continue": "Continuer",

--- a/frontend/server/api/share/resolution.get.spec.ts
+++ b/frontend/server/api/share/resolution.get.spec.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProductDto } from '~~/shared/api-client'
+
+type ShareResolutionHandler = (typeof import('./resolution.get'))['default']
+
+const createErrorMock = vi.hoisted(() =>
+  vi.fn((input: { statusCode: number; statusMessage: string }) => ({
+    ...input,
+    isCreateError: true,
+  }))
+)
+const setDomainLanguageCacheHeadersMock = vi.hoisted(() => vi.fn())
+const extractBackendErrorDetailsMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    statusCode: 502,
+    statusMessage: 'Bad Gateway',
+  })
+)
+const useProductServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    getProductByGtin: getProductByGtinMock,
+    searchProducts: searchProductsMock,
+  }))
+)
+const resolveDomainLanguageMock = vi.hoisted(() =>
+  vi.fn(() => ({ domainLanguage: 'en' as const }))
+)
+const getProductByGtinMock = vi.hoisted(() => vi.fn<[], Promise<ProductDto | undefined>>())
+const searchProductsMock = vi.hoisted(() =>
+  vi.fn<[], Promise<{ products?: { data?: ProductDto[] } }>>()
+)
+
+let currentQuery: Record<string, unknown> = {}
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: ShareResolutionHandler) => fn,
+  getQuery: () => currentQuery,
+  createError: createErrorMock,
+}))
+
+vi.mock('../../utils/cache-headers', () => ({
+  setDomainLanguageCacheHeaders: setDomainLanguageCacheHeadersMock,
+}))
+
+vi.mock('../../utils/log-backend-error', () => ({
+  extractBackendErrorDetails: extractBackendErrorDetailsMock,
+}))
+
+vi.mock('~~/shared/utils/domain-language', () => ({
+  resolveDomainLanguage: resolveDomainLanguageMock,
+}))
+
+vi.mock('~~/shared/api-client/services/products.services', () => ({
+  useProductService: useProductServiceMock,
+}))
+
+describe('server/api/share/resolution', () => {
+  let handler: ShareResolutionHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    currentQuery = {}
+    setDomainLanguageCacheHeadersMock.mockReset()
+    extractBackendErrorDetailsMock.mockClear()
+    createErrorMock.mockClear()
+    getProductByGtinMock.mockReset()
+    searchProductsMock.mockReset()
+    resolveDomainLanguageMock.mockReturnValue({ domainLanguage: 'en' })
+
+    handler = (await import('./resolution.get')).default
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns a resolved product when GTIN is provided', async () => {
+    const product: ProductDto = { gtin: '12345678' } as ProductDto
+    currentQuery = { gtin: '12345678' }
+    getProductByGtinMock.mockResolvedValue(product)
+
+    const result = await handler({} as never)
+
+    expect(setDomainLanguageCacheHeadersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'private, no-store'
+    )
+    expect(result.status).toBe('resolved')
+    expect(result.products).toEqual([product])
+    expect(result.primary).toEqual(product)
+  })
+
+  it('searches with query when no GTIN is present', async () => {
+    const products: ProductDto[] = [
+      { gtin: '1', identity: { bestName: 'First' } } as ProductDto,
+      { gtin: '2', identity: { bestName: 'Second' } } as ProductDto,
+    ]
+    currentQuery = { q: 'eco fridge' }
+    searchProductsMock.mockResolvedValue({ products: { data: products } })
+
+    const result = await handler({} as never)
+
+    expect(searchProductsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageNumber: 0,
+        pageSize: 6,
+        body: { query: 'eco fridge' },
+      })
+    )
+    expect(result.status).toBe('resolved')
+    expect(result.products).toHaveLength(2)
+  })
+
+  it('returns timeout status when resolution exceeds SLA', async () => {
+    vi.useFakeTimers()
+    currentQuery = { q: 'slow search' }
+    searchProductsMock.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(() => resolve({ products: { data: [] } }), 5000)
+        })
+    )
+
+    const resolutionPromise = handler({} as never)
+    vi.advanceTimersByTime(5000)
+    const result = await resolutionPromise
+
+    expect(result.status).toBe('timeout')
+  })
+
+  it('throws createError on backend failure', async () => {
+    currentQuery = { q: 'boom' }
+    searchProductsMock.mockRejectedValue(new Error('backend down'))
+
+    await expect(handler({} as never)).rejects.toMatchObject({
+      isCreateError: true,
+      statusCode: 502,
+    })
+  })
+})

--- a/frontend/server/api/share/resolution.get.ts
+++ b/frontend/server/api/share/resolution.get.ts
@@ -1,0 +1,124 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+} from 'h3'
+import type { ProductDto } from '~~/shared/api-client'
+import { useProductService } from '~~/shared/api-client/services/products.services'
+import { extractGtinParam } from '~~/shared/utils/_gtin'
+import { deriveQueryFromUrl } from '~~/shared/utils/share-intent'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
+
+const SEARCH_PAGE_SIZE = 6
+const SLA_TIMEOUT_MS = 4000
+
+const deriveSearchQuery = (
+  query?: string | null,
+  url?: string | null
+): string | null => {
+  if (query && query.trim().length) {
+    return query.trim().slice(0, 160)
+  }
+
+  const fromUrl = deriveQueryFromUrl(url)
+  return fromUrl ? fromUrl.slice(0, 160) : null
+}
+
+export default defineEventHandler(async event => {
+  const { domainLanguage } = resolveDomainLanguage(event)
+  setDomainLanguageCacheHeaders(event, 'private, no-store')
+
+  const productService = useProductService(domainLanguage)
+  const query = getQuery(event)
+
+  const gtinParam = extractGtinParam(
+    typeof query.gtin === 'string' ? query.gtin : null
+  )
+  const searchQuery = deriveSearchQuery(
+    typeof query.q === 'string' ? query.q : null,
+    typeof query.url === 'string' ? query.url : null
+  )
+
+  const origin = {
+    gtin: gtinParam,
+    query: searchQuery,
+    url: typeof query.url === 'string' ? query.url : null,
+    title: typeof query.title === 'string' ? query.title : null,
+    text: typeof query.text === 'string' ? query.text : null,
+  }
+
+  const withTimeout = async <T>(promise: Promise<T>) => {
+    let timeoutHandle: ReturnType<typeof setTimeout>
+    const timeoutPromise = new Promise<null>(resolve => {
+      timeoutHandle = setTimeout(() => resolve(null), SLA_TIMEOUT_MS)
+    })
+
+    const result = await Promise.race([promise, timeoutPromise])
+    return { result, timeoutHandle: timeoutHandle! }
+  }
+
+  const response: {
+    status: 'resolved' | 'empty' | 'error' | 'timeout'
+    products: ProductDto[]
+    primary: ProductDto | null
+    origin: typeof origin
+  } = {
+    status: 'resolved',
+    products: [],
+    primary: null,
+    origin,
+  }
+
+  try {
+    if (gtinParam) {
+      const { result, timeoutHandle } = await withTimeout(
+        productService.getProductByGtin(gtinParam)
+      )
+      clearTimeout(timeoutHandle)
+
+      if (result === null) {
+        response.status = 'timeout'
+      } else {
+        response.products = result ? [result] : []
+        response.primary = result ?? null
+      }
+    } else if (searchQuery) {
+      const { result, timeoutHandle } = await withTimeout(
+        productService.searchProducts({
+          pageNumber: 0,
+          pageSize: SEARCH_PAGE_SIZE,
+          body: {
+            query: searchQuery,
+          },
+        })
+      )
+      clearTimeout(timeoutHandle)
+
+      if (result === null) {
+        response.status = 'timeout'
+      } else {
+        response.products = result.products?.data ?? []
+        response.primary = response.products[0] ?? null
+      }
+    } else {
+      response.status = 'empty'
+    }
+
+    if (response.status === 'resolved' && response.products.length === 0) {
+      response.status = 'empty'
+    }
+  } catch (error: unknown) {
+    const details = await extractBackendErrorDetails(error)
+    response.status = 'error'
+
+    throw createError({
+      statusCode: details.statusCode ?? 500,
+      statusMessage: details.statusMessage ?? 'Share resolution failed',
+      cause: error,
+    })
+  }
+
+  return response
+})

--- a/frontend/server/routes/share-target.post.ts
+++ b/frontend/server/routes/share-target.post.ts
@@ -1,0 +1,101 @@
+import {
+  createError,
+  defineEventHandler,
+  readBody,
+  readMultipartFormData,
+  sendRedirect,
+} from 'h3'
+import { resolveShareIntent } from '~~/shared/utils/share-intent'
+
+type ShareTargetBody = {
+  title?: string
+  text?: string
+  url?: string
+}
+
+const SHARE_TARGET_REDIRECT = '/share-target'
+
+const parseMultipartShareBody = async (
+  event: Parameters<ReturnType<typeof defineEventHandler>>[0]
+): Promise<ShareTargetBody & { fileText?: string | null }> => {
+  const formData = await readMultipartFormData(event)
+  const payload: ShareTargetBody & { fileText?: string | null } = {}
+
+  if (!formData) {
+    return payload
+  }
+
+  for (const part of formData) {
+    if (!part) {
+      continue
+    }
+
+    if (part.name === 'title') {
+      payload.title = part.data.toString('utf-8')
+    }
+
+    if (part.name === 'text') {
+      payload.text = part.data.toString('utf-8')
+    }
+
+    if (part.name === 'url') {
+      payload.url = part.data.toString('utf-8')
+    }
+
+    if (!payload.fileText && part.type?.startsWith('text/')) {
+      payload.fileText = part.data.toString('utf-8')
+    }
+  }
+
+  return payload
+}
+
+const readShareTargetPayload = async (
+  event: Parameters<ReturnType<typeof defineEventHandler>>[0]
+): Promise<ShareTargetBody & { fileText?: string | null }> => {
+  const contentType = event.node.req.headers['content-type'] ?? ''
+
+  if (contentType.includes('multipart/form-data')) {
+    return parseMultipartShareBody(event)
+  }
+
+  const body = await readBody<ShareTargetBody | null>(event)
+
+  return {
+    title: body?.title,
+    text: body?.text,
+    url: body?.url,
+    fileText: null,
+  }
+}
+
+export default defineEventHandler(async event => {
+  const payload = await readShareTargetPayload(event)
+  const resolution = resolveShareIntent(payload)
+
+  if (!resolution.gtin && !resolution.query) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Share payload was empty or invalid',
+    })
+  }
+
+  const params = new URLSearchParams()
+  if (resolution.gtin) {
+    params.set('gtin', resolution.gtin)
+  }
+  if (resolution.query) {
+    params.set('q', resolution.query)
+  }
+  if (payload.url) {
+    params.set('url', payload.url)
+  }
+
+  event.node.res.setHeader('Cache-Control', 'no-store, max-age=0')
+
+  return sendRedirect(
+    event,
+    `${SHARE_TARGET_REDIRECT}${params.size ? `?${params.toString()}` : ''}`,
+    303
+  )
+})

--- a/frontend/shared/utils/_gtin.spec.ts
+++ b/frontend/shared/utils/_gtin.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractGtinParam, isValidGtinParam } from './_gtin'
+import { extractGtinParam, findGtinInText, isValidGtinParam } from './_gtin'
 
 describe('shared/utils/_gtin', () => {
   describe('isValidGtinParam', () => {
@@ -34,6 +34,23 @@ describe('shared/utils/_gtin', () => {
       expect(extractGtinParam('123')).toBeNull()
       expect(extractGtinParam(['abc', '12345'])).toBeNull()
       expect(extractGtinParam('123456a')).toBeNull()
+    })
+  })
+
+  describe('findGtinInText', () => {
+    it('finds GTINs embedded within text', () => {
+      expect(findGtinInText('Produit 5901234123457 disponible')).toBe('5901234123457')
+      expect(findGtinInText('Code: 01234567. Merci')).toBe('01234567')
+    })
+
+    it('ignores numbers shorter than eight digits', () => {
+      expect(findGtinInText('id=123456')).toBeNull()
+      expect(findGtinInText('test 1234 567')).toBeNull()
+    })
+
+    it('returns null for non-string inputs', () => {
+      expect(findGtinInText(undefined)).toBeNull()
+      expect(findGtinInText(12345678 as unknown as string)).toBeNull()
     })
   })
 })

--- a/frontend/shared/utils/_gtin.ts
+++ b/frontend/shared/utils/_gtin.ts
@@ -1,4 +1,5 @@
 const GTIN_CAPTURE_PATTERN = /^(\d{6,})(?:$|[-_].*)$/
+const GTIN_INLINE_PATTERN = /(?<!\d)(\d{8,14})(?!\d)/
 
 export const isValidGtinParam = (value: unknown): value is string => {
   return typeof value === 'string' && GTIN_CAPTURE_PATTERN.test(value)
@@ -24,4 +25,13 @@ export const extractGtinParam = (value: unknown): string | null => {
   }
 
   return null
+}
+
+export const findGtinInText = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const match = value.match(GTIN_INLINE_PATTERN)
+  return match ? match[1] : null
 }

--- a/frontend/shared/utils/share-intent.spec.ts
+++ b/frontend/shared/utils/share-intent.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { deriveQueryFromUrl, resolveShareIntent } from './share-intent'
+
+describe('shared/utils/share-intent', () => {
+  it('returns a GTIN when found in text', () => {
+    const result = resolveShareIntent({ text: 'Check 5901234123457 now' })
+
+    expect(result.gtin).toBe('5901234123457')
+    expect(result.query).toBe('Check 5901234123457 now')
+  })
+
+  it('returns a GTIN when found in URLs', () => {
+    const result = resolveShareIntent({ url: 'https://example.test/product/00012345678905' })
+
+    expect(result.gtin).toBe('00012345678905')
+    expect(result.query).toBe('https://example.test/product/00012345678905')
+  })
+
+  it('falls back to text query when no GTIN is present', () => {
+    const result = resolveShareIntent({
+      title: 'Amazing eco-friendly fridge',
+      text: 'Eco Fridge 3000',
+    })
+
+    expect(result.gtin).toBeNull()
+    expect(result.query).toBe('Eco Fridge 3000')
+  })
+
+  it('caps overly long queries', () => {
+    const longText = 'a'.repeat(200)
+    const result = resolveShareIntent({ text: longText })
+
+    expect(result.query?.length).toBeLessThanOrEqual(160)
+  })
+
+  it('extracts a cleaned last segment from URL', () => {
+    const query = deriveQueryFromUrl('https://shop.test/category/product-super_clean-123/')
+
+    expect(query).toBe('product super clean 123')
+  })
+
+  it('falls back to hostname when no path segment exists', () => {
+    const query = deriveQueryFromUrl('https://www.vendor.example/')
+
+    expect(query).toBe('vendor.example')
+  })
+})

--- a/frontend/shared/utils/share-intent.ts
+++ b/frontend/shared/utils/share-intent.ts
@@ -1,0 +1,119 @@
+import { extractGtinParam, findGtinInText } from './_gtin'
+
+export interface ShareIntentPayload {
+  title?: string | null
+  text?: string | null
+  url?: string | null
+  fileText?: string | null
+}
+
+export interface ShareIntentResolution {
+  gtin: string | null
+  query: string | null
+}
+
+export const deriveQueryFromUrl = (rawUrl?: string | null): string | null => {
+  if (!rawUrl) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(rawUrl)
+    const pathname = parsed.pathname || ''
+    const segments = pathname
+      .split('/')
+      .map(segment => segment.trim())
+      .filter(Boolean)
+
+    if (segments.length) {
+      const lastSegment = segments[segments.length - 1]!
+      const cleaned = lastSegment.replace(/[-_]+/g, ' ').trim()
+      if (cleaned) {
+        return cleaned
+      }
+    }
+
+    const host = parsed.hostname.replace(/^www\./i, '').trim()
+    return host || null
+  } catch {
+    return null
+  }
+}
+
+const MAX_QUERY_LENGTH = 160
+
+const normalizeText = (value?: string | null): string | null => {
+  const trimmed = value?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : null
+}
+
+const extractGtinFromUrl = (rawUrl?: string | null): string | null => {
+  if (!rawUrl) {
+    return null
+  }
+
+  try {
+    const parsedUrl = new URL(rawUrl)
+    const searchParamCandidates = [
+      parsedUrl.searchParams.get('gtin'),
+      parsedUrl.searchParams.get('ean'),
+      parsedUrl.searchParams.get('barcode'),
+    ]
+
+    for (const candidate of searchParamCandidates) {
+      const normalized = extractGtinParam(candidate)
+      if (normalized) {
+        return normalized
+      }
+    }
+
+    const pathSegments = parsedUrl.pathname.split('/')
+    for (const segment of pathSegments.reverse()) {
+      const normalized = extractGtinParam(segment) ?? findGtinInText(segment)
+      if (normalized) {
+        return normalized
+      }
+    }
+  } catch {
+    const normalized = extractGtinParam(rawUrl) ?? findGtinInText(rawUrl)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  return null
+}
+
+export const resolveShareIntent = (
+  payload: ShareIntentPayload
+): ShareIntentResolution => {
+  const candidates = [payload.text, payload.title, payload.fileText]
+
+  for (const candidate of candidates) {
+    const gtin = findGtinInText(candidate)
+    if (gtin) {
+      return { gtin, query: normalizeText(candidate) }
+    }
+  }
+
+  const urlGtin = extractGtinFromUrl(payload.url)
+  if (urlGtin) {
+    return {
+      gtin: urlGtin,
+      query: normalizeText(payload.text || payload.title || payload.url),
+    }
+  }
+
+  const fallbackQuery =
+    normalizeText(payload.text) ||
+    normalizeText(payload.title) ||
+    normalizeText(payload.fileText) ||
+    normalizeText(payload.url)
+
+  const safeQuery = fallbackQuery?.slice(0, MAX_QUERY_LENGTH) ?? null
+
+  return {
+    gtin: null,
+    query: safeQuery,
+  }
+}


### PR DESCRIPTION
## Summary
- add a share-resolution Nuxt server endpoint with SLA timeout handling and coverage
- extend the share landing page to show loaders, multiple candidate cards, and origin details from shared URLs
- improve share intent parsing with URL-derived queries and updated translations

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942e7e76d8483228bb8942b291a4f64)