### PR TITLE
Refine Nudger wizard corner layout

### DIFF
--- a/frontend/prompts/speech-to-spec.prompt
+++ b/frontend/prompts/speech-to-spec.prompt
@@ -1,0 +1,11 @@
+# Context
+Voici une demande de feature saisie vocalement sur le projet nudger, qui sera fournie à un agent de codage.
+Reste tres fidele à la saisie vocale de l'utilisateur, mais il peut y 'avoir des mots "phonetiquement" approchant
+Enleve les hésitations de langage
+Génére un transcript orienté spécifications fonctionnelles, et indique en bonus quelques points clés à questionner si cela te semble pertinent
+Essaie de correler au projet / elements techniques si tu cernes le périmetre (en mode RAG aux docuiments nudger auxquels tu as acces)
+
+Génere au format markdown
+
+
+#


### PR DESCRIPTION
## Summary
- Resize the Nudger wizard corner, enlarging the smiley identity and keeping it visible across steps
- Split the wizard into left identity and right interaction zones with padding that prevents navigation overlap
- Add subtle corner/left-zone transitions and responsive tweaks to align the home experience with other screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943cdaa9818832287e73d1ef65d7275)