### PR TITLE
Add async share resolution API to front API

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/ShareResolutionConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/ShareResolutionConfig.java
@@ -1,0 +1,48 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.time.Clock;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.open4goods.nudgerfrontapi.service.share.InMemoryShareResolutionStore;
+import org.open4goods.nudgerfrontapi.service.share.ShareResolutionStore;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wiring for share resolution infrastructure components.
+ */
+@Configuration
+public class ShareResolutionConfig {
+
+    @Bean
+    /**
+     * Clock used to timestamp share resolutions.
+     *
+     * @return UTC system clock
+     */
+    public Clock shareResolutionClock() {
+        return Clock.systemUTC();
+    }
+
+    @Bean
+    /**
+     * In-memory store keeping resolution snapshots with TTL.
+     *
+     * @param shareResolutionClock clock used for expiration
+     * @return store implementation
+     */
+    public ShareResolutionStore shareResolutionStore(Clock shareResolutionClock) {
+        return new InMemoryShareResolutionStore(shareResolutionClock);
+    }
+
+    @Bean
+    /**
+     * Dedicated executor used to process share resolutions asynchronously.
+     *
+     * @return configured executor
+     */
+    public Executor shareResolutionExecutor() {
+        return Executors.newCachedThreadPool();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/ShareResolutionProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/ShareResolutionProperties.java
@@ -1,0 +1,76 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties steering the share resolution workflow.
+ */
+@ConfigurationProperties(prefix = "front.share")
+public class ShareResolutionProperties {
+
+    private boolean crawlerExtractionEnabled = false;
+    private Duration resolutionWindow = Duration.ofSeconds(4);
+    private Duration storeTtl = Duration.ofMinutes(20);
+    private int maxUrlLength = 2048;
+    private int maxTextLength = 2048;
+    private int maxTitleLength = 256;
+    private int maxCandidates = 5;
+
+    public boolean isCrawlerExtractionEnabled() {
+        return crawlerExtractionEnabled;
+    }
+
+    public void setCrawlerExtractionEnabled(boolean crawlerExtractionEnabled) {
+        this.crawlerExtractionEnabled = crawlerExtractionEnabled;
+    }
+
+    public Duration getResolutionWindow() {
+        return resolutionWindow;
+    }
+
+    public void setResolutionWindow(Duration resolutionWindow) {
+        this.resolutionWindow = resolutionWindow;
+    }
+
+    public Duration getStoreTtl() {
+        return storeTtl;
+    }
+
+    public void setStoreTtl(Duration storeTtl) {
+        this.storeTtl = storeTtl;
+    }
+
+    public int getMaxUrlLength() {
+        return maxUrlLength;
+    }
+
+    public void setMaxUrlLength(int maxUrlLength) {
+        this.maxUrlLength = maxUrlLength;
+    }
+
+    public int getMaxTextLength() {
+        return maxTextLength;
+    }
+
+    public void setMaxTextLength(int maxTextLength) {
+        this.maxTextLength = maxTextLength;
+    }
+
+    public int getMaxTitleLength() {
+        return maxTitleLength;
+    }
+
+    public void setMaxTitleLength(int maxTitleLength) {
+        this.maxTitleLength = maxTitleLength;
+    }
+
+    public int getMaxCandidates() {
+        return maxCandidates;
+    }
+
+    public void setMaxCandidates(int maxCandidates) {
+        this.maxCandidates = maxCandidates;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/CacheControlConstants.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/CacheControlConstants.java
@@ -8,8 +8,9 @@ import org.springframework.http.CacheControl;
  * Shared constants for cache control
  */
 public class CacheControlConstants {
-	 public static final CacheControl FIFTEEN_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(15)).cachePublic();
-	 public static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
-	 public static final CacheControl FIVE_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(5)).cachePublic();
+         public static final CacheControl FIFTEEN_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(15)).cachePublic();
+         public static final CacheControl ONE_HOUR_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofHours(1)).cachePublic();
+         public static final CacheControl FIVE_MINUTES_PUBLIC_CACHE = CacheControl.maxAge(Duration.ofMinutes(5)).cachePublic();
+         public static final CacheControl PRIVATE_NO_STORE_CACHE = CacheControl.noStore().cachePrivate();
 
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ShareResolutionController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ShareResolutionController.java
@@ -1,0 +1,129 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.util.Optional;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionRequestDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.share.ShareResolutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing asynchronous share resolution endpoints.
+ */
+@RestController
+@RequestMapping("/share/resolutions")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Share", description = "Resolve shared URLs into product candidates")
+public class ShareResolutionController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShareResolutionController.class);
+
+    private final ShareResolutionService shareResolutionService;
+
+    public ShareResolutionController(ShareResolutionService shareResolutionService) {
+        this.shareResolutionService = shareResolutionService;
+    }
+
+    /**
+     * Trigger share resolution for a shared URL.
+     *
+     * @param request        payload containing the shared URL and optional hints
+     * @param domainLanguage localisation hint to forward downstream
+     * @return pending snapshot with the assigned token
+     */
+    @PostMapping
+    @Operation(summary = "Create a share resolution", description = "Accepts a shared URL and starts asynchronous resolution",
+            security = @SecurityRequirement(name = "sharedToken"),
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language hint used to resolve locale specific data.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "202", description = "Resolution accepted",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ShareResolutionResponseDto.class)),
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for the response",
+                                    schema = @Schema(type = "string", example = "fr"))),
+                    @ApiResponse(responseCode = "400", description = "Invalid request"),
+                    @ApiResponse(responseCode = "401", description = "Authentication required"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "500", description = "Unexpected error")
+            })
+    public ResponseEntity<ShareResolutionResponseDto> createResolution(
+            @RequestBody ShareResolutionRequestDto request,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Accepted share resolution for url='{}' language={}.", request.url(), domainLanguage);
+        ShareResolutionResponseDto response = shareResolutionService.createResolution(request, domainLanguage);
+        return ResponseEntity.accepted()
+                .cacheControl(CacheControlConstants.PRIVATE_NO_STORE_CACHE)
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(response);
+    }
+
+    /**
+     * Retrieve the latest status of a resolution.
+     *
+     * @param token          resolution token
+     * @param domainLanguage localisation hint used to echo the locale header
+     * @return snapshot when present or 404 otherwise
+     */
+    @GetMapping("/{token}")
+    @Operation(summary = "Get share resolution status",
+            description = "Poll for the current status of a share resolution token.",
+            security = @SecurityRequirement(name = "sharedToken"),
+            parameters = {
+                    @Parameter(name = "token", in = ParameterIn.PATH, required = true,
+                            description = "Resolution token returned by the create endpoint",
+                            schema = @Schema(type = "string", example = "0df7ce2f-3f9e-44d5-a0c4-5f3f0f7d31a7")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language hint used to resolve locale specific data.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Snapshot found",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ShareResolutionResponseDto.class)),
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for the response",
+                                    schema = @Schema(type = "string", example = "en"))),
+                    @ApiResponse(responseCode = "404", description = "Unknown token"),
+                    @ApiResponse(responseCode = "401", description = "Authentication required"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden")
+            })
+    public ResponseEntity<ShareResolutionResponseDto> getResolution(
+            @PathVariable("token") String token,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Polling resolution token={} language={}", token, domainLanguage);
+        Optional<ShareResolutionResponseDto> snapshot = shareResolutionService.getResolution(token);
+        return snapshot.map(body -> ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.PRIVATE_NO_STORE_CACHE)
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(body))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareCandidateDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareCandidateDto.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.dto.share;
+
+import org.open4goods.nudgerfrontapi.dto.product.ProductAggregatedPriceDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Candidate returned for a share resolution request.
+ */
+public record ShareCandidateDto(
+        @Schema(description = "Identifier of the product (GTIN or slug)", example = "7612345678901")
+        String productId,
+        @Schema(description = "Candidate display name", example = "Fairphone 4")
+        String name,
+        @Schema(description = "Preferred image for the candidate", format = "uri", example = "https://cdn.example.org/image.jpg")
+        String image,
+        @Schema(description = "Eco score when available", example = "15.2")
+        Double ecoScore,
+        @Schema(description = "Environmental impact score when available", example = "12.5")
+        Double impactScore,
+        @Schema(description = "Best indexed price without triggering live scraping", implementation = ProductAggregatedPriceDto.class)
+        ProductAggregatedPriceDto bestPrice,
+        @Schema(description = "Confidence score associated to the match", example = "0.86")
+        Double confidence
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareExtractionDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareExtractionDto.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.share;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Lightweight representation of the extracted payload from a shared URL.
+ */
+public record ShareExtractionDto(
+        @Schema(description = "Extracted GTIN when resolvable", example = "7612345678901")
+        String gtin,
+        @Schema(description = "Query derived from the URL or shared content", example = "fairphone 4 smartphone")
+        String query
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionRequestDto.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.dto.share;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Payload accepted by the share resolution endpoint.
+ */
+public record ShareResolutionRequestDto(
+        @Schema(description = "Product URL shared from a merchant site", required = true,
+                example = "https://shop.example.org/product/fairphone-4")
+        String url,
+        @Schema(description = "Optional title forwarded by the share sheet", example = "Great phone")
+        String title,
+        @Schema(description = "Optional free-form text forwarded by the share sheet", example = "Worth checking this out")
+        String text
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionResponseDto.java
@@ -1,0 +1,31 @@
+package org.open4goods.nudgerfrontapi.dto.share;
+
+import java.time.Instant;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Snapshot of a share resolution execution.
+ */
+public record ShareResolutionResponseDto(
+        @Schema(description = "Token assigned to the resolution request", example = "0df7ce2f-3f9e-44d5-a0c4-5f3f0f7d31a7")
+        String token,
+        @Schema(description = "Current status of the resolution", implementation = ShareResolutionStatus.class)
+        ShareResolutionStatus status,
+        @Schema(description = "Original URL provided by the user", example = "https://shop.example.org/product/fairphone-4")
+        String originUrl,
+        @Schema(description = "Timestamp when the resolution started", example = "2024-06-05T12:00:00Z")
+        Instant startedAt,
+        @Schema(description = "Timestamp when the resolution completed", example = "2024-06-05T12:00:02Z", nullable = true)
+        Instant resolvedAt,
+        @Schema(description = "Best-effort extraction result", implementation = ShareExtractionDto.class, nullable = true)
+        ShareExtractionDto extracted,
+        @ArraySchema(arraySchema = @Schema(description = "List of matching candidates"),
+                schema = @Schema(implementation = ShareCandidateDto.class))
+        List<ShareCandidateDto> candidates,
+        @Schema(description = "Optional diagnostic message", example = "Resolution timed out after 4 seconds", nullable = true)
+        String message
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionStatus.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/share/ShareResolutionStatus.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.dto.share;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Possible states of the share resolution pipeline.
+ */
+@Schema(description = "State of the share resolution process", allowableValues = { "PENDING", "RESOLVED", "TIMEOUT", "ERROR" })
+public enum ShareResolutionStatus {
+    /** Request accepted and currently being resolved. */
+    PENDING,
+    /** Resolution completed with candidates. */
+    RESOLVED,
+    /** Resolution exceeded its SLA budget. */
+    TIMEOUT,
+    /** Resolution failed due to invalid input or extractor error. */
+    ERROR
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/http/SimpleHttpFetcher.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/http/SimpleHttpFetcher.java
@@ -1,0 +1,44 @@
+package org.open4goods.nudgerfrontapi.service.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Lightweight HTTP fetcher reused by share resolution to hit crawler endpoints
+ * or remote URLs.
+ */
+@Service
+public class SimpleHttpFetcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleHttpFetcher.class);
+
+    private final RestClient restClient;
+
+    public SimpleHttpFetcher(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder.build();
+    }
+
+    /**
+     * Fetch the raw body of the provided URL using a simple GET request.
+     *
+     * @param url target URL
+     * @return body when the request succeeds or {@code null} otherwise
+     */
+    public String fetch(String url) {
+        try {
+            return restClient.get().uri(url).retrieve().body(String.class);
+        } catch (RestClientResponseException e) {
+            HttpStatusCode statusCode = e.getStatusCode();
+            LOGGER.warn("HTTP {} while fetching {} for share resolution: {}", statusCode, url, e.getResponseBodyAsString());
+            return null;
+        } catch (RestClientException e) {
+            LOGGER.warn("HTTP client error while fetching {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/InMemoryShareResolutionStore.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/InMemoryShareResolutionStore.java
@@ -1,0 +1,43 @@
+package org.open4goods.nudgerfrontapi.service.share;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+
+/**
+ * In-memory implementation of {@link ShareResolutionStore} with TTL eviction.
+ */
+public class InMemoryShareResolutionStore implements ShareResolutionStore {
+
+    private final Map<String, StoredResolution> store = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    public InMemoryShareResolutionStore(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void save(ShareResolutionResponseDto response, Instant expiresAt) {
+        store.put(response.token(), new StoredResolution(response, expiresAt));
+    }
+
+    @Override
+    public Optional<ShareResolutionResponseDto> get(String token) {
+        StoredResolution holder = store.get(token);
+        if (holder == null) {
+            return Optional.empty();
+        }
+        if (clock.instant().isAfter(holder.expiresAt())) {
+            store.remove(token);
+            return Optional.empty();
+        }
+        return Optional.of(holder.response());
+    }
+
+    private record StoredResolution(ShareResolutionResponseDto response, Instant expiresAt) {
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareExtractionService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareExtractionService.java
@@ -1,0 +1,146 @@
+package org.open4goods.nudgerfrontapi.service.share;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.open4goods.nudgerfrontapi.config.properties.ShareResolutionProperties;
+import org.open4goods.nudgerfrontapi.dto.share.ShareExtractionDto;
+import org.open4goods.nudgerfrontapi.service.http.SimpleHttpFetcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Best-effort extractor for shared URLs.
+ */
+@Service
+public class ShareExtractionService {
+
+    private static final Pattern GTIN_PATTERN = Pattern.compile("\\b(\\d{8,14})\\b");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShareExtractionService.class);
+
+    private final ShareResolutionProperties properties;
+    private final SimpleHttpFetcher httpFetcher;
+
+    public ShareExtractionService(ShareResolutionProperties properties, SimpleHttpFetcher httpFetcher) {
+        this.properties = properties;
+        this.httpFetcher = httpFetcher;
+    }
+
+    /**
+     * Extract a GTIN or fallback query from the URL and optional content.
+     *
+     * @param url   origin URL
+     * @param title optional title
+     * @param text  optional text
+     * @return optional extraction result
+     */
+    public Optional<ShareExtractionDto> extract(String url, String title, String text) {
+        String content = null;
+        if (properties.isCrawlerExtractionEnabled()) {
+            content = httpFetcher.fetch(url);
+        }
+
+        String gtin = firstMatch(url, content, title, text);
+        String query = buildQuery(url, title, text);
+
+        if (!StringUtils.hasText(gtin) && !StringUtils.hasText(query)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ShareExtractionDto(gtin, query));
+    }
+
+    /**
+     * Identify the first GTIN-like segment across all provided content fragments.
+     *
+     * @param url     shared URL
+     * @param content body fetched from the crawler when enabled
+     * @param title   optional title
+     * @param text    optional text
+     * @return matched GTIN or {@code null}
+     */
+    private String firstMatch(String url, String content, String title, String text) {
+        Matcher matcher = GTIN_PATTERN.matcher(concatenate(url, content, title, text));
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    /**
+     * Merge all content sources into a single searchable string.
+     *
+     * @param url     shared URL
+     * @param content fetched body
+     * @param title   optional title
+     * @param text    optional text
+     * @return concatenated representation
+     */
+    private String concatenate(String url, String content, String title, String text) {
+        StringBuilder builder = new StringBuilder();
+        if (StringUtils.hasText(url)) {
+            builder.append(url).append(' ');
+        }
+        if (StringUtils.hasText(content)) {
+            builder.append(content).append(' ');
+        }
+        if (StringUtils.hasText(title)) {
+            builder.append(title).append(' ');
+        }
+        if (StringUtils.hasText(text)) {
+            builder.append(text);
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Build a search query using user provided hints or a slug fallback.
+     *
+     * @param url   shared URL
+     * @param title optional title
+     * @param text  optional text
+     * @return derived query or {@code null}
+     */
+    private String buildQuery(String url, String title, String text) {
+        if (StringUtils.hasText(title)) {
+            return title;
+        }
+        if (StringUtils.hasText(text)) {
+            return text;
+        }
+        return deriveSlugQuery(url);
+    }
+
+    /**
+     * Derive a readable query from the last URL segment.
+     *
+     * @param url shared URL
+     * @return slug-based query
+     */
+    private String deriveSlugQuery(String url) {
+        try {
+            URI uri = new URI(url);
+            String path = uri.getPath();
+            if (!StringUtils.hasText(path)) {
+                return null;
+            }
+            String[] segments = path.split("/");
+            for (int i = segments.length - 1; i >= 0; i--) {
+                String segment = segments[i];
+                if (StringUtils.hasText(segment)) {
+                    return segment.replace('-', ' ').replace('_', ' ').trim();
+                }
+            }
+            return null;
+        } catch (URISyntaxException e) {
+            LOGGER.warn("Failed to derive slug query from URL {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionService.java
@@ -1,0 +1,294 @@
+package org.open4goods.nudgerfrontapi.service.share;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import org.open4goods.nudgerfrontapi.config.properties.ShareResolutionProperties;
+import org.open4goods.nudgerfrontapi.dto.product.ProductAggregatedPriceDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductBaseDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductOffersDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductResourcesDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductScoresDto;
+import org.open4goods.nudgerfrontapi.dto.product.ProductScoreDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareCandidateDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareExtractionDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionRequestDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionStatus;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.ProductMappingService;
+import org.open4goods.nudgerfrontapi.service.SearchService;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchHit;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchResult;
+import org.open4goods.nudgerfrontapi.service.exception.InvalidAffiliationTokenException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Orchestrates asynchronous share resolution while enforcing SLA constraints.
+ */
+@Service
+public class ShareResolutionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShareResolutionService.class);
+
+    private final ShareExtractionService extractionService;
+    private final SearchService searchService;
+    private final ProductMappingService productMappingService;
+    private final ShareResolutionStore store;
+    private final ShareResolutionProperties properties;
+    private final Clock clock;
+    private final Executor executor;
+
+    public ShareResolutionService(ShareExtractionService extractionService, SearchService searchService,
+            ProductMappingService productMappingService, ShareResolutionStore store,
+            ShareResolutionProperties properties, Clock clock, Executor executor) {
+        this.extractionService = extractionService;
+        this.searchService = searchService;
+        this.productMappingService = productMappingService;
+        this.store = store;
+        this.properties = properties;
+        this.clock = clock;
+        this.executor = executor;
+    }
+
+    /**
+     * Accept a share resolution request and start asynchronous processing.
+     *
+     * @param request        incoming payload
+     * @param domainLanguage localisation hint forwarded to downstream services
+     * @return pending response containing the resolution token
+     */
+    public ShareResolutionResponseDto createResolution(ShareResolutionRequestDto request, DomainLanguage domainLanguage) {
+        validateRequest(request);
+
+        Instant startedAt = clock.instant();
+        String token = UUID.randomUUID().toString();
+
+        ShareResolutionResponseDto pending = new ShareResolutionResponseDto(token, ShareResolutionStatus.PENDING,
+                request.url(), startedAt, null, null, List.of(), null);
+
+        store.save(pending, startedAt.plus(properties.getStoreTtl()));
+
+        executor.execute(() -> resolve(token, request, domainLanguage, startedAt));
+
+        return pending;
+    }
+
+    /**
+     * Retrieve an existing resolution snapshot.
+     *
+     * @param token unique token
+     * @return optional snapshot
+     */
+    public Optional<ShareResolutionResponseDto> getResolution(String token) {
+        return store.get(token);
+    }
+
+    /**
+     * Execute share resolution asynchronously while respecting the SLA budget.
+     *
+     * @param token          resolution token
+     * @param request        initial request payload
+     * @param domainLanguage localisation hint
+     * @param startedAt      creation timestamp
+     */
+    private void resolve(String token, ShareResolutionRequestDto request, DomainLanguage domainLanguage,
+            Instant startedAt) {
+        try {
+            Optional<ShareExtractionDto> extraction = extractionService.extract(request.url(), request.title(),
+                    request.text());
+
+            if (extraction.isEmpty()) {
+                updateAndStore(token, request.url(), ShareResolutionStatus.ERROR, startedAt, null, List.of(),
+                        "No candidate could be extracted from the provided URL");
+                return;
+            }
+
+            List<ShareCandidateDto> candidates = resolveCandidates(extraction.get(), domainLanguage);
+
+            Instant now = clock.instant();
+            ShareResolutionStatus status = now.isAfter(startedAt.plus(properties.getResolutionWindow()))
+                    ? ShareResolutionStatus.TIMEOUT
+                    : ShareResolutionStatus.RESOLVED;
+
+            updateAndStore(token, request.url(), status, startedAt, extraction.get(), candidates,
+                    status == ShareResolutionStatus.TIMEOUT ? "Resolution timed out" : null);
+        } catch (Exception e) {
+            LOGGER.error("Resolution failed for token {}: {}", token, e.getMessage(), e);
+            updateAndStore(token, request.url(), ShareResolutionStatus.ERROR, startedAt, null, List.of(), e.getMessage());
+        }
+    }
+
+    /**
+     * Validate the share resolution payload and enforce size/scheme constraints.
+     *
+     * @param request incoming request
+     */
+    private void validateRequest(ShareResolutionRequestDto request) {
+        if (request == null || !StringUtils.hasText(request.url())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The url parameter is required");
+        }
+        if (request.url().length() > properties.getMaxUrlLength()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shared URL is too long");
+        }
+        try {
+            URI uri = new URI(request.url());
+            if (!"http".equalsIgnoreCase(uri.getScheme()) && !"https".equalsIgnoreCase(uri.getScheme())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only HTTP/HTTPS URLs are accepted");
+            }
+        } catch (URISyntaxException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid URL");
+        }
+
+        if (StringUtils.hasText(request.text()) && request.text().length() > properties.getMaxTextLength()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shared text is too long");
+        }
+        if (StringUtils.hasText(request.title()) && request.title().length() > properties.getMaxTitleLength()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Shared title is too long");
+        }
+    }
+
+    /**
+     * Resolve candidates either directly from a GTIN or using a search query.
+     *
+     * @param extraction     extraction payload
+     * @param domainLanguage localisation hint
+     * @return ordered list of candidates limited by configuration
+     */
+    private List<ShareCandidateDto> resolveCandidates(ShareExtractionDto extraction, DomainLanguage domainLanguage) {
+        List<ShareCandidateDto> candidates = new ArrayList<>();
+
+        if (StringUtils.hasText(extraction.gtin())) {
+            mapProductByGtin(extraction.gtin(), domainLanguage).ifPresent(candidates::add);
+        }
+
+        if (candidates.isEmpty() && StringUtils.hasText(extraction.query())) {
+            candidates.addAll(searchByQuery(extraction.query(), domainLanguage));
+        }
+
+        return candidates.stream()
+                .limit(properties.getMaxCandidates())
+                .toList();
+    }
+
+    /**
+     * Map a GTIN to a candidate using the repository and mapping service.
+     *
+     * @param gtin           extracted GTIN
+     * @param domainLanguage localisation hint
+     * @return optional candidate
+     */
+    private Optional<ShareCandidateDto> mapProductByGtin(String gtin, DomainLanguage domainLanguage) {
+        try {
+            long numericGtin = Long.parseLong(gtin);
+            ProductDto dto = productMappingService.getProduct(numericGtin,
+                    Locale.forLanguageTag(domainLanguage.languageTag()), null, domainLanguage);
+            return Optional.of(toCandidate(dto, null));
+        } catch (InvalidAffiliationTokenException e) {
+            LOGGER.warn("Invalid affiliation token while mapping GTIN {}: {}", gtin, e.getMessage());
+            return Optional.empty();
+        } catch (Exception e) {
+            LOGGER.warn("No product found for GTIN {}: {}", gtin, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Run a search query and convert the resulting hits into candidates.
+     *
+     * @param query          derived search query
+     * @param domainLanguage localisation hint
+     * @return ordered list of candidates
+     */
+    private List<ShareCandidateDto> searchByQuery(String query, DomainLanguage domainLanguage) {
+        GlobalSearchResult searchResult = searchService.globalSearch(query, domainLanguage);
+        List<ShareCandidateDto> mapped = new ArrayList<>();
+
+        searchResult.verticalGroups().forEach(group -> group.results().stream()
+                .sorted(Comparator.comparingDouble(GlobalSearchHit::score).reversed())
+                .map(hit -> toCandidate(hit.product(), hit.score()))
+                .forEach(mapped::add));
+
+        searchResult.fallbackResults().stream()
+                .sorted(Comparator.comparingDouble(GlobalSearchHit::score).reversed())
+                .map(hit -> toCandidate(hit.product(), hit.score()))
+                .forEach(mapped::add);
+
+        return mapped;
+    }
+
+    /**
+     * Convert a product DTO into a share candidate.
+     *
+     * @param product product DTO to convert
+     * @param score   optional confidence score
+     * @return populated candidate
+     */
+    private ShareCandidateDto toCandidate(ProductDto product, Double score) {
+        ProductBaseDto base = product.base();
+        ProductResourcesDto resources = product.resources();
+        ProductOffersDto offers = product.offers();
+
+        String image = base != null ? base.coverImagePath()
+                : resources != null ? resources.coverImagePath() : null;
+        ProductAggregatedPriceDto bestPrice = offers != null ? offers.bestPrice() : null;
+        Double ecoScore = base != null ? base.ecoscoreValue() : null;
+        Double impactScore = resolveImpactScore(product);
+
+        String productId = product.slug() != null ? product.slug() : String.valueOf(product.gtin());
+        String name = base != null ? base.bestName() : product.identity() != null ? product.identity().model() : productId;
+
+        return new ShareCandidateDto(productId, name, image, ecoScore, impactScore, bestPrice, score);
+    }
+
+    /**
+     * Extract the impact score when present in the score map.
+     *
+     * @param product product DTO containing scores
+     * @return numeric impact value when available
+     */
+    private Double resolveImpactScore(ProductDto product) {
+        if (product.scores() == null || product.scores().scores() == null) {
+            return null;
+        }
+        ProductScoreDto score = product.scores().scores().get("IMPACT");
+        if (score != null) {
+            return score.value();
+        }
+        return null;
+    }
+
+    /**
+     * Persist the latest resolution snapshot using the store abstraction.
+     *
+     * @param token       resolution token
+     * @param originUrl   original URL provided by the caller
+     * @param status      new status
+     * @param startedAt   creation timestamp
+     * @param extraction  extraction payload
+     * @param candidates  resolved candidates
+     * @param message     optional diagnostic message
+     */
+    private void updateAndStore(String token, String originUrl, ShareResolutionStatus status, Instant startedAt,
+            ShareExtractionDto extraction, List<ShareCandidateDto> candidates, String message) {
+        Instant resolvedAt = clock.instant();
+        ShareResolutionResponseDto response = new ShareResolutionResponseDto(token, status, originUrl, startedAt, resolvedAt,
+                extraction, candidates, message);
+        store.save(response, resolvedAt.plus(properties.getStoreTtl()));
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionStore.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionStore.java
@@ -1,0 +1,28 @@
+package org.open4goods.nudgerfrontapi.service.share;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+
+/**
+ * Abstraction for storing share resolution snapshots.
+ */
+public interface ShareResolutionStore {
+
+    /**
+     * Persist the provided snapshot until the given expiration time.
+     *
+     * @param response  response to store
+     * @param expiresAt expiration timestamp
+     */
+    void save(ShareResolutionResponseDto response, Instant expiresAt);
+
+    /**
+     * Retrieve the snapshot associated with the token when still valid.
+     *
+     * @param token unique token identifying the resolution
+     * @return optional snapshot
+     */
+    Optional<ShareResolutionResponseDto> get(String token);
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -54,6 +54,11 @@
       "name": "price-config",
       "type": "org.open4goods.nudgerfrontapi.config.properties.PriceRestitutionProperties",
       "sourceType": "org.open4goods.nudgerfrontapi.config.properties.PriceRestitutionProperties"
+    },
+    {
+      "name": "front.share",
+      "type": "org.open4goods.nudgerfrontapi.config.properties.ShareResolutionProperties",
+      "sourceType": "org.open4goods.nudgerfrontapi.config.properties.ShareResolutionProperties"
     }
   ],
   "properties": [
@@ -192,6 +197,48 @@
       "type": "java.lang.String",
       "description": "Path appended to the base URL when triggering or polling review generation.",
       "defaultValue": "/review"
+    },
+    {
+      "name": "front.share.crawler-extraction-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable extraction through the crawler service before applying slug fallback.",
+      "defaultValue": false
+    },
+    {
+      "name": "front.share.resolution-window",
+      "type": "java.time.Duration",
+      "description": "Maximum duration allocated to complete share resolution before timing out.",
+      "defaultValue": "PT4S"
+    },
+    {
+      "name": "front.share.store-ttl",
+      "type": "java.time.Duration",
+      "description": "Time to live applied to in-memory share resolution snapshots.",
+      "defaultValue": "PT20M"
+    },
+    {
+      "name": "front.share.max-url-length",
+      "type": "java.lang.Integer",
+      "description": "Maximum length accepted for shared URLs.",
+      "defaultValue": 2048
+    },
+    {
+      "name": "front.share.max-text-length",
+      "type": "java.lang.Integer",
+      "description": "Maximum length accepted for shared text snippets.",
+      "defaultValue": 2048
+    },
+    {
+      "name": "front.share.max-title-length",
+      "type": "java.lang.Integer",
+      "description": "Maximum length accepted for optional shared titles.",
+      "defaultValue": 256
+    },
+    {
+      "name": "front.share.max-candidates",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of candidates returned per resolution.",
+      "defaultValue": 5
     },
     {
       "name": "front.contact.email",

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ShareResolutionControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ShareResolutionControllerTest.java
@@ -1,0 +1,84 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.share.ShareCandidateDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionRequestDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionStatus;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.share.ShareResolutionService;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Unit tests for {@link ShareResolutionController}.
+ */
+class ShareResolutionControllerTest {
+
+    private ShareResolutionService shareResolutionService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        shareResolutionService = mock(ShareResolutionService.class);
+        mockMvc = MockMvcBuilders.standaloneSetup(new ShareResolutionController(shareResolutionService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    void createResolutionReturnsAcceptedSnapshot() throws Exception {
+        ShareResolutionResponseDto pending = new ShareResolutionResponseDto("token", ShareResolutionStatus.PENDING,
+                "https://example.org", Instant.parse("2024-06-10T10:00:00Z"), null, null, List.of(), null);
+        when(shareResolutionService.createResolution(any(ShareResolutionRequestDto.class), eq(DomainLanguage.fr)))
+                .thenReturn(pending);
+
+        mockMvc.perform(post("/share/resolutions")
+                        .param("domainLanguage", "fr")
+                        .contentType("application/json")
+                        .content("{\"url\":\"https://example.org\"}"))
+                .andExpect(status().isAccepted())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("no-store")))
+                .andExpect(jsonPath("$.token").value("token"));
+    }
+
+    @Test
+    void getResolutionReturnsNotFoundWhenMissing() throws Exception {
+        when(shareResolutionService.getResolution("missing")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/share/resolutions/missing").param("domainLanguage", "en"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getResolutionReturnsSnapshot() throws Exception {
+        ShareCandidateDto candidate = new ShareCandidateDto("1", "name", null, null, null, null, 0.5d);
+        ShareResolutionResponseDto response = new ShareResolutionResponseDto("token", ShareResolutionStatus.RESOLVED,
+                "https://example.org", Instant.parse("2024-06-10T10:00:00Z"), Instant.parse("2024-06-10T10:00:01Z"), null,
+                List.of(candidate), null);
+        when(shareResolutionService.getResolution("token")).thenReturn(Optional.of(response));
+
+        mockMvc.perform(get("/share/resolutions/token").param("domainLanguage", "en"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "en"))
+                .andExpect(header().string("Cache-Control", org.hamcrest.Matchers.containsString("no-store")))
+                .andExpect(jsonPath("$.candidates[0].productId").value("1"));
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionServiceTest.java
@@ -1,0 +1,135 @@
+package org.open4goods.nudgerfrontapi.service.share;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.config.properties.ShareResolutionProperties;
+import org.open4goods.nudgerfrontapi.dto.product.ProductDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareExtractionDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionRequestDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionResponseDto;
+import org.open4goods.nudgerfrontapi.dto.share.ShareResolutionStatus;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.ProductMappingService;
+import org.open4goods.nudgerfrontapi.service.SearchService;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchHit;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchResult;
+import org.open4goods.nudgerfrontapi.service.SearchService.GlobalSearchVerticalGroup;
+
+/**
+ * Unit tests for {@link ShareResolutionService}.
+ */
+class ShareResolutionServiceTest {
+
+    private final Executor sameThreadExecutor = Runnable::run;
+
+    @Test
+    void createResolutionResolvesCandidates() {
+        ShareExtractionService extractionService = mock(ShareExtractionService.class);
+        SearchService searchService = mock(SearchService.class);
+        ProductMappingService mappingService = mock(ProductMappingService.class);
+
+        ShareResolutionProperties properties = new ShareResolutionProperties();
+        properties.setResolutionWindow(Duration.ofSeconds(4));
+        Clock clock = Clock.systemUTC();
+        ShareResolutionStore store = new InMemoryShareResolutionStore(clock);
+
+        ShareResolutionService service = new ShareResolutionService(extractionService, searchService, mappingService, store,
+                properties, clock, sameThreadExecutor);
+
+        when(extractionService.extract("https://example.org/p/slug", null, null))
+                .thenReturn(Optional.of(new ShareExtractionDto(null, "fairphone")));
+
+        ProductDto product = new ProductDto(1L, "fairphone-4", null, null, null, null, null, null, null, null, null, null,
+                null, null);
+        GlobalSearchHit hit = new GlobalSearchHit("phones", product, 0.92d);
+        GlobalSearchResult searchResult = new GlobalSearchResult(List.of(new GlobalSearchVerticalGroup("phones", List.of(hit))),
+                List.of(), false);
+        when(searchService.globalSearch("fairphone", DomainLanguage.fr)).thenReturn(searchResult);
+
+        ShareResolutionResponseDto pending = service
+                .createResolution(new ShareResolutionRequestDto("https://example.org/p/slug", null, null), DomainLanguage.fr);
+
+        Optional<ShareResolutionResponseDto> resolved = store.get(pending.token());
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().status()).isEqualTo(ShareResolutionStatus.RESOLVED);
+        assertThat(resolved.get().candidates()).hasSize(1);
+        assertThat(resolved.get().candidates().getFirst().productId()).isEqualTo("fairphone-4");
+
+        verify(searchService).globalSearch("fairphone", DomainLanguage.fr);
+    }
+
+    @Test
+    void resolutionTimesOutWhenClockExceedsWindow() {
+        ShareExtractionService extractionService = mock(ShareExtractionService.class);
+        SearchService searchService = mock(SearchService.class);
+        ProductMappingService mappingService = mock(ProductMappingService.class);
+
+        ShareResolutionProperties properties = new ShareResolutionProperties();
+        properties.setResolutionWindow(Duration.ofSeconds(1));
+
+        StepClock clock = new StepClock(Instant.parse("2024-06-01T10:00:00Z"));
+        ShareResolutionStore store = new InMemoryShareResolutionStore(clock);
+
+        ShareResolutionService service = new ShareResolutionService(extractionService, searchService, mappingService, store,
+                properties, clock, sameThreadExecutor);
+
+        when(extractionService.extract("https://example.org/p/slow", null, null))
+                .thenReturn(Optional.of(new ShareExtractionDto(null, "slow-query")));
+
+        ProductDto product = new ProductDto(9L, "slow", null, null, null, null, null, null, null, null, null, null, null, null);
+        GlobalSearchHit hit = new GlobalSearchHit(null, product, 0.1d);
+        GlobalSearchResult searchResult = new GlobalSearchResult(List.of(), List.of(hit), true);
+        when(searchService.globalSearch("slow-query", DomainLanguage.en)).then(invocation -> {
+            clock.step();
+            return searchResult;
+        });
+
+        ShareResolutionResponseDto pending = service
+                .createResolution(new ShareResolutionRequestDto("https://example.org/p/slow", null, null), DomainLanguage.en);
+
+        Optional<ShareResolutionResponseDto> resolved = store.get(pending.token());
+        assertThat(resolved).isPresent();
+        assertThat(resolved.get().status()).isEqualTo(ShareResolutionStatus.TIMEOUT);
+        assertThat(resolved.get().message()).contains("timed out");
+        assertThat(resolved.get().candidates()).hasSize(1);
+    }
+
+    private static final class StepClock extends Clock {
+        private Instant instant;
+
+        StepClock(Instant start) {
+            this.instant = start;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        void step() {
+            instant = instant.plusSeconds(2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add asynchronous POST/GET `/share/resolutions` endpoints with SpringDoc annotations, cache-control, and required domain language handling
- implement share resolution workflow with feature-flagged extraction, SLA-aware service, reusable HTTP fetcher, and in-memory store
- document new front.share configuration knobs and add controller/service tests for resolution and timeouts

## Testing
- mvn --offline test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943cffa6774832bb4e9424b16d2c73d)