### PR TITLE
Refine nudge wizard header actions

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
@@ -17,6 +17,9 @@ vi.mock('vuetify', () => ({
 vi.mock('~/composables/categories/useCategories', () => ({
     useCategories: () => ({ fetchCategories: vi.fn().mockResolvedValue([]) })
 }))
+vi.mock('~/components/nudge-tool/NudgeWizardHeader.vue', () => ({
+    default: { template: '<div class="header-stub"></div>' }
+}))
 
 vi.mock('#components', () => ({
     NudgeToolStepCategory: { template: '<div>Category</div>' },

--- a/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
+++ b/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
@@ -22,28 +22,42 @@
         </div>
       </div>
 
-      <div class="wizard-header__actions">
-        <v-btn
-          v-if="hasPrevious"
-          variant="text"
-          prepend-icon="mdi-chevron-left"
-          class="wizard-header__action"
-          @click="emit('previous')"
+      <div
+        class="wizard-header__actions"
+        :class="{ 'wizard-header__actions--mobile': isMobile }"
+      >
+        <v-btn-group
+          class="wizard-header__action-group"
+          :class="{ 'wizard-header__action-group--mobile': isMobile }"
+          density="comfortable"
         >
-          {{ previousLabel }}
-        </v-btn>
+          <v-btn
+            v-if="hasPrevious"
+            color="primary"
+            variant="outlined"
+            rounded="pill"
+            elevation="0"
+            prepend-icon="mdi-chevron-left"
+            class="wizard-header__action-btn wizard-header__action-btn--previous"
+            @click="emit('previous')"
+          >
+            {{ previousLabel }}
+          </v-btn>
 
-        <v-btn
-          v-if="hasNext"
-          color="primary"
-          variant="flat"
-          :disabled="nextDisabled"
-          append-icon="mdi-chevron-right"
-          class="wizard-header__action"
-          @click="emit('next')"
-        >
-          {{ nextLabel }}
-        </v-btn>
+          <v-btn
+            v-if="hasNext"
+            color="primary"
+            variant="tonal"
+            rounded="pill"
+            elevation="0"
+            :disabled="nextDisabled"
+            append-icon="mdi-chevron-right"
+            class="wizard-header__action-btn wizard-header__action-btn--next"
+            @click="emit('next')"
+          >
+            {{ nextLabel }}
+          </v-btn>
+        </v-btn-group>
       </div>
     </div>
   </header>
@@ -51,6 +65,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
 import type {
   AccentCorner,
   CornerSize,
@@ -96,6 +111,11 @@ const emit = defineEmits<{
 }>()
 
 const isStacked = computed(() => props.accentCorner === 'top-left')
+const display = useDisplay()
+const isMobile = computed(() => {
+  const breakpoint = display && 'mdAndDown' in display ? display.mdAndDown : undefined
+  return typeof breakpoint?.value === 'boolean' ? breakpoint.value : false
+})
 
 const headerOffsetStyle = computed(() => {
   if (props.accentCorner !== 'top-left') {
@@ -180,13 +200,68 @@ const headerOffsetStyle = computed(() => {
   }
 
   &__actions {
-    display: inline-flex;
-    gap: 8px;
+    display: flex;
     align-items: center;
+    justify-content: flex-end;
   }
 
-  &__action {
+  &__action-group {
+    display: inline-flex;
+    gap: 6px;
+    padding: 6px 8px;
+    border-radius: 999px;
+    background-color: rgba(var(--v-theme-surface-primary-080), 0.55);
+    border: 1px solid rgb(var(--v-theme-border-primary-strong));
+    transition: background-color 160ms ease, border-color 160ms ease;
+  }
+
+  &__action-group--mobile {
+    width: 100%;
+    max-width: 420px;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+    padding: 10px;
+    gap: 10px;
+  }
+
+  &__action-btn {
     font-weight: 700;
+
+    :deep(.v-btn) {
+      border-width: 1px;
+      transition:
+        background-color 160ms ease,
+        color 160ms ease,
+        border-color 160ms ease;
+    }
+
+    :deep(.v-btn:hover),
+    :deep(.v-btn:focus-visible) {
+      background-color: rgba(var(--v-theme-surface-primary-100), 0.75);
+      color: rgb(var(--v-theme-text-neutral-strong));
+      box-shadow: none;
+    }
+
+    :deep(.v-btn:focus-visible) {
+      outline: 2px solid rgb(var(--v-theme-accent-primary-highlight));
+      outline-offset: 2px;
+    }
+
+    :deep(.v-btn--disabled) {
+      color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+      border-color: rgba(var(--v-theme-border-primary-strong), 0.5);
+      background-color: rgba(var(--v-theme-surface-primary-080), 0.55);
+      box-shadow: none;
+    }
+  }
+
+  &__actions--mobile {
+    justify-content: center;
+  }
+
+  &__action-btn--next :deep(.v-btn) {
+    color: rgb(var(--v-theme-text-on-accent));
   }
 
   @media (max-width: 960px) {
@@ -196,6 +271,16 @@ const headerOffsetStyle = computed(() => {
 
     &__meta {
       justify-content: center;
+      gap: 10px;
+    }
+
+    &__actions {
+      width: 100%;
+      order: 2;
+    }
+
+    &__action-group--mobile :deep(.v-btn) {
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
## Summary
- restyle the nudge wizard header actions into grouped pill buttons with updated hover and focus states
- add responsive spacing/background treatment for the action group with subtle surface and border styling
- stub the header component in the wizard spec to keep tests isolated after the layout change

## Testing
- pnpm lint
- pnpm vitest run components/nudge-tool/NudgeToolWizard.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ee7bf76883228abc05f589e4a50a)