### PR TITLE
Exclude Playwright visual tests from Vitest runs

### DIFF
--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -1,7 +1,9 @@
 import { defineVitestConfig } from '@nuxt/test-utils/config'
+import { configDefaults } from 'vitest/config'
 
 export default defineVitestConfig({
   test: {
     environment: 'nuxt',
+    exclude: [...configDefaults.exclude, 'tests/visual/**'],
   },
 })


### PR DESCRIPTION
## Summary
- prevent Vitest from collecting the Playwright visual regression suite by excluding `tests/visual/**`
- keep Vitest focused on unit and integration specs to avoid cross-runner `test.describe` errors

## Testing
- pnpm test --run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f7c3e4d88322b19b506689484d6b)