### PR TITLE
Display partner counts in home hero

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -68,7 +68,11 @@
           },
           {
             "icon": "🏷️",
-            "label": "The best prices on the market"
+            "label": "The best prices on the market",
+            "segments": [
+              { "text": "Stay smart on prices with" },
+              { "text": "{partnersLink}", "to": "/partners" }
+            ]
           },
           {
             "icon": "🛡️",
@@ -91,6 +95,9 @@
             ]
           }
         ]
+        ,
+        "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
+        "partnerLinkFallback": "our partners"
       },
       "context": {
         "cornerLabel": "Impact digest",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -73,9 +73,16 @@
           },
           {
             "icon": "🏷️",
-            "label": "Sans se faire avoir sur les prix"
+            "label": "Sans se faire avoir sur les prix",
+            "segments": [
+              { "text": "Sans se faire avoir sur les prix avec" },
+              { "text": "{partnersLink}", "to": "/partenaires" }
+            ]
           }
         ]
+        ,
+        "partnerLinkLabel": "{formattedCount} partenaire | {formattedCount} partenaires",
+        "partnerLinkFallback": "nos partenaires"
       },
       "context": {
         "cornerLabel": "Résumé impact",


### PR DESCRIPTION
## Summary
- Fetch affiliation partners during home SSR to surface a localized partner count in the hero helper
- Add partner link placeholders in FR/EN hero translations and replace them dynamically in the hero helper copy
- Extend hero helper tests to cover partner link/count rendering

## Testing
- pnpm vitest run app/components/home/sections/HomeHeroSection.spec.ts
- pnpm vitest run app/pages/index.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943f3ff7e048322908b1ebdcb36c6f9)