### PR TITLE
Align home backgrounds with themed assets and add audit guide

### DIFF
--- a/frontend/app/assets/themes/README.md
+++ b/frontend/app/assets/themes/README.md
@@ -14,3 +14,8 @@ Theme-specific assets live under `app/assets/themes/<theme>/` with shared fallba
 - `common/`: neutral visuals usable across all themes (e.g., hero backgrounds, generic illustrations).
 
 Use the `useThemedAsset` composable to resolve the correct URL instead of importing assets directly.
+
+## Recommended sizes & ratios
+- **Hero & parallax backgrounds**: keep a single large viewBox such as `1600x900` or `1920x1080` with `preserveAspectRatio="xMidYMid slice"` and generous bleed (10–15%) so the image covers wide and tall viewports without revealing empty bands.
+- **Placeholders/illustrations**: max ~`1200x900`, still exported as SVG where possible.
+- Avoid fixing `height="800"` in SVG outputs; prefer `width="100%" height="100%"` and rely on the viewBox to remain crisp when parallax and overlays are applied.

--- a/frontend/app/components/home/sections/HomeFeaturesSection.vue
+++ b/frontend/app/components/home/sections/HomeFeaturesSection.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
-
 type FeatureCard = {
   icon: string
   title: string
@@ -15,14 +13,8 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <ParallaxSection
-    class="home-features"
-    aria-label="home-features-title"
-    :background-light="'/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg'"
-    :background-dark="'/assets/themes/dark/parallax/parallax-background-bubbles-1.svg'"
-    :parallax-amount="0.12"
-  >
-    <div class="home-features__inner">
+  <section class="home-features" aria-labelledby="home-features-title">
+    <div class="home-features__inner home-section__inner">
       <header class="home-section__header">
         <h2 id="home-features-title">{{ t('home.features.title') }}</h2>
         <!-- eslint-disable vue/no-v-html -->
@@ -54,13 +46,10 @@ const { t } = useI18n()
         </v-col>
       </v-row>
     </div>
-  </ParallaxSection>
+  </section>
 </template>
 
 <style scoped lang="sass">
-// .home-features
-  // background managed by ParallaxSection
-
 .home-section__inner
   max-width: 1180px
   margin: 0 auto
@@ -105,5 +94,4 @@ const { t } = useI18n()
   color: rgb(var(--v-theme-text-neutral-secondary))
 
 </style>
-
 

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
 
 type SolutionBenefit = {
   emoji: string
@@ -19,14 +18,7 @@ const sectionDescription = computed(() => t('home.solution.description'))
 </script>
 
 <template>
-  <ParallaxSection
-    id="home-solution"
-    class="home-solution"
-    aria-label="home-solution-title"
-    :background-light="'/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg'"
-    :background-dark="'/assets/themes/dark/parallax/parallax-background-bubbles-1.svg'"
-    :parallax-amount="0.16"
-  >
+  <section id="home-solution" class="home-solution" aria-labelledby="home-solution-title">
     <div class="home-solution__inner">
       <v-row class="home-solution__layout" align="center" justify="space-between">
         <v-col cols="12" md="6" class="home-solution__copy">
@@ -73,12 +65,10 @@ const sectionDescription = computed(() => t('home.solution.description'))
         </v-col>
       </v-row>
     </div>
-  </ParallaxSection>
+  </section>
 </template>
 
 <style scoped lang="sass">
-// .home-solution managed solely by ParallaxSection
-
 .home-solution__inner
   max-width: 1180px
   margin: 0 auto
@@ -131,8 +121,6 @@ const sectionDescription = computed(() => t('home.solution.description'))
   display: flex
   gap: 1rem
   align-items: flex-start
-  // Ensure transparent background for item if needed, but Sheet has default surface.
-  // We keep it as is.
 
 .home-solution__item::after
   display: none
@@ -172,5 +160,4 @@ const sectionDescription = computed(() => t('home.solution.description'))
     align-items: center
 
 </style>
-
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -48,11 +48,6 @@ const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
 
 const BLOG_ARTICLES_LIMIT = 4
 
-const heroBackgrounds = computed(() => ({
-  light: '/images/home/hero-full-viewport-light.jpg',
-  dark: '/images/home/hero-full-viewport-dark.jpg',
-}))
-
 const { data: affiliationPartners } = await useAsyncData<AffiliationPartnerDto[]>(
   'home-affiliation-partners',
   () =>
@@ -674,8 +669,6 @@ useHead(() => ({
       v-model:search-query="searchQuery"
       :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
       :verticals="rawCategories"
-      :hero-image-light="heroBackgrounds.light"
-      :hero-image-dark="heroBackgrounds.dark"
       :partners-count="heroPartnersCount"
       @submit="handleSearchSubmit"
       @select-category="handleCategorySuggestion"

--- a/frontend/docs/home-assets-audit.md
+++ b/frontend/docs/home-assets-audit.md
@@ -1,0 +1,34 @@
+# Audit des fonds et assets d’accueil (frontend)
+
+Ce document recense l’état actuel des visuels de la page d’accueil et propose un plan de remise à plat avant régénération des SVG (light/dark et variantes saisonnières).
+
+## Cartographie rapide
+- **Hero** : résolu via `useHeroBackgroundAsset` (`config/theme/assets.ts`), fichiers `app/assets/themes/light/hero-background.webp` (light) et fallback `app/assets/themes/common/hero-background.svg` pour le dark. Les références manuelles inexistantes ont été retirées de `app/pages/index.vue`.
+- **Parallax packs** : définis dans `config/theme/assets.ts` et résolus par `useThemedParallaxBackgrounds`.
+  - Light : `parallax/parallax-background-{1..3}.svg` (pack default) et `parallax-background-bubbles-*.svg` (pack christmas). Variantes transparentes pour les bubbles présentes **uniquement** en light.
+  - Dark : uniquement `parallax-background-{1..3}.svg` et `parallax-background-bubbles-*.svg` (pas de versions « transparent »).
+  - Common : `hero-background.svg`, `illustration-generic.svg`, `backgrounds/texture-grid.svg`.
+- **Aplats** : `/app/public/images/home/parallax-aplats.svg` utilisé via `ParallaxSection` (`enableAplats`).
+- **Composants** : `HomeSolutionSection.vue` et `HomeFeaturesSection.vue` sont désormais agnostiques du background (parallax géré par `app/pages/index.vue`).
+
+## Lacunes constatées
+1) Packs saisonniers incomplets : pack `sdg` vide, pack `christmas` dépend de fichiers bubbles non symétriques (transparent seulement en light).
+2) Tailles hétérogènes : mélange de SVG 1440×800 et 1600×800 avec `height="800"` explicite, provoquant des bandes/blancs sur grands écrans malgré `preserveAspectRatio="xMidYMid slice"`.
+
+## Recommandations de taille (SVG)
+- **Hero & parallax plein écran** : viewBox `1600x900` (ou `1920x1080`), `width="100%" height="100%"`, `preserveAspectRatio="xMidYMid slice"`, contenu utile centré avec 10–15% de marge de sécurité pour le parallaxe.
+- **Illustrations/placeholder** : viewBox ~`1200x900` max, toujours en SVG si possible.
+- Garder le poids <200 Ko par fond après optimisation (SVGO), éviter les filtres SVG lourds ; privilégier dégradés et patterns.
+- Harmoniser l’opacité pour matcher les overlays du composant `ParallaxSection` (`overlayOpacity` ~0.35–0.6 selon le thème).
+
+## Plan d’action proposé
+1) **Aligner le hero** : rester sur `useHeroBackgroundAsset` + `config/theme/assets.ts`; ajouter une variante dark dédiée si besoin pour dépasser le fallback commun.
+2) **Compléter les packs** : remplir le pack `sdg` avec une déclinaison par section (light/dark) et ajouter les versions « transparent » côté dark pour le pack `christmas` afin de garder un rendu cohérent.
+3) **Régénérer les SVG** : appliquer le gabarit 1600×900 (ou 1920×1080) à tous les fichiers `app/assets/themes/{light,dark}/parallax/*.svg`, en gardant la palette décrite dans les commentaires existants (tokens `hero-gradient-*`, `accent-primary-highlight`, `surface-*`).
+4) **Placeholders de validation** : produire 2–3 SVG exemples (light, dark, Noël) montrant l’effet parallaxe et la répartition des aplats, à stocker dans `app/assets/themes/common/` ou `light/` le temps de la régénération complète.
+5) **Tests visuels** : valider le rendu avec `ParallaxSection.vue` aux breakpoints mobiles/tablettes/desktop (largeur <960 px désactive le parallaxe) pour vérifier l’absence d’artefacts de bord.
+
+## Points d’attention
+- Les overlays (`overlayOpacity`) varient par section dans `app/pages/index.vue` ; conserver des couleurs de fond suffisamment contrastées pour éviter le « wash out » en light comme en dark.
+- Le fallback d’assets suit l’ordre `theme -> common -> THEME_ASSETS_FALLBACK` ; garder des noms symétriques entre thèmes pour faciliter la régénération automatisée.
+- Les packs saisonniers sont sélectionnés par `config/theme/seasons.ts` (fenêtres de dates UTC) — toute nouvelle variante doit y être référencée.


### PR DESCRIPTION
## Summary
- Remove unused hero image overrides and rely on themed hero assets for the homepage
- Make the Home Solution and Features sections background-agnostic so page-level parallax packs drive the visuals
- Add a homepage assets audit with size guidance and document recommended SVG dimensions in the theme README

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ff195b448322bcc10375c9f3dfc3)