### PR TITLE
Refine nudge wizard navigation and category icons

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -1,6 +1,34 @@
 <template>
   <div class="nudge-step-subset">
-    <!-- Header removed, moved to Wizard -->
+    <div class="nudge-step-subset__header">
+      <div class="nudge-step-subset__title-block">
+        <v-avatar
+          class="nudge-step-subset__group-avatar"
+          size="44"
+          color="rgba(var(--v-theme-surface-primary-080), 0.9)"
+        >
+          <v-icon :icon="groupIcon" size="24" />
+        </v-avatar>
+        <div class="nudge-step-subset__titles">
+          <p class="nudge-step-subset__title">{{ group.title }}</p>
+          <p v-if="group.description" class="nudge-step-subset__description">
+            {{ group.description }}
+          </p>
+        </div>
+      </div>
+
+      <v-chip
+        v-if="categoryLabel"
+        class="nudge-step-subset__category-chip"
+        color="primary"
+        variant="tonal"
+        size="small"
+        @click="emit('return-to-category')"
+      >
+        <v-icon start :icon="categoryIcon || 'mdi-tag-outline'" />
+        {{ categoryLabel }}
+      </v-chip>
+    </div>
 
     <v-row dense>
       <v-col v-for="subset in subsets" :key="subset.id" cols="12" sm="6">
@@ -47,6 +75,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type {
   NudgeToolSubsetGroupDto,
   VerticalSubsetDto,
@@ -57,11 +86,14 @@ const props = defineProps<{
   subsets: VerticalSubsetDto[]
   modelValue: string[]
   stepNumber: number
+  categoryIcon?: string | null
+  categoryLabel?: string | null
 }>()
 
 const emit = defineEmits<{
   (event: 'update:modelValue', value: string[]): void
   (event: 'continue'): void
+  (event: 'return-to-category'): void
 }>()
 
 const isSelected = (subsetId?: string | null) =>
@@ -69,6 +101,8 @@ const isSelected = (subsetId?: string | null) =>
 
 const getSubsetIcon = (subset: VerticalSubsetDto) =>
   subset.mdiIcon ?? 'mdi-sprout'
+
+const groupIcon = computed(() => props.group.mdiIcon ?? 'mdi-format-list-bulleted')
 
 const toggle = (subsetId: string) => {
   const next = new Set(props.modelValue)
@@ -94,18 +128,35 @@ const toggle = (subsetId: string) => {
     margin-bottom: 16px;
   }
 
+  &__title-block {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  &__group-avatar {
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45);
+  }
+
+  &__titles {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
   &__title {
-    font-size: 1.5rem;
+    font-size: 1.1rem;
     font-weight: 700;
     margin: 0;
-    display: flex;
-    align-items: center;
-    gap: 8px;
   }
 
   &__description {
     margin: 0;
     color: rgb(var(--v-theme-text-neutral-secondary));
+  }
+
+  &__category-chip {
+    font-weight: 700;
   }
 
   &__card {

--- a/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
+++ b/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
@@ -21,51 +21,12 @@
           </span>
         </div>
       </div>
-
-      <div
-        class="wizard-header__actions"
-        :class="{ 'wizard-header__actions--mobile': isMobile }"
-      >
-        <v-btn-group
-          class="wizard-header__action-group"
-          :class="{ 'wizard-header__action-group--mobile': isMobile }"
-          density="comfortable"
-        >
-          <v-btn
-            v-if="hasPrevious"
-            color="primary"
-            variant="outlined"
-            rounded="pill"
-            elevation="0"
-            prepend-icon="mdi-chevron-left"
-            class="wizard-header__action-btn wizard-header__action-btn--previous"
-            @click="emit('previous')"
-          >
-            {{ previousLabel }}
-          </v-btn>
-
-          <v-btn
-            v-if="hasNext"
-            color="primary"
-            variant="tonal"
-            rounded="pill"
-            elevation="0"
-            :disabled="nextDisabled"
-            append-icon="mdi-chevron-right"
-            class="wizard-header__action-btn wizard-header__action-btn--next"
-            @click="emit('next')"
-          >
-            {{ nextLabel }}
-          </v-btn>
-        </v-btn-group>
-      </div>
     </div>
   </header>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useDisplay } from 'vuetify'
 import type {
   AccentCorner,
   CornerSize,
@@ -82,11 +43,6 @@ const props = withDefaults(
   defineProps<{
     title: string
     subtitle?: string
-    hasPrevious?: boolean
-    hasNext?: boolean
-    nextDisabled?: boolean
-    previousLabel: string
-    nextLabel: string
     accentCorner?: AccentCorner
     cornerSize?: CornerSize
     categorySummary?: {
@@ -97,25 +53,13 @@ const props = withDefaults(
   }>(),
   {
     subtitle: '',
-    hasPrevious: false,
-    hasNext: false,
-    nextDisabled: false,
     accentCorner: 'top-left',
     cornerSize: 'lg',
     categorySummary: null,
   }
 )
 
-const emit = defineEmits<{
-  (e: 'previous' | 'next'): void
-}>()
-
 const isStacked = computed(() => props.accentCorner === 'top-left')
-const display = useDisplay()
-const isMobile = computed(() => {
-  const breakpoint = display && 'mdAndDown' in display ? display.mdAndDown : undefined
-  return typeof breakpoint?.value === 'boolean' ? breakpoint.value : false
-})
 
 const headerOffsetStyle = computed(() => {
   if (props.accentCorner !== 'top-left') {
@@ -199,71 +143,6 @@ const headerOffsetStyle = computed(() => {
     color: rgb(var(--v-theme-text-neutral-secondary));
   }
 
-  &__actions {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-  }
-
-  &__action-group {
-    display: inline-flex;
-    gap: 6px;
-    padding: 6px 8px;
-    border-radius: 999px;
-    background-color: rgba(var(--v-theme-surface-primary-080), 0.55);
-    border: 1px solid rgb(var(--v-theme-border-primary-strong));
-    transition: background-color 160ms ease, border-color 160ms ease;
-  }
-
-  &__action-group--mobile {
-    width: 100%;
-    max-width: 420px;
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
-    padding: 10px;
-    gap: 10px;
-  }
-
-  &__action-btn {
-    font-weight: 700;
-
-    :deep(.v-btn) {
-      border-width: 1px;
-      transition:
-        background-color 160ms ease,
-        color 160ms ease,
-        border-color 160ms ease;
-    }
-
-    :deep(.v-btn:hover),
-    :deep(.v-btn:focus-visible) {
-      background-color: rgba(var(--v-theme-surface-primary-100), 0.75);
-      color: rgb(var(--v-theme-text-neutral-strong));
-      box-shadow: none;
-    }
-
-    :deep(.v-btn:focus-visible) {
-      outline: 2px solid rgb(var(--v-theme-accent-primary-highlight));
-      outline-offset: 2px;
-    }
-
-    :deep(.v-btn--disabled) {
-      color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
-      border-color: rgba(var(--v-theme-border-primary-strong), 0.5);
-      background-color: rgba(var(--v-theme-surface-primary-080), 0.55);
-      box-shadow: none;
-    }
-  }
-
-  &__actions--mobile {
-    justify-content: center;
-  }
-
-  &__action-btn--next :deep(.v-btn) {
-    color: rgb(var(--v-theme-text-on-accent));
-  }
-
   @media (max-width: 960px) {
     grid-template-columns: 1fr;
     text-align: center;
@@ -272,15 +151,6 @@ const headerOffsetStyle = computed(() => {
     &__meta {
       justify-content: center;
       gap: 10px;
-    }
-
-    &__actions {
-      width: 100%;
-      order: 2;
-    }
-
-    &__action-group--mobile :deep(.v-btn) {
-      width: 100%;
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove header navigation controls and rely on footer actions while revealing progress steps only after they are visited
- track visited wizard steps so progress bubbles stay hidden on the category page and unlock sequentially
- surface configured mdi icons and a category chip on subset panels to anchor navigation back to the first step

## Testing
- pnpm test --filter NudgeToolWizard *(fails: Vitest CLI does not support --filter; no tests executed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944080ed8008322bf7517f0547065da)