### PR TITLE
Refine wizard toggle cards

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -21,24 +21,33 @@
         class="d-flex"
       >
         <v-card
-          class="nudge-step-condition__card nudge-option-card"
+          class="nudge-step-condition__card nudge-toggle-card"
           :class="{
-            'nudge-option-card--selected': isSelected(option.value),
+            'nudge-toggle-card--selected': isSelected(option.value),
           }"
           rounded="lg"
           role="button"
           :aria-pressed="isSelected(option.value).toString()"
+          :aria-label="option.label"
+          tabindex="0"
           @click="() => toggleOption(option.value)"
+          @keydown.enter.prevent="toggleOption(option.value)"
+          @keydown.space.prevent="toggleOption(option.value)"
         >
-          <div class="nudge-step-condition__content">
-              <div class="nudge-step-condition__icon-wrapper">
+          <div class="nudge-toggle-card__body">
+            <div class="nudge-toggle-card__icon-rail">
+              <div class="nudge-toggle-card__icon-shell">
                 <v-icon :icon="option.icon" size="26" />
               </div>
-              <p class="nudge-step-condition__label">{{ option.label }}</p>
-          </div>
-          
-          <div class="nudge-step-condition__indicator">
-             <v-icon v-if="isSelected(option.value)" icon="mdi-check" size="20" color="white" />
+            </div>
+
+            <div class="nudge-toggle-card__content">
+              <p class="nudge-toggle-card__title">{{ option.label }}</p>
+            </div>
+
+            <div class="nudge-toggle-card__indicator" aria-hidden="true">
+              <v-icon v-if="isSelected(option.value)" icon="mdi-check" size="20" color="white" />
+            </div>
           </div>
         </v-card>
       </v-col>
@@ -106,67 +115,105 @@ const toggleOption = (choice: ProductConditionChoice) => {
     row-gap: 12px;
   }
 
-  &__card {
+  .nudge-toggle-card {
     width: 100%;
     display: flex;
-    flex-direction: row;
-    align-items: stretch; /* Stretch to fill height */
+    flex-direction: column;
+    align-items: stretch;
     justify-content: space-between;
-    padding: 0; /* Remove padding from card, handle in content */
+    padding: 0;
     overflow: hidden;
-    background: rgb(var(--v-theme-surface-primary-050)) !important; /* Lighter background */
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-    transition: all 0.2s ease;
-    
-    &.nudge-option-card--selected {
-        background: rgb(var(--v-theme-surface-primary-100)) !important;
-        border-color: rgb(var(--v-theme-primary));
-        
-        .nudge-step-condition__indicator {
-            background: rgb(var(--v-theme-primary));
-            border-left: 1px solid rgb(var(--v-theme-primary));
-        }
+    background: rgb(var(--v-theme-surface-primary-050)) !important;
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+    box-shadow: none;
+    transition: transform 140ms ease, border-color 160ms ease,
+      box-shadow 160ms ease, background-color 160ms ease;
+    cursor: pointer;
+
+    &__body {
+      display: grid;
+      grid-template-columns: 0.32fr 1fr auto;
+      align-items: stretch;
+      height: 100%;
     }
-  }
 
-  &__content {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 14px 16px;
-  }
-
-  &__indicator {
-      width: 40px;
+    &__icon-rail {
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(var(--v-theme-primary), 0.1);
-      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-      transition: background 0.2s ease;
+      background: rgba(var(--v-theme-accent-supporting), 0.08);
+      padding: 14px;
+      transition: background 160ms ease;
+    }
+
+    &__icon-shell {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      color: rgb(var(--v-theme-accent-supporting));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
+      transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+    }
+
+    &__content {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 18px;
+      min-height: 100%;
+    }
+
+    &__title {
+      margin: 0;
+      font-weight: 700;
+      flex: 1;
+      line-height: 1.35;
+    }
+
+    &__indicator {
+      width: 52px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+      transition: background 160ms ease, border-color 160ms ease;
+    }
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(var(--v-theme-accent-supporting), 0.6);
+      box-shadow: 0 10px 20px rgba(var(--v-theme-shadow-primary-600), 0.08);
+      outline: none;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-supporting), 0.25);
+    }
   }
 
-  &__label {
-    margin: 0;
-    font-weight: 600;
-    flex: 1;
-  }
+  .nudge-toggle-card--selected {
+    background: rgba(var(--v-theme-accent-supporting), 0.12) !important;
+    border-color: rgb(var(--v-theme-accent-supporting));
 
-  &__icon-wrapper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    background: rgba(var(--v-theme-surface-default), 0.6);
-    color: rgb(var(--v-theme-primary));
-  }
-  
-  /* Remove old check style */
-  &__check {
-    display: none;
+    .nudge-toggle-card__icon-rail {
+      background: rgba(var(--v-theme-accent-supporting), 0.18);
+    }
+
+    .nudge-toggle-card__icon-shell {
+      background: rgba(var(--v-theme-accent-supporting), 0.2);
+      color: rgb(var(--v-theme-surface-default));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-accent-supporting), 0.5);
+    }
+
+    .nudge-toggle-card__indicator {
+      background: rgb(var(--v-theme-accent-supporting));
+      border-color: rgb(var(--v-theme-accent-supporting));
+      color: rgb(var(--v-theme-surface-default));
+    }
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -12,32 +12,36 @@
           <template #activator="{ props: activatorProps }">
             <v-card
               v-bind="activatorProps"
-              class="nudge-step-scores__card nudge-option-card" variant="flat" border="thin"
+              class="nudge-step-scores__card nudge-toggle-card"
+              variant="flat"
+              border="thin"
               :class="{
-                'nudge-option-card--selected': isSelected(score.scoreName),
-                'nudge-step-scores__card--selected': isSelected(
-                  score.scoreName ?? ''
-                ),
+                'nudge-toggle-card--selected': isSelected(score.scoreName),
               }"
               rounded="lg"
               role="button"
               :aria-pressed="isSelected(score.scoreName).toString()"
+              :aria-label="score.title"
+              tabindex="0"
               @click="toggle(score.scoreName ?? '')"
+              @keydown.enter.prevent="toggle(score.scoreName ?? '')"
+              @keydown.space.prevent="toggle(score.scoreName ?? '')"
             >
-              <div class="d-flex align-stretch flex-grow-1">
-                <div class="nudge-step-scores__content">
-                  <div class="nudge-step-scores__titles">
-                    <p class="nudge-step-scores__name">{{ score.title }}</p>
-                    <p v-if="score.caption" class="nudge-step-scores__caption">
-                      {{ score.caption }}
-                    </p>
-                  </div>
-                  <div class="nudge-step-scores__icon-wrapper">
+              <div class="nudge-toggle-card__body">
+                <div class="nudge-toggle-card__icon-rail">
+                  <div class="nudge-toggle-card__icon-shell">
                     <v-icon :icon="getScoreIcon(score)" size="28" />
                   </div>
                 </div>
-                
-                <div class="nudge-step-scores__indicator">
+
+                <div class="nudge-toggle-card__content">
+                  <p class="nudge-toggle-card__title">{{ score.title }}</p>
+                  <p v-if="score.caption" class="nudge-toggle-card__caption">
+                    {{ score.caption }}
+                  </p>
+                </div>
+
+                <div class="nudge-toggle-card__indicator" aria-hidden="true">
                   <v-icon v-if="isSelected(score.scoreName)" icon="mdi-check" size="20" color="white" />
                 </div>
               </div>
@@ -103,7 +107,7 @@ const toggle = (scoreName: string) => {
     row-gap: 12px;
   }
 
-  &__card {
+  .nudge-toggle-card {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -112,68 +116,108 @@ const toggle = (scoreName: string) => {
     overflow: hidden;
     position: relative;
     background: rgb(var(--v-theme-surface-primary-050)) !important;
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-    transition: all 0.2s ease;
-  }
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+    box-shadow: none;
+    transition: transform 140ms ease, border-color 160ms ease,
+      box-shadow 160ms ease, background-color 160ms ease;
+    cursor: pointer;
 
-  &__card--selected {
-    background: rgb(var(--v-theme-surface-primary-100)) !important;
-    border-color: rgb(var(--v-theme-primary));
-    
-    .nudge-step-scores__indicator {
-        background: rgb(var(--v-theme-primary));
-        border-left: 1px solid rgb(var(--v-theme-primary));
+    &__body {
+      display: grid;
+      grid-template-columns: 0.32fr 1fr auto;
+      align-items: stretch;
+      height: 100%;
     }
-  }
-  
-  &__content {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 14px 16px;
-  }
 
-  &__indicator {
-      width: 40px;
+    &__icon-rail {
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(var(--v-theme-primary), 0.1);
-      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-      transition: background 0.2s ease;
+      background: rgba(var(--v-theme-accent-supporting), 0.08);
+      padding: 14px;
+      min-height: 100%;
+      transition: background 160ms ease;
+    }
+
+    &__icon-shell {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      color: rgb(var(--v-theme-accent-supporting));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
+      transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+    }
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 14px 18px;
+      justify-content: center;
+      min-height: 100%;
+    }
+
+    &__title {
+      margin: 0;
+      font-weight: 700;
+      line-height: 1.4;
+    }
+
+    &__caption {
+      margin: 0;
+      color: rgb(var(--v-theme-text-neutral-secondary));
+      font-size: 0.95rem;
+      line-height: 1.4;
+    }
+
+    &__indicator {
+      width: 52px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+      transition: background 160ms ease, border-color 160ms ease;
+    }
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(var(--v-theme-accent-supporting), 0.6);
+      box-shadow: 0 10px 20px rgba(var(--v-theme-shadow-primary-600), 0.08);
+      outline: none;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-supporting), 0.25);
+    }
   }
 
-  &__titles {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    flex: 1;
-  }
+  .nudge-toggle-card--selected {
+    background: rgba(var(--v-theme-accent-supporting), 0.12) !important;
+    border-color: rgb(var(--v-theme-accent-supporting));
 
-  &__name {
-    margin: 0;
-    font-weight: 700;
-    line-height: 1.4;
-  }
+    .nudge-toggle-card__icon-rail {
+      background: rgba(var(--v-theme-accent-supporting), 0.18);
+    }
 
-  &__caption {
-    margin: 0;
-    color: rgb(var(--v-theme-text-neutral-secondary));
-    font-size: 0.95rem;
-  }
+    .nudge-toggle-card__icon-shell {
+      background: rgba(var(--v-theme-accent-supporting), 0.2);
+      color: rgb(var(--v-theme-surface-default));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-accent-supporting), 0.5);
+    }
 
-  &__icon-wrapper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    background: rgba(var(--v-theme-surface-default), 0.6);
-    position: relative;
-    color: rgb(var(--v-theme-primary));
+    .nudge-toggle-card__indicator {
+      background: rgb(var(--v-theme-accent-supporting));
+      border-color: rgb(var(--v-theme-accent-supporting));
+      color: rgb(var(--v-theme-surface-default));
+    }
+
+    .nudge-toggle-card__title {
+      color: rgb(var(--v-theme-text-neutral-strong));
+    }
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -12,29 +12,34 @@
           <template #activator="{ props: activatorProps }">
             <v-card
               v-bind="activatorProps"
-              class="nudge-step-subset__card nudge-option-card"
+              class="nudge-step-subset__card nudge-toggle-card"
               :class="{
-                'nudge-option-card--selected': isSelected(subset.id),
+                'nudge-toggle-card--selected': isSelected(subset.id),
               }"
               rounded="lg"
               role="button"
               :aria-pressed="isSelected(subset.id).toString()"
+              :aria-label="subset.title"
+              tabindex="0"
               @click="toggle(subset.id ?? '')"
+              @keydown.enter.prevent="toggle(subset.id ?? '')"
+              @keydown.space.prevent="toggle(subset.id ?? '')"
             >
-              <div class="d-flex align-stretch flex-grow-1">
-                <div class="nudge-step-subset__content">
-                  <div class="nudge-step-subset__text">
-                    <p class="nudge-step-subset__name">{{ subset.title }}</p>
-                    <p v-if="subset.caption" class="nudge-step-subset__caption">
-                      {{ subset.caption }}
-                    </p>
-                  </div>
-                  <div class="nudge-step-subset__icon-wrapper">
+              <div class="nudge-toggle-card__body">
+                <div class="nudge-toggle-card__icon-rail">
+                  <div class="nudge-toggle-card__icon-shell">
                     <v-icon :icon="getSubsetIcon(subset)" size="24" />
                   </div>
                 </div>
 
-                <div class="nudge-step-subset__indicator">
+                <div class="nudge-toggle-card__content">
+                  <p class="nudge-toggle-card__title">{{ subset.title }}</p>
+                  <p v-if="subset.caption" class="nudge-toggle-card__caption">
+                    {{ subset.caption }}
+                  </p>
+                </div>
+
+                <div class="nudge-toggle-card__indicator" aria-hidden="true">
                   <v-icon v-if="isSelected(subset.id)" icon="mdi-check" size="20" color="white" />
                 </div>
               </div>
@@ -108,7 +113,7 @@ const toggle = (subsetId: string) => {
     color: rgb(var(--v-theme-text-neutral-secondary));
   }
 
-  &__card {
+  .nudge-toggle-card {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -116,65 +121,104 @@ const toggle = (subsetId: string) => {
     padding: 0;
     overflow: hidden;
     background: rgb(var(--v-theme-surface-primary-050)) !important;
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-    transition: all 0.2s ease;
-  }
-  
-  .nudge-option-card--selected {
-    background: rgb(var(--v-theme-surface-primary-100)) !important;
-    border-color: rgb(var(--v-theme-primary));
-    
-    .nudge-step-subset__indicator {
-        background: rgb(var(--v-theme-primary));
-        border-left: 1px solid rgb(var(--v-theme-primary));
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+    box-shadow: none;
+    transition: transform 140ms ease, border-color 160ms ease,
+      box-shadow 160ms ease, background-color 160ms ease;
+    cursor: pointer;
+
+    &__body {
+      display: grid;
+      grid-template-columns: 0.32fr 1fr auto;
+      align-items: stretch;
+      height: 100%;
     }
-  }
 
-  &__content {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 14px 16px;
-  }
-
-  &__indicator {
-      width: 40px;
+    &__icon-rail {
       display: flex;
       align-items: center;
       justify-content: center;
-      background: rgba(var(--v-theme-primary), 0.1);
-      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3);
-      transition: background 0.2s ease;
+      background: rgba(var(--v-theme-accent-supporting), 0.08);
+      padding: 14px;
+      min-height: 100%;
+      transition: background 160ms ease;
+    }
+
+    &__icon-shell {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      color: rgb(var(--v-theme-accent-supporting));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
+      transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+    }
+
+    &__content {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 14px 18px;
+      justify-content: center;
+      min-height: 100%;
+    }
+
+    &__title {
+      margin: 0;
+      font-weight: 700;
+      line-height: 1.4;
+    }
+
+    &__caption {
+      margin: 0;
+      color: rgb(var(--v-theme-text-neutral-secondary));
+      font-size: 0.95rem;
+      line-height: 1.4;
+    }
+
+    &__indicator {
+      width: 52px;
+      display: grid;
+      place-items: center;
+      background: rgba(var(--v-theme-accent-supporting), 0.12);
+      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+      transition: background 160ms ease, border-color 160ms ease;
+    }
+
+    &:hover,
+    &:focus-visible {
+      transform: translateY(-2px);
+      border-color: rgba(var(--v-theme-accent-supporting), 0.6);
+      box-shadow: 0 10px 20px rgba(var(--v-theme-shadow-primary-600), 0.08);
+      outline: none;
+    }
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-supporting), 0.25);
+    }
   }
 
-  &__text {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    flex: 1;
-  }
+  .nudge-toggle-card--selected {
+    background: rgba(var(--v-theme-accent-supporting), 0.12) !important;
+    border-color: rgb(var(--v-theme-accent-supporting));
 
-  &__name {
-    margin: 0;
-    font-weight: 700;
-  }
+    .nudge-toggle-card__icon-rail {
+      background: rgba(var(--v-theme-accent-supporting), 0.18);
+    }
 
-  &__caption {
-    margin: 0;
-    color: rgb(var(--v-theme-text-neutral-secondary));
-  }
+    .nudge-toggle-card__icon-shell {
+      background: rgba(var(--v-theme-accent-supporting), 0.2);
+      color: rgb(var(--v-theme-surface-default));
+      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-accent-supporting), 0.5);
+    }
 
-  &__icon-wrapper {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    background: rgba(var(--v-theme-surface-default), 0.6);
-    color: rgb(var(--v-theme-primary));
+    .nudge-toggle-card__indicator {
+      background: rgb(var(--v-theme-accent-supporting));
+      border-color: rgb(var(--v-theme-accent-supporting));
+      color: rgb(var(--v-theme-surface-default));
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- redesign score, condition, and subset wizard cards into branded toggle layout with icon rail and accent-supporting states
- improve accessibility with keyboard activation and focus styling
- keep responsive two-column layout while using theme tokens for hover/selected feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440bf2310483229ecf486cf0dbe667)