### PR TITLE
Improve zoom toggle accessibility styling

### DIFF
--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -201,7 +201,7 @@
 
       <v-list-item class="px-6 py-4">
         <template #prepend>
-          <v-icon icon="mdi-magnify-plus-outline" class="me-4" />
+          <v-icon icon="mdi-human-cane" class="me-4" />
         </template>
         <v-list-item-title class="text-body-1">
           {{ t('siteIdentity.menu.zoom.label') }}

--- a/frontend/app/components/shared/menus/ZoomToggle.vue
+++ b/frontend/app/components/shared/menus/ZoomToggle.vue
@@ -8,11 +8,12 @@
     :size="size"
     :data-testid="testId"
     :aria-label="t('siteIdentity.menu.zoom.label')"
+    :aria-pressed="isZoomed"
     @click="toggleZoom"
   >
     <v-icon
       :icon="
-        isZoomed ? 'mdi-magnify-minus-outline' : 'mdi-magnify-plus-outline'
+        isZoomed ? 'mdi-human-walker' : 'mdi-human-cane'
       "
     />
     <v-tooltip activator="parent" location="bottom">
@@ -68,9 +69,12 @@ onMounted(() => {
 
 <style scoped lang="sass">
 .zoom-toggle
-  background-color: rgba(var(--v-theme-surface-muted), 0.6)
   color: rgb(var(--v-theme-text-neutral-strong))
 
   &.v-btn--active
     color: rgb(var(--v-theme-accent-supporting))
+
+  &:focus-visible
+    outline: 2px solid rgba(var(--v-theme-accent-supporting), 0.6)
+    outline-offset: 3px
 </style>


### PR DESCRIPTION
## Summary
- replace the zoom toggle icon with an accessibility-friendly MDI design and align the mobile menu icon
- add an explicit `aria-pressed` state and focus outline so the zoom control is clearer for assistive tech
- rely on Vuetify styling for active backgrounds to avoid odd selection fills

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440dda268883228c5ce2f02bc01942)