### PR TITLE
Add Spring Boot DevTools for local development

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,12 @@
 			<artifactId>logback-classic</artifactId>
 		</dependency>
 
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- add spring-boot-devtools as an optional runtime dependency in the parent POM to enable local hot-reload support across modules
- rely on Spring Boot’s default repackaging behavior so devtools stays out of production artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440e9921108322ade52ed24ea772f6)