### PR TITLE
Add SDG parallax assets and dark bubble variants

### DIFF
--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-1.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Dark transparent parallax background with rising bubbles on the left">
+  <defs>
+    <radialGradient id="darkAmbient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 320) scale(980 620)">
+      <stop offset="0" stop-color="#2D7CD8" stop-opacity="0.28" />
+      <stop offset="0.6" stop-color="#1B3B6E" stop-opacity="0.14" />
+      <stop offset="1" stop-color="#0A1728" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="darkAmbient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1220 720) rotate(-10) scale(900 520)">
+      <stop offset="0" stop-color="#1FA173" stop-opacity="0.2" />
+      <stop offset="0.7" stop-color="#1FA173" stop-opacity="0.08" />
+      <stop offset="1" stop-color="#0A1728" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="darkBubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(260 420) scale(520 560)">
+      <stop offset="0" stop-color="#2497E0" stop-opacity="0.4" />
+      <stop offset="0.55" stop-color="#6AC3FF" stop-opacity="0.22" />
+      <stop offset="1" stop-color="#2497E0" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="darkBubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#0F2234" stop-opacity="0.3" />
+      <stop offset="0.35" stop-color="#1E7ACB" stop-opacity="0.26" />
+      <stop offset="1" stop-color="#1E7ACB" stop-opacity="0.06" />
+    </radialGradient>
+    <linearGradient id="darkBubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#71C6FF" stop-opacity="0.52" />
+      <stop offset="0.55" stop-color="#2B99E6" stop-opacity="0.58" />
+      <stop offset="1" stop-color="#1FA173" stop-opacity="0.32" />
+    </linearGradient>
+    <filter id="darkBlur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="28" />
+    </filter>
+    <filter id="darkBubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" result="b" />
+      <feMerge>
+        <feMergeNode in="b" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="800" fill="#0B1626" />
+  <rect width="1600" height="800" fill="url(#darkAmbient)" />
+  <rect width="1600" height="800" fill="url(#darkAmbient2)" />
+
+  <g id="parallax-back">
+    <ellipse cx="240" cy="430" rx="420" ry="520" fill="url(#darkBubbleGlow)" filter="url(#darkBlur28)" />
+    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#1E7BCB" stroke-opacity="0.24" stroke-width="10" filter="url(#darkBlur28)" />
+  </g>
+
+  <g id="parallax-bubbles" filter="url(#darkBlur28)">
+    <g transform="translate(150 650)">
+      <circle cx="0" cy="0" r="44" fill="url(#darkBubbleFill)" opacity="0.9" />
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#darkBubbleStroke)" stroke-width="2.2" opacity="0.85" />
+      <circle cx="-14" cy="-16" r="10" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft)" />
+    </g>
+    <g transform="translate(230 520)">
+      <circle cx="0" cy="0" r="30" fill="url(#darkBubbleFill)" opacity="0.85" />
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#darkBubbleStroke)" stroke-width="2" opacity="0.78" />
+      <circle cx="-10" cy="-12" r="7" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft)" />
+    </g>
+    <g transform="translate(170 400)">
+      <circle cx="0" cy="0" r="56" fill="url(#darkBubbleFill)" opacity="0.8" />
+      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#darkBubbleStroke)" stroke-width="2.4" opacity="0.76" />
+      <circle cx="-18" cy="-20" r="12" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft)" />
+    </g>
+    <g transform="translate(260 270)">
+      <circle cx="0" cy="0" r="26" fill="url(#darkBubbleFill)" opacity="0.8" />
+      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#darkBubbleStroke)" stroke-width="1.9" opacity="0.74" />
+      <circle cx="-8" cy="-10" r="6" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft)" />
+    </g>
+    <g transform="translate(190 140)">
+      <circle cx="0" cy="0" r="38" fill="url(#darkBubbleFill)" opacity="0.78" />
+      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#darkBubbleStroke)" stroke-width="2.1" opacity="0.72" />
+      <circle cx="-12" cy="-14" r="8" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft)" />
+    </g>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-2.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-2.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Dark transparent parallax background with bubbles on both sides">
+  <defs>
+    <linearGradient id="darkBubbleSky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B1626" />
+      <stop offset="1" stop-color="#0D2337" />
+    </linearGradient>
+    <radialGradient id="darkBubbleAmbientLeft" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(320 520) scale(520 420)">
+      <stop offset="0" stop-color="#1D84D0" stop-opacity="0.32" />
+      <stop offset="1" stop-color="#1D84D0" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="darkBubbleAmbientRight" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1300 300) scale(460 360)">
+      <stop offset="0" stop-color="#1FA173" stop-opacity="0.3" />
+      <stop offset="1" stop-color="#1FA173" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="darkBubbleFillAlt" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#0E2232" stop-opacity="0.32" />
+      <stop offset="0.35" stop-color="#1F7FCC" stop-opacity="0.26" />
+      <stop offset="1" stop-color="#1F7FCC" stop-opacity="0.06" />
+    </radialGradient>
+    <linearGradient id="darkBubbleStrokeAlt" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6AC2FF" stop-opacity="0.52" />
+      <stop offset="0.55" stop-color="#2A95E0" stop-opacity="0.6" />
+      <stop offset="1" stop-color="#21A07A" stop-opacity="0.34" />
+    </linearGradient>
+    <filter id="darkBubbleSoftAlt" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.2" />
+    </filter>
+  </defs>
+
+  <rect width="1600" height="800" fill="url(#darkBubbleSky)" />
+  <rect width="1600" height="800" fill="url(#darkBubbleAmbientLeft)" />
+  <rect width="1600" height="800" fill="url(#darkBubbleAmbientRight)" />
+
+  <g id="parallax-bubbles-left">
+    <g transform="translate(220 560)">
+      <circle cx="0" cy="0" r="44" fill="url(#darkBubbleFillAlt)" opacity="0.9" />
+      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="2.2" opacity="0.85" />
+      <circle cx="-14" cy="-16" r="10" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoftAlt)" />
+    </g>
+    <g transform="translate(320 420)">
+      <circle cx="0" cy="0" r="30" fill="url(#darkBubbleFillAlt)" opacity="0.85" />
+      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="2" opacity="0.78" />
+      <circle cx="-10" cy="-12" r="7" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoftAlt)" />
+    </g>
+    <g transform="translate(260 300)">
+      <circle cx="0" cy="0" r="22" fill="url(#darkBubbleFillAlt)" opacity="0.8" />
+      <circle cx="0" cy="0" r="22" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="1.8" opacity="0.72" />
+    </g>
+  </g>
+
+  <g id="parallax-bubbles-right">
+    <g transform="translate(1260 320)">
+      <circle cx="0" cy="0" r="40" fill="url(#darkBubbleFillAlt)" opacity="0.9" />
+      <circle cx="0" cy="0" r="40" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="2.2" opacity="0.82" />
+      <circle cx="-12" cy="-12" r="9" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoftAlt)" />
+    </g>
+    <g transform="translate(1340 420)">
+      <circle cx="0" cy="0" r="28" fill="url(#darkBubbleFillAlt)" opacity="0.86" />
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="1.9" opacity="0.76" />
+    </g>
+    <g transform="translate(1420 500)">
+      <circle cx="0" cy="0" r="18" fill="url(#darkBubbleFillAlt)" opacity="0.8" />
+      <circle cx="0" cy="0" r="18" fill="none" stroke="url(#darkBubbleStrokeAlt)" stroke-width="1.6" opacity="0.7" />
+    </g>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-3.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-transparent-3.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Dark transparent parallax background with floating bubbles and arcs">
+  <defs>
+    <linearGradient id="darkBubbleSky3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0B1626" />
+      <stop offset="1" stop-color="#0D253A" />
+    </linearGradient>
+    <radialGradient id="darkBubbleGlow3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 360) scale(820 460)">
+      <stop offset="0" stop-color="#2A93E0" stop-opacity="0.3" />
+      <stop offset="1" stop-color="#0B1626" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="darkBubbleArc" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#1E7ACB" stop-opacity="0.28" />
+      <stop offset="1" stop-color="#1FA173" stop-opacity="0.32" />
+    </linearGradient>
+    <radialGradient id="darkBubbleFill3" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
+      <stop offset="0" stop-color="#0E2234" stop-opacity="0.32" />
+      <stop offset="0.35" stop-color="#1F7FCC" stop-opacity="0.26" />
+      <stop offset="1" stop-color="#1F7FCC" stop-opacity="0.06" />
+    </radialGradient>
+    <linearGradient id="darkBubbleStroke3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6BC5FF" stop-opacity="0.5" />
+      <stop offset="0.55" stop-color="#2B99E6" stop-opacity="0.6" />
+      <stop offset="1" stop-color="#22A276" stop-opacity="0.34" />
+    </linearGradient>
+    <filter id="darkBubbleSoft3" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="2.4" />
+    </filter>
+  </defs>
+
+  <rect width="1600" height="800" fill="url(#darkBubbleSky3)" />
+  <rect width="1600" height="800" fill="url(#darkBubbleGlow3)" />
+
+  <path d="M-80 520C220 420 520 420 820 520C1120 620 1420 620 1680 520" stroke="url(#darkBubbleArc)" stroke-width="140" stroke-opacity="0.26" />
+  <path d="M-120 360C240 280 620 280 940 360C1240 430 1480 430 1700 360" stroke="url(#darkBubbleArc)" stroke-width="90" stroke-opacity="0.26" />
+
+  <g id="parallax-bubbles">
+    <g transform="translate(620 540)">
+      <circle cx="0" cy="0" r="36" fill="url(#darkBubbleFill3)" opacity="0.86" />
+      <circle cx="0" cy="0" r="36" fill="none" stroke="url(#darkBubbleStroke3)" stroke-width="2" opacity="0.78" />
+      <circle cx="-10" cy="-12" r="8" fill="#CDEAFE" opacity="0.12" filter="url(#darkBubbleSoft3)" />
+    </g>
+    <g transform="translate(760 420)">
+      <circle cx="0" cy="0" r="28" fill="url(#darkBubbleFill3)" opacity="0.82" />
+      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#darkBubbleStroke3)" stroke-width="1.8" opacity="0.74" />
+    </g>
+    <g transform="translate(900 500)">
+      <circle cx="0" cy="0" r="24" fill="url(#darkBubbleFill3)" opacity="0.82" />
+      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#darkBubbleStroke3)" stroke-width="1.8" opacity="0.72" />
+    </g>
+    <g transform="translate(1040 360)">
+      <circle cx="0" cy="0" r="20" fill="url(#darkBubbleFill3)" opacity="0.8" />
+      <circle cx="0" cy="0" r="20" fill="none" stroke="url(#darkBubbleStroke3)" stroke-width="1.7" opacity="0.7" />
+    </g>
+    <g transform="translate(1180 470)">
+      <circle cx="0" cy="0" r="18" fill="url(#darkBubbleFill3)" opacity="0.8" />
+      <circle cx="0" cy="0" r="18" fill="none" stroke="url(#darkBubbleStroke3)" stroke-width="1.6" opacity="0.7" />
+    </g>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-blog.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-blog.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Dark SDG blog parallax background with grid and glow">
+  <defs>
+    <linearGradient id="sdgDarkBlogBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0B1828" />
+      <stop offset="100%" stop-color="#0C2A38" />
+    </linearGradient>
+    <linearGradient id="sdgDarkBlogBand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3AA7F2" stop-opacity="0.38" />
+      <stop offset="100%" stop-color="#2BB07D" stop-opacity="0.32" />
+    </linearGradient>
+    <radialGradient id="sdgDarkBlogGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1380 260) scale(520 420)">
+      <stop offset="0%" stop-color="#2FB2FF" stop-opacity="0.36" />
+      <stop offset="100%" stop-color="#2FB2FF" stop-opacity="0" />
+    </radialGradient>
+    <pattern id="sdgDarkBlogGrid" width="120" height="120" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="120" y2="0" stroke="#2B77C4" stroke-opacity="0.32" stroke-width="2" />
+      <line x1="0" y1="60" x2="120" y2="60" stroke="#2B77C4" stroke-opacity="0.2" stroke-width="1.4" />
+      <line x1="0" y1="120" x2="120" y2="120" stroke="#2B77C4" stroke-opacity="0.32" stroke-width="2" />
+      <line x1="0" y1="0" x2="0" y2="120" stroke="#2B77C4" stroke-opacity="0.32" stroke-width="2" />
+      <line x1="60" y1="0" x2="60" y2="120" stroke="#2B77C4" stroke-opacity="0.2" stroke-width="1.4" />
+      <line x1="120" y1="0" x2="120" y2="120" stroke="#2B77C4" stroke-opacity="0.32" stroke-width="2" />
+    </pattern>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgDarkBlogBase)" />
+  <rect width="1600" height="900" fill="url(#sdgDarkBlogGrid)" opacity="0.18" />
+  <circle cx="1380" cy="260" r="360" fill="url(#sdgDarkBlogGlow)" />
+
+  <path d="M-20 500C220 440 540 420 820 450C1080 480 1320 560 1600 540V900H-20Z" fill="url(#sdgDarkBlogBand)" />
+  <path d="M-20 640C280 600 560 640 880 650C1180 656 1400 630 1600 600V900H-20Z" fill="#0F3B3F" opacity="0.7" />
+
+  <g fill="#2CBC87" opacity="0.5">
+    <circle cx="260" cy="360" r="9" />
+    <circle cx="520" cy="300" r="7" />
+    <circle cx="740" cy="380" r="8" />
+    <circle cx="980" cy="330" r="6" />
+  </g>
+
+  <g fill="#2A8EE5" opacity="0.5">
+    <circle cx="1160" cy="360" r="7" />
+    <circle cx="1240" cy="420" r="8" />
+    <circle cx="1360" cy="360" r="6" />
+    <circle cx="1480" cy="420" r="7" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-cta.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-cta.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Dark SDG call-to-action parallax background with converging beams">
+  <defs>
+    <linearGradient id="sdgDarkCtaBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0A1626" />
+      <stop offset="100%" stop-color="#0C2938" />
+    </linearGradient>
+    <linearGradient id="sdgDarkCtaBeamA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2B88D7" stop-opacity="0.44" />
+      <stop offset="100%" stop-color="#1F9C73" stop-opacity="0.5" />
+    </linearGradient>
+    <linearGradient id="sdgDarkCtaBeamB" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3EA9EF" stop-opacity="0.36" />
+      <stop offset="100%" stop-color="#4CD1A3" stop-opacity="0.24" />
+    </linearGradient>
+    <radialGradient id="sdgDarkCtaGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 260) scale(640 360)">
+      <stop offset="0%" stop-color="#2EAEFF" stop-opacity="0.38" />
+      <stop offset="100%" stop-color="#2EAEFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgDarkCtaBase)" />
+  <circle cx="800" cy="260" r="360" fill="url(#sdgDarkCtaGlow)" />
+
+  <path d="M-40 500L520 360C780 300 980 320 1260 400L1640 500V900H-40Z" fill="url(#sdgDarkCtaBeamA)" />
+  <path d="M-20 640L460 520C740 460 960 470 1260 540L1640 640V900H-20Z" fill="url(#sdgDarkCtaBeamB)" />
+
+  <g fill="none" stroke="#2B99E7" stroke-width="2.4" opacity="0.42">
+    <path d="M200 420C440 360 740 350 960 380C1200 412 1420 400 1600 360" />
+    <path d="M240 520C520 470 760 470 1000 500C1260 540 1440 520 1640 470" />
+  </g>
+
+  <g opacity="0.56" fill="#25C08B">
+    <circle cx="360" cy="360" r="8" />
+    <circle cx="560" cy="320" r="7" />
+    <circle cx="760" cy="360" r="8" />
+    <circle cx="1040" cy="320" r="7" />
+    <circle cx="1280" cy="360" r="9" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-essentials.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-essentials.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Dark SDG essentials parallax background with layered currents">
+  <defs>
+    <linearGradient id="sdgDarkSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0E1A2D" />
+      <stop offset="50%" stop-color="#0B2139" />
+      <stop offset="100%" stop-color="#0C2B3A" />
+    </linearGradient>
+    <linearGradient id="sdgDarkWave" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1E7BCB" stop-opacity="0.4" />
+      <stop offset="100%" stop-color="#1F9C74" stop-opacity="0.5" />
+    </linearGradient>
+    <radialGradient id="sdgDarkGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1240 240) scale(520 420)">
+      <stop offset="0%" stop-color="#37B0FF" stop-opacity="0.36" />
+      <stop offset="100%" stop-color="#37B0FF" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="sdgDarkHalo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(320 760) scale(820 420)">
+      <stop offset="0%" stop-color="#1C5A7A" stop-opacity="0.42" />
+      <stop offset="100%" stop-color="#1C5A7A" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgDarkSky)" />
+  <circle cx="1240" cy="240" r="360" fill="url(#sdgDarkGlow)" />
+  <circle cx="320" cy="760" r="520" fill="url(#sdgDarkHalo)" />
+
+  <path d="M0 620C240 560 520 520 820 550C1120 580 1380 640 1600 600V900H0Z" fill="#0F2743" />
+  <path d="M0 690C260 640 540 680 840 700C1120 720 1380 690 1600 650V900H0Z" fill="#0F3142" />
+  <path d="M0 740C220 720 520 760 820 760C1140 760 1400 720 1600 700V900H0Z" fill="url(#sdgDarkWave)" />
+
+  <g opacity="0.48" fill="none" stroke="#2B9AE3" stroke-width="2.6">
+    <path d="M160 380C260 340 340 340 420 360C520 386 620 350 760 300" />
+    <path d="M1180 320C1280 300 1380 300 1520 340" />
+    <path d="M220 480C340 460 440 440 560 470C700 510 860 500 980 450" />
+  </g>
+
+  <g opacity="0.6" fill="#2BC18D">
+    <circle cx="180" cy="520" r="10" />
+    <circle cx="260" cy="410" r="8" />
+    <circle cx="340" cy="560" r="12" />
+    <circle cx="1260" cy="360" r="9" />
+    <circle cx="1340" cy="430" r="7" />
+    <circle cx="1180" cy="500" r="10" />
+  </g>
+
+  <g opacity="0.4" fill="#2C8AE0">
+    <circle cx="980" cy="260" r="6" />
+    <circle cx="890" cy="320" r="5" />
+    <circle cx="1040" cy="340" r="7" />
+    <circle cx="1160" cy="420" r="6" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-features.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-features.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Dark SDG features parallax background with angular ribbons">
+  <defs>
+    <linearGradient id="sdgDarkFeaturesBase" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0A1728" />
+      <stop offset="60%" stop-color="#0A2236" />
+      <stop offset="100%" stop-color="#0C293F" />
+    </linearGradient>
+    <linearGradient id="sdgDarkFeaturesRibbonA" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1E7DD7" stop-opacity="0.44" />
+      <stop offset="100%" stop-color="#1FA273" stop-opacity="0.48" />
+    </linearGradient>
+    <linearGradient id="sdgDarkFeaturesRibbonB" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#48B4F0" stop-opacity="0.36" />
+      <stop offset="100%" stop-color="#4CD1A3" stop-opacity="0.22" />
+    </linearGradient>
+    <radialGradient id="sdgDarkFeaturesGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 220) scale(420 320)">
+      <stop offset="0%" stop-color="#2FBBFF" stop-opacity="0.36" />
+      <stop offset="100%" stop-color="#2FBBFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgDarkFeaturesBase)" />
+  <circle cx="1180" cy="220" r="320" fill="url(#sdgDarkFeaturesGlow)" />
+
+  <path d="M-40 360L460 520C640 580 820 580 1040 520L1640 360V900H-40Z" fill="url(#sdgDarkFeaturesRibbonA)" />
+  <path d="M-20 520L360 640C600 720 900 760 1200 700L1650 600V900H-20Z" fill="url(#sdgDarkFeaturesRibbonB)" />
+
+  <g fill="none" stroke="#2C9DE6" stroke-width="2.6" opacity="0.44">
+    <path d="M100 320C260 280 520 280 760 340C1000 400 1320 420 1500 360" />
+    <path d="M200 220C420 190 680 210 920 280C1180 356 1430 370 1600 330" />
+  </g>
+
+  <g opacity="0.46" fill="#2BBE87">
+    <circle cx="320" cy="360" r="9" />
+    <circle cx="480" cy="310" r="8" />
+    <circle cx="640" cy="380" r="7" />
+    <circle cx="820" cy="300" r="10" />
+    <circle cx="1000" cy="260" r="8" />
+    <circle cx="1380" cy="320" r="9" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-objections.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-sdg-objections.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Dark SDG objections parallax background with layered leaves">
+  <defs>
+    <linearGradient id="sdgDarkObjBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0B1726" />
+      <stop offset="100%" stop-color="#0C2937" />
+    </linearGradient>
+    <linearGradient id="sdgDarkObjLeafA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2C88D7" stop-opacity="0.42" />
+      <stop offset="100%" stop-color="#1E9C72" stop-opacity="0.46" />
+    </linearGradient>
+    <linearGradient id="sdgDarkObjLeafB" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3FA3EB" stop-opacity="0.34" />
+      <stop offset="100%" stop-color="#4BC89E" stop-opacity="0.24" />
+    </linearGradient>
+    <radialGradient id="sdgDarkObjHalo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 260) scale(460 340)">
+      <stop offset="0%" stop-color="#2588D6" stop-opacity="0.46" />
+      <stop offset="100%" stop-color="#2588D6" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgDarkObjBase)" />
+  <circle cx="240" cy="260" r="340" fill="url(#sdgDarkObjHalo)" />
+
+  <path d="M-60 520C180 500 340 420 520 360C780 276 1080 260 1380 340C1480 368 1580 410 1680 470V900H-60Z" fill="url(#sdgDarkObjLeafA)" />
+  <path d="M-60 640C180 600 420 520 660 520C940 520 1240 620 1600 610L1680 600V900H-60Z" fill="url(#sdgDarkObjLeafB)" />
+
+  <g opacity="0.48" fill="none" stroke="#2B99E7" stroke-width="2.2">
+    <path d="M160 440C320 400 520 400 760 450C1000 500 1240 500 1440 440" />
+    <path d="M220 520C420 480 680 480 880 520C1120 568 1340 560 1520 520" />
+  </g>
+
+  <g opacity="0.56" fill="#27C18A">
+    <circle cx="360" cy="360" r="9" />
+    <circle cx="520" cy="320" r="8" />
+    <circle cx="700" cy="360" r="7" />
+    <circle cx="980" cy="320" r="7" />
+    <circle cx="1240" cy="360" r="9" />
+    <circle cx="1400" cy="300" r="8" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-sdg-blog.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-sdg-blog.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Light SDG blog parallax background with gentle grid and highlights">
+  <defs>
+    <linearGradient id="sdgLightBlogBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F3F8FF" />
+      <stop offset="100%" stop-color="#E8FFF5" />
+    </linearGradient>
+    <linearGradient id="sdgLightBlogBand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7FD3FF" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#43D39D" stop-opacity="0.24" />
+    </linearGradient>
+    <radialGradient id="sdgLightBlogGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1380 260) scale(520 420)">
+      <stop offset="0%" stop-color="#8AD8FF" stop-opacity="0.3" />
+      <stop offset="100%" stop-color="#8AD8FF" stop-opacity="0" />
+    </radialGradient>
+    <pattern id="sdgLightBlogGrid" width="120" height="120" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="120" y2="0" stroke="#9CCDF6" stroke-opacity="0.18" stroke-width="2" />
+      <line x1="0" y1="60" x2="120" y2="60" stroke="#9CCDF6" stroke-opacity="0.12" stroke-width="1.4" />
+      <line x1="0" y1="120" x2="120" y2="120" stroke="#9CCDF6" stroke-opacity="0.18" stroke-width="2" />
+      <line x1="0" y1="0" x2="0" y2="120" stroke="#9CCDF6" stroke-opacity="0.18" stroke-width="2" />
+      <line x1="60" y1="0" x2="60" y2="120" stroke="#9CCDF6" stroke-opacity="0.12" stroke-width="1.4" />
+      <line x1="120" y1="0" x2="120" y2="120" stroke="#9CCDF6" stroke-opacity="0.18" stroke-width="2" />
+    </pattern>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgLightBlogBase)" />
+  <rect width="1600" height="900" fill="url(#sdgLightBlogGrid)" opacity="0.16" />
+  <circle cx="1380" cy="260" r="360" fill="url(#sdgLightBlogGlow)" />
+
+  <path d="M-20 500C220 440 540 420 820 450C1080 480 1320 560 1600 540V900H-20Z" fill="url(#sdgLightBlogBand)" />
+  <path d="M-20 640C280 600 560 640 880 650C1180 656 1400 630 1600 600V900H-20Z" fill="#CFF5E2" opacity="0.8" />
+
+  <g fill="#2FB97E" opacity="0.4">
+    <circle cx="260" cy="360" r="9" />
+    <circle cx="520" cy="300" r="7" />
+    <circle cx="740" cy="380" r="8" />
+    <circle cx="980" cy="330" r="6" />
+  </g>
+
+  <g fill="#2C8CE8" opacity="0.38">
+    <circle cx="1160" cy="360" r="7" />
+    <circle cx="1240" cy="420" r="8" />
+    <circle cx="1360" cy="360" r="6" />
+    <circle cx="1480" cy="420" r="7" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-sdg-cta.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-sdg-cta.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Light SDG call-to-action parallax background with converging beams">
+  <defs>
+    <linearGradient id="sdgLightCtaBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#E9F5FF" />
+      <stop offset="100%" stop-color="#E7FFF2" />
+    </linearGradient>
+    <linearGradient id="sdgLightCtaBeamA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2F9AE6" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#2ED18A" stop-opacity="0.34" />
+    </linearGradient>
+    <linearGradient id="sdgLightCtaBeamB" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#8BD9FF" stop-opacity="0.3" />
+      <stop offset="100%" stop-color="#7FE3B4" stop-opacity="0.22" />
+    </linearGradient>
+    <radialGradient id="sdgLightCtaGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 260) scale(640 360)">
+      <stop offset="0%" stop-color="#8AD8FF" stop-opacity="0.34" />
+      <stop offset="100%" stop-color="#8AD8FF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgLightCtaBase)" />
+  <circle cx="800" cy="260" r="360" fill="url(#sdgLightCtaGlow)" />
+
+  <path d="M-40 500L520 360C780 300 980 320 1260 400L1640 500V900H-40Z" fill="url(#sdgLightCtaBeamA)" />
+  <path d="M-20 640L460 520C740 460 960 470 1260 540L1640 640V900H-20Z" fill="url(#sdgLightCtaBeamB)" />
+
+  <g fill="none" stroke="#3AA2E9" stroke-width="2.4" opacity="0.32">
+    <path d="M200 420C440 360 740 350 960 380C1200 412 1420 400 1600 360" />
+    <path d="M240 520C520 470 760 470 1000 500C1260 540 1440 520 1640 470" />
+  </g>
+
+  <g opacity="0.44" fill="#2CC08E">
+    <circle cx="360" cy="360" r="8" />
+    <circle cx="560" cy="320" r="7" />
+    <circle cx="760" cy="360" r="8" />
+    <circle cx="1040" cy="320" r="7" />
+    <circle cx="1280" cy="360" r="9" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-sdg-essentials.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-sdg-essentials.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Light SDG essentials parallax background with layered waves and seeds">
+  <defs>
+    <linearGradient id="sdgLightSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ECF5FF" />
+      <stop offset="45%" stop-color="#E6F8FF" />
+      <stop offset="100%" stop-color="#E9FFF4" />
+    </linearGradient>
+    <linearGradient id="sdgLightWave" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#44B5F2" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#36D28E" stop-opacity="0.28" />
+    </linearGradient>
+    <radialGradient id="sdgLightGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1250 200) scale(520 420)">
+      <stop offset="0%" stop-color="#8BD2FF" stop-opacity="0.32" />
+      <stop offset="80%" stop-color="#3BC59D" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="sdgLightHalo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(360 780) scale(820 420)">
+      <stop offset="0%" stop-color="#CFF0FF" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#CFF0FF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgLightSky)" />
+  <circle cx="1280" cy="200" r="320" fill="url(#sdgLightGlow)" />
+  <circle cx="280" cy="760" r="520" fill="url(#sdgLightHalo)" />
+
+  <path d="M0 610C240 560 520 520 820 550C1100 576 1380 640 1600 610V900H0Z" fill="#D7F4FF" />
+  <path d="M0 670C280 630 520 670 840 690C1140 706 1380 690 1600 660V900H0Z" fill="#D9FCEB" />
+  <path d="M0 720C220 700 520 750 820 750C1140 750 1400 700 1600 680V900H0Z" fill="url(#sdgLightWave)" />
+
+  <g opacity="0.42" fill="none" stroke="#3AA0F3" stroke-width="2.4">
+    <path d="M160 360C260 320 340 320 420 340C520 366 620 330 760 280" />
+    <path d="M1180 320C1280 300 1380 290 1520 320" />
+    <path d="M220 460C340 440 440 430 560 460C700 500 860 480 980 430" />
+  </g>
+
+  <g opacity="0.55" fill="#36C59E">
+    <circle cx="180" cy="520" r="10" />
+    <circle cx="260" cy="410" r="8" />
+    <circle cx="340" cy="560" r="12" />
+    <circle cx="1260" cy="360" r="9" />
+    <circle cx="1340" cy="430" r="7" />
+    <circle cx="1180" cy="500" r="10" />
+  </g>
+
+  <g opacity="0.28" fill="#2C7BE5">
+    <circle cx="980" cy="260" r="6" />
+    <circle cx="890" cy="320" r="5" />
+    <circle cx="1040" cy="340" r="7" />
+    <circle cx="1160" cy="420" r="6" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-sdg-features.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-sdg-features.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Light SDG features parallax background with geometric ribbons">
+  <defs>
+    <linearGradient id="sdgLightBase" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F0F7FF" />
+      <stop offset="60%" stop-color="#E8FFF7" />
+      <stop offset="100%" stop-color="#E5F3FF" />
+    </linearGradient>
+    <linearGradient id="sdgLightRibbonA" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#35B9EB" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#2ED18A" stop-opacity="0.32" />
+    </linearGradient>
+    <linearGradient id="sdgLightRibbonB" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9AD8FF" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#7FE1B9" stop-opacity="0.18" />
+    </linearGradient>
+    <radialGradient id="sdgLightSpark" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 200) scale(400 320)">
+      <stop offset="0%" stop-color="#7FDAFF" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#7FDAFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgLightBase)" />
+  <circle cx="1180" cy="200" r="320" fill="url(#sdgLightSpark)" />
+
+  <path d="M-40 360L460 520C640 580 820 580 1040 520L1640 360V900H-40Z" fill="url(#sdgLightRibbonA)" />
+  <path d="M-20 520L360 640C600 720 900 760 1200 700L1650 600V900H-20Z" fill="url(#sdgLightRibbonB)" />
+
+  <g fill="none" stroke="#34A5E5" stroke-width="2.6" opacity="0.35">
+    <path d="M100 320C260 280 520 280 760 340C1000 400 1320 420 1500 360" />
+    <path d="M200 220C420 190 680 210 920 280C1180 356 1430 370 1600 330" />
+  </g>
+
+  <g opacity="0.38" fill="#2CC18F">
+    <circle cx="320" cy="360" r="9" />
+    <circle cx="480" cy="310" r="8" />
+    <circle cx="640" cy="380" r="7" />
+    <circle cx="820" cy="300" r="10" />
+    <circle cx="1000" cy="260" r="8" />
+    <circle cx="1380" cy="320" r="9" />
+  </g>
+</svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-sdg-objections.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-sdg-objections.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Light SDG objections parallax background with layered leaves">
+  <defs>
+    <linearGradient id="sdgLightObjBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#EEF6FF" />
+      <stop offset="100%" stop-color="#E9FFF5" />
+    </linearGradient>
+    <linearGradient id="sdgLightObjLeafA" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#30B0EC" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#2EC788" stop-opacity="0.32" />
+    </linearGradient>
+    <linearGradient id="sdgLightObjLeafB" x1="1" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#7FD0FF" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#9EE8C0" stop-opacity="0.24" />
+    </linearGradient>
+    <radialGradient id="sdgLightObjHalo" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 260) scale(460 340)">
+      <stop offset="0%" stop-color="#9FDFFF" stop-opacity="0.34" />
+      <stop offset="100%" stop-color="#9FDFFF" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#sdgLightObjBase)" />
+  <circle cx="240" cy="260" r="340" fill="url(#sdgLightObjHalo)" />
+
+  <path d="M-60 520C180 500 340 420 520 360C780 276 1080 260 1380 340C1480 368 1580 410 1680 470V900H-60Z" fill="url(#sdgLightObjLeafA)" />
+  <path d="M-60 640C180 600 420 520 660 520C940 520 1240 620 1600 610L1680 600V900H-60Z" fill="url(#sdgLightObjLeafB)" />
+
+  <g opacity="0.35" fill="none" stroke="#3A9FE8" stroke-width="2.2">
+    <path d="M160 440C320 400 520 400 760 450C1000 500 1240 500 1440 440" />
+    <path d="M220 520C420 480 680 480 880 520C1120 568 1340 560 1520 520" />
+  </g>
+
+  <g opacity="0.42" fill="#2FC08A">
+    <circle cx="360" cy="360" r="9" />
+    <circle cx="520" cy="320" r="8" />
+    <circle cx="700" cy="360" r="7" />
+    <circle cx="980" cy="320" r="7" />
+    <circle cx="1240" cy="360" r="9" />
+    <circle cx="1400" cy="300" r="8" />
+  </g>
+</svg>

--- a/frontend/config/theme/assets.ts
+++ b/frontend/config/theme/assets.ts
@@ -64,7 +64,13 @@ export const parallaxPacks: Record<
       objections: ['parallax/parallax-background-1.svg'],
       cta: ['parallax/parallax-background-2.svg'],
     },
-    sdg: {},
+    sdg: {
+      essentials: ['parallax/parallax-background-sdg-essentials.svg'],
+      features: ['parallax/parallax-background-sdg-features.svg'],
+      blog: ['parallax/parallax-background-sdg-blog.svg'],
+      objections: ['parallax/parallax-background-sdg-objections.svg'],
+      cta: ['parallax/parallax-background-sdg-cta.svg'],
+    },
     christmas: {
       essentials: ['parallax/parallax-background-bubbles-1.svg'],
       features: ['parallax/parallax-background-bubbles-2.svg'],
@@ -81,7 +87,13 @@ export const parallaxPacks: Record<
       objections: ['parallax/parallax-background-1.svg'],
       cta: ['parallax/parallax-background-2.svg'],
     },
-    sdg: {},
+    sdg: {
+      essentials: ['parallax/parallax-background-sdg-essentials.svg'],
+      features: ['parallax/parallax-background-sdg-features.svg'],
+      blog: ['parallax/parallax-background-sdg-blog.svg'],
+      objections: ['parallax/parallax-background-sdg-objections.svg'],
+      cta: ['parallax/parallax-background-sdg-cta.svg'],
+    },
     christmas: {
       essentials: ['parallax/parallax-background-bubbles-1.svg'],
       features: ['parallax/parallax-background-bubbles-2.svg'],


### PR DESCRIPTION
## Summary
- add SDG-themed parallax SVGs for every home section in both light and dark themes
- register the SDG pack in the theme asset config so seasonal switching resolves dedicated files instead of falling back
- supply dark transparent bubble backgrounds to mirror the light Christmas variants

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440f7afc488322a50da5a4ea2249cd)