### PR TITLE
Refresh Christmas parallax backgrounds

### DIFF
--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-1.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-1.svg
@@ -1,143 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified dark parallax background with rising bubbles on the left">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive dark parallax background with gifts and stars framing the edges">
   <defs>
-    <!-- Unified base background -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0B1220"></stop>
-      <stop offset="0.55" stop-color="#0F172A"></stop>
-      <stop offset="1" stop-color="#111827"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00B97F" />
+      <stop offset="52%" stop-color="#0087AD" />
+      <stop offset="100%" stop-color="#006199" />
     </linearGradient>
-
-    <!-- Gentle ambient wash (keeps everything unified) -->
-    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
-      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
-      <stop offset="0.55" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.12" cy="0.74" r="0.8">
+      <stop offset="0%" stop-color="#009CC7" stop-opacity="0.32" />
+      <stop offset="100%" stop-color="#009CC7" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#22C55E" stop-opacity="0.12"></stop>
-      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.06"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.9" cy="0.18" r="0.86">
+      <stop offset="0%" stop-color="#006199" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#006199" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Left-side bubble glow -->
-    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
-      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.22"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + highlight -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
-      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.18"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.32"></stop>
-      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.38"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0.18"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture / dots -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#FFFFFF" opacity="0.1" />
     </pattern>
-
-    <!-- Soft vignette -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
-      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    <filter id="blur12" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="16" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.55 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.16 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur8" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#ambient)"></rect>
-  <rect width="1600" height="800" fill="url(#ambient2)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+  <rect width="1600" height="800" fill="#04121C" opacity="0.14" />
 
-  <!-- Left lane glow (so bubbles feel integrated) -->
-  <g id="parallax-back">
-    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
-    <!-- faint upward current -->
-    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#38BDF8" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  <g id="parallax-back" opacity="0.85">
+    <ellipse cx="220" cy="520" rx="340" ry="240" fill="#0087AD" opacity="0.26" filter="url(#blur12)" />
+    <ellipse cx="1480" cy="120" rx="300" ry="210" fill="#006199" opacity="0.24" filter="url(#blur8)" />
+    <path d="M-120 640 C 140 520, 420 540, 700 690" fill="none" stroke="#BFE9FF" stroke-width="10" opacity="0.14" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Large bubbles -->
-    <g transform="translate(150 650)">
-      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
-      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
-      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g stroke="#FF8479" stroke-width="1.3" fill="none" opacity="0.2">
+      <circle cx="1340" cy="130" r="50" />
+      <circle cx="1460" cy="210" r="70" />
+      <circle cx="1520" cy="300" r="44" />
+    </g>
+    <g fill="#E6F4FF">
+      <circle cx="160" cy="200" r="42" opacity="0.2" />
+      <circle cx="230" cy="280" r="22" opacity="0.22" />
+      <circle cx="190" cy="120" r="30" opacity="0.18" />
+      <circle cx="1480" cy="650" r="36" opacity="0.19" />
+      <circle cx="1380" cy="720" r="26" opacity="0.18" />
+      <circle cx="1540" cy="520" r="32" opacity="0.18" />
+    </g>
+  </g>
+
+  <g id="parallax-front">
+    <g fill="#E6F4FF" opacity="0.2">
+      <path d="M120 90 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M1500 700 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M240 740 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1540 520 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M180 520 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
     </g>
 
-    <g transform="translate(230 520)">
-      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
-      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    <g stroke="#FF8479" stroke-width="1.4" fill="none" opacity="0.28">
+      <rect x="88" y="600" width="76" height="64" rx="7" />
+      <path d="M88 632h76" />
+      <path d="M126 600v64" />
+      <path d="M126 600c-4-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-19 18-26 2" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.2" fill="none" opacity="0.25">
+      <rect x="1448" y="70" width="70" height="58" rx="7" />
+      <path d="M1448 101h70" />
+      <path d="M1483 70v58" />
+      <path d="M1483 70c-3-14 20-16 22-4 1 5-3 11-9 14 6-2 18-2 19 8 1 12-15 14-19 1" />
     </g>
 
-    <g transform="translate(170 400)">
-      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
-      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="660" r="7" />
+      <circle cx="1400" cy="710" r="9" />
+      <circle cx="1470" cy="620" r="6" />
+      <circle cx="1520" cy="690" r="8" />
+      <circle cx="1560" cy="610" r="9" />
+      <circle cx="1420" cy="760" r="7" />
     </g>
-
-    <g transform="translate(260 270)">
-      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
-      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(190 140)">
-      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
-      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles (more “motion”) -->
-    <g opacity="0.75">
-      <g transform="translate(110 720)">
-        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(270 610)">
-        </g></g></g></svg>
+  </g>
+</svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-2.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-2.svg
@@ -1,191 +1,88 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising in the middle">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive dark parallax background with balanced stars and gifts">
   <defs>
-    <!-- Unified base background -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0B1220"></stop>
-      <stop offset="0.55" stop-color="#0F172A"></stop>
-      <stop offset="1" stop-color="#111827"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(26 0.5 0.5)">
+      <stop offset="0%" stop-color="#00B97F" />
+      <stop offset="50%" stop-color="#0087AD" />
+      <stop offset="100%" stop-color="#006199" />
     </linearGradient>
-
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
-      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.1" cy="0.25" r="0.72">
+      <stop offset="0%" stop-color="#009CC7" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#009CC7" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
-      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.92" cy="0.8" r="0.86">
+      <stop offset="0%" stop-color="#006199" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#006199" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Center column glow -->
-    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
-      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.20"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.10"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
-      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
-      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#FFFFFF" opacity="0.1" />
     </pattern>
-
-    <!-- Vignette -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
-      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    <filter id="blur16" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="16" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.52 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.16 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur10" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
-  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+  <rect width="1600" height="800" fill="#04121C" opacity="0.14" />
 
-  <!-- Center column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
-    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <g id="parallax-back" opacity="0.86">
+    <ellipse cx="240" cy="160" rx="320" ry="210" fill="#0087AD" opacity="0.24" filter="url(#blur16)" />
+    <ellipse cx="1360" cy="660" rx="320" ry="220" fill="#006199" opacity="0.22" filter="url(#blur10)" />
+    <path d="M-100 120 C 260 220, 520 160, 840 80" fill="none" stroke="#BFE9FF" stroke-width="10" opacity="0.14" />
+    <path d="M780 760 C 980 720, 1260 710, 1680 820" fill="none" stroke="#BFE9FF" stroke-width="9" opacity="0.12" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(720 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g fill="#E6F4FF">
+      <circle cx="180" cy="640" r="32" opacity="0.2" />
+      <circle cx="220" cy="700" r="22" opacity="0.21" />
+      <circle cx="1500" cy="160" r="34" opacity="0.19" />
+      <circle cx="1420" cy="120" r="22" opacity="0.18" />
+      <circle cx="1500" cy="520" r="28" opacity="0.18" />
+      <circle cx="1560" cy="580" r="20" opacity="0.17" />
     </g>
-
-    <g transform="translate(865 600)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(790 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(905 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(770 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(840 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles (adds motion) -->
-    <g opacity="0.75">
-      <g transform="translate(690 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(925 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(720 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(950 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(700 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(930 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(735 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(905 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g stroke="#FF8479" stroke-width="1.25" fill="none" opacity="0.22">
+      <circle cx="220" cy="620" r="58" />
+      <circle cx="210" cy="710" r="38" />
+      <circle cx="1460" cy="190" r="68" />
+      <circle cx="1520" cy="260" r="44" />
     </g>
   </g>
 
-  <!-- Very subtle tech accents (kept unified) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="1345" cy="320" r="5" fill="#38BDF8" opacity="0.30"></circle>
-    <circle cx="1282" cy="513" r="5" fill="#22C55E" opacity="0.26"></circle>
-  </g>
+  <g id="parallax-front">
+    <g fill="#E6F4FF" opacity="0.2">
+      <path d="M110 180 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M320 110 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1380 680 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1500 560 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M230 650 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
 
-  <!-- Vignette + grain -->
-  <rect width="1600" height="800" fill="url(#vignette)"></rect>
-  <g filter="url(#grain)">
-    <rect width="1600" height="800" fill="transparent"></rect>
+    <g stroke="#FF8479" stroke-width="1.4" fill="none" opacity="0.28">
+      <rect x="126" y="76" width="78" height="66" rx="7" />
+      <path d="M126 108h78" />
+      <path d="M166 76v66" />
+      <path d="M166 76c-5-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.2" fill="none" opacity="0.25">
+      <rect x="1418" y="602" width="76" height="62" rx="7" />
+      <path d="M1418 633h76" />
+      <path d="M1456 602v62" />
+      <path d="M1456 602c-4-16 22-20 24-6 1 5-2 12-9 16 7-3 20-2 21 8 1 12-19 16-24 2" />
+    </g>
+
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="120" r="7" />
+      <circle cx="1380" cy="160" r="9" />
+      <circle cx="1460" cy="90" r="6" />
+      <circle cx="1540" cy="150" r="8" />
+      <circle cx="1580" cy="90" r="9" />
+      <circle cx="1420" cy="200" r="7" />
+    </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-3.svg
+++ b/frontend/app/assets/themes/dark/parallax/parallax-background-bubbles-3.svg
@@ -1,191 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified dark parallax background with bubbles rising on the right">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive dark parallax background with right-side sparkles and gifts">
   <defs>
-    <!-- Unified base background -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0B1220"></stop>
-      <stop offset="0.55" stop-color="#0F172A"></stop>
-      <stop offset="1" stop-color="#111827"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00B97F" />
+      <stop offset="50%" stop-color="#0087AD" />
+      <stop offset="100%" stop-color="#006199" />
     </linearGradient>
-
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
-      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.08" cy="0.18" r="0.74">
+      <stop offset="0%" stop-color="#009CC7" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#009CC7" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
-      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.9" cy="0.7" r="0.82">
+      <stop offset="0%" stop-color="#006199" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#006199" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Right column glow -->
-    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
-      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.18"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.09"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
-      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
-      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#FFFFFF" opacity="0.1" />
     </pattern>
-
-    <!-- Vignette -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
-      <stop offset="0" stop-color="#000000" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#000000" stop-opacity="0.58"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    <filter id="blur14" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.52 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.16 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur10" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
-  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.75"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+  <rect width="1600" height="800" fill="#04121C" opacity="0.14" />
 
-  <!-- Right column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
-    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <g id="parallax-back" opacity="0.86">
+    <ellipse cx="180" cy="180" rx="320" ry="220" fill="#0087AD" opacity="0.24" filter="url(#blur14)" />
+    <ellipse cx="1420" cy="620" rx="340" ry="240" fill="#006199" opacity="0.22" filter="url(#blur10)" />
+    <path d="M-60 540 C 220 450, 480 480, 760 610" fill="none" stroke="#BFE9FF" stroke-width="10" opacity="0.14" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(1375 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g stroke="#FF8479" stroke-width="1.3" fill="none" opacity="0.22">
+      <circle cx="180" cy="160" r="64" />
+      <circle cx="220" cy="240" r="40" />
+      <circle cx="1420" cy="640" r="72" />
+      <circle cx="1500" cy="720" r="48" />
     </g>
-
-    <g transform="translate(1235 610)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1310 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1195 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1330 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1250 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles -->
-    <g opacity="0.75">
-      <g transform="translate(1410 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1175 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1395 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1160 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1400 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1170 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1370 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1190 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g fill="#E6F4FF">
+      <circle cx="1500" cy="560" r="34" opacity="0.2" />
+      <circle cx="1560" cy="640" r="26" opacity="0.19" />
+      <circle cx="140" cy="660" r="32" opacity="0.2" />
+      <circle cx="200" cy="720" r="22" opacity="0.2" />
+      <circle cx="260" cy="120" r="20" opacity="0.18" />
     </g>
   </g>
 
-  <!-- Subtle tech accents on left (balances composition) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="335" cy="340" r="5" fill="#38BDF8" opacity="0.30"></circle>
-    <circle cx="282" cy="528" r="5" fill="#22C55E" opacity="0.26"></circle>
-  </g>
+  <g id="parallax-front">
+    <g fill="#E6F4FF" opacity="0.2">
+      <path d="M90 120 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M300 620 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1500 200 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1360 120 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1520 440 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
 
-  <!-- Vignette + grain -->
-  <rect width="1600" height="800" fill="url(#vignette)"></rect>
-  <g filter="url(#grain)">
-    <rect width="1600" height="800" fill="transparent"></rect>
+    <g stroke="#5BDB3B" stroke-width="1.25" fill="none" opacity="0.25">
+      <rect x="1444" y="82" width="78" height="66" rx="7" />
+      <path d="M1444 114h78" />
+      <path d="M1483 82v66" />
+      <path d="M1483 82c-4-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+    <g stroke="#FF8479" stroke-width="1.35" fill="none" opacity="0.28">
+      <rect x="96" y="560" width="82" height="68" rx="8" />
+      <path d="M96 594h82" />
+      <path d="M138 560v68" />
+      <path d="M138 560c-5-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="580" r="7" />
+      <circle cx="1360" cy="660" r="9" />
+      <circle cx="1460" cy="520" r="6" />
+      <circle cx="1540" cy="600" r="8" />
+      <circle cx="1580" cy="520" r="9" />
+      <circle cx="1400" cy="720" r="7" />
+    </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-1.svg
@@ -1,146 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified light parallax background with rising bubbles on the left">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive light parallax background with gifts and stars along the edges">
   <defs>
-    <!-- Unified base background: Light Theme -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#FFFFFF"></stop>
-      <stop offset="0.55" stop-color="#F8FAFC"></stop>
-      <stop offset="1" stop-color="#F1F5F9"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Gentle ambient wash (keeps everything unified) -->
-    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
-      <stop offset="0" stop-color="#BFDBFE" stop-opacity="0.4"></stop>
-      <stop offset="0.55" stop-color="#DBEAFE" stop-opacity="0.25"></stop>
-      <stop offset="1" stop-color="#BFDBFE" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.12" cy="0.72" r="0.78">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.3" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#BBF7D0" stop-opacity="0.3"></stop>
-      <stop offset="0.7" stop-color="#DCFCE7" stop-opacity="0.15"></stop>
-      <stop offset="1" stop-color="#BBF7D0" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.92" cy="0.18" r="0.85">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Left-side bubble glow -->
-    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
-      <stop offset="0" stop-color="#BAE6FD" stop-opacity="0.35"></stop>
-      <stop offset="0.55" stop-color="#E0F2FE" stop-opacity="0.2"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + highlight -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.5"></stop>
-      <stop offset="0.35" stop-color="#E0F2FE" stop-opacity="0.4"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0.05"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#93C5FD" stop-opacity="0.4"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.45"></stop>
-      <stop offset="1" stop-color="#4ADE80" stop-opacity="0.25"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture / dots -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#1E293B" opacity="0.03"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#1E293B" opacity="0.02"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.1" />
     </pattern>
-
-    <!-- Soft vignette: White instead of black -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.6"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
+    <filter id="blur12" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="16" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.25 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.08 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur8" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#ambient)"></rect>
-  <rect width="1600" height="800" fill="url(#ambient2)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.6"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
 
-  <!-- Left lane glow (so bubbles feel integrated) -->
-  <g id="parallax-back">
-    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
-    <!-- faint upward current -->
-    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#38BDF8" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  <g id="parallax-back" opacity="0.85">
+    <ellipse cx="200" cy="520" rx="340" ry="240" fill="#00A1C2" opacity="0.25" filter="url(#blur12)" />
+    <ellipse cx="1480" cy="120" rx="300" ry="210" fill="#0088D6" opacity="0.22" filter="url(#blur8)" />
+    <path d="M-120 640 C 140 520, 420 540, 700 690" fill="none" stroke="#F4F4F4" stroke-width="10" opacity="0.14" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Large bubbles -->
-    <g transform="translate(150 650)">
-      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
-      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
-      <circle cx="-14" cy="-16" r="10" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g stroke="#FF8479" stroke-width="1.3" fill="none" opacity="0.18">
+      <circle cx="1340" cy="130" r="50" />
+      <circle cx="1460" cy="210" r="70" />
+      <circle cx="1520" cy="300" r="44" />
     </g>
-
-    <g transform="translate(230 520)">
-      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
-      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(170 400)">
-      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
-      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(260 270)">
-      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
-      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(190 140)">
-      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
-      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles (more “motion”) -->
-    <g opacity="0.75">
-      <g transform="translate(110 720)">
-        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(270 610)">
-      </g>
+    <g fill="#F4F4F4">
+      <circle cx="160" cy="200" r="42" opacity="0.18" />
+      <circle cx="230" cy="280" r="22" opacity="0.2" />
+      <circle cx="190" cy="120" r="30" opacity="0.16" />
+      <circle cx="1480" cy="650" r="36" opacity="0.17" />
+      <circle cx="1380" cy="720" r="26" opacity="0.15" />
+      <circle cx="1540" cy="520" r="32" opacity="0.16" />
     </g>
   </g>
+
+  <g id="parallax-front">
+    <g fill="#F4F4F4" opacity="0.2">
+      <path d="M120 90 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M1500 700 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M240 740 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1540 520 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M180 520 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
+
+    <g stroke="#FF8479" stroke-width="1.4" fill="none" opacity="0.26">
+      <rect x="88" y="600" width="76" height="64" rx="7" />
+      <path d="M88 632h76" />
+      <path d="M126 600v64" />
+      <path d="M126 600c-4-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-19 18-26 2" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.2" fill="none" opacity="0.24">
+      <rect x="1448" y="70" width="70" height="58" rx="7" />
+      <path d="M1448 101h70" />
+      <path d="M1483 70v58" />
+      <path d="M1483 70c-3-14 20-16 22-4 1 5-3 11-9 14 6-2 18-2 19 8 1 12-15 14-19 1" />
+    </g>
+
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="660" r="7" />
+      <circle cx="1400" cy="710" r="9" />
+      <circle cx="1470" cy="620" r="6" />
+      <circle cx="1520" cy="690" r="8" />
+      <circle cx="1560" cy="610" r="9" />
+      <circle cx="1420" cy="760" r="7" />
+    </g>
+  </g>
+
+  <!-- Safe area (center kept clear for content) -->
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-2.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-2.svg
@@ -1,191 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified light parallax background with bubbles rising in the middle">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive light parallax background with stars framing the content">
   <defs>
-    <!-- Unified base background: Light Theme -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#FFFFFF"></stop>
-      <stop offset="0.55" stop-color="#F8FAFC"></stop>
-      <stop offset="1" stop-color="#F1F5F9"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(26 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#BFDBFE" stop-opacity="0.4"></stop>
-      <stop offset="0.6" stop-color="#DBEAFE" stop-opacity="0.25"></stop>
-      <stop offset="1" stop-color="#BFDBFE" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.1" cy="0.25" r="0.7">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.28" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#BBF7D0" stop-opacity="0.3"></stop>
-      <stop offset="0.7" stop-color="#DCFCE7" stop-opacity="0.15"></stop>
-      <stop offset="1" stop-color="#BBF7D0" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.92" cy="0.8" r="0.85">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.24" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Center column glow -->
-    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
-      <stop offset="0" stop-color="#BAE6FD" stop-opacity="0.3"></stop>
-      <stop offset="0.55" stop-color="#E0F2FE" stop-opacity="0.15"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.5"></stop>
-      <stop offset="0.35" stop-color="#E0F2FE" stop-opacity="0.4"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0.05"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#93C5FD" stop-opacity="0.4"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.45"></stop>
-      <stop offset="1" stop-color="#4ADE80" stop-opacity="0.25"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#1E293B" opacity="0.03"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#1E293B" opacity="0.02"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.1" />
     </pattern>
-
-    <!-- Vignette: White instead of black -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.6"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    <filter id="blur16" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="16" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.25 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.08 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur10" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
-  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.6"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
 
-  <!-- Center column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
-    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <g id="parallax-back" opacity="0.85">
+    <ellipse cx="240" cy="160" rx="320" ry="210" fill="#00A1C2" opacity="0.22" filter="url(#blur16)" />
+    <ellipse cx="1360" cy="660" rx="320" ry="220" fill="#0088D6" opacity="0.2" filter="url(#blur10)" />
+    <path d="M-100 120 C 260 220, 520 160, 840 80" fill="none" stroke="#F4F4F4" stroke-width="10" opacity="0.12" />
+    <path d="M780 760 C 980 720, 1260 710, 1680 820" fill="none" stroke="#F4F4F4" stroke-width="9" opacity="0.1" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(720 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g fill="#F4F4F4">
+      <circle cx="180" cy="640" r="32" opacity="0.18" />
+      <circle cx="220" cy="700" r="22" opacity="0.19" />
+      <circle cx="1500" cy="160" r="34" opacity="0.17" />
+      <circle cx="1420" cy="120" r="22" opacity="0.16" />
+      <circle cx="1500" cy="520" r="28" opacity="0.16" />
+      <circle cx="1560" cy="580" r="20" opacity="0.15" />
     </g>
-
-    <g transform="translate(865 600)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(790 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(905 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(770 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(840 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles (adds motion) -->
-    <g opacity="0.75">
-      <g transform="translate(690 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(925 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(720 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(950 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(700 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(930 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(735 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(905 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g stroke="#FF8479" stroke-width="1.25" fill="none" opacity="0.2">
+      <circle cx="220" cy="620" r="58" />
+      <circle cx="210" cy="710" r="38" />
+      <circle cx="1460" cy="190" r="68" />
+      <circle cx="1520" cy="260" r="44" />
     </g>
   </g>
 
-  <!-- Very subtle tech accents (kept unified) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#2563EB" stroke-opacity="0.25" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#10B981" stroke-opacity="0.25" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="1345" cy="320" r="5" fill="#3B82F6" opacity="0.4"></circle>
-    <circle cx="1282" cy="513" r="5" fill="#10B981" opacity="0.35"></circle>
-  </g>
+  <g id="parallax-front">
+    <g fill="#F4F4F4" opacity="0.2">
+      <path d="M110 180 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M320 110 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1380 680 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1500 560 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M230 650 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
 
-  <!-- Vignette + grain -->
-  <rect width="1600" height="800" fill="url(#vignette)"></rect>
-  <g filter="url(#grain)">
-    <rect width="1600" height="800" fill="transparent"></rect>
+    <g stroke="#FF8479" stroke-width="1.4" fill="none" opacity="0.25">
+      <rect x="126" y="76" width="78" height="66" rx="7" />
+      <path d="M126 108h78" />
+      <path d="M166 76v66" />
+      <path d="M166 76c-5-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.2" fill="none" opacity="0.24">
+      <rect x="1418" y="602" width="76" height="62" rx="7" />
+      <path d="M1418 633h76" />
+      <path d="M1456 602v62" />
+      <path d="M1456 602c-4-16 22-20 24-6 1 5-2 12-9 16 7-3 20-2 21 8 1 12-19 16-24 2" />
+    </g>
+
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="120" r="7" />
+      <circle cx="1380" cy="160" r="9" />
+      <circle cx="1460" cy="90" r="6" />
+      <circle cx="1540" cy="150" r="8" />
+      <circle cx="1580" cy="90" r="9" />
+      <circle cx="1420" cy="200" r="7" />
+    </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-3.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-3.svg
@@ -1,191 +1,85 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Unified light parallax background with bubbles rising on the right">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Festive light parallax background with right-edge gifts and sparkles">
   <defs>
-    <!-- Unified base background: Light Theme -->
-    <linearGradient id="base" x1="0" y1="0" x2="0" y2="800" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#FFFFFF"></stop>
-      <stop offset="0.55" stop-color="#F8FAFC"></stop>
-      <stop offset="1" stop-color="#F1F5F9"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#BFDBFE" stop-opacity="0.4"></stop>
-      <stop offset="0.6" stop-color="#DBEAFE" stop-opacity="0.25"></stop>
-      <stop offset="1" stop-color="#BFDBFE" stop-opacity="0"></stop>
+    <radialGradient id="glowL" cx="0.08" cy="0.18" r="0.72">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.26" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
     </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#BBF7D0" stop-opacity="0.3"></stop>
-      <stop offset="0.7" stop-color="#DCFCE7" stop-opacity="0.15"></stop>
-      <stop offset="1" stop-color="#BBF7D0" stop-opacity="0"></stop>
+    <radialGradient id="glowR" cx="0.9" cy="0.7" r="0.82">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.24" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Right column glow -->
-    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
-      <stop offset="0" stop-color="#BAE6FD" stop-opacity="0.3"></stop>
-      <stop offset="0.55" stop-color="#E0F2FE" stop-opacity="0.15"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.5"></stop>
-      <stop offset="0.35" stop-color="#E0F2FE" stop-opacity="0.4"></stop>
-      <stop offset="1" stop-color="#BAE6FD" stop-opacity="0.05"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#93C5FD" stop-opacity="0.4"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.45"></stop>
-      <stop offset="1" stop-color="#4ADE80" stop-opacity="0.25"></stop>
-    </linearGradient>
-
-    <!-- Subtle texture -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#1E293B" opacity="0.03"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#1E293B" opacity="0.02"></circle>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.1" />
     </pattern>
-
-    <!-- Vignette: White instead of black -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 400) scale(980 600)">
-      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.6"></stop>
-    </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
+    <filter id="blur14" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
     </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.25 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.08 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <filter id="blur10" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="12" />
     </filter>
   </defs>
 
-  <!-- Unified background -->
-  <rect width="1600" height="800" fill="url(#base)"></rect>
-  <rect width="1600" height="800" fill="url(#washBlue)"></rect>
-  <rect width="1600" height="800" fill="url(#washGreen)"></rect>
-  <rect width="1600" height="800" fill="url(#microDots)" opacity="0.6"></rect>
+  <rect width="1600" height="800" fill="url(#bg)" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
 
-  <!-- Right column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
-    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <g id="parallax-back" opacity="0.85">
+    <ellipse cx="180" cy="180" rx="320" ry="220" fill="#00A1C2" opacity="0.24" filter="url(#blur14)" />
+    <ellipse cx="1420" cy="620" rx="340" ry="240" fill="#0088D6" opacity="0.22" filter="url(#blur10)" />
+    <path d="M-60 540 C 220 450, 480 480, 760 610" fill="none" stroke="#F4F4F4" stroke-width="10" opacity="0.12" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(1375 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid">
+    <g stroke="#FF8479" stroke-width="1.3" fill="none" opacity="0.2">
+      <circle cx="180" cy="160" r="64" />
+      <circle cx="220" cy="240" r="40" />
+      <circle cx="1420" cy="640" r="72" />
+      <circle cx="1500" cy="720" r="48" />
     </g>
-
-    <g transform="translate(1235 610)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1310 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1195 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1330 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1250 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#FFFFFF" opacity="0.4" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles -->
-    <g opacity="0.75">
-      <g transform="translate(1410 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1175 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1395 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1160 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1400 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1170 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1370 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1190 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g fill="#F4F4F4">
+      <circle cx="1500" cy="560" r="34" opacity="0.18" />
+      <circle cx="1560" cy="640" r="26" opacity="0.17" />
+      <circle cx="140" cy="660" r="32" opacity="0.18" />
+      <circle cx="200" cy="720" r="22" opacity="0.19" />
+      <circle cx="260" cy="120" r="20" opacity="0.17" />
     </g>
   </g>
 
-  <!-- Subtle tech accents on left (balances composition) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#2563EB" stroke-opacity="0.25" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#10B981" stroke-opacity="0.25" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="335" cy="340" r="5" fill="#3B82F6" opacity="0.4"></circle>
-    <circle cx="282" cy="528" r="5" fill="#10B981" opacity="0.35"></circle>
-  </g>
+  <g id="parallax-front">
+    <g fill="#F4F4F4" opacity="0.2">
+      <path d="M90 120 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M300 620 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1500 200 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1360 120 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1520 440 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
 
-  <!-- Vignette + grain -->
-  <rect width="1600" height="800" fill="url(#vignette)"></rect>
-  <g filter="url(#grain)">
-    <rect width="1600" height="800" fill="transparent"></rect>
+    <g stroke="#5BDB3B" stroke-width="1.25" fill="none" opacity="0.24">
+      <rect x="1444" y="82" width="78" height="66" rx="7" />
+      <path d="M1444 114h78" />
+      <path d="M1483 82v66" />
+      <path d="M1483 82c-4-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+    <g stroke="#FF8479" stroke-width="1.35" fill="none" opacity="0.26">
+      <rect x="96" y="560" width="82" height="68" rx="8" />
+      <path d="M96 594h82" />
+      <path d="M138 560v68" />
+      <path d="M138 560c-5-18 24-22 26-6 1 6-3 13-10 17 7-3 20-2 21 9 1 14-20 18-26 2" />
+    </g>
+
+    <g fill="#5BDB3B" opacity="0.16">
+      <circle cx="1320" cy="580" r="7" />
+      <circle cx="1360" cy="660" r="9" />
+      <circle cx="1460" cy="520" r="6" />
+      <circle cx="1540" cy="600" r="8" />
+      <circle cx="1580" cy="520" r="9" />
+      <circle cx="1400" cy="720" r="7" />
+    </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-1.svg
@@ -1,137 +1,68 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Transparent parallax background with rising bubbles on the left">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Translucent festive light parallax background with subtle gifts and stars">
   <defs>
-    <!-- Gentle ambient wash (keeps everything unified) -->
-    <radialGradient id="ambient" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 320) scale(980 620)">
-      <stop offset="0" stop-color="#4C82F3" stop-opacity="0.18"></stop>
-      <stop offset="0.55" stop-color="#2F54C3" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#4C82F3" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <radialGradient id="ambient2" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 740) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#30D17A" stop-opacity="0.12"></stop>
-      <stop offset="0.7" stop-color="#30D17A" stop-opacity="0.06"></stop>
-      <stop offset="1" stop-color="#30D17A" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Left-side bubble glow -->
-    <radialGradient id="bubbleGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(240 420) scale(520 560)">
-      <stop offset="0" stop-color="#30B2F6" stop-opacity="0.22"></stop>
-      <stop offset="0.55" stop-color="#8BC4FF" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#30B2F6" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + highlight -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(0 0) scale(1 1)">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.22"></stop>
-      <stop offset="0.35" stop-color="#30B2F6" stop-opacity="0.18"></stop>
-      <stop offset="1" stop-color="#30B2F6" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#E4EBFF" stop-opacity="0.32"></stop>
-      <stop offset="0.55" stop-color="#30B2F6" stop-opacity="0.38"></stop>
-      <stop offset="1" stop-color="#30D17A" stop-opacity="0.18"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Subtle texture / dots -->
-    <pattern id="microDots" width="30" height="30" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="1.1" fill="#F8FAFC" opacity="0.06"></circle>
-      <circle cx="18" cy="12" r="0.9" fill="#F8FAFC" opacity="0.045"></circle>
-    </pattern>
-
-    <!-- Soft vignette -->
-    <radialGradient id="vignette" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(820 380) scale(980 600)">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0"></stop>
-      <stop offset="1" stop-color="#F8FAFC" stop-opacity="0.58"></stop>
+    <radialGradient id="glowL" cx="0.12" cy="0.72" r="0.8">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.22" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
     </radialGradient>
-
-    <!-- Filters -->
-    <filter id="blur28" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="28"></feGaussianBlur>
-    </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.4" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.55 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="grain" x="-20%" y="-20%" width="140%" height="140%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" result="n"></feTurbulence>
-      <feColorMatrix type="matrix" in="n" values="0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0 0
-                0 0 0 0.16 0" result="a"></feColorMatrix>
-      <feBlend in="SourceGraphic" in2="a" mode="overlay"></feBlend>
+    <radialGradient id="glowR" cx="0.9" cy="0.2" r="0.84">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
+    </radialGradient>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.08" />
+    </pattern>
+    <filter id="blur12" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
     </filter>
   </defs>
 
-  <!-- Left lane glow (so bubbles feel integrated) -->
-  <g id="parallax-back">
-    <ellipse cx="230" cy="430" rx="420" ry="520" fill="url(#bubbleGlow)" filter="url(#blur28)"></ellipse>
-    <!-- faint upward current -->
-    <path d="M120 820C130 700 105 600 140 510C175 420 150 340 190 260C230 180 210 120 250 40" stroke="#30B2F6" stroke-opacity="0.12" stroke-width="10" filter="url(#blur28)"></path>
+  <rect width="1600" height="800" fill="url(#bg)" opacity="0.88" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+
+  <g id="parallax-back" opacity="0.7">
+    <ellipse cx="210" cy="520" rx="320" ry="230" fill="#00A1C2" opacity="0.22" filter="url(#blur12)" />
+    <ellipse cx="1480" cy="140" rx="280" ry="200" fill="#0088D6" opacity="0.18" filter="url(#blur12)" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Large bubbles -->
-    <g transform="translate(150 650)">
-      <circle cx="0" cy="0" r="44" fill="url(#bubbleFill)" opacity="0.9"></circle>
-      <circle cx="0" cy="0" r="44" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.75"></circle>
-      <circle cx="-14" cy="-16" r="10" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid" opacity="0.75">
+    <g stroke="#FF8479" stroke-width="1.1" fill="none" opacity="0.2">
+      <circle cx="1360" cy="140" r="42" />
+      <circle cx="1480" cy="220" r="58" />
     </g>
-
-    <g transform="translate(230 520)">
-      <circle cx="0" cy="0" r="30" fill="url(#bubbleFill)" opacity="0.85"></circle>
-      <circle cx="0" cy="0" r="30" fill="none" stroke="url(#bubbleStroke)" stroke-width="2" opacity="0.7"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    <g fill="#F4F4F4">
+      <circle cx="180" cy="200" r="34" opacity="0.16" />
+      <circle cx="230" cy="300" r="18" opacity="0.17" />
+      <circle cx="1500" cy="660" r="28" opacity="0.15" />
     </g>
+  </g>
 
-    <g transform="translate(170 400)">
-      <circle cx="0" cy="0" r="56" fill="url(#bubbleFill)" opacity="0.75"></circle>
-      <circle cx="0" cy="0" r="56" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.68"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-front" opacity="0.78">
+    <g fill="#F4F4F4" opacity="0.16">
+      <path d="M130 90 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M1500 700 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
     </g>
-
-    <g transform="translate(260 270)">
-      <circle cx="0" cy="0" r="26" fill="url(#bubbleFill)" opacity="0.8"></circle>
-      <circle cx="0" cy="0" r="26" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.7"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    <g stroke="#FF8479" stroke-width="1.3" fill="none" opacity="0.24">
+      <rect x="94" y="612" width="70" height="56" rx="7" />
+      <path d="M94 640h70" />
+      <path d="M129 612v56" />
     </g>
-
-    <g transform="translate(190 140)">
-      <circle cx="0" cy="0" r="38" fill="url(#bubbleFill)" opacity="0.7"></circle>
-      <circle cx="0" cy="0" r="38" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.65"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+    <g stroke="#5BDB3B" stroke-width="1.1" fill="none" opacity="0.22">
+      <rect x="1450" y="78" width="66" height="52" rx="7" />
+      <path d="M1450 104h66" />
+      <path d="M1483 78v52" />
     </g>
-
-    <!-- Small bubbles (more “motion”) -->
-    <g opacity="0.75">
-      <g transform="translate(110 720)">
-        <circle cx="0" cy="0" r="12" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="12" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.6" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(270 610)">
-        <circle cx="0" cy="0" r="5" fill="none" stroke="url(#bubbleStroke)" stroke-width="1" opacity="0.6"></circle>
-      </g>
-      <g transform="translate(180 80)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)" opacity="0.6"></circle>
-      </g>
+    <g fill="#5BDB3B" opacity="0.12">
+      <circle cx="1320" cy="660" r="6" />
+      <circle cx="1400" cy="710" r="7" />
+      <circle cx="1480" cy="620" r="6" />
+      <circle cx="1520" cy="690" r="7" />
     </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-2.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-2.svg
@@ -1,151 +1,68 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Transparent parallax background with bubbles rising in the middle">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Translucent festive light parallax background with soft stars framing content">
   <defs>
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
-      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
-      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Center column glow -->
-    <radialGradient id="columnGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(800 420) scale(720 620)">
-      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.20"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.10"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
-      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
-      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(26 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
-    </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.52 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
+    <radialGradient id="glowL" cx="0.1" cy="0.26" r="0.72">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="glowR" cx="0.9" cy="0.82" r="0.82">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
+    </radialGradient>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.08" />
+    </pattern>
+    <filter id="blur14" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
     </filter>
   </defs>
 
-  <!-- Center column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="800" cy="430" rx="560" ry="560" fill="url(#columnGlow)" filter="url(#blur26)"></ellipse>
-    <path d="M790 840C770 740 820 650 800 560C780 470 820 390 805 300C790 210 820 150 805 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <rect width="1600" height="800" fill="url(#bg)" opacity="0.86" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+
+  <g id="parallax-back" opacity="0.7">
+    <ellipse cx="240" cy="170" rx="300" ry="200" fill="#00A1C2" opacity="0.2" filter="url(#blur14)" />
+    <ellipse cx="1360" cy="660" rx="300" ry="210" fill="#0088D6" opacity="0.18" filter="url(#blur14)" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(720 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid" opacity="0.75">
+    <g fill="#F4F4F4">
+      <circle cx="190" cy="660" r="28" opacity="0.16" />
+      <circle cx="1540" cy="170" r="30" opacity="0.15" />
+      <circle cx="1500" cy="520" r="26" opacity="0.14" />
     </g>
-
-    <g transform="translate(865 600)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(790 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(905 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(770 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(840 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles (adds motion) -->
-    <g opacity="0.75">
-      <g transform="translate(690 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(925 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(720 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(950 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(700 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(930 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(735 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(905 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g stroke="#FF8479" stroke-width="1.1" fill="none" opacity="0.2">
+      <circle cx="230" cy="640" r="50" />
+      <circle cx="1460" cy="200" r="60" />
     </g>
   </g>
 
-  <!-- Very subtle tech accents (kept unified) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M1040 240H1265C1310 240 1345 275 1345 320V360C1345 405 1380 440 1425 440H1560" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M980 585H1210C1250 585 1282 553 1282 513V450C1282 410 1314 378 1354 378H1560" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="1345" cy="320" r="5" fill="#38BDF8" opacity="0.30"></circle>
-    <circle cx="1282" cy="513" r="5" fill="#22C55E" opacity="0.26"></circle>
+  <g id="parallax-front" opacity="0.75">
+    <g fill="#F4F4F4" opacity="0.16">
+      <path d="M130 200 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M1400 680 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
+    <g stroke="#FF8479" stroke-width="1.25" fill="none" opacity="0.22">
+      <rect x="140" y="86" width="70" height="56" rx="7" />
+      <path d="M140 112h70" />
+      <path d="M174 86v56" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.1" fill="none" opacity="0.21">
+      <rect x="1418" y="612" width="72" height="58" rx="7" />
+      <path d="M1418 641h72" />
+      <path d="M1454 612v58" />
+    </g>
+    <g fill="#5BDB3B" opacity="0.12">
+      <circle cx="1320" cy="130" r="6" />
+      <circle cx="1380" cy="170" r="7" />
+      <circle cx="1460" cy="110" r="6" />
+      <circle cx="1540" cy="160" r="7" />
+    </g>
   </g>
 </svg>

--- a/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-3.svg
+++ b/frontend/app/assets/themes/light/parallax/parallax-background-bubbles-transparent-3.svg
@@ -1,151 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Transparent parallax background with bubbles rising on the right">
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="800" viewBox="0 0 1600 800" preserveAspectRatio="xMidYMid slice" fill="none" role="img" aria-label="Translucent festive light parallax background with right-aligned sparkles">
   <defs>
-    <!-- Ambient washes -->
-    <radialGradient id="washBlue" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 300) scale(980 620)">
-      <stop offset="0" stop-color="#1D4ED8" stop-opacity="0.18"></stop>
-      <stop offset="0.6" stop-color="#1E3A8A" stop-opacity="0.12"></stop>
-      <stop offset="1" stop-color="#1D4ED8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <radialGradient id="washGreen" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1180 760) rotate(-10) scale(900 520)">
-      <stop offset="0" stop-color="#22C55E" stop-opacity="0.10"></stop>
-      <stop offset="0.7" stop-color="#22C55E" stop-opacity="0.05"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Right column glow -->
-    <radialGradient id="columnGlowR" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1320 420) scale(720 620)">
-      <stop offset="0" stop-color="#38BDF8" stop-opacity="0.18"></stop>
-      <stop offset="0.55" stop-color="#60A5FA" stop-opacity="0.09"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0"></stop>
-    </radialGradient>
-
-    <!-- Bubble fill + stroke -->
-    <radialGradient id="bubbleFill" cx="0" cy="0" r="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#F8FAFC" stop-opacity="0.20"></stop>
-      <stop offset="0.35" stop-color="#38BDF8" stop-opacity="0.16"></stop>
-      <stop offset="1" stop-color="#38BDF8" stop-opacity="0.02"></stop>
-    </radialGradient>
-
-    <linearGradient id="bubbleStroke" x1="0" y1="0" x2="1" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="#CBD5F5" stop-opacity="0.30"></stop>
-      <stop offset="0.55" stop-color="#38BDF8" stop-opacity="0.36"></stop>
-      <stop offset="1" stop-color="#22C55E" stop-opacity="0.16"></stop>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%" gradientUnits="userSpaceOnUse" gradientTransform="rotate(25 0.5 0.5)">
+      <stop offset="0%" stop-color="#00DE9F" />
+      <stop offset="50%" stop-color="#00A1C2" />
+      <stop offset="100%" stop-color="#0088D6" />
     </linearGradient>
-
-    <!-- Filters -->
-    <filter id="blur26" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="26"></feGaussianBlur>
-    </filter>
-
-    <filter id="bubbleSoft" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="2.2" result="b"></feGaussianBlur>
-      <feMerge>
-        <feMergeNode in="b"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
-    </filter>
-
-    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="10" result="g"></feGaussianBlur>
-      <feColorMatrix in="g" type="matrix" values="1 0 0 0 0
-                0 1 0 0 0
-                0 0 1 0 0
-                0 0 0 0.52 0" result="ga"></feColorMatrix>
-      <feMerge>
-        <feMergeNode in="ga"></feMergeNode>
-        <feMergeNode in="SourceGraphic"></feMergeNode>
-      </feMerge>
+    <radialGradient id="glowL" cx="0.08" cy="0.2" r="0.74">
+      <stop offset="0%" stop-color="#00A1C2" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#00A1C2" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="glowR" cx="0.9" cy="0.7" r="0.82">
+      <stop offset="0%" stop-color="#0088D6" stop-opacity="0.18" />
+      <stop offset="100%" stop-color="#0088D6" stop-opacity="0" />
+    </radialGradient>
+    <pattern id="micro" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="11" cy="11" r="1.2" fill="#F4F4F4" opacity="0.08" />
+    </pattern>
+    <filter id="blur14" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="14" />
     </filter>
   </defs>
 
-  <!-- Right column glow + “current” -->
-  <g id="parallax-back">
-    <ellipse cx="1320" cy="430" rx="560" ry="560" fill="url(#columnGlowR)" filter="url(#blur26)"></ellipse>
-    <path d="M1330 840C1350 740 1300 650 1320 560C1340 470 1300 390 1315 300C1330 210 1300 150 1315 40" stroke="#38BDF8" stroke-opacity="0.10" stroke-width="12" filter="url(#blur26)"></path>
+  <rect width="1600" height="800" fill="url(#bg)" opacity="0.86" />
+  <rect width="1600" height="800" fill="url(#glowL)" />
+  <rect width="1600" height="800" fill="url(#glowR)" />
+  <rect width="1600" height="800" fill="url(#micro)" />
+
+  <g id="parallax-back" opacity="0.7">
+    <ellipse cx="190" cy="190" rx="300" ry="210" fill="#00A1C2" opacity="0.2" filter="url(#blur14)" />
+    <ellipse cx="1420" cy="620" rx="320" ry="230" fill="#0088D6" opacity="0.18" filter="url(#blur14)" />
   </g>
 
-  <!-- Bubble column (move this group for parallax) -->
-  <g id="parallax-bubbles" filter="url(#glow)">
-    <!-- Big / medium bubbles -->
-    <g transform="translate(1375 675)">
-      <circle cx="0" cy="0" r="52" fill="url(#bubbleFill)" opacity="0.78"></circle>
-      <circle cx="0" cy="0" r="52" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.4" opacity="0.70"></circle>
-      <circle cx="-18" cy="-20" r="12" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
+  <g id="parallax-mid" opacity="0.75">
+    <g stroke="#FF8479" stroke-width="1.1" fill="none" opacity="0.2">
+      <circle cx="200" cy="180" r="58" />
+      <circle cx="220" cy="260" r="36" />
+      <circle cx="1440" cy="660" r="64" />
     </g>
-
-    <g transform="translate(1235 610)">
-      <circle cx="0" cy="0" r="34" fill="url(#bubbleFill)" opacity="0.82"></circle>
-      <circle cx="0" cy="0" r="34" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.1" opacity="0.70"></circle>
-      <circle cx="-12" cy="-14" r="8" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1310 470)">
-      <circle cx="0" cy="0" r="64" fill="url(#bubbleFill)" opacity="0.70"></circle>
-      <circle cx="0" cy="0" r="64" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.6" opacity="0.65"></circle>
-      <circle cx="-22" cy="-24" r="14" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1195 350)">
-      <circle cx="0" cy="0" r="28" fill="url(#bubbleFill)" opacity="0.80"></circle>
-      <circle cx="0" cy="0" r="28" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.0" opacity="0.68"></circle>
-      <circle cx="-10" cy="-12" r="7" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1330 210)">
-      <circle cx="0" cy="0" r="42" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="42" fill="none" stroke="url(#bubbleStroke)" stroke-width="2.2" opacity="0.62"></circle>
-      <circle cx="-14" cy="-16" r="9" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <g transform="translate(1250 95)">
-      <circle cx="0" cy="0" r="24" fill="url(#bubbleFill)" opacity="0.72"></circle>
-      <circle cx="0" cy="0" r="24" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.9" opacity="0.60"></circle>
-      <circle cx="-8" cy="-10" r="6" fill="#F8FAFC" opacity="0.10" filter="url(#bubbleSoft)"></circle>
-    </g>
-
-    <!-- Small bubbles -->
-    <g opacity="0.75">
-      <g transform="translate(1410 735)">
-        <circle cx="0" cy="0" r="10" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="10" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.5" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1175 700)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1395 560)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1160 510)">
-        <circle cx="0" cy="0" r="9" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="9" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1400 360)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1170 280)">
-        <circle cx="0" cy="0" r="7" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="7" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.3" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1370 125)">
-        <circle cx="0" cy="0" r="8" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="8" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.4" opacity="0.7"></circle>
-      </g>
-      <g transform="translate(1190 60)">
-        <circle cx="0" cy="0" r="6" fill="url(#bubbleFill)"></circle>
-        <circle cx="0" cy="0" r="6" fill="none" stroke="url(#bubbleStroke)" stroke-width="1.2" opacity="0.7"></circle>
-      </g>
+    <g fill="#F4F4F4">
+      <circle cx="1500" cy="560" r="30" opacity="0.16" />
+      <circle cx="1560" cy="640" r="22" opacity="0.16" />
+      <circle cx="150" cy="670" r="28" opacity="0.16" />
     </g>
   </g>
 
-  <!-- Subtle tech accents on left (balances composition) -->
-  <g id="parallax-front" opacity="0.9">
-    <path d="M40 260H255C300 260 335 295 335 340V380C335 425 370 460 415 460H620" stroke="#60A5FA" stroke-opacity="0.12" stroke-width="2.2" stroke-linecap="round"></path>
-    <path d="M40 600H210C250 600 282 568 282 528V465C282 425 314 393 354 393H620" stroke="#22C55E" stroke-opacity="0.09" stroke-width="2.2" stroke-linecap="round"></path>
-    <circle cx="335" cy="340" r="5" fill="#38BDF8" opacity="0.30"></circle>
-    <circle cx="282" cy="528" r="5" fill="#22C55E" opacity="0.26"></circle>
+  <g id="parallax-front" opacity="0.75">
+    <g fill="#F4F4F4" opacity="0.16">
+      <path d="M100 130 l6 10 12 2-9 8 2 12-11-6-11 6 2-12-9-8 12-2z" />
+      <path d="M1500 210 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+      <path d="M1360 130 l5 8 10 2-7 6 2 10-9-5-9 5 2-10-7-6 10-2z" />
+    </g>
+    <g stroke="#5BDB3B" stroke-width="1.15" fill="none" opacity="0.22">
+      <rect x="1448" y="90" width="72" height="60" rx="7" />
+      <path d="M1448 120h72" />
+      <path d="M1484 90v60" />
+    </g>
+    <g stroke="#FF8479" stroke-width="1.25" fill="none" opacity="0.23">
+      <rect x="104" y="574" width="74" height="60" rx="7" />
+      <path d="M104 602h74" />
+      <path d="M141 574v60" />
+    </g>
+    <g fill="#5BDB3B" opacity="0.12">
+      <circle cx="1320" cy="590" r="6" />
+      <circle cx="1360" cy="660" r="8" />
+      <circle cx="1460" cy="520" r="6" />
+      <circle cx="1540" cy="600" r="7" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- regenerate the Christmas parallax SVGs for the light theme with holiday gradients, glows, and edge-focused gifts/stars
- update matching transparent variants to stay lightweight and center-safe for parallax overlays
- refresh the dark theme Christmas parallax set with the same layered festive treatment and micro-texture

## Testing
- Not run (asset-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944106b4f1c832298f4e04308d6eacb)