### PR TITLE
Add mobile-first PWA landing experience

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -97,8 +97,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (event: 'update:modelValue', value: string[]): void
-  (event: 'continue'): void
-  (event: 'return-to-category'): void
+  (event: 'continue' | 'return-to-category'): void
 }>()
 
 const isSelected = (subsetId?: string | null) =>
@@ -165,91 +164,91 @@ const toggle = (subsetId: string) => {
   }
 
   &__card {
-  .nudge-toggle-card {
-
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    border-radius: 16px;
-    padding: 0;
-    overflow: hidden;
-    background: rgb(var(--v-theme-surface-primary-050)) !important;
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
-    box-shadow: none;
-    transition: transform 140ms ease, border-color 160ms ease,
-      box-shadow 160ms ease, background-color 160ms ease;
-    cursor: pointer;
-
-    &__body {
-      display: grid;
-      grid-template-columns: 0.32fr 1fr auto;
-      align-items: stretch;
-      height: 100%;
-    }
-
-    &__icon-rail {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(var(--v-theme-accent-supporting), 0.08);
-      padding: 14px;
-      min-height: 100%;
-      transition: background 160ms ease;
-    }
-
-    &__icon-shell {
-      width: 44px;
-      height: 44px;
-      border-radius: 14px;
-      display: grid;
-      place-items: center;
-      background: rgba(var(--v-theme-accent-supporting), 0.12);
-      color: rgb(var(--v-theme-accent-supporting));
-      box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
-      transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
-    }
-
-    &__content {
+    .nudge-toggle-card {
       display: flex;
       flex-direction: column;
-      gap: 4px;
-      padding: 14px 18px;
-      justify-content: center;
-      min-height: 100%;
-    }
+      height: 100%;
+      border-radius: 16px;
+      padding: 0;
+      overflow: hidden;
+      background: rgb(var(--v-theme-surface-primary-050)) !important;
+      border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+      box-shadow: none;
+      transition: transform 140ms ease, border-color 160ms ease,
+        box-shadow 160ms ease, background-color 160ms ease;
+      cursor: pointer;
 
-    &__title {
-      margin: 0;
-      font-weight: 700;
-      line-height: 1.4;
-    }
+      &__body {
+        display: grid;
+        grid-template-columns: 0.32fr 1fr auto;
+        align-items: stretch;
+        height: 100%;
+      }
 
-    &__caption {
-      margin: 0;
-      color: rgb(var(--v-theme-text-neutral-secondary));
-      font-size: 0.95rem;
-      line-height: 1.4;
-    }
+      &__icon-rail {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(var(--v-theme-accent-supporting), 0.08);
+        padding: 14px;
+        min-height: 100%;
+        transition: background 160ms ease;
+      }
 
-    &__indicator {
-      width: 52px;
-      display: grid;
-      place-items: center;
-      background: rgba(var(--v-theme-accent-supporting), 0.12);
-      border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
-      transition: background 160ms ease, border-color 160ms ease;
-    }
+      &__icon-shell {
+        width: 44px;
+        height: 44px;
+        border-radius: 14px;
+        display: grid;
+        place-items: center;
+        background: rgba(var(--v-theme-accent-supporting), 0.12);
+        color: rgb(var(--v-theme-accent-supporting));
+        box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.2);
+        transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease;
+      }
 
-    &:hover,
-    &:focus-visible {
-      transform: translateY(-2px);
-      border-color: rgba(var(--v-theme-accent-supporting), 0.6);
-      box-shadow: 0 10px 20px rgba(var(--v-theme-shadow-primary-600), 0.08);
-      outline: none;
-    }
+      &__content {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 14px 18px;
+        justify-content: center;
+        min-height: 100%;
+      }
 
-    &:focus-visible {
-      box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-supporting), 0.25);
+      &__title {
+        margin: 0;
+        font-weight: 700;
+        line-height: 1.4;
+      }
+
+      &__caption {
+        margin: 0;
+        color: rgb(var(--v-theme-text-neutral-secondary));
+        font-size: 0.95rem;
+        line-height: 1.4;
+      }
+
+      &__indicator {
+        width: 52px;
+        display: grid;
+        place-items: center;
+        background: rgba(var(--v-theme-accent-supporting), 0.12);
+        border-left: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+        transition: background 160ms ease, border-color 160ms ease;
+      }
+
+      &:hover,
+      &:focus-visible {
+        transform: translateY(-2px);
+        border-color: rgba(var(--v-theme-accent-supporting), 0.6);
+        box-shadow: 0 10px 20px rgba(var(--v-theme-shadow-primary-600), 0.08);
+        outline: none;
+      }
+
+      &:focus-visible {
+        box-shadow: 0 0 0 3px rgba(var(--v-theme-accent-supporting), 0.25);
+      }
     }
   }
 

--- a/frontend/app/components/pwa/PwaMobileActionBar.spec.ts
+++ b/frontend/app/components/pwa/PwaMobileActionBar.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeAll } from 'vitest'
+
+const messages: Record<string, string> = {
+  'pwa.landing.actionBar.ariaLabel': 'Mobile quick actions',
+  'pwa.landing.actions.scan.title': 'Scan',
+  'pwa.landing.actions.wizard.title': 'Wizard',
+  'pwa.landing.actions.search.title': 'Search',
+  'pwa.landing.actions.share.title': 'Share',
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key,
+  }),
+}))
+
+type ActionBarComponent = (typeof import('./PwaMobileActionBar.vue'))['default']
+let PwaMobileActionBar: ActionBarComponent
+
+describe('PwaMobileActionBar', () => {
+  beforeAll(async () => {
+    PwaMobileActionBar = (await import('./PwaMobileActionBar.vue')).default
+  })
+
+  it('emits actions on button click', async () => {
+    const wrapper = mount(PwaMobileActionBar, {
+      global: {
+        stubs: {
+          VSheet: {
+            template: '<div><slot /></div>',
+          },
+          VContainer: {
+            template: '<div><slot /></div>',
+          },
+          VBtn: {
+            props: ['prependIcon'],
+            emits: ['click'],
+            template:
+              '<button class="v-btn-stub" @click="$emit(\'click\')"><slot /></button>',
+          },
+        },
+      },
+    })
+
+    const buttons = wrapper.findAll('.v-btn-stub')
+    expect(buttons).toHaveLength(4)
+
+    await buttons[0].trigger('click')
+    await buttons[1].trigger('click')
+    await buttons[2].trigger('click')
+    await buttons[3].trigger('click')
+
+    expect(wrapper.emitted('scan')).toBeTruthy()
+    expect(wrapper.emitted('wizard')).toBeTruthy()
+    expect(wrapper.emitted('search')).toBeTruthy()
+    expect(wrapper.emitted('share')).toBeTruthy()
+  })
+})

--- a/frontend/app/components/pwa/PwaMobileActionBar.vue
+++ b/frontend/app/components/pwa/PwaMobileActionBar.vue
@@ -1,0 +1,101 @@
+<template>
+  <v-sheet
+    class="pwa-action-bar"
+    elevation="12"
+    border
+    color="surface-default"
+    role="navigation"
+    :aria-label="t('pwa.landing.actionBar.ariaLabel')"
+  >
+    <v-container class="py-2">
+      <div class="pwa-action-bar__grid">
+        <v-btn
+          v-for="action in actions"
+          :key="action.key"
+          :data-testid="`pwa-action-${action.key}`"
+          class="pwa-action-bar__btn"
+          variant="flat"
+          color="primary"
+          size="large"
+          block
+          :prepend-icon="action.icon"
+          @click="emit(action.event)"
+        >
+          <span class="pwa-action-bar__label">{{ action.label }}</span>
+        </v-btn>
+      </div>
+    </v-container>
+  </v-sheet>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const emit = defineEmits<{
+  (event: 'scan' | 'wizard' | 'search' | 'share'): void
+}>()
+
+const { t } = useI18n()
+
+const actions = computed(() => [
+  {
+    key: 'scan',
+    icon: 'mdi-barcode-scan',
+    label: t('pwa.landing.actions.scan.title'),
+    event: 'scan' as const,
+  },
+  {
+    key: 'wizard',
+    icon: 'mdi-sparkles',
+    label: t('pwa.landing.actions.wizard.title'),
+    event: 'wizard' as const,
+  },
+  {
+    key: 'search',
+    icon: 'mdi-magnify',
+    label: t('pwa.landing.actions.search.title'),
+    event: 'search' as const,
+  },
+  {
+    key: 'share',
+    icon: 'mdi-share-variant',
+    label: t('pwa.landing.actions.share.title'),
+    event: 'share' as const,
+  },
+])
+</script>
+
+<style scoped lang="sass">
+.pwa-action-bar
+  position: sticky
+  bottom: 0
+  z-index: 12
+  padding-bottom: env(safe-area-inset-bottom, 0px)
+
+.pwa-action-bar__grid
+  display: grid
+  grid-template-columns: 1fr 1fr
+  gap: 0.5rem
+
+.pwa-action-bar__btn
+  text-transform: none
+  border-radius: 12px
+  font-weight: 700
+  justify-content: flex-start
+  padding-inline: 1rem
+
+  :deep(.v-btn__content)
+    gap: 0.35rem
+
+.pwa-action-bar__label
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
+
+@media (max-width: 340px)
+  .pwa-action-bar__grid
+    grid-template-columns: 1fr
+
+  .pwa-action-bar__btn
+    justify-content: center
+</style>

--- a/frontend/app/components/pwa/PwaMobileLanding.vue
+++ b/frontend/app/components/pwa/PwaMobileLanding.vue
@@ -1,0 +1,414 @@
+<template>
+  <div class="pwa-landing">
+    <v-container class="py-6" fluid>
+      <v-row class="justify-center">
+        <v-col cols="12" md="10" lg="8">
+          <v-sheet
+            class="pwa-landing__hero"
+            color="surface-primary-080"
+            rounded="xl"
+            elevation="0"
+            border
+          >
+            <div class="pwa-landing__hero-content">
+              <v-chip
+                color="accent-supporting"
+                variant="flat"
+                class="font-weight-bold text-uppercase"
+                size="small"
+              >
+                {{ t('pwa.landing.hero.eyebrow') }}
+              </v-chip>
+              <h1 class="pwa-landing__title">
+                {{ t('pwa.landing.hero.title') }}
+              </h1>
+              <p class="pwa-landing__subtitle">
+                {{ t('pwa.landing.hero.subtitle') }}
+              </p>
+
+              <v-card class="pwa-landing__search" variant="elevated" rounded="lg">
+                <v-card-title class="text-subtitle-1 font-weight-bold pb-1">
+                  {{ t('pwa.landing.search.title') }}
+                </v-card-title>
+                <v-card-text class="pt-0">
+                  <v-text-field
+                    v-model="searchQuery"
+                    :label="t('pwa.landing.search.label')"
+                    :placeholder="t('pwa.landing.search.placeholder')"
+                    density="comfortable"
+                    variant="outlined"
+                    color="primary"
+                    prepend-inner-icon="mdi-magnify"
+                    hide-details
+                    class="mb-3"
+                    data-testid="pwa-search-input"
+                    @keyup.enter="handleSearch"
+                  />
+                  <v-btn
+                    block
+                    color="primary"
+                    variant="flat"
+                    size="large"
+                    class="font-weight-bold"
+                    prepend-icon="mdi-arrow-right"
+                    data-testid="pwa-search-submit"
+                    @click="handleSearch"
+                  >
+                    {{ t('pwa.landing.search.cta') }}
+                  </v-btn>
+                </v-card-text>
+              </v-card>
+            </div>
+          </v-sheet>
+        </v-col>
+      </v-row>
+
+      <v-row class="justify-center mt-4" dense>
+        <v-col
+          v-for="action in quickActions"
+          :key="action.key"
+          cols="12"
+          sm="6"
+          lg="3"
+        >
+          <v-card
+            class="pwa-landing__action-card"
+            border
+            rounded="xl"
+            color="surface-default"
+            @click="action.onClick()"
+          >
+            <v-card-item>
+              <div class="d-flex align-center justify-space-between mb-2">
+                <v-avatar size="40" color="surface-primary-120">
+                  <v-icon :icon="action.icon" color="accent-primary-highlight" />
+                </v-avatar>
+                <v-chip
+                  v-if="action.badge"
+                  size="x-small"
+                  color="accent-supporting"
+                  variant="flat"
+                  class="font-weight-bold text-uppercase"
+                >
+                  {{ action.badge }}
+                </v-chip>
+              </div>
+              <v-card-title class="text-subtitle-1 font-weight-bold px-0">
+                {{ action.title }}
+              </v-card-title>
+              <v-card-subtitle class="text-body-2 text-neutral-secondary px-0">
+                {{ action.description }}
+              </v-card-subtitle>
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-row class="justify-center mt-2">
+        <v-col cols="12" md="10" lg="8">
+          <v-card
+            class="pwa-landing__share"
+            rounded="xl"
+            color="surface-primary-100"
+            border
+          >
+            <v-card-item class="d-flex align-center ga-3">
+              <v-avatar size="56" color="surface-primary-120">
+                <v-icon icon="mdi-account-tie" size="30" color="accent-primary-highlight" />
+              </v-avatar>
+              <div class="flex-1">
+                <v-card-title class="text-subtitle-1 font-weight-bold px-0">
+                  {{ t('pwa.landing.share.title') }}
+                </v-card-title>
+                <v-card-subtitle class="text-body-2 text-neutral-secondary px-0">
+                  {{ t('pwa.landing.share.description') }}
+                </v-card-subtitle>
+              </div>
+              <v-btn
+                color="accent-supporting"
+                variant="tonal"
+                class="text-none font-weight-bold"
+                prepend-icon="mdi-open-in-new"
+                data-testid="pwa-share-more"
+                @click="isShareDialogOpen = true"
+              >
+                {{ t('pwa.landing.share.cta') }}
+              </v-btn>
+            </v-card-item>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <ClientOnly>
+      <v-dialog v-model="isScannerOpen" max-width="520" transition="dialog-bottom-transition">
+        <v-card rounded="xl" class="pwa-landing__dialog-card">
+          <v-card-title class="d-flex align-center justify-space-between">
+            <span class="text-h6 font-weight-bold">
+              {{ t('pwa.landing.actions.scan.title') }}
+            </span>
+            <v-btn icon="mdi-close" variant="text" @click="isScannerOpen = false" />
+          </v-card-title>
+          <v-card-text>
+            <p class="text-body-2 text-neutral-secondary mb-3">
+              {{ t('pwa.landing.actions.scan.helper') }}
+            </p>
+            <PwaBarcodeScanner
+              :active="isScannerOpen"
+              :loading-label="t('pwa.landing.actions.scan.loading')"
+              :error-label="t('pwa.landing.actions.scan.error')"
+              @decode="handleScanDecode"
+              @error="handleScannerError"
+            />
+          </v-card-text>
+        </v-card>
+      </v-dialog>
+
+      <v-dialog
+        v-model="isWizardOpen"
+        max-width="640"
+        :fullscreen="display.smAndDown"
+      >
+        <v-card rounded="xl" class="pwa-landing__dialog-card">
+          <v-card-title class="d-flex align-center justify-space-between">
+            <span class="text-h6 font-weight-bold">
+              {{ t('pwa.landing.actions.wizard.title') }}
+            </span>
+            <v-btn icon="mdi-close" variant="text" @click="isWizardOpen = false" />
+          </v-card-title>
+          <v-card-text class="pt-0">
+            <NudgeToolWizard
+              :verticals="verticals"
+              @navigate="handleWizardNavigate"
+              @close="isWizardOpen = false"
+            />
+          </v-card-text>
+        </v-card>
+      </v-dialog>
+
+      <v-dialog v-model="isShareDialogOpen" max-width="520" transition="dialog-bottom-transition">
+        <v-card rounded="xl" class="pwa-landing__dialog-card">
+          <v-card-title class="d-flex align-center justify-space-between">
+            <span class="text-h6 font-weight-bold">
+              {{ t('pwa.landing.share.modalTitle') }}
+            </span>
+            <v-btn icon="mdi-close" variant="text" @click="isShareDialogOpen = false" />
+          </v-card-title>
+          <v-card-text>
+            <div class="pwa-landing__share-preview">
+              <div class="pwa-landing__share-preview__header">
+                <v-icon icon="mdi-shield-star" size="26" color="accent-primary-highlight" />
+                <span class="font-weight-bold">{{ t('pwa.landing.share.preview.title') }}</span>
+              </div>
+              <p class="text-body-2 text-neutral-secondary mt-2">
+                {{ t('pwa.landing.share.preview.description') }}
+              </p>
+              <div class="pwa-landing__share-preview__tags">
+                <v-chip
+                  v-for="tag in shareTags"
+                  :key="tag"
+                  size="small"
+                  color="surface-primary-120"
+                  variant="flat"
+                  class="font-weight-bold"
+                >
+                  {{ tag }}
+                </v-chip>
+              </div>
+            </div>
+            <p class="text-body-2 text-neutral-secondary mb-0 mt-3">
+              {{ t('pwa.landing.share.note') }}
+            </p>
+          </v-card-text>
+        </v-card>
+      </v-dialog>
+    </ClientOnly>
+
+    <PwaMobileActionBar
+      class="pwa-landing__action-bar"
+      @scan="isScannerOpen = true"
+      @wizard="isWizardOpen = true"
+      @search="handleSearch"
+      @share="isShareDialogOpen = true"
+    />
+
+    <v-snackbar v-model="scannerError" color="error" timeout="3000">
+      {{ scannerErrorMessage }}
+    </v-snackbar>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { VerticalConfigDto } from '~~/shared/api-client'
+import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
+import PwaBarcodeScanner from './PwaBarcodeScanner.vue'
+import PwaMobileActionBar from './PwaMobileActionBar.vue'
+import { useDisplay } from 'vuetify'
+import { computed, ref } from 'vue'
+
+interface Props {
+  verticals?: VerticalConfigDto[]
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  verticals: () => [],
+})
+
+const router = useRouter()
+const localePath = useLocalePath()
+const { t } = useI18n()
+const display = useDisplay()
+
+const searchQuery = ref('')
+const isScannerOpen = ref(false)
+const isWizardOpen = ref(false)
+const isShareDialogOpen = ref(false)
+const scannerError = ref(false)
+const scannerErrorMessage = ref('')
+
+const shareTags = computed(() => [
+  t('pwa.landing.share.preview.tags.impact'),
+  t('pwa.landing.share.preview.tags.feedback'),
+  t('pwa.landing.share.preview.tags.ecoGuide'),
+])
+
+const quickActions = computed(() => [
+  {
+    key: 'scan',
+    icon: 'mdi-barcode-scan',
+    title: t('pwa.landing.actions.scan.title'),
+    description: t('pwa.landing.actions.scan.description'),
+    onClick: () => (isScannerOpen.value = true),
+    badge: t('pwa.landing.actions.scan.badge'),
+  },
+  {
+    key: 'wizard',
+    icon: 'mdi-sparkles',
+    title: t('pwa.landing.actions.wizard.title'),
+    description: t('pwa.landing.actions.wizard.description'),
+    onClick: () => (isWizardOpen.value = true),
+    badge: null,
+  },
+  {
+    key: 'search',
+    icon: 'mdi-magnify',
+    title: t('pwa.landing.actions.search.title'),
+    description: t('pwa.landing.actions.search.description'),
+    onClick: () => handleSearch(),
+    badge: null,
+  },
+  {
+    key: 'share',
+    icon: 'mdi-share-variant',
+    title: t('pwa.landing.actions.share.title'),
+    description: t('pwa.landing.actions.share.description'),
+    onClick: () => (isShareDialogOpen.value = true),
+    badge: t('pwa.landing.actions.share.badge'),
+  },
+])
+
+const navigateToSearch = (query?: string) => {
+  const trimmed = query?.trim() ?? ''
+  const path = localePath({
+    name: 'search',
+    query: trimmed ? { q: trimmed } : undefined,
+  })
+
+  router.push(path)
+}
+
+const handleSearch = () => {
+  navigateToSearch(searchQuery.value)
+}
+
+const handleScanDecode = (value: string) => {
+  isScannerOpen.value = false
+  navigateToSearch(value)
+}
+
+const handleScannerError = (message: string) => {
+  scannerErrorMessage.value = message
+  scannerError.value = true
+}
+
+const handleWizardNavigate = () => {
+  isWizardOpen.value = false
+}
+
+const verticals = computed(() => props.verticals)
+</script>
+
+<style scoped lang="sass">
+.pwa-landing
+  padding-bottom: calc(env(safe-area-inset-bottom) + 88px)
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-100), 0.8), rgba(var(--v-theme-surface-default), 0.9))
+
+.pwa-landing__hero
+  padding: clamp(1.5rem, 4vw, 2rem)
+  background: radial-gradient(circle at 20% 20%, rgba(var(--v-theme-hero-gradient-start), 0.08), transparent 35%), radial-gradient(circle at 80% 30%, rgba(var(--v-theme-hero-gradient-mid), 0.08), transparent 40%), rgba(var(--v-theme-surface-default), 0.85)
+  backdrop-filter: blur(8px)
+
+.pwa-landing__hero-content
+  display: flex
+  flex-direction: column
+  gap: 0.85rem
+
+.pwa-landing__title
+  font-size: clamp(1.35rem, 5vw, 1.85rem)
+  font-weight: 800
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.pwa-landing__subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-size: 1rem
+
+.pwa-landing__search
+  background: rgb(var(--v-theme-surface-default))
+
+.pwa-landing__action-card
+  cursor: pointer
+  transition: transform 0.2s ease, box-shadow 0.2s ease
+  height: 100%
+  background: rgba(var(--v-theme-surface-default), 0.92)
+
+  &:hover
+    transform: translateY(-4px)
+    box-shadow: 0 16px 40px rgba(var(--v-theme-shadow-primary-600), 0.16)
+
+.pwa-landing__share
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-primary-080), 0.9), rgba(var(--v-theme-surface-primary-120), 0.9))
+
+.pwa-landing__share-preview
+  background: rgba(var(--v-theme-surface-default), 0.9)
+  border-radius: 16px
+  padding: 1rem
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.5)
+
+.pwa-landing__share-preview__header
+  display: flex
+  align-items: center
+  gap: 0.5rem
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.pwa-landing__share-preview__tags
+  display: flex
+  flex-wrap: wrap
+  gap: 0.35rem
+  margin-top: 0.75rem
+
+.pwa-landing__dialog-card
+  background: rgb(var(--v-theme-surface-default))
+
+.pwa-landing__action-bar
+  box-shadow: 0 -10px 32px rgba(var(--v-theme-shadow-primary-600), 0.12)
+
+@media (min-width: 960px)
+  .pwa-landing
+    max-width: 1200px
+    margin: 0 auto
+
+  .pwa-landing__title
+    font-size: 2rem
+</style>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -25,6 +25,8 @@ import {
   PARALLAX_SECTION_KEYS,
   type ParallaxSectionKey,
 } from '~~/config/theme/assets'
+import PwaMobileLanding from '~/components/pwa/PwaMobileLanding.vue'
+import { useDisplay } from 'vuetify'
 
 definePageMeta({
   ssr: true,
@@ -35,6 +37,9 @@ const router = useRouter()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+const display = useDisplay()
+
+const isMobileLanding = computed(() => display.smAndDown.value)
 
 const searchQuery = ref('')
 
@@ -625,17 +630,47 @@ const handleProductSuggestion = (suggestion: ProductSuggestionItem) => {
   navigateToSearch(suggestion.title)
 }
 
+const seoTitle = computed(() =>
+  String(
+    t(
+      isMobileLanding.value
+        ? 'pwa.landing.hero.meta.title'
+        : 'home.seo.title'
+    )
+  )
+)
+
+const seoDescription = computed(() =>
+  String(
+    t(
+      isMobileLanding.value
+        ? 'pwa.landing.hero.meta.description'
+        : 'home.seo.description'
+    )
+  )
+)
+
+const seoImageAlt = computed(() =>
+  String(
+    t(
+      isMobileLanding.value
+        ? 'pwa.landing.hero.meta.imageAlt'
+        : 'home.seo.imageAlt'
+    )
+  )
+)
+
 useSeoMeta({
-  title: () => String(t('home.seo.title')),
-  description: () => String(t('home.seo.description')),
-  ogTitle: () => String(t('home.seo.title')),
-  ogDescription: () => String(t('home.seo.description')),
+  title: () => seoTitle.value,
+  description: () => seoDescription.value,
+  ogTitle: () => seoTitle.value,
+  ogDescription: () => seoDescription.value,
   ogUrl: () => canonicalUrl.value,
   ogType: () => 'website',
   ogImage: () => ogImageUrl.value,
   ogSiteName: () => siteName.value,
   ogLocale: () => locale.value.replace('-', '_'),
-  ogImageAlt: () => String(t('home.seo.imageAlt')),
+  ogImageAlt: () => seoImageAlt.value,
 })
 
 useHead(() => ({
@@ -664,7 +699,8 @@ useHead(() => ({
 </script>
 
 <template>
-  <div class="home-page">
+  <PwaMobileLanding v-if="isMobileLanding" :verticals="rawCategories" />
+  <div v-else class="home-page">
     <HomeHeroSection
       v-model:search-query="searchQuery"
       :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2343,6 +2343,68 @@
       "mobileHelper": "Content stays cached but live data resumes when you're back online.",
       "cta": "Retry",
       "dismiss": "Dismiss"
+    },
+    "landing": {
+      "hero": {
+        "eyebrow": "PWA",
+        "title": "Your eco-companion, right on mobile",
+        "subtitle": "Scan, compare, and nudge in a few taps. Designed for quick, on-the-go decisions.",
+        "meta": {
+          "title": "Nudger – Mobile impact companion",
+          "description": "Experience Nudger as a mobile-first PWA: scan barcodes, launch the AI wizard, and share eco-guides instantly.",
+          "imageAlt": "Mobile view of Nudger with quick actions and barcode scanner."
+        }
+      },
+      "search": {
+        "title": "Quick search",
+        "label": "Search a product",
+        "placeholder": "Type a brand or product name",
+        "cta": "Search now"
+      },
+      "actions": {
+        "scan": {
+          "title": "Scan barcode",
+          "description": "Use your camera to get instant impact and price insights.",
+          "helper": "Align the barcode inside the frame to decode instantly.",
+          "loading": "Starting scanner…",
+          "error": "Scanner unavailable. Try again or search manually.",
+          "badge": "Live"
+        },
+        "wizard": {
+          "title": "AI wizard",
+          "description": "Answer a few questions and get tailored eco picks.",
+          "badge": "New"
+        },
+        "search": {
+          "title": "Search",
+          "description": "Browse products with the full Nudger database.",
+          "badge": "Quick"
+        },
+        "share": {
+          "title": "Share with your manager",
+          "description": "Show teammates how Nudger reacts instantly on product pages.",
+          "badge": "Demo"
+        }
+      },
+      "share": {
+        "title": "Share Nudger as a pro tip",
+        "description": "Send a screenshot or link from your product page: the manager sees the impact feedback instantly.",
+        "cta": "See how it looks",
+        "modalTitle": "Show the eco-guide in action",
+        "preview": {
+          "title": "Nudger eco-guide",
+          "description": "Real-time nudges appear when sharing a commercial page with Nudger enabled.",
+          "tags": {
+            "impact": "Impact score",
+            "feedback": "Instant feedback",
+            "ecoGuide": "Eco guide"
+          }
+        },
+        "note": "No data is shared without your action. It is a visual preview to explain the experience."
+      },
+      "actionBar": {
+        "ariaLabel": "Mobile quick actions"
+      }
     }
   },
   "nudge-tool": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2331,6 +2331,68 @@
       "mobileHelper": "Le cache reste disponible, les données en direct reprendront dès le retour du réseau.",
       "cta": "Réessayer",
       "dismiss": "Fermer"
+    },
+    "landing": {
+      "hero": {
+        "eyebrow": "PWA",
+        "title": "Votre compagnon éco sur mobile",
+        "subtitle": "Scanne, compare et nudger en quelques gestes. Pensé pour la décision rapide.",
+        "meta": {
+          "title": "Nudger – Compagnon mobile de l'impact",
+          "description": "Découvrez Nudger en version mobile-first : scanner de codes-barres, assistant IA et partage d'éco-guides.",
+          "imageAlt": "Vue mobile de Nudger avec actions rapides et scanner de code-barres."
+        }
+      },
+      "search": {
+        "title": "Recherche rapide",
+        "label": "Rechercher un produit",
+        "placeholder": "Tape une marque ou un produit",
+        "cta": "Rechercher"
+      },
+      "actions": {
+        "scan": {
+          "title": "Scanner un code-barres",
+          "description": "Utilise ta caméra pour obtenir instantanément impact et prix.",
+          "helper": "Aligne le code-barres dans le cadre pour un décodage immédiat.",
+          "loading": "Démarrage du scanner…",
+          "error": "Scanner indisponible. Réessaie ou lance une recherche.",
+          "badge": "Live"
+        },
+        "wizard": {
+          "title": "Assistant IA",
+          "description": "Quelques questions pour des choix éco personnalisés.",
+          "badge": "Nouveau"
+        },
+        "search": {
+          "title": "Rechercher",
+          "description": "Parcourir les produits dans toute la base Nudger.",
+          "badge": "Rapide"
+        },
+        "share": {
+          "title": "Partager au manager",
+          "description": "Montre comment Nudger réagit instantanément sur les pages produits.",
+          "badge": "Démo"
+        }
+      },
+      "share": {
+        "title": "Partager Nudger comme astuce",
+        "description": "Envoie une capture ou un lien depuis ta page produit : le manager voit immédiatement le retour Nudger.",
+        "cta": "Voir le rendu",
+        "modalTitle": "Montrer l'éco-guide en action",
+        "preview": {
+          "title": "Éco-guide Nudger",
+          "description": "Les nudges apparaissent en temps réel quand on partage une page commerciale avec Nudger activé.",
+          "tags": {
+            "impact": "Score d'impact",
+            "feedback": "Retour instantané",
+            "ecoGuide": "Éco-guide"
+          }
+        },
+        "note": "Aucune donnée n'est partagée sans action explicite. C'est une prévisualisation pour expliquer l'expérience."
+      },
+      "actionBar": {
+        "ariaLabel": "Actions rapides mobiles"
+      }
     }
   },
   "nudge-tool": {


### PR DESCRIPTION
## Summary
- add dedicated mobile/PWA landing experience with quick actions and promotional share messaging
- introduce reusable bottom action bar component plus localized strings for the mobile-first flow
- align home page SEO metadata for mobile visitors and tidy nudge subset styles

## Testing
- pnpm lint
- pnpm test --run app/components/pwa/PwaMobileActionBar.spec.ts
- pnpm build
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944173c28248322ab54bec9f8465db8)