### PR TITLE
Add accessibility layout widening and icon refresh

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -84,3 +84,10 @@
 .nudger_degrade-defaut
     background-image: linear-gradient(to left, rgb(var(--v-theme-primary)), rgb(var(--v-theme-secondary)))!important
     color: #ffffff!important
+
+:root.accessibility-layout
+    .v-container:not(.v-container--fluid)
+        max-width: min(1560px, 96vw)
+
+    .cms-page__container--container
+        max-width: min(1560px, 100%) !important

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -201,7 +201,7 @@
 
       <v-list-item class="px-6 py-4">
         <template #prepend>
-          <v-icon icon="mdi-human-cane" class="me-4" />
+          <v-icon icon="mdi-face-woman-outline" class="me-4" />
         </template>
         <v-list-item-title class="text-body-1">
           {{ t('siteIdentity.menu.zoom.label') }}

--- a/frontend/app/components/shared/menus/ZoomToggle.vue
+++ b/frontend/app/components/shared/menus/ZoomToggle.vue
@@ -13,7 +13,7 @@
   >
     <v-icon
       :icon="
-        isZoomed ? 'mdi-human-walker' : 'mdi-human-cane'
+        isZoomed ? 'mdi-face-woman' : 'mdi-face-woman-outline'
       "
     />
     <v-tooltip activator="parent" location="bottom">
@@ -53,9 +53,14 @@ const toggleZoom = () => {
 }
 
 const applyZoom = (zoomed: boolean) => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.style.fontSize = zoomed ? '120%' : ''
+  if (typeof document === 'undefined') {
+    return
   }
+
+  const rootElement = document.documentElement
+
+  rootElement.style.fontSize = zoomed ? '120%' : ''
+  rootElement.classList.toggle('accessibility-layout', zoomed)
 }
 
 watch(isZoomed, val => {


### PR DESCRIPTION
## Summary
- broaden layout styling in accessibility zoom mode by toggling a root class
- adjust global container widths to mirror the semi-fluid layout when accessibility is enabled
- refresh the accessibility toggle icon to a friendlier option across desktop and mobile menus

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944248057fc832bbe11ebb2bc1a1426)