### PR TITLE
Improve nudge wizard layout and headers

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -49,9 +49,9 @@
       <NudgeWizardHeader
         :title="currentStepTitle"
         :subtitle="currentStepSubtitle"
+        :title-icon="currentStepIcon"
         :accent-corner="'top-left'"
         :corner-size="resolvedCornerSize"
-        :category-summary="categorySummary"
       />
     </div>
 
@@ -281,6 +281,7 @@ type WizardStep = {
   props: Record<string, unknown>
   title: string
   subtitle?: string
+  icon?: string | null
   onUpdate?: (value: unknown) => void
 }
 
@@ -335,7 +336,8 @@ const steps = computed<WizardStep[]>(() => {
       key: `group-${group.id}`,
       component: NudgeToolStepSubsetGroup,
       title: group.title ?? '',
-      subtitle: t('nudge-tool.steps.subset.subtitle'),
+      subtitle: group.description ?? t('nudge-tool.steps.subset.subtitle'),
+      icon: group.mdiIcon ?? 'mdi-format-list-bulleted',
       props: {
         group,
         subsets,
@@ -375,6 +377,7 @@ const currentStep = computed(() =>
 
 const currentStepTitle = computed(() => currentStep.value?.title ?? '')
 const currentStepSubtitle = computed(() => currentStep.value?.subtitle ?? '')
+const currentStepIcon = computed(() => currentStep.value?.icon ?? null)
 
 watch(
   activeStepKey,
@@ -881,13 +884,28 @@ const cornerIconSize = computed(() => (isContentMode.value ? 38 : 32))
     flex: 1;
     display: flex;
     flex-direction: column;
+    justify-content: center;
     overflow-y: auto;
     height: 100%;
+
+    :deep(.v-window__container) {
+      align-items: center;
+    }
+
+    :deep(.v-window-item) {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 
   &__window-wrapper {
     width: 100%;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(0.5rem, 1vw, 1rem) 0;
   }
 
   &__footer {

--- a/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
+++ b/frontend/app/components/nudge-tool/NudgeWizardHeader.vue
@@ -5,22 +5,16 @@
     :style="headerOffsetStyle"
   >
     <div class="wizard-header__titles">
-      <h2 class="wizard-header__title">{{ title }}</h2>
-      <p v-if="subtitle" class="wizard-header__subtitle">{{ subtitle }}</p>
-    </div>
-
-    <div class="wizard-header__meta">
-      <div v-if="categorySummary" class="wizard-header__category" aria-live="polite">
-        <v-avatar size="38" class="wizard-header__category-avatar" color="primary">
-          <v-icon :icon="categorySummary.icon" size="24" color="white" />
-        </v-avatar>
-        <div class="wizard-header__category-text">
-          <span class="wizard-header__category-label">{{ categorySummary.label }}</span>
-          <span v-if="categorySummary.matches != null" class="wizard-header__category-meta">
-            {{ categorySummary.matches }}
-          </span>
-        </div>
+      <div class="wizard-header__title">
+        <v-icon
+          v-if="titleIcon"
+          :icon="titleIcon"
+          size="26"
+          class="wizard-header__title-icon"
+        />
+        <h2 class="wizard-header__title-text">{{ title }}</h2>
       </div>
+      <p v-if="subtitle" class="wizard-header__subtitle">{{ subtitle }}</p>
     </div>
   </header>
 </template>
@@ -45,17 +39,13 @@ const props = withDefaults(
     subtitle?: string
     accentCorner?: AccentCorner
     cornerSize?: CornerSize
-    categorySummary?: {
-      label: string
-      icon?: string
-      matches?: number
-    } | null
+    titleIcon?: string | null
   }>(),
   {
     subtitle: '',
     accentCorner: 'top-left',
     cornerSize: 'lg',
-    categorySummary: null,
+    titleIcon: null,
   }
 )
 
@@ -75,9 +65,10 @@ const headerOffsetStyle = computed(() => {
 <style scoped lang="scss">
 .wizard-header {
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 12px;
+  grid-template-columns: 1fr;
+  gap: 10px;
   align-items: center;
+  justify-items: center;
   margin-bottom: 10px;
 
   &--stacked {
@@ -91,67 +82,31 @@ const headerOffsetStyle = computed(() => {
     display: flex;
     flex-direction: column;
     gap: 4px;
+    align-items: center;
   }
 
   &__title {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__title-text {
     margin: 0;
     font-weight: 800;
     font-size: clamp(1.25rem, 1.8vw, 1.5rem);
     text-align: center;
   }
 
+  &__title-icon {
+    color: rgb(var(--v-theme-accent-supporting));
+  }
+
   &__subtitle {
     margin: 0;
     color: rgb(var(--v-theme-text-neutral-secondary));
     text-align: center;
-  }
-
-  &__meta {
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-  }
-
-  &__category {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 10px;
-    border-radius: 999px;
-    background: rgba(var(--v-theme-surface-primary-080), 0.85);
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.5);
-  }
-
-  &__category-avatar {
-    flex-shrink: 0;
-  }
-
-  &__category-text {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.15;
-  }
-
-  &__category-label {
-    font-weight: 700;
-  }
-
-  &__category-meta {
-    font-size: 0.85rem;
-    color: rgb(var(--v-theme-text-neutral-secondary));
-  }
-
-  @media (max-width: 960px) {
-    grid-template-columns: 1fr;
-    text-align: center;
-    justify-items: center;
-
-    &__meta {
-      justify-content: center;
-      gap: 10px;
-    }
+    max-width: 680px;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- center the nudge tool wizard window content to avoid top-heavy layouts
- remove the category pill from the wizard header and allow displaying step icons
- surface subset group icons and descriptions from YAML config in the wizard header

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694437a7b378832b8c1ca908c8b260f4)