### PR TITLE
Refine parallax layering controls

### DIFF
--- a/frontend/app/components/shared/ui/ParallaxSection.spec.ts
+++ b/frontend/app/components/shared/ui/ParallaxSection.spec.ts
@@ -1,0 +1,124 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+
+import ParallaxSection from './ParallaxSection.vue'
+
+const scrollY = ref(0)
+const motionPreference = ref<'reduce' | 'no-preference'>('no-preference')
+const displayWidth = ref(1280)
+
+vi.mock('@vueuse/core', () => ({
+  usePreferredReducedMotion: () => motionPreference,
+  useWindowScroll: () => ({ x: ref(0), y: scrollY }),
+}))
+
+vi.mock('vuetify', () => ({
+  useDisplay: () => ({ width: displayWidth }),
+  useTheme: () => ({
+    global: {
+      name: ref('light'),
+      current: ref({ dark: false }),
+    },
+  }),
+}))
+
+const stubs = {
+  VContainer: defineComponent({
+    name: 'VContainerStub',
+    setup(_, { slots, attrs }) {
+      return () => h('div', { class: 'v-container', ...attrs }, slots.default?.())
+    },
+  }),
+}
+
+const mountParallax = (props?: Record<string, unknown>) =>
+  mount(ParallaxSection, {
+    props: {
+      backgrounds: ['/images/sample.svg'],
+      ...props,
+    },
+    global: {
+      stubs,
+    },
+  })
+
+describe('ParallaxSection', () => {
+  beforeEach(() => {
+    scrollY.value = 0
+    motionPreference.value = 'no-preference'
+    displayWidth.value = 1280
+  })
+
+  it('applies per-layer speeds and blend modes', async () => {
+    scrollY.value = 300
+    const wrapper = mountParallax({
+      backgrounds: [
+        { src: '/layers/back.svg', speed: 0.5, blendMode: 'screen' },
+        { src: '/layers/front.svg', speed: 0.2 },
+      ],
+      parallaxAmount: 0.3,
+    })
+
+    await nextTick()
+
+    const layers = wrapper.findAll('.parallax-section__layer')
+    expect(layers).toHaveLength(2)
+    expect(layers[0].element.style.backgroundImage).toContain('layers/back.svg')
+    expect(layers[0].element.style.transform).toBe('translate3d(0, -150px, 0)')
+    expect(layers[0].element.style.mixBlendMode).toBe('screen')
+    expect(layers[1].element.style.transform).toBe('translate3d(0, -60px, 0)')
+  })
+
+  it('halts parallax when reduced motion is preferred', async () => {
+    motionPreference.value = 'reduce'
+    scrollY.value = 500
+
+    const wrapper = mountParallax({
+      backgrounds: [{ src: '/layers/back.svg', speed: 0.6 }],
+      parallaxAmount: 0.2,
+    })
+
+    await nextTick()
+
+    const layer = wrapper.get('.parallax-section__layer')
+    expect(layer.element.style.transform).toBe('translate3d(0, 0px, 0)')
+  })
+
+  it('disables parallax below the configured breakpoint', async () => {
+    displayWidth.value = 640
+    scrollY.value = 400
+
+    const wrapper = mountParallax({
+      backgrounds: ['/images/parallax.svg'],
+      disableParallaxBelow: 960,
+      parallaxAmount: 0.4,
+    })
+
+    await nextTick()
+
+    const layer = wrapper.get('.parallax-section__layer')
+    expect(layer.element.style.transform).toBe('translate3d(0, 0px, 0)')
+  })
+
+  it('caps translation when a max offset ratio is provided', async () => {
+    const innerHeightSpy = vi
+      .spyOn(window, 'innerHeight', 'get')
+      .mockReturnValue(1000)
+
+    scrollY.value = 3000
+
+    const wrapper = mountParallax({
+      backgrounds: [{ src: '/images/long-scroll.svg', speed: 1 }],
+      parallaxAmount: 1,
+      maxOffsetRatio: 0.1,
+    })
+
+    await nextTick()
+
+    const layer = wrapper.get('.parallax-section__layer')
+    expect(layer.element.style.transform).toBe('translate3d(0, -100px, 0)')
+
+    innerHeightSpy.mockRestore()
+  })
+})

--- a/frontend/app/composables/useParallaxConfig.ts
+++ b/frontend/app/composables/useParallaxConfig.ts
@@ -1,0 +1,70 @@
+import { computed } from 'vue'
+import { PARALLAX_SECTION_KEYS, type ParallaxSectionKey } from '~~/config/theme/assets'
+
+export type ParallaxSectionConfig = {
+  overlay: number
+  parallaxAmount: number
+  ariaLabel: string
+  maxOffsetRatio: number | null
+}
+
+type ParallaxSectionOverride = Partial<Omit<ParallaxSectionConfig, 'ariaLabel'>> & {
+  ariaLabel?: string
+}
+
+export const useParallaxConfig = () => {
+  const { t } = useI18n()
+  const runtimeConfig = useRuntimeConfig()
+
+  const defaults = computed<Record<ParallaxSectionKey, ParallaxSectionConfig>>(
+    () => ({
+      essentials: {
+        overlay: 0.62,
+        parallaxAmount: 0.16,
+        ariaLabel: String(t('home.parallax.essentials.ariaLabel')),
+        maxOffsetRatio: null,
+      },
+      features: {
+        overlay: 0.55,
+        parallaxAmount: 0.12,
+        ariaLabel: String(t('home.parallax.features.ariaLabel')),
+        maxOffsetRatio: null,
+      },
+      blog: {
+        overlay: 0.5,
+        parallaxAmount: 0.1,
+        ariaLabel: String(t('home.parallax.knowledge.ariaLabel')),
+        maxOffsetRatio: null,
+      },
+      objections: {
+        overlay: 0.58,
+        parallaxAmount: 0.11,
+        ariaLabel: String(t('home.parallax.knowledge.ariaLabel')),
+        maxOffsetRatio: null,
+      },
+      cta: {
+        overlay: 0.48,
+        parallaxAmount: 0.08,
+        ariaLabel: String(t('home.parallax.cta.ariaLabel')),
+        maxOffsetRatio: null,
+      },
+    })
+  )
+
+  const overrides = computed<
+    Partial<Record<ParallaxSectionKey, ParallaxSectionOverride>>
+  >(() => runtimeConfig.public?.parallaxSections ?? {})
+
+  return computed<Record<ParallaxSectionKey, ParallaxSectionConfig>>(() =>
+    PARALLAX_SECTION_KEYS.reduce<Record<ParallaxSectionKey, ParallaxSectionConfig>>(
+      (acc, section) => ({
+        ...acc,
+        [section]: {
+          ...defaults.value[section],
+          ...overrides.value[section],
+        },
+      }),
+      {} as Record<ParallaxSectionKey, ParallaxSectionConfig>
+    )
+  )
+}

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -19,10 +19,12 @@ import type {
 } from '~/components/search/SearchSuggestField.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useBlog } from '~/composables/blog/useBlog'
+import { useParallaxConfig } from '~/composables/useParallaxConfig'
 import { useSeasonalParallaxPack } from '~/composables/useSeasonalParallaxPack'
 import { useThemedParallaxBackgrounds } from '~/composables/useThemedParallaxBackgrounds'
 import {
   PARALLAX_SECTION_KEYS,
+  type ParallaxLayerConfig,
   type ParallaxSectionKey,
 } from '~~/config/theme/assets'
 import PwaMobileLanding from '~/components/pwa/PwaMobileLanding.vue'
@@ -72,55 +74,32 @@ const heroPartnersCount = computed(
 
 const seasonalParallaxPack = useSeasonalParallaxPack()
 
+const parallaxConfig = useParallaxConfig()
 const parallaxLayers = useThemedParallaxBackgrounds(seasonalParallaxPack)
 
-const parallaxOverlayConfig = computed<Record<ParallaxSectionKey, {
-  overlay: number
+type ParallaxSectionRenderConfig = {
+  backgrounds: ParallaxLayerConfig[]
+  overlayOpacity: number
   parallaxAmount: number
   ariaLabel: string
-}>>(() => ({
-  essentials: {
-    overlay: 0.62,
-    parallaxAmount: 0.16,
-    ariaLabel: String(t('home.parallax.essentials.ariaLabel')),
-  },
-  features: {
-    overlay: 0.55,
-    parallaxAmount: 0.12,
-    ariaLabel: String(t('home.parallax.features.ariaLabel')),
-  },
-  blog: {
-    overlay: 0.5,
-    parallaxAmount: 0.1,
-    ariaLabel: String(t('home.parallax.knowledge.ariaLabel')),
-  },
-  objections: {
-    overlay: 0.58,
-    parallaxAmount: 0.11,
-    ariaLabel: String(t('home.parallax.knowledge.ariaLabel')),
-  },
-  cta: {
-    overlay: 0.48,
-    parallaxAmount: 0.08,
-    ariaLabel: String(t('home.parallax.cta.ariaLabel')),
-  },
-}))
+  maxOffsetRatio: number | null
+}
 
-const parallaxBackgrounds = computed(() =>
-  PARALLAX_SECTION_KEYS.reduce(
+const parallaxBackgrounds = computed<
+  Record<ParallaxSectionKey, ParallaxSectionRenderConfig>
+>(() =>
+  PARALLAX_SECTION_KEYS.reduce<Record<ParallaxSectionKey, ParallaxSectionRenderConfig>>(
     (acc, section) => ({
       ...acc,
       [section]: {
         backgrounds: parallaxLayers.value[section] || [],
-        ...parallaxOverlayConfig.value[section],
+        overlayOpacity: parallaxConfig.value[section].overlay,
+        parallaxAmount: parallaxConfig.value[section].parallaxAmount,
+        ariaLabel: parallaxConfig.value[section].ariaLabel,
+        maxOffsetRatio: parallaxConfig.value[section].maxOffsetRatio,
       },
     }),
-    {} as Record<ParallaxSectionKey, {
-      backgrounds: string[]
-      overlay: number
-      parallaxAmount: number
-      ariaLabel: string
-    }>
+    {} as Record<ParallaxSectionKey, ParallaxSectionRenderConfig>
   )
 )
 
@@ -715,9 +694,10 @@ useHead(() => ({
         id="home-essentials"
         class="home-page__parallax"
         :backgrounds="parallaxBackgrounds.essentials.backgrounds"
-        :overlay-opacity="parallaxBackgrounds.essentials.overlay"
+        :overlay-opacity="parallaxBackgrounds.essentials.overlayOpacity"
         :parallax-amount="parallaxBackgrounds.essentials.parallaxAmount"
         :aria-label="parallaxBackgrounds.essentials.ariaLabel"
+        :max-offset-ratio="parallaxBackgrounds.essentials.maxOffsetRatio"
         :enable-aplats="true"
       >
         <div class="home-page__stack">
@@ -749,9 +729,10 @@ useHead(() => ({
         id="home-features"
         class="home-page__parallax home-page__parallax--centered"
         :backgrounds="parallaxBackgrounds.features.backgrounds"
-        :overlay-opacity="parallaxBackgrounds.features.overlay"
+        :overlay-opacity="parallaxBackgrounds.features.overlayOpacity"
         :parallax-amount="parallaxBackgrounds.features.parallaxAmount"
         :aria-label="parallaxBackgrounds.features.ariaLabel"
+        :max-offset-ratio="parallaxBackgrounds.features.maxOffsetRatio"
         content-align="center"
       >
         <div
@@ -770,9 +751,10 @@ useHead(() => ({
         id="home-knowledge-blog"
         class="home-page__parallax"
         :backgrounds="parallaxBackgrounds.blog.backgrounds"
-        :overlay-opacity="parallaxBackgrounds.blog.overlay"
+        :overlay-opacity="parallaxBackgrounds.blog.overlayOpacity"
         :parallax-amount="parallaxBackgrounds.blog.parallaxAmount"
         :aria-label="parallaxBackgrounds.blog.ariaLabel"
+        :max-offset-ratio="parallaxBackgrounds.blog.maxOffsetRatio"
         :enable-aplats="true"
       >
         <div class="home-page__stack">
@@ -797,9 +779,10 @@ useHead(() => ({
         id="home-knowledge-objections"
         class="home-page__parallax"
         :backgrounds="parallaxBackgrounds.objections.backgrounds"
-        :overlay-opacity="parallaxBackgrounds.objections.overlay"
+        :overlay-opacity="parallaxBackgrounds.objections.overlayOpacity"
         :parallax-amount="parallaxBackgrounds.objections.parallaxAmount"
         :aria-label="parallaxBackgrounds.objections.ariaLabel"
+        :max-offset-ratio="parallaxBackgrounds.objections.maxOffsetRatio"
         :enable-aplats="true"
       >
         <div class="home-page__stack">
@@ -820,9 +803,10 @@ useHead(() => ({
         id="home-cta"
         class="home-page__parallax home-page__parallax--centered"
         :backgrounds="parallaxBackgrounds.cta.backgrounds"
-        :overlay-opacity="parallaxBackgrounds.cta.overlay"
+        :overlay-opacity="parallaxBackgrounds.cta.overlayOpacity"
         :parallax-amount="parallaxBackgrounds.cta.parallaxAmount"
         :aria-label="parallaxBackgrounds.cta.ariaLabel"
+        :max-offset-ratio="parallaxBackgrounds.cta.maxOffsetRatio"
         content-align="center"
       >
         <div class="home-page__stack home-page__stack--compact">

--- a/frontend/config/theme/assets.ts
+++ b/frontend/config/theme/assets.ts
@@ -29,7 +29,17 @@ export type ParallaxPackName = (typeof PARALLAX_PACK_NAMES)[number]
 
 export const DEFAULT_PARALLAX_PACK: ParallaxPackName = 'default'
 
-export type ParallaxPackConfig = Partial<Record<ParallaxSectionKey, string[]>>
+export type ParallaxLayerConfig = {
+  src: string
+  speed?: number
+  blendMode?: string
+}
+
+export type ParallaxLayerSource = string | ParallaxLayerConfig
+
+export type ParallaxPackConfig = Partial<
+  Record<ParallaxSectionKey, ParallaxLayerSource[]>
+>
 
 export const themeAssets: Record<ThemeName | 'common', ThemeAssetConfig> = {
   light: {


### PR DESCRIPTION
## Summary
- add per-layer parallax configuration including speed, blend mode, and max offset controls
- expose configurable parallax settings via a dedicated composable and updated home page bindings
- expand parallax coverage with unit tests and ensure themed assets handle layered sources

## Testing
- pnpm lint
- pnpm exec vitest run --reporter=dot
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694434fa3574832b8044ffabcca8ac4f)