### PR TITLE
Import createError helper for categories slug page

### DIFF
--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -53,6 +53,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { createError } from '#imports'
 import type { CategoryNavigationDto } from '~~/shared/api-client'
 
 import CategoryNavigationGrid from '~/components/category/navigation/CategoryNavigationGrid.vue'


### PR DESCRIPTION
## Summary
- add the missing createError import to the categories slug page
- ensure the server-side error path throws using the imported helper

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944433367f8832b87918088419e106f)