### PR TITLE
Use themed launcher icon for home page elements

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -7,7 +7,13 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 </script>
 
 <template>
-  <v-app-bar app flat color="surface-default" class="main-menu-app-bar">
+  <v-app-bar
+    app
+    flat
+    fixed
+    color="surface-default"
+    class="main-menu-app-bar"
+  >
     <v-container fluid class="py-0 mt-2">
       <div class="d-flex align-center w-100">
         <v-app-bar-title class="d-flex align-center mt-sm">
@@ -26,6 +32,7 @@ const handleToggleDrawer = () => emit('toggle-drawer')
   background-color: rgb(var(--v-theme-surface-default))
   border-radius: 0 0 40px 40px
   box-shadow: 0 16px 28px rgba(var(--v-theme-shadow-primary-600), 0.12);
+  z-index: 10
 
 @media (max-width: 959px)
   .main-menu-app-bar

--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { defineComponent, h, ref } from 'vue'
+import { computed, defineComponent, h, ref } from 'vue'
 import HomeHeroSection from './HomeHeroSection.vue'
 
 const messages: Record<string, string> = {
@@ -71,6 +71,11 @@ vi.mock('vue-i18n', () => ({
       key === 'home.hero.search.helpers' ? helperItems : [],
     locale: ref('fr-FR'),
   }),
+}))
+
+vi.mock('~~/app/composables/useThemedAsset', () => ({
+  useHeroBackgroundAsset: () => computed(() => ''),
+  useThemeAsset: () => computed(() => '/themed/launcher-icon.svg'),
 }))
 
 const createStub = (tag: string, className = '') =>
@@ -152,9 +157,7 @@ describe('HomeHeroSection', () => {
     const icon = wrapper.find('.home-hero__icon')
 
     expect(eyebrow.text()).toBe(messages['home.hero.eyebrow'])
-    expect(icon.attributes('src')).toBe(
-      '/pwa-assets/icons/android/android-launchericon-512-512.png'
-    )
+    expect(icon.attributes('src')).toBe('/themed/launcher-icon.svg')
     expect(icon.attributes('alt')).toBe(messages['home.hero.iconAlt'])
 
     await wrapper.unmount()

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -8,7 +8,10 @@ import SearchSuggestField, {
 } from '~/components/search/SearchSuggestField.vue'
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
-import { useHeroBackgroundAsset } from '~~/app/composables/useThemedAsset'
+import {
+  useHeroBackgroundAsset,
+  useThemeAsset,
+} from '~~/app/composables/useThemedAsset'
 
 type HeroHelperSegment = {
   text: string
@@ -248,7 +251,7 @@ const applyPartnerLinkPlaceholder = (items: HeroHelperItem[]) => {
 }
 
 const heroIconAlt = computed(() => String(t('home.hero.iconAlt')).trim())
-const heroIconSrc = '/pwa-assets/icons/android/android-launchericon-512-512.png'
+const heroIconSrc = useThemeAsset('launcherIcon')
 const heroIconAnimationOptions = [
   'home-hero__icon--fade',
   'home-hero__icon--scale',
@@ -259,7 +262,9 @@ const heroIconAnimation = ref(
     Math.floor(Math.random() * heroIconAnimationOptions.length)
   ] || heroIconAnimationOptions[0]
 )
-const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
+const showHeroIcon = computed(
+  () => Boolean(heroIconAlt.value && heroIconSrc.value)
+)
 
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundSrc = computed(() => {

--- a/frontend/app/components/shared/ui/PageLoadingOverlay.vue
+++ b/frontend/app/components/shared/ui/PageLoadingOverlay.vue
@@ -11,7 +11,24 @@
         :style="{ backgroundColor: scrimColor }"
       >
         <div class="page-loading-overlay__content">
+          <v-avatar
+            v-if="showLoaderIcon"
+            data-testid="page-loading-icon-wrapper"
+            class="page-loading-overlay__avatar"
+            color="surface-glass"
+            size="96"
+            variant="flat"
+          >
+            <v-img
+              data-testid="page-loading-icon"
+              :src="loaderIcon"
+              :alt="spinnerLabel"
+              cover
+              eager
+            />
+          </v-avatar>
           <v-progress-circular
+            v-else
             data-testid="page-loading-spinner"
             color="primary"
             size="64"
@@ -27,6 +44,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useThemeAsset } from '~~/app/composables/useThemedAsset'
 
 const routeLoading = useState<boolean>('routeLoading', () => false)
 const { t } = useI18n()
@@ -35,6 +53,8 @@ const spinnerLabel = computed(() =>
   String(t('components.pageLoadingOverlay.label'))
 )
 const scrimColor = computed(() => 'rgba(var(--v-theme-surface-default), 0.72)')
+const loaderIcon = useThemeAsset('launcherIcon')
+const showLoaderIcon = computed(() => Boolean(loaderIcon.value))
 
 const previousOverflow = ref<string | null>(null)
 
@@ -110,6 +130,10 @@ onBeforeUnmount(() => {
   border-radius: 999px
   background: rgba(var(--v-theme-surface-glass), 0.85)
   box-shadow: 0 12px 40px rgba(var(--v-theme-shadow-primary-600), 0.12)
+
+.page-loading-overlay__avatar
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.24)
+  box-shadow: inset 0 0 0 2px rgba(var(--v-theme-surface-default), 0.48)
 
 .visually-hidden
   position: absolute

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -10,7 +10,6 @@ import HomeFeaturesSection from '~/components/home/sections/HomeFeaturesSection.
 import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
 import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
-import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
 import ParallaxSection from '~/components/shared/ui/ParallaxSection.vue'
 import type {
   CategorySuggestionItem,
@@ -109,7 +108,6 @@ type AnimatedSectionKey =
   | 'blog'
   | 'objections'
   | 'faq'
-  | 'cta'
 
 const prefersReducedMotion = usePreferredReducedMotion()
 
@@ -120,7 +118,6 @@ const animatedSections = reactive<Record<AnimatedSectionKey, boolean>>({
   blog: false,
   objections: false,
   faq: false,
-  cta: false,
 })
 
 const markAllSectionsVisible = () => {
@@ -818,24 +815,6 @@ useHead(() => ({
                 <HomeFaqSection :items="faqPanels" />
               </div>
             </v-fade-transition>
-          </div>
-
-          <div
-            v-intersect="createIntersectHandler('cta')"
-            class="home-page__section"
-          >
-            <v-slide-y-transition :disabled="prefersReducedMotion">
-              <div v-show="animatedSections.cta">
-                <HomeCtaSection
-                  v-model:search-query="searchQuery"
-                  :categories-landing-url="categoriesLandingUrl"
-                  :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
-                  @submit="handleSearchSubmit"
-                  @select-category="handleCategorySuggestion"
-                  @select-product="handleProductSuggestion"
-                />
-              </div>
-            </v-slide-y-transition>
           </div>
         </div>
       </ParallaxSection>

--- a/frontend/config/theme/assets.ts
+++ b/frontend/config/theme/assets.ts
@@ -8,6 +8,7 @@ export const THEME_ASSET_KEYS = [
   'favicon',
   'heroBackground',
   'illustration',
+  'launcherIcon',
 ] as const
 
 export type ThemeAssetKey = (typeof THEME_ASSET_KEYS)[number]
@@ -48,6 +49,7 @@ export const themeAssets: Record<ThemeName | 'common', ThemeAssetConfig> = {
     favicon: 'favicon.svg',
     heroBackground: 'hero-background.webp',
     illustration: 'illustration-generic.svg',
+    launcherIcon: 'nudger-icon-light-rot-shape-only.svg',
   },
   dark: {
     logo: 'logo.png',
@@ -55,10 +57,12 @@ export const themeAssets: Record<ThemeName | 'common', ThemeAssetConfig> = {
     favicon: 'favicon.svg',
     heroBackground: 'hero-background.svg',
     illustration: 'illustration-generic.svg',
+    launcherIcon: 'nudger-icon-light-rot-shape-only.svg',
   },
   common: {
     heroBackground: 'hero-background.svg',
     illustration: 'illustration-generic.svg',
+    launcherIcon: 'nudger-icon-light-rot-shape-only.svg',
   },
 }
 


### PR DESCRIPTION
## Summary
- fix the home page app bar so the manager logo stays pinned while scrolling
- source the home hero and loading overlay launcher visuals from the themed asset library
- simplify the CTA parallax stack by keeping only the FAQ block

## Testing
- pnpm vitest run --root app app/components/home/sections/HomeHeroSection.spec.ts app/components/shared/ui/PageLoadingOverlay.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944426901e4832b9024d7cbecd935c5)