### PR TITLE
Remove footer test cards from Fontaine

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -2,13 +2,6 @@
 import type { RouteLocationRaw } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
-import FooterTimeSaverVariantFocus from '~/components/shared/footers/time-saver/FooterTimeSaverVariantFocus.vue'
-import FooterTimeSaverVariantMinimal from '~/components/shared/footers/time-saver/FooterTimeSaverVariantMinimal.vue'
-import FooterTimeSaverVariantRibbon from '~/components/shared/footers/time-saver/FooterTimeSaverVariantRibbon.vue'
-import type {
-  TimeSaverHelper,
-  TimeSaverModel,
-} from '~/components/shared/footers/time-saver/FooterTimeSaverVariantFocus.vue'
 import { useFooterLogoAsset } from '~~/app/composables/useThemedAsset'
 
 import {
@@ -36,10 +29,6 @@ const feedbackPath = computed(() =>
 const categoriesPath = computed(() =>
   resolveLocalizedRoutePath('categories', currentLocale.value)
 )
-const homePath = computed(
-  () => resolveLocalizedRoutePath('/', currentLocale.value) ?? '/'
-)
-
 const currentYear = computed(() => new Date().getFullYear())
 const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
 
@@ -101,27 +90,6 @@ const feedbackLinks = computed<FooterLink[]>(() => [
 
 const footerLogo = useFooterLogoAsset()
 
-const timeSaverHelpers = computed<TimeSaverHelper[]>(() => [
-  { icon: '🌿', label: t('siteIdentity.footer.timeSaver.helpers.impact') },
-  { icon: '💶', label: t('siteIdentity.footer.timeSaver.helpers.price') },
-  { icon: '🛡️', label: t('siteIdentity.footer.timeSaver.helpers.trust') },
-])
-
-const timeSaverModel = computed<TimeSaverModel>(() => ({
-  eyebrow: t('siteIdentity.footer.timeSaver.eyebrow'),
-  title: t('siteIdentity.footer.timeSaver.titleFull'),
-  subtitle: t('siteIdentity.footer.timeSaver.subtitle'),
-  badge: t('siteIdentity.footer.timeSaver.badge'),
-  helpers: timeSaverHelpers.value,
-  primaryCta: {
-    label: t('siteIdentity.footer.timeSaver.primaryCta'),
-    to: homePath.value,
-  },
-  secondaryCta: {
-    label: t('siteIdentity.footer.timeSaver.secondaryCta'),
-    to: categoriesPath.value,
-  },
-}))
 </script>
 
 <template>
@@ -129,24 +97,6 @@ const timeSaverModel = computed<TimeSaverModel>(() => ({
     <h2 id="footer-heading" class="sr-only">
       {{ t('siteIdentity.footer.accessibleTitle') }}
     </h2>
-
-    <v-row class="footer-time-saver g-4 mb-8">
-      <v-col cols="12">
-        <FooterTimeSaverVariantFocus :model="timeSaverModel" />
-      </v-col>
-      <v-col cols="12">
-        <FooterTimeSaverVariantRibbon
-          :model="timeSaverModel"
-          :learn-more-cta="{
-            label: t('siteIdentity.footer.timeSaver.learnMoreCta'),
-            to: categoriesPath,
-          }"
-        />
-      </v-col>
-      <v-col cols="12">
-        <FooterTimeSaverVariantMinimal :model="timeSaverModel" />
-      </v-col>
-    </v-row>
 
     <v-row class="g-8 footer-upper">
       <v-col cols="12" md="4">
@@ -288,11 +238,6 @@ const timeSaverModel = computed<TimeSaverModel>(() => ({
 }
 
 .footer-upper {
-  position: relative;
-  z-index: 1;
-}
-
-.footer-time-saver {
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- remove the experimental time-saver cards from the main footer
- simplify the footer component now that the test cards are gone

## Testing
- pnpm lint *(fails: existing @typescript-eslint/no-unused-vars in app/pages/blog/[slug].vue unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447483a5d8832b8784500263db2177)