### PR TITLE
Add accessibility store and adjust home spacing

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -86,8 +86,14 @@
     color: #ffffff!important
 
 :root.accessibility-layout
-    .v-container:not(.v-container--fluid)
-        max-width: min(1560px, 96vw)
+    .v-container
+        max-width: 100% !important
+        width: 100%
+
+    .container
+        max-width: 100% !important
+        width: 100%
 
     .cms-page__container--container
-        max-width: min(1560px, 100%) !important
+        max-width: 100% !important
+        width: 100% !important

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -1,10 +1,11 @@
 <template>
-  <RoundedCornerCard
-    class="nudge-wizard"
-    rounded="xl"
-    :elevation="3"
-    accent-corner="top-left"
-    corner-variant="custom"
+    <RoundedCornerCard
+      class="nudge-wizard"
+      rounded="xl"
+      :elevation="3"
+      :hover-elevation="3"
+      accent-corner="top-left"
+      corner-variant="custom"
     :corner-size="resolvedCornerSize"
     :style="wizardStyle"
     :class="{ 'nudge-wizard--content-mode': isContentMode }"

--- a/frontend/app/components/shared/menus/ZoomToggle.vue
+++ b/frontend/app/components/shared/menus/ZoomToggle.vue
@@ -23,9 +23,9 @@
 </template>
 
 <script setup lang="ts">
-import { useStorage } from '@vueuse/core'
-import { watch, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
+import { useAccessibilityStore } from '~/stores/useAccessibilityStore'
 
 withDefaults(
   defineProps<{
@@ -41,31 +41,9 @@ withDefaults(
 )
 
 const { t } = useI18n()
-
-const isZoomed = useStorage('is-zoomed', false)
-
-const toggleZoom = () => {
-  isZoomed.value = !isZoomed.value
-}
-
-const applyZoom = (zoomed: boolean) => {
-  if (typeof document === 'undefined') {
-    return
-  }
-
-  const rootElement = document.documentElement
-
-  rootElement.style.fontSize = zoomed ? '120%' : ''
-  rootElement.classList.toggle('accessibility-layout', zoomed)
-}
-
-watch(isZoomed, val => {
-  applyZoom(val)
-})
-
-onMounted(() => {
-  applyZoom(isZoomed.value)
-})
+const accessibilityStore = useAccessibilityStore()
+const { isZoomed } = storeToRefs(accessibilityStore)
+const { toggleZoom } = accessibilityStore
 </script>
 
 <style scoped lang="sass">

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -674,6 +674,7 @@ useHead(() => ({
         <ParallaxSection
           id="home-essentials"
           class="home-page__parallax"
+          :gapless="true"
           :backgrounds="parallaxBackgrounds.essentials.backgrounds"
           :overlay-opacity="parallaxBackgrounds.essentials.overlayOpacity"
           :parallax-amount="parallaxBackgrounds.essentials.parallaxAmount"

--- a/frontend/app/stores/useAccessibilityStore.ts
+++ b/frontend/app/stores/useAccessibilityStore.ts
@@ -1,0 +1,26 @@
+import { useStorage } from '@vueuse/core'
+import { defineStore } from 'pinia'
+import { watch } from 'vue'
+import { applyAccessibilityLayout } from '~/utils/accessibilityLayout'
+
+export const useAccessibilityStore = defineStore('accessibility', () => {
+  const isZoomed = useStorage('is-zoomed', false)
+
+  const setZoomed = (value: boolean) => {
+    isZoomed.value = value
+  }
+
+  const toggleZoom = () => {
+    isZoomed.value = !isZoomed.value
+  }
+
+  watch(
+    isZoomed,
+    zoomed => {
+      applyAccessibilityLayout(zoomed)
+    },
+    { immediate: true }
+  )
+
+  return { isZoomed, setZoomed, toggleZoom }
+})

--- a/frontend/app/utils/accessibilityLayout.ts
+++ b/frontend/app/utils/accessibilityLayout.ts
@@ -1,0 +1,14 @@
+export const ACCESSIBILITY_LAYOUT_CLASS = 'accessibility-layout'
+export const ACCESSIBILITY_LAYOUT_FLUID_CLASS = 'accessibility-layout--fluid'
+
+export const applyAccessibilityLayout = (isZoomed: boolean) => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const rootElement = document.documentElement
+
+  rootElement.style.fontSize = isZoomed ? '120%' : ''
+  rootElement.classList.toggle(ACCESSIBILITY_LAYOUT_CLASS, isZoomed)
+  rootElement.classList.toggle(ACCESSIBILITY_LAYOUT_FLUID_CLASS, isZoomed)
+}


### PR DESCRIPTION
## Summary
- add a reusable accessibility layout utility and pinia store to persist zoom state and apply global fluid container styling
- update zoom toggle to rely on the accessibility store and keep home hero and parallax sections flush
- remove hover elevation shift from the nudge wizard card to keep a consistent shadow

## Testing
- pnpm lint
- pnpm test pages/index.spec.ts
- pnpm build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451b1f30c0832b894111b4bfe2a1fd)