### PR TITLE
Use medium category image and clean category header

### DIFF
--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -202,7 +202,6 @@
           itemprop="mainEntity"
           itemtype="https://schema.org/ItemList"
         >
-          <h2 class="sr-only">{{ $t('category.products.title') }}</h2>
           <meta itemprop="name" :content="seoTitle" />
           <meta itemprop="numberOfItems" :content="String(resultsCount)" />
 
@@ -597,8 +596,8 @@ const heroImage = computed(() => {
 
   return (
     category.value.imageMedium ??
-    category.value.imageLarge ??
     category.value.imageSmall ??
+    category.value.imageLarge ??
     null
   )
 })


### PR DESCRIPTION
## Summary
- prefer the medium-sized category image when rendering the hero section
- remove the unused accessible products title heading from the category page markup

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945518f0750832ba3342eb2417c7930)