### PR TITLE
Align release workflow tag propagation and test mode

### DIFF
--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -3,6 +3,16 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Mode d'exécution (release ou test)"
+        required: false
+        default: release
+        type: choice
+        options:
+          - release
+          - test
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -17,12 +27,14 @@ concurrency:
   
 jobs:
   release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     environment:
       name: test-github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     name: prod-release-deploy
     runs-on: ubuntu-latest
+    env:
+      MODE: ${{ inputs.mode || 'release' }}
     concurrency:
       group: deploy-prod
       cancel-in-progress: true
@@ -32,6 +44,8 @@ jobs:
       # Checkout Main Repository
       ###########################################
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       ############################################
       # Cache Maven Dependencies
@@ -82,6 +96,7 @@ jobs:
       # Build Maven site and Artifacts
       ###########################################
       - name: Build Maven Site
+        if: env.MODE != 'test'
         run: mvn --batch-mode clean install site site:stage
 
 
@@ -95,10 +110,12 @@ jobs:
           version: 10.26.1
 
       - name: Install dependencies
+        if: env.MODE != 'test'
         run: pnpm install --frozen-lockfile
         working-directory: frontend
 
       - name: Build Nuxt (Node SSR)
+        if: env.MODE != 'test'
         run: pnpm build
         working-directory: frontend
         env:
@@ -107,6 +124,7 @@ jobs:
           HCAPTCHA_SITE_KEY: ${{ secrets.HCAPTCHA_SITE_KEY }}
           APP_ENV: production
       - name: Deploy SSR output to Beta server
+        if: env.MODE != 'test'
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -117,6 +135,7 @@ jobs:
           TARGET: "/opt/open4goods/bin/latest/frontend-ssr"
 
       - name: Publish frontend
+        if: env.MODE != 'test'
         uses: appleboy/ssh-action@v1.2.4
         with:
           host: ${{ secrets.REMOTE_HOST }}
@@ -193,9 +212,43 @@ jobs:
         run: cat PUSH-CHANGELOG.txt >> PR-CHANGELOG.txt
 
       ############################################
+      # Persist Release Notes to Repository
+      ###########################################
+      - name: Publish release notes to frontend/Release
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -eo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout main
+          git pull --ff-only origin main
+
+          NOTE_DIR="frontend/Release"
+          mkdir -p "${NOTE_DIR}"
+          cp PR-CHANGELOG.txt "${NOTE_DIR}/${VERSION}.md"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "frontend/Release/${VERSION}.md"
+
+          if git diff --cached --quiet; then
+            echo "Release notes already present; nothing to commit."
+            exit 0
+          fi
+
+          git commit -m "chore: add release notes for ${VERSION}"
+          git push origin main
+
+          git tag -f "${VERSION}"
+          git push --force-with-lease origin "${VERSION}"
+
+      ############################################
       # Create the GitHub Release
       ###########################################
       - name: Create Release
+        if: env.MODE != 'test'
         uses: mikepenz/action-gh-release@v1
         with:
           body_path: ${{ github.workspace }}/PR-CHANGELOG.txt
@@ -210,6 +263,7 @@ jobs:
       # Deploy JARs to Production Server
       ###########################################
       - name: Deploy SBADMIN to Server
+        if: env.MODE != 'test'
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -220,6 +274,7 @@ jobs:
           TARGET: "/opt/open4goods/bin/latest/sbadmin-latest.jar"
 
       - name: Deploy API to Server
+        if: env.MODE != 'test'
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -230,6 +285,7 @@ jobs:
           TARGET: "/opt/open4goods/bin/latest/api-latest.jar"
 
       - name: Deploy UI (static server) to Production Server
+        if: env.MODE != 'test'
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -241,6 +297,7 @@ jobs:
 
           
       - name: Deploy front-api to Qualification Server
+        if: env.MODE != 'test'
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -255,6 +312,7 @@ jobs:
       # Restart Applications
       ###########################################
       - name: Start Applications
+        if: env.MODE != 'test'
         uses: appleboy/ssh-action@v1.2.4
         with:
           host: ${{ secrets.REMOTE_HOST }}
@@ -266,17 +324,21 @@ jobs:
       # GitHub Pages Deployment
       ###########################################
       - name: Setup GitHub Pages
-        uses: actions/configure-pages@v5    
+        if: env.MODE != 'test'
+        uses: actions/configure-pages@v5
 
       - name: Merge Site
+        if: env.MODE != 'test'
         run: cp -r target/staging/* src/main/site/maven/
-                        
+
       - name: Upload Custom Site to GitHub Pages
+        if: env.MODE != 'test'
         uses: actions/upload-pages-artifact@v4
         with:
           path: './src/main/site/'
 
       - name: Deploy to GitHub Pages
+        if: env.MODE != 'test'
         id: deployment
         uses: actions/deploy-pages@v4
       


### PR DESCRIPTION
## Summary
- allow manual test mode execution that skips builds, deployments, and release publication while still generating notes
- write release notes directly on main, retag the release, and push both branch and tag to include the markdown in the tagged revision
- add protections to skip deployment steps when running in test mode

## Testing
- Not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694550fe6018832b8ceda1e89730e499)