### PR TITLE
Add releases page and release notes caching

### DIFF
--- a/frontend/app/components/domains/releases/LatestReleaseBadge.vue
+++ b/frontend/app/components/domains/releases/LatestReleaseBadge.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-chip
+    v-if="latestName"
+    color="primary"
+    prepend-icon="mdi-rocket-launch"
+    class="latest-release-badge"
+    variant="flat"
+  >
+    {{ t('releases.latestLabel', { name: latestName }) }}
+  </v-chip>
+</template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+
+const { data: latestRelease } = await useLatestRelease()
+
+const latestName = computed(() => latestRelease.value?.name ?? '')
+</script>
+
+<style scoped lang="sass">
+.latest-release-badge
+  font-weight: 700
+  letter-spacing: 0.01em
+</style>

--- a/frontend/app/components/domains/releases/ReleaseAccordion.vue
+++ b/frontend/app/components/domains/releases/ReleaseAccordion.vue
@@ -1,0 +1,190 @@
+<template>
+  <v-sheet class="release-accordion" color="transparent">
+    <v-progress-linear
+      v-if="loading"
+      indeterminate
+      color="primary"
+      class="mb-4"
+      :aria-label="t('releases.loading')"
+      role="progressbar"
+    />
+
+    <v-alert
+      v-if="error"
+      type="error"
+      variant="tonal"
+      border="start"
+      prominent
+      class="mb-4"
+      role="alert"
+    >
+      <div class="d-flex align-center gap-2">
+        <span>{{ t('releases.errors.loadFailed') }}</span>
+        <v-btn
+          size="small"
+          variant="tonal"
+          color="primary"
+          @click="$emit('retry')"
+        >
+          {{ t('common.actions.retry') }}
+        </v-btn>
+      </div>
+    </v-alert>
+
+    <v-alert
+      v-else-if="!loading && releases.length === 0"
+      type="info"
+      variant="tonal"
+      border="start"
+      class="mb-4"
+      role="status"
+    >
+      {{ t('releases.empty') }}
+    </v-alert>
+
+    <v-expansion-panels
+      v-model="expanded"
+      elevation="0"
+      variant="accordion"
+      class="release-accordion__panels"
+    >
+      <v-expansion-panel
+        v-for="(release, index) in releases"
+        :key="release.slug"
+        :value="release.slug"
+        class="release-accordion__panel"
+      >
+        <v-expansion-panel-title class="release-accordion__title">
+          <div class="release-accordion__title-content">
+            <div class="release-accordion__meta">
+              <span class="release-accordion__eyebrow">
+                {{ formatPublishedDate(release.publishedAt) }}
+              </span>
+              <div class="d-flex align-center gap-2">
+                <span class="release-accordion__name">{{ release.name }}</span>
+                <v-chip
+                  v-if="index === 0"
+                  color="primary"
+                  size="small"
+                  variant="flat"
+                  density="comfortable"
+                >
+                  {{ t('releases.latest') }}
+                </v-chip>
+              </div>
+            </div>
+            <v-icon
+              icon="mdi-chevron-down"
+              class="release-accordion__icon"
+            />
+          </div>
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div class="release-accordion__content" v-html="release.contentHtml" />
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </v-sheet>
+</template>
+
+<script setup lang="ts">
+import type { ReleaseNote } from '~~/types/releases'
+
+const props = defineProps<{
+  releases: ReleaseNote[]
+  loading?: boolean
+  error?: unknown
+}>()
+
+defineEmits<{
+  (event: 'retry'): void
+}>()
+
+const { t, locale } = useI18n()
+
+const expanded = ref<string[]>([])
+
+watch(
+  () => props.releases,
+  (list) => {
+    if (list.length > 0) {
+      expanded.value = [list[0]?.slug]
+    }
+  },
+  { immediate: true }
+)
+
+const formatPublishedDate = (isoDate: string): string => {
+  try {
+    const parsed = new Date(isoDate)
+
+    return new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' })
+      .format(parsed)
+  }
+  catch {
+    return isoDate
+  }
+}
+</script>
+
+<style scoped lang="sass">
+.release-accordion
+  &__panels
+    background: transparent
+    border: 1px solid rgba(var(--v-theme-on-surface), 0.08)
+    border-radius: 18px
+    overflow: hidden
+
+  &__panel
+    &::after
+      display: none
+
+  &__title
+    padding: 16px 20px
+
+  &__title-content
+    display: flex
+    justify-content: space-between
+    align-items: center
+    gap: 12px
+
+  &__meta
+    display: flex
+    flex-direction: column
+    gap: 6px
+
+  &__eyebrow
+    text-transform: uppercase
+    letter-spacing: 0.08em
+    font-size: 0.75rem
+    color: rgba(var(--v-theme-on-surface), 0.6)
+
+  &__name
+    font-weight: 700
+    font-size: 1.05rem
+    color: rgb(var(--v-theme-on-surface))
+
+  &__icon
+    color: rgba(var(--v-theme-on-surface), 0.6)
+
+  &__content
+    padding: 10px 4px 20px
+
+    :deep(h1),
+    :deep(h2),
+    :deep(h3)
+      margin: 16px 0 10px
+      font-weight: 700
+
+    :deep(p)
+      margin: 10px 0
+      color: rgba(var(--v-theme-on-surface), 0.8)
+
+    :deep(ul)
+      padding-left: 24px
+      margin: 10px 0
+
+    :deep(li)
+      margin: 6px 0
+</style>

--- a/frontend/app/composables/useLatestRelease.ts
+++ b/frontend/app/composables/useLatestRelease.ts
@@ -1,0 +1,18 @@
+import type { ReleaseNote } from '~~/types/releases'
+
+export const useLatestRelease = async () => {
+  const existing = useNuxtData<ReleaseNote | null>('latest-release')
+  const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+
+  const hasExistingData = existing?.data.value !== undefined
+
+  const asyncData = hasExistingData && existing
+    ? existing
+    : await useAsyncData<ReleaseNote | null>(
+        'latest-release',
+        () => $fetch('/api/releases/latest', { headers: requestHeaders }),
+        { default: () => null }
+      )
+
+  return asyncData
+}

--- a/frontend/app/composables/useReleaseNotes.ts
+++ b/frontend/app/composables/useReleaseNotes.ts
@@ -1,0 +1,25 @@
+import type { ReleaseNote } from '~~/types/releases'
+
+export const useReleaseNotes = async () => {
+  const existing = useNuxtData<ReleaseNote[]>('release-notes')
+  const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
+
+  const hasExistingData = existing?.data.value !== undefined
+
+  const asyncData = hasExistingData && existing
+    ? existing
+    : await useAsyncData<ReleaseNote[]>(
+        'release-notes',
+        () => $fetch('/api/releases', { headers: requestHeaders }),
+        { default: () => [] }
+      )
+
+  const releases = computed(() => asyncData.data.value ?? [])
+  const latestRelease = computed(() => releases.value[0] ?? null)
+
+  return {
+    ...asyncData,
+    releases,
+    latestRelease,
+  }
+}

--- a/frontend/app/pages/releases/index.vue
+++ b/frontend/app/pages/releases/index.vue
@@ -1,0 +1,205 @@
+<template>
+  <div class="releases-page">
+    <v-container class="releases-page__hero" max-width="lg">
+      <v-row>
+        <v-col cols="12" md="7" class="d-flex flex-column gap-4">
+          <p class="releases-page__eyebrow">
+            {{ t('releases.hero.eyebrow') }}
+          </p>
+          <div class="d-flex align-center gap-3 flex-wrap">
+            <h1 class="releases-page__title">{{ t('releases.hero.title') }}</h1>
+            <LatestReleaseBadge />
+          </div>
+          <p class="releases-page__subtitle">
+            {{ t('releases.hero.subtitle') }}
+          </p>
+          <p class="releases-page__description">
+            {{ t('releases.hero.description') }}
+          </p>
+          <div class="d-flex gap-3 flex-wrap">
+            <v-btn
+              color="primary"
+              variant="flat"
+              size="large"
+              :to="t('releases.hero.ctaLink')"
+            >
+              {{ t('releases.hero.cta') }}
+            </v-btn>
+            <v-btn
+              color="primary"
+              variant="tonal"
+              size="large"
+              :to="localePath('contact')"
+            >
+              {{ t('releases.hero.secondaryCta') }}
+            </v-btn>
+          </div>
+        </v-col>
+        <v-col cols="12" md="5" class="d-flex justify-center align-center">
+          <v-sheet class="releases-page__card" rounded="xl" elevation="4">
+            <div class="releases-page__card-header">
+              <v-icon icon="mdi-text-box-multiple-outline" size="36" color="primary" />
+              <div>
+                <p class="releases-page__card-eyebrow">{{ t('releases.summary.eyebrow') }}</p>
+                <p class="releases-page__card-title">{{ t('releases.summary.title') }}</p>
+              </div>
+            </div>
+            <p class="releases-page__card-body">
+              {{ t('releases.summary.body') }}
+            </p>
+            <div class="releases-page__metadata">
+              <div>
+                <p class="releases-page__meta-label">{{ t('releases.summary.latest') }}</p>
+                <p class="releases-page__meta-value">{{ latestReleaseName }}</p>
+              </div>
+              <div>
+                <p class="releases-page__meta-label">{{ t('releases.summary.count') }}</p>
+                <p class="releases-page__meta-value">{{ releasesCount }}</p>
+              </div>
+            </div>
+          </v-sheet>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <v-container class="releases-page__content" max-width="lg">
+      <ReleaseAccordion
+        :releases="releases"
+        :loading="pending"
+        :error="error"
+        @retry="refresh"
+      />
+    </v-container>
+  </div>
+</template>
+
+<script setup lang="ts">
+import LatestReleaseBadge from '~/components/domains/releases/LatestReleaseBadge.vue'
+import ReleaseAccordion from '~/components/domains/releases/ReleaseAccordion.vue'
+import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
+
+definePageMeta({
+  name: 'releases',
+  ssr: false,
+})
+
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+const requestURL = useRequestURL()
+
+const { releases, pending, error, refresh, latestRelease } = await useReleaseNotes()
+
+const releasesCount = computed(() => releases.value.length)
+const latestReleaseName = computed(() => latestRelease.value?.name ?? t('releases.empty'))
+
+const canonicalUrl = computed(() =>
+  new URL(
+    resolveLocalizedRoutePath('releases', locale.value),
+    requestURL.origin
+  ).toString()
+)
+
+const ogImageUrl = computed(() =>
+  new URL('/nudger-icon-512x512.png', requestURL.origin).toString()
+)
+
+useSeoMeta({
+  title: () => String(t('releases.seo.title')),
+  description: () => String(t('releases.seo.description')),
+  ogTitle: () => String(t('releases.seo.title')),
+  ogDescription: () => String(t('releases.seo.description')),
+  ogUrl: () => canonicalUrl.value,
+  ogType: () => 'website',
+  ogImage: () => ogImageUrl.value,
+})
+
+useHead(() => ({
+  link: [{ rel: 'canonical', href: canonicalUrl.value }],
+}))
+</script>
+
+<style scoped lang="sass">
+.releases-page
+  display: flex
+  flex-direction: column
+  gap: 32px
+
+  &__hero
+    padding-top: 48px
+    padding-bottom: 24px
+
+  &__eyebrow
+    text-transform: uppercase
+    letter-spacing: 0.08em
+    color: rgba(var(--v-theme-on-surface), 0.7)
+    font-weight: 700
+    margin-bottom: 4px
+
+  &__title
+    font-size: clamp(2rem, 3vw, 2.6rem)
+    font-weight: 800
+    margin: 0
+
+  &__subtitle
+    font-size: 1.1rem
+    color: rgba(var(--v-theme-on-surface), 0.72)
+    margin: 0
+
+  &__description
+    font-size: 1rem
+    color: rgba(var(--v-theme-on-surface), 0.82)
+    margin: 0
+
+  &__card
+    width: 100%
+    padding: 24px
+    background: rgba(var(--v-theme-surface-muted-contrast), 0.8)
+
+  &__card-header
+    display: flex
+    align-items: center
+    gap: 12px
+    margin-bottom: 12px
+
+  &__card-eyebrow
+    margin: 0
+    text-transform: uppercase
+    letter-spacing: 0.08em
+    font-size: 0.78rem
+    color: rgba(var(--v-theme-on-surface), 0.6)
+
+  &__card-title
+    margin: 0
+    font-weight: 700
+    font-size: 1.1rem
+    color: rgb(var(--v-theme-on-surface))
+
+  &__card-body
+    margin: 4px 0 18px
+    color: rgba(var(--v-theme-on-surface), 0.75)
+
+  &__metadata
+    display: grid
+    grid-template-columns: repeat(2, minmax(0, 1fr))
+    gap: 12px
+
+  &__meta-label
+    margin: 0
+    font-size: 0.85rem
+    color: rgba(var(--v-theme-on-surface), 0.6)
+
+  &__meta-value
+    margin: 4px 0 0
+    font-weight: 700
+    color: rgb(var(--v-theme-on-surface))
+
+  &__content
+    padding-bottom: 56px
+
+@media (max-width: 960px)
+  .releases-page
+    &__hero
+      padding-top: 28px
+    &__metadata
+      grid-template-columns: repeat(1, minmax(0, 1fr))
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2275,20 +2275,49 @@
         "nudgerAriaLabel": "Activate Nudger signature theme",
         "nudgerTooltip": "Switch to the Nudger signature theme"
       },
-      "zoom": {
-        "label": "Toggle zoom",
-        "activate": "Zoom in (120%)",
-        "reset": "Reset zoom"
-      },
-      "themeToggle": "Toggle theme",
-      "title": "Menu"
+    "zoom": {
+      "label": "Toggle zoom",
+      "activate": "Zoom in (120%)",
+      "reset": "Reset zoom"
     },
-    "siteName": "Nudger"
+    "themeToggle": "Toggle theme",
+    "title": "Menu"
   },
-  "team": {
-    "callouts": {
-      "contact": {
-        "cta": "Contact us",
+  "siteName": "Nudger"
+},
+"releases": {
+  "hero": {
+    "cta": "Browse updates",
+    "ctaLink": "/releases",
+    "description": "Every release captures our latest improvements, from new impact insights to performance fixes.",
+    "eyebrow": "Product updates",
+    "secondaryCta": "Contact us",
+    "subtitle": "Follow how Nudger evolves across versions.",
+    "title": "Release notes"
+  },
+  "summary": {
+    "body": "Release notes are sourced directly from our repository. Each Markdown file represents one published version.",
+    "count": "Published releases",
+    "eyebrow": "Snapshot",
+    "latest": "Latest version",
+    "title": "Release overview"
+  },
+  "latest": "Latest",
+  "latestLabel": "Latest release: {name}",
+  "loading": "Loading release notes…",
+  "empty": "Release notes will arrive soon.",
+  "errors": {
+    "loadFailed": "We could not load the release notes. Please try again."
+  },
+  "seo": {
+    "description": "Explore every Nudger release with publication dates and detailed changelogs.",
+    "title": "Nudger release notes"
+  }
+},
+"team": {
+  "callouts": {
+    "contact": {
+      "cta": "Contact us",
         "description": "Want to co-create the future of responsible shopping or ask us something specific? We would love to talk.",
         "title": "Curious to chat?"
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2284,7 +2284,36 @@
       "themeToggle": "Changer de thème",
       "title": "Menu"
     },
-    "siteName": "Nudger"
+  "siteName": "Nudger"
+},
+  "releases": {
+    "hero": {
+      "cta": "Parcourir les mises à jour",
+      "ctaLink": "/versions",
+      "description": "Chaque publication regroupe nos dernières améliorations, des nouvelles données d'impact aux optimisations de performance.",
+      "eyebrow": "Mises à jour produit",
+      "secondaryCta": "Nous contacter",
+      "subtitle": "Suivez l'évolution de Nudger version après version.",
+      "title": "Notes de version"
+    },
+    "summary": {
+      "body": "Les notes de version proviennent directement de notre dépôt. Chaque fichier Markdown correspond à une version publiée.",
+      "count": "Versions publiées",
+      "eyebrow": "En un coup d'œil",
+      "latest": "Version la plus récente",
+      "title": "Vue d'ensemble des versions"
+    },
+    "latest": "Dernière",
+    "latestLabel": "Dernière version : {name}",
+    "loading": "Chargement des notes de version…",
+    "empty": "Les notes de version seront publiées bientôt.",
+    "errors": {
+      "loadFailed": "Impossible de charger les notes de version. Merci de réessayer."
+    },
+    "seo": {
+      "description": "Découvrez chaque version de Nudger avec les dates de publication et les journaux détaillés.",
+      "title": "Notes de version Nudger"
+    }
   },
   "team": {
     "callouts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "jsdom": "^27.0.0",
     "jwt-decode": "^4.0.0",
     "lz-string": "^1.5.0",
+    "markdown-it": "^14.1.0",
     "nuxt": "^4.0.0",
     "nuxt-device": "^2.1.0",
     "pinia": "^3.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       lz-string:
         specifier: ^1.5.0
         version: 1.5.0
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
       nuxt:
         specifier: ^4.0.0
         version: 4.2.2(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@25.0.1)(@vue/compiler-sfc@3.5.25)(cac@6.7.14)(db0@0.3.4)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.5.1)(meow@13.2.0)(optionator@0.9.4)(rollup@4.53.3)(sass@1.97.0)(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.1.8(typescript@5.9.3))(xml2js@0.6.2)(yaml@2.8.2)
@@ -6707,6 +6710,9 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   listhen@1.9.0:
     resolution: {integrity: sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==}
     hasBin: true
@@ -6844,6 +6850,10 @@ packages:
     resolution: {integrity: sha512-T9BPOmEOhp6SmV25SwLVcHK4E6JyG/coH3C6F1NjNXSziv/fd4GmsqMk8YR6qpPOswfaOCApSNkZv6fxoaYFcQ==}
     engines: {node: '>=18'}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
     engines: {node: '>=16.0.0'}
@@ -6867,6 +6877,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -7996,6 +8009,10 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -8941,6 +8958,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
@@ -17267,6 +17287,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   listhen@1.9.0:
     dependencies:
       '@parcel/watcher': 2.5.1
@@ -17418,6 +17442,15 @@ snapshots:
       type-fest: 4.41.0
       web-worker: 1.2.0
 
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   marked-terminal@7.3.0(marked@15.0.12):
     dependencies:
       ansi-escapes: 7.2.0
@@ -17438,6 +17471,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -18812,6 +18847,8 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   qs@6.14.0:
@@ -19971,6 +20008,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.1: {}
 

--- a/frontend/server/api/releases/index.get.ts
+++ b/frontend/server/api/releases/index.get.ts
@@ -1,0 +1,3 @@
+import { getReleaseNotes } from '../../utils/releases'
+
+export default defineEventHandler(async () => getReleaseNotes())

--- a/frontend/server/api/releases/latest.get.ts
+++ b/frontend/server/api/releases/latest.get.ts
@@ -1,0 +1,3 @@
+import { getLatestRelease } from '../../utils/releases'
+
+export default defineEventHandler(async () => getLatestRelease())

--- a/frontend/server/plugins/releases.ts
+++ b/frontend/server/plugins/releases.ts
@@ -1,0 +1,5 @@
+import { warmReleaseCache } from '../utils/releases'
+
+export default defineNitroPlugin(async () => {
+  await warmReleaseCache()
+})

--- a/frontend/server/utils/releases.ts
+++ b/frontend/server/utils/releases.ts
@@ -1,0 +1,109 @@
+import { execFile } from 'node:child_process'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import createDOMPurify from 'isomorphic-dompurify'
+import { JSDOM, type DOMWindow } from 'jsdom'
+import MarkdownIt from 'markdown-it'
+import type { ReleaseNote } from '~~/types/releases'
+
+const execFileAsync = promisify(execFile)
+const markdown = new MarkdownIt({
+  html: true,
+  linkify: true,
+  breaks: true,
+})
+const DOMPurify = createDOMPurify(new JSDOM('').window as unknown as DOMWindow)
+
+const PROJECT_ROOT = path.resolve(process.cwd())
+const RELEASES_DIRECTORY = path.join(PROJECT_ROOT, 'Release')
+
+let cachedReleaseNotes: ReleaseNote[] | null = null
+
+const getCreationDateFromGit = async (
+  filePath: string
+): Promise<string | null> => {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['log', '--diff-filter=A', '--follow', '--format=%cI', '-1', '--', filePath],
+      { cwd: PROJECT_ROOT }
+    )
+
+    const isoDate = stdout.trim().split('\n').filter(Boolean).at(-1)
+
+    return isoDate ?? null
+  }
+  catch (error: unknown) {
+    console.warn('Unable to compute release creation date from git', error)
+    return null
+  }
+}
+
+const getReleasePublishedAt = async (filePath: string): Promise<string> => {
+  const gitDate = await getCreationDateFromGit(filePath)
+
+  if (gitDate) {
+    return gitDate
+  }
+
+  const stats = await fs.stat(filePath)
+  const fallbackDate = stats.birthtimeMs > 0 ? stats.birthtime : stats.mtime
+
+  return fallbackDate.toISOString()
+}
+
+const buildReleaseNote = async (fileName: string): Promise<ReleaseNote | null> => {
+  if (!fileName.toLowerCase().endsWith('.md')) {
+    return null
+  }
+
+  const fullPath = path.join(RELEASES_DIRECTORY, fileName)
+  const [rawContent, publishedAt] = await Promise.all([
+    fs.readFile(fullPath, 'utf-8'),
+    getReleasePublishedAt(fullPath),
+  ])
+
+  const name = path.basename(fileName, path.extname(fileName))
+
+  return {
+    name,
+    slug: name,
+    contentHtml: DOMPurify.sanitize(markdown.render(rawContent)),
+    publishedAt,
+  }
+}
+
+export const getReleaseNotes = async (): Promise<ReleaseNote[]> => {
+  if (cachedReleaseNotes) {
+    return cachedReleaseNotes
+  }
+
+  try {
+    const files = await fs.readdir(RELEASES_DIRECTORY)
+    const releases = (await Promise.all(files.map(buildReleaseNote)))
+      .filter(Boolean) as ReleaseNote[]
+
+    cachedReleaseNotes = releases.sort((left, right) =>
+      new Date(right.publishedAt).getTime() - new Date(left.publishedAt).getTime()
+    )
+
+    return cachedReleaseNotes
+  }
+  catch (error: unknown) {
+    console.error('Failed to read release notes', error)
+    cachedReleaseNotes = []
+    return cachedReleaseNotes
+  }
+}
+
+export const warmReleaseCache = async (): Promise<ReleaseNote[]> => {
+  cachedReleaseNotes = null
+  return getReleaseNotes()
+}
+
+export const getLatestRelease = async (): Promise<ReleaseNote | null> => {
+  const releases = await getReleaseNotes()
+
+  return releases[0] ?? null
+}

--- a/frontend/shared/utils/localized-routes.spec.ts
+++ b/frontend/shared/utils/localized-routes.spec.ts
@@ -21,6 +21,8 @@ describe('localized-routes utilities', () => {
   it('resolves localized static paths', () => {
     expect(resolveLocalizedRoutePath('team', 'fr-FR')).toBe('/equipe')
     expect(resolveLocalizedRoutePath('team', 'en-US')).toBe('/team')
+    expect(resolveLocalizedRoutePath('releases', 'fr-FR')).toBe('/versions')
+    expect(resolveLocalizedRoutePath('releases', 'en-US')).toBe('/releases')
     expect(resolveLocalizedRoutePath('legal-notice', 'fr-FR')).toBe(
       '/mentions-legales'
     )
@@ -42,6 +44,14 @@ describe('localized-routes utilities', () => {
     })
     expect(matchLocalizedRouteByPath('/team')).toEqual({
       routeName: 'team',
+      locale: 'en-US',
+    })
+    expect(matchLocalizedRouteByPath('/versions')).toEqual({
+      routeName: 'releases',
+      locale: 'fr-FR',
+    })
+    expect(matchLocalizedRouteByPath('/releases')).toEqual({
+      routeName: 'releases',
       locale: 'en-US',
     })
     expect(matchLocalizedRouteByPath('/mentions-legales')).toEqual({

--- a/frontend/shared/utils/localized-routes.ts
+++ b/frontend/shared/utils/localized-routes.ts
@@ -6,6 +6,7 @@ const SUPPORTED_LOCALES: readonly NuxtLocale[] = ['en-US', 'fr-FR'] as const
 export type LocalizedRouteName =
   | 'compare'
   | 'partners'
+  | 'releases'
   | 'team'
   | 'search'
   | LocalizedWikiRouteName
@@ -84,6 +85,10 @@ export const LOCALIZED_ROUTE_PATHS: LocalizedRoutePaths = {
   team: {
     'fr-FR': '/equipe',
     'en-US': '/team',
+  },
+  releases: {
+    'fr-FR': '/versions',
+    'en-US': '/releases',
   },
   ...LOCALIZED_WIKI_ROUTE_PATHS,
 } satisfies LocalizedRoutePaths

--- a/frontend/types/releases.ts
+++ b/frontend/types/releases.ts
@@ -1,0 +1,6 @@
+export interface ReleaseNote {
+  name: string
+  slug: string
+  contentHtml: string
+  publishedAt: string
+}


### PR DESCRIPTION
## Summary
- add localized releases page with latest release badge and accordion display of markdown release notes
- introduce server-side release note loader with caching, sanitization, and API endpoints
- wire localized routes, translations, and composables for sharing release metadata

## Testing
- pnpm lint
- pnpm test --run
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457b892d20832b9d8a6c8ab81958f3)