### PR TITLE
Fix nudge tool visuals and recommendations

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepRecommendations.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepRecommendations.vue
@@ -8,7 +8,7 @@
     </div>
     <div v-else>
       <CategoryProductCardGrid
-        v-if="products.length"
+        v-if="hasProducts"
         :products="products"
         :popular-attributes="popularAttributes"
         size="compact"
@@ -19,13 +19,41 @@
     </div>
 
     <p class="nudge-step-recos__footnote">
-      {{ $t('nudge-tool.steps.recommendations.total', { count: totalCount }) }}
+      {{
+        $t('nudge-tool.steps.recommendations.total', {
+          count: totalCount,
+        })
+      }}
     </p>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
+
+const props = withDefaults(
+  defineProps<{
+    products?: ProductDto[]
+    popularAttributes?: AttributeConfigDto[]
+    totalCount?: number
+    loading?: boolean
+  }>(),
+  {
+    products: () => [],
+    popularAttributes: () => [],
+    totalCount: 0,
+    loading: false,
+  }
+)
+
+const products = computed(() => props.products)
+const popularAttributes = computed(() => props.popularAttributes)
+const totalCount = computed(() => props.totalCount)
+const loading = computed(() => props.loading)
+
+const hasProducts = computed(() => products.value.length > 0)
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Summary
- enlarge the nudge wizard corner icon and ensure the selected category mdi icon surfaces alongside a stable progress bar layout
- harden the recommendations step with typed props and null-safe rendering so the product grid displays correctly

## Testing
- pnpm lint
- pnpm vitest run app/components/nudge-tool/NudgeToolWizard.spec.ts
- pnpm build *(fails: missing `markdown-it` during Nuxt prerendering)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694581a31744832b8d684f1dacacebb5)