### PR TITLE
Refactor releases hero layout and scroll behaviour

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useSlots } from 'vue'
+
 import HeroEducationCard from '~/components/shared/ui/HeroEducationCard.vue'
 
 interface HeroCta {
@@ -36,6 +38,8 @@ const props = withDefaults(
     educationCard: undefined,
   }
 )
+
+const slots = useSlots()
 
 const handlePrimaryClick = (event: MouseEvent) => {
   const href = props.primaryCta?.href
@@ -95,9 +99,15 @@ const handleSubtitleClick = (event: MouseEvent) => {
               v-html="subtitle"
             />
             <!-- eslint-enable vue/no-v-html -->
+
+            <slot name="below-title" />
           </div>
 
-          <div class="mt-4 opendata-hero__actions" role="group">
+          <div
+            v-if="primaryCta || slots.actions"
+            class="mt-4 opendata-hero__actions"
+            role="group"
+          >
             <v-btn
               v-if="primaryCta"
               :href="primaryCta.href"
@@ -111,6 +121,8 @@ const handleSubtitleClick = (event: MouseEvent) => {
             >
               {{ primaryCta.label }}
             </v-btn>
+
+            <slot name="actions" />
           </div>
         </v-col>
 

--- a/frontend/app/components/domains/releases/LatestReleaseBadge.vue
+++ b/frontend/app/components/domains/releases/LatestReleaseBadge.vue
@@ -1,22 +1,44 @@
-<template>
-  <v-chip
-    v-if="latestName"
-    color="primary"
-    prepend-icon="mdi-rocket-launch"
-    class="latest-release-badge"
-    variant="flat"
-  >
-    {{ t('releases.latestLabel', { name: latestName }) }}
-  </v-chip>
-</template>
-
 <script setup lang="ts">
+const props = withDefaults(defineProps<{ scrollTarget?: string }>(), {
+  scrollTarget: undefined,
+})
+
 const { t } = useI18n()
 
 const { data: latestRelease } = await useLatestRelease()
 
 const latestName = computed(() => latestRelease.value?.name ?? '')
+
+const handleClick = (event: MouseEvent) => {
+  const { scrollTarget } = props
+
+  if (!import.meta.client || !scrollTarget || !scrollTarget.startsWith('#')) {
+    return
+  }
+
+  event.preventDefault()
+  const target = document.querySelector(scrollTarget)
+  if (target instanceof HTMLElement) {
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+}
 </script>
+
+<template>
+  <v-chip
+    v-if="latestName"
+    class="latest-release-badge"
+    color="primary"
+    prepend-icon="mdi-rocket-launch"
+    :href="props.scrollTarget"
+    :ripple="Boolean(props.scrollTarget)"
+    :role="props.scrollTarget ? 'link' : undefined"
+    variant="flat"
+    @click="handleClick"
+  >
+    {{ t('releases.latestLabel', { name: latestName }) }}
+  </v-chip>
+</template>
 
 <style scoped lang="sass">
 .latest-release-badge

--- a/frontend/app/pages/releases/index.vue
+++ b/frontend/app/pages/releases/index.vue
@@ -1,68 +1,27 @@
 <template>
   <div class="releases-page">
-    <v-container class="releases-page__hero" max-width="lg">
-      <v-row>
-        <v-col cols="12" md="7" class="d-flex flex-column gap-4">
-          <p class="releases-page__eyebrow">
-            {{ t('releases.hero.eyebrow') }}
-          </p>
-          <div class="d-flex align-center gap-3 flex-wrap">
-            <h1 class="releases-page__title">{{ t('releases.hero.title') }}</h1>
-            <LatestReleaseBadge />
-          </div>
-          <p class="releases-page__subtitle">
-            {{ t('releases.hero.subtitle') }}
-          </p>
-          <p class="releases-page__description">
-            {{ t('releases.hero.description') }}
-          </p>
-          <div class="d-flex gap-3 flex-wrap">
-            <v-btn
-              color="primary"
-              variant="flat"
-              size="large"
-              :to="t('releases.hero.ctaLink')"
-            >
-              {{ t('releases.hero.cta') }}
-            </v-btn>
-            <v-btn
-              color="primary"
-              variant="tonal"
-              size="large"
-              :to="localePath('contact')"
-            >
-              {{ t('releases.hero.secondaryCta') }}
-            </v-btn>
-          </div>
-        </v-col>
-        <v-col cols="12" md="5" class="d-flex justify-center align-center">
-          <v-sheet class="releases-page__card" rounded="xl" elevation="4">
-            <div class="releases-page__card-header">
-              <v-icon icon="mdi-text-box-multiple-outline" size="36" color="primary" />
-              <div>
-                <p class="releases-page__card-eyebrow">{{ t('releases.summary.eyebrow') }}</p>
-                <p class="releases-page__card-title">{{ t('releases.summary.title') }}</p>
-              </div>
-            </div>
-            <p class="releases-page__card-body">
-              {{ t('releases.summary.body') }}
-            </p>
-            <div class="releases-page__metadata">
-              <div>
-                <p class="releases-page__meta-label">{{ t('releases.summary.latest') }}</p>
-                <p class="releases-page__meta-value">{{ latestReleaseName }}</p>
-              </div>
-              <div>
-                <p class="releases-page__meta-label">{{ t('releases.summary.count') }}</p>
-                <p class="releases-page__meta-value">{{ releasesCount }}</p>
-              </div>
-            </div>
-          </v-sheet>
-        </v-col>
-      </v-row>
-    </v-container>
+    <OpendataHero
+      :eyebrow="t('releases.hero.eyebrow')"
+      :title="t('releases.hero.title')"
+      :subtitle="heroSubtitle"
+      :education-card="educationCard"
+    >
+      <template #below-title>
+        <LatestReleaseBadge
+          class="releases-page__latest-chip"
+          :scroll-target="faqAnchor"
+        />
+      </template>
+    </OpendataHero>
 
     <v-container class="releases-page__content" max-width="lg">
+      <div :id="faqAnchorId" class="releases-page__anchor" aria-hidden="true" />
+      <h2 class="releases-page__section-title">
+        {{ t('releases.faq.title') }}
+      </h2>
+      <p class="releases-page__section-subtitle">
+        {{ t('releases.faq.subtitle') }}
+      </p>
       <ReleaseAccordion
         :releases="releases"
         :loading="pending"
@@ -74,7 +33,10 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+
 import LatestReleaseBadge from '~/components/domains/releases/LatestReleaseBadge.vue'
+import OpendataHero from '~/components/domains/opendata/OpendataHero.vue'
 import ReleaseAccordion from '~/components/domains/releases/ReleaseAccordion.vue'
 import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
 
@@ -84,13 +46,40 @@ definePageMeta({
 })
 
 const { t, locale } = useI18n()
-const localePath = useLocalePath()
 const requestURL = useRequestURL()
+
+const faqAnchorId = 'releases-faq'
+const faqAnchor = `#${faqAnchorId}`
 
 const { releases, pending, error, refresh, latestRelease } = await useReleaseNotes()
 
 const releasesCount = computed(() => releases.value.length)
-const latestReleaseName = computed(() => latestRelease.value?.name ?? t('releases.empty'))
+const latestReleaseName = computed(
+  () => latestRelease.value?.name ?? t('releases.empty')
+)
+
+const heroSubtitle = computed(() => {
+  const faqLink = `<a href="${faqAnchor}" data-scroll-target="${faqAnchor}">${t(
+    'releases.hero.faqLink'
+  )}</a>`
+  return String(t('releases.hero.subtitleWithLink', { faqLink }))
+})
+
+const educationCard = computed(() => ({
+  icon: 'mdi-text-box-multiple-outline',
+  title: String(t('releases.summary.title')),
+  bodyHtml: String(t('releases.summary.body')),
+  items: [
+    {
+      icon: 'mdi-rocket-launch',
+      text: String(t('releases.summary.latestItem', { name: latestReleaseName.value })),
+    },
+    {
+      icon: 'mdi-format-list-bulleted-square',
+      text: String(t('releases.summary.countItem', { count: releasesCount.value })),
+    },
+  ],
+}))
 
 const canonicalUrl = computed(() =>
   new URL(
@@ -124,82 +113,22 @@ useHead(() => ({
   flex-direction: column
   gap: 32px
 
-  &__hero
-    padding-top: 48px
-    padding-bottom: 24px
+.releases-page__content
+  padding-bottom: 56px
 
-  &__eyebrow
-    text-transform: uppercase
-    letter-spacing: 0.08em
-    color: rgba(var(--v-theme-on-surface), 0.7)
-    font-weight: 700
-    margin-bottom: 4px
+.releases-page__anchor
+  position: relative
+  top: -80px
+  height: 1px
 
-  &__title
-    font-size: clamp(2rem, 3vw, 2.6rem)
-    font-weight: 800
-    margin: 0
+.releases-page__section-title
+  margin-bottom: 8px
 
-  &__subtitle
-    font-size: 1.1rem
-    color: rgba(var(--v-theme-on-surface), 0.72)
-    margin: 0
+.releases-page__section-subtitle
+  margin-top: 0
+  margin-bottom: 24px
+  color: rgba(var(--v-theme-on-surface), 0.72)
 
-  &__description
-    font-size: 1rem
-    color: rgba(var(--v-theme-on-surface), 0.82)
-    margin: 0
-
-  &__card
-    width: 100%
-    padding: 24px
-    background: rgba(var(--v-theme-surface-muted-contrast), 0.8)
-
-  &__card-header
-    display: flex
-    align-items: center
-    gap: 12px
-    margin-bottom: 12px
-
-  &__card-eyebrow
-    margin: 0
-    text-transform: uppercase
-    letter-spacing: 0.08em
-    font-size: 0.78rem
-    color: rgba(var(--v-theme-on-surface), 0.6)
-
-  &__card-title
-    margin: 0
-    font-weight: 700
-    font-size: 1.1rem
-    color: rgb(var(--v-theme-on-surface))
-
-  &__card-body
-    margin: 4px 0 18px
-    color: rgba(var(--v-theme-on-surface), 0.75)
-
-  &__metadata
-    display: grid
-    grid-template-columns: repeat(2, minmax(0, 1fr))
-    gap: 12px
-
-  &__meta-label
-    margin: 0
-    font-size: 0.85rem
-    color: rgba(var(--v-theme-on-surface), 0.6)
-
-  &__meta-value
-    margin: 4px 0 0
-    font-weight: 700
-    color: rgb(var(--v-theme-on-surface))
-
-  &__content
-    padding-bottom: 56px
-
-@media (max-width: 960px)
-  .releases-page
-    &__hero
-      padding-top: 28px
-    &__metadata
-      grid-template-columns: repeat(1, minmax(0, 1fr))
+.releases-page__latest-chip
+  margin-top: 4px
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2291,14 +2291,18 @@
     "ctaLink": "/releases",
     "description": "Every release captures our latest improvements, from new impact insights to performance fixes.",
     "eyebrow": "Product updates",
+    "faqLink": "Jump to the release FAQ",
     "secondaryCta": "Contact us",
     "subtitle": "Follow how Nudger evolves across versions.",
+    "subtitleWithLink": "Follow how Nudger evolves across versions. {{faqLink}}",
     "title": "Release notes"
   },
   "summary": {
     "body": "Release notes are sourced directly from our repository. Each Markdown file represents one published version.",
     "count": "Published releases",
+    "countItem": "{count} published versions",
     "eyebrow": "Snapshot",
+    "latestItem": "Latest release: {name}",
     "latest": "Latest version",
     "title": "Release overview"
   },
@@ -2308,6 +2312,10 @@
   "empty": "Release notes will arrive soon.",
   "errors": {
     "loadFailed": "We could not load the release notes. Please try again."
+  },
+  "faq": {
+    "subtitle": "Read the changelog and answers to frequent questions about our releases.",
+    "title": "Release FAQ"
   },
   "seo": {
     "description": "Explore every Nudger release with publication dates and detailed changelogs.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2287,34 +2287,42 @@
   "siteName": "Nudger"
 },
   "releases": {
-    "hero": {
-      "cta": "Parcourir les mises à jour",
-      "ctaLink": "/versions",
-      "description": "Chaque publication regroupe nos dernières améliorations, des nouvelles données d'impact aux optimisations de performance.",
-      "eyebrow": "Mises à jour produit",
-      "secondaryCta": "Nous contacter",
-      "subtitle": "Suivez l'évolution de Nudger version après version.",
-      "title": "Notes de version"
-    },
-    "summary": {
-      "body": "Les notes de version proviennent directement de notre dépôt. Chaque fichier Markdown correspond à une version publiée.",
-      "count": "Versions publiées",
-      "eyebrow": "En un coup d'œil",
-      "latest": "Version la plus récente",
-      "title": "Vue d'ensemble des versions"
-    },
-    "latest": "Dernière",
-    "latestLabel": "Dernière version : {name}",
+  "hero": {
+    "cta": "Parcourir les mises à jour",
+    "ctaLink": "/versions",
+    "description": "Chaque publication regroupe nos dernières améliorations, des nouvelles données d'impact aux optimisations de performance.",
+    "eyebrow": "Mises à jour produit",
+    "faqLink": "Aller à la FAQ des versions",
+    "secondaryCta": "Nous contacter",
+    "subtitle": "Suivez l'évolution de Nudger version après version.",
+    "subtitleWithLink": "Suivez l'évolution de Nudger version après version. {{faqLink}}",
+    "title": "Notes de version"
+  },
+  "summary": {
+    "body": "Les notes de version proviennent directement de notre dépôt. Chaque fichier Markdown correspond à une version publiée.",
+    "count": "Versions publiées",
+    "countItem": "{count} versions publiées",
+    "eyebrow": "En un coup d'œil",
+    "latestItem": "Dernière version : {name}",
+    "latest": "Version la plus récente",
+    "title": "Vue d'ensemble des versions"
+  },
+  "latest": "Dernière",
+  "latestLabel": "Dernière version : {name}",
     "loading": "Chargement des notes de version…",
     "empty": "Les notes de version seront publiées bientôt.",
-    "errors": {
-      "loadFailed": "Impossible de charger les notes de version. Merci de réessayer."
-    },
-    "seo": {
-      "description": "Découvrez chaque version de Nudger avec les dates de publication et les journaux détaillés.",
-      "title": "Notes de version Nudger"
-    }
+  "errors": {
+    "loadFailed": "Impossible de charger les notes de version. Merci de réessayer."
   },
+  "faq": {
+    "subtitle": "Parcourez le journal des versions et les réponses aux questions fréquentes.",
+    "title": "FAQ et changelog"
+  },
+  "seo": {
+    "description": "Découvrez chaque version de Nudger avec les dates de publication et les journaux détaillés.",
+    "title": "Notes de version Nudger"
+  }
+},
   "team": {
     "callouts": {
       "contact": {


### PR DESCRIPTION
## Summary
- replace releases hero with shared OpendataHero and education card layout while wiring smooth-scroll subtitle and latest badge
- add scroll-enabled latest release chip and anchor around the FAQ accordion content with localized copy updates
- extend shared hero component slots/actions for optional content placement without CTAs

## Testing
- pnpm lint
- pnpm test
- pnpm build
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694583b7ed20832b9d10c4463fcae878)