### PR TITLE
Adjust releases page content and add footer version badge

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -31,11 +31,13 @@ const props = withDefaults(
     subtitle: string
     primaryCta?: HeroCta
     educationCard?: HeroEducationCardProps
+    fluid?: boolean
   }>(),
   {
     eyebrow: undefined,
     primaryCta: undefined,
     educationCard: undefined,
+    fluid: false,
   }
 )
 
@@ -82,7 +84,11 @@ const handleSubtitleClick = (event: MouseEvent) => {
     aria-labelledby="opendata-hero-heading"
     variant="orbit"
   >
-    <v-container class="py-16" max-width="lg">
+    <v-container
+      class="py-16"
+      :max-width="props.fluid ? undefined : 'lg'"
+      :fluid="props.fluid"
+    >
       <v-row align="center" class="g-8">
         <v-col cols="12" md="7" class="d-flex flex-column gap-6">
           <div class="opendata-hero__header">

--- a/frontend/app/components/domains/releases/LatestReleaseBadge.vue
+++ b/frontend/app/components/domains/releases/LatestReleaseBadge.vue
@@ -1,15 +1,23 @@
 <script setup lang="ts">
-const props = withDefaults(defineProps<{ scrollTarget?: string }>(), {
-  scrollTarget: undefined,
-})
+const props = withDefaults(
+  defineProps<{ scrollTarget?: string; dense?: boolean }>(),
+  {
+    scrollTarget: undefined,
+    dense: false,
+  }
+)
 
 const { t } = useI18n()
 
 const { data: latestRelease } = await useLatestRelease()
 
 const latestName = computed(() => latestRelease.value?.name ?? '')
+const badgeLabel = computed(() => t('releases.latest'))
+const badgeAriaLabel = computed(() =>
+  t('releases.latestLabel', { name: latestName.value })
+)
 
-const handleClick = (event: MouseEvent) => {
+const handleClick = (event: Event) => {
   const { scrollTarget } = props
 
   if (!import.meta.client || !scrollTarget || !scrollTarget.startsWith('#')) {
@@ -25,23 +33,65 @@ const handleClick = (event: MouseEvent) => {
 </script>
 
 <template>
-  <v-chip
+  <a
     v-if="latestName"
-    class="latest-release-badge"
-    color="primary"
-    prepend-icon="mdi-rocket-launch"
     :href="props.scrollTarget"
-    :ripple="Boolean(props.scrollTarget)"
+    class="latest-release-badge"
+    :class="{ 'latest-release-badge--dense': props.dense }"
     :role="props.scrollTarget ? 'link' : undefined"
-    variant="flat"
+    :aria-label="badgeAriaLabel"
     @click="handleClick"
+    @keydown.enter.prevent="handleClick"
   >
-    {{ t('releases.latestLabel', { name: latestName }) }}
-  </v-chip>
+    <span class="latest-release-badge__label">{{ badgeLabel }}</span>
+    <span class="latest-release-badge__value">{{ latestName }}</span>
+  </a>
 </template>
 
 <style scoped lang="sass">
 .latest-release-badge
-  font-weight: 700
-  letter-spacing: 0.01em
+  display: inline-flex
+  align-items: stretch
+  gap: 10px
+  padding: 6px 12px 6px 0
+  border-radius: 999px
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.16)
+  background: linear-gradient(90deg, rgba(var(--v-theme-surface-default), 0.85), rgba(var(--v-theme-surface-muted), 0.9))
+  color: rgb(var(--v-theme-on-surface))
+  text-decoration: none
+  box-shadow: 0 6px 20px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease
+  width: fit-content
+
+  &:hover
+    border-color: rgba(var(--v-theme-primary), 0.4)
+    box-shadow: 0 10px 26px rgba(var(--v-theme-shadow-primary-600), 0.18)
+    transform: translateY(-1px)
+
+  &:active
+    transform: translateY(0)
+
+  &--dense
+    padding-block: 4px
+    gap: 8px
+
+  &__label
+    display: inline-flex
+    align-items: center
+    gap: 6px
+    padding: 6px 12px
+    border-radius: 999px
+    background: rgba(var(--v-theme-primary), 0.14)
+    color: rgb(var(--v-theme-primary))
+    font-weight: 800
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    font-size: 0.75rem
+
+  &__value
+    display: inline-flex
+    align-items: center
+    font-weight: 700
+    letter-spacing: 0.01em
+    padding-right: 6px
 </style>

--- a/frontend/app/components/domains/releases/ReleaseAccordion.vue
+++ b/frontend/app/components/domains/releases/ReleaseAccordion.vue
@@ -54,30 +54,36 @@
         :value="release.slug"
         class="release-accordion__panel"
       >
-        <v-expansion-panel-title class="release-accordion__title">
-          <div class="release-accordion__title-content">
-            <div class="release-accordion__meta">
-              <span class="release-accordion__eyebrow">
-                {{ formatPublishedDate(release.publishedAt) }}
-              </span>
-              <div class="d-flex align-center gap-2">
+        <v-expansion-panel-title class="release-accordion__title" hide-actions>
+          <template #default="{ expanded }">
+            <div class="release-accordion__title-content">
+              <div class="release-accordion__meta">
+                <span class="release-accordion__eyebrow">
+                  {{ formatPublishedDate(release.publishedAt) }}
+                </span>
                 <span class="release-accordion__name">{{ release.name }}</span>
+              </div>
+
+              <div class="release-accordion__actions">
                 <v-chip
                   v-if="index === 0"
                   color="primary"
                   size="small"
                   variant="flat"
                   density="comfortable"
+                  class="release-accordion__latest-chip"
                 >
                   {{ t('releases.latest') }}
                 </v-chip>
+
+                <v-icon
+                  icon="mdi-chevron-down"
+                  class="release-accordion__icon"
+                  :class="{ 'release-accordion__icon--expanded': expanded }"
+                />
               </div>
             </div>
-            <v-icon
-              icon="mdi-chevron-down"
-              class="release-accordion__icon"
-            />
-          </div>
+          </template>
         </v-expansion-panel-title>
         <v-expansion-panel-text>
           <!-- eslint-disable-next-line vue/no-v-html -->
@@ -149,6 +155,14 @@ const formatPublishedDate = (isoDate: string): string => {
     align-items: center
     gap: 12px
 
+  &__actions
+    display: flex
+    align-items: center
+    gap: 12px
+
+  &__latest-chip
+    font-weight: 700
+
   &__meta
     display: flex
     flex-direction: column
@@ -167,6 +181,10 @@ const formatPublishedDate = (isoDate: string): string => {
 
   &__icon
     color: rgba(var(--v-theme-on-surface), 0.6)
+    transition: transform 0.2s ease
+
+  &__icon--expanded
+    transform: rotate(180deg)
 
   &__content
     padding: 10px 4px 20px

--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -3,6 +3,7 @@ import type { RouteLocationRaw } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
 import { useFooterLogoAsset } from '~~/app/composables/useThemedAsset'
+import LatestReleaseBadge from '~/components/domains/releases/LatestReleaseBadge.vue'
 
 import {
   normalizeLocale,
@@ -28,6 +29,9 @@ const feedbackPath = computed(() =>
 )
 const categoriesPath = computed(() =>
   resolveLocalizedRoutePath('categories', currentLocale.value)
+)
+const releasesPath = computed(() =>
+  resolveLocalizedRoutePath('releases', currentLocale.value)
 )
 const currentYear = computed(() => new Date().getFullYear())
 const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
@@ -229,6 +233,12 @@ const footerLogo = useFooterLogoAsset()
             cover
           />
         </NuxtLink>
+
+        <LatestReleaseBadge
+          class="footer-latest-badge"
+          dense
+          :scroll-target="releasesPath"
+        />
         <p class="footer-meta mb-0 text-body-2">
           {{ t('siteIdentity.footer.copyright', { year: currentYear }) }}
         </p>
@@ -303,6 +313,10 @@ const footerLogo = useFooterLogoAsset()
 .footer-bottom {
   position: relative;
   z-index: 1;
+}
+
+.footer-latest-badge {
+  align-self: center;
 }
 
 .footer-logo {

--- a/frontend/app/pages/releases/index.vue
+++ b/frontend/app/pages/releases/index.vue
@@ -3,8 +3,9 @@
     <OpendataHero
       :eyebrow="t('releases.hero.eyebrow')"
       :title="t('releases.hero.title')"
-      :subtitle="heroSubtitle"
+      :subtitle="t('releases.hero.subtitle')"
       :education-card="educationCard"
+      fluid
     >
       <template #below-title>
         <LatestReleaseBadge
@@ -14,7 +15,7 @@
       </template>
     </OpendataHero>
 
-    <v-container class="releases-page__content" max-width="lg">
+    <v-container class="releases-page__content" fluid>
       <div :id="faqAnchorId" class="releases-page__anchor" aria-hidden="true" />
       <h2 class="releases-page__section-title">
         {{ t('releases.faq.title') }}
@@ -57,13 +58,6 @@ const releasesCount = computed(() => releases.value.length)
 const latestReleaseName = computed(
   () => latestRelease.value?.name ?? t('releases.empty')
 )
-
-const heroSubtitle = computed(() => {
-  const faqLink = `<a href="${faqAnchor}" data-scroll-target="${faqAnchor}">${t(
-    'releases.hero.faqLink'
-  )}</a>`
-  return String(t('releases.hero.subtitleWithLink', { faqLink }))
-})
 
 const educationCard = computed(() => ({
   icon: 'mdi-text-box-multiple-outline',

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2290,12 +2290,12 @@
     "cta": "Browse updates",
     "ctaLink": "/releases",
     "description": "Every release captures our latest improvements, from new impact insights to performance fixes.",
-    "eyebrow": "Product updates",
+    "eyebrow": "Nudger: its life!",
     "faqLink": "Jump to the release FAQ",
     "secondaryCta": "Contact us",
-    "subtitle": "Follow how Nudger evolves across versions.",
-    "subtitleWithLink": "Follow how Nudger evolves across versions. {{faqLink}}",
-    "title": "Release notes"
+    "subtitle": "Discover Nudger's story.",
+    "subtitleWithLink": "Discover Nudger's story.",
+    "title": "Historic"
   },
   "summary": {
     "body": "Release notes are sourced directly from our repository. Each Markdown file represents one published version.",
@@ -2314,8 +2314,8 @@
     "loadFailed": "We could not load the release notes. Please try again."
   },
   "faq": {
-    "subtitle": "Read the changelog and answers to frequent questions about our releases.",
-    "title": "Release FAQ"
+    "subtitle": "At Nudger: its boss!",
+    "title": "Historic des versions"
   },
   "seo": {
     "description": "Explore every Nudger release with publication dates and detailed changelogs.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2291,12 +2291,12 @@
     "cta": "Parcourir les mises à jour",
     "ctaLink": "/versions",
     "description": "Chaque publication regroupe nos dernières améliorations, des nouvelles données d'impact aux optimisations de performance.",
-    "eyebrow": "Mises à jour produit",
+    "eyebrow": "Nudger : sa vie !",
     "faqLink": "Aller à la FAQ des versions",
     "secondaryCta": "Nous contacter",
-    "subtitle": "Suivez l'évolution de Nudger version après version.",
-    "subtitleWithLink": "Suivez l'évolution de Nudger version après version. {{faqLink}}",
-    "title": "Notes de version"
+    "subtitle": "Découvre l'histoire de Nudger.",
+    "subtitleWithLink": "Découvre l'histoire de Nudger.",
+    "title": "Historic"
   },
   "summary": {
     "body": "Les notes de version proviennent directement de notre dépôt. Chaque fichier Markdown correspond à une version publiée.",
@@ -2315,8 +2315,8 @@
     "loadFailed": "Impossible de charger les notes de version. Merci de réessayer."
   },
   "faq": {
-    "subtitle": "Parcourez le journal des versions et les réponses aux questions fréquentes.",
-    "title": "FAQ et changelog"
+    "subtitle": "chez Nudger, sa boss !",
+    "title": "Historic des versions"
   },
   "seo": {
     "description": "Découvrez chaque version de Nudger avec les dates de publication et les journaux détaillés.",


### PR DESCRIPTION
## Summary
- restyled the latest release badge to a compact GitHub-like pill and reused it in the footer to surface the current version
- updated release page hero and FAQ wording per the new Nudger messaging and switched the hero container to a fluid layout
- aligned the accordion header controls by moving the latest chip to the right and keeping a single toggle action

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459e62d468832b9c5e7667b627d6b5)