### PR TITLE
Wrap Vite dev plugins behind env guard

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -281,10 +281,14 @@ export default defineNuxtConfig({
 
   vite: {
     plugins: [
-      VueMcp(),
-      VueDevTools({
-        launchEditor: 'code', // Antigravity is VS Code-based
-      }),
+      ...(process.env.NODE_ENV !== 'production'
+        ? [
+            VueMcp(),
+            VueDevTools({
+              launchEditor: 'code', // Antigravity is VS Code-based
+            }),
+          ]
+        : []),
     ],
   },
 


### PR DESCRIPTION
## Summary
- wrap the VueMcp and VueDevTools Vite plugins so they are only enabled outside production
- keep the Vite configuration intact for development builds while excluding the dev-only plugins from production bundles

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459f51cf38832bbba83a6c6a59c421)