### PR TITLE
feat(frontend): centralize highlight.js loading for code blocks

### DIFF
--- a/frontend/app/utils/highlight-loader.ts
+++ b/frontend/app/utils/highlight-loader.ts
@@ -1,0 +1,52 @@
+import type { HLJSApi, LanguageFn } from 'highlight.js'
+
+export type HighlightLanguage = 'json' | 'yaml'
+
+const languageLoaders: Record<HighlightLanguage, () => Promise<{ default: LanguageFn }>> = {
+  json: () => import('highlight.js/lib/languages/json'),
+  yaml: () => import('highlight.js/lib/languages/yaml'),
+}
+
+let highlighterPromise: Promise<HLJSApi> | null = null
+const registeredLanguages = new Set<HighlightLanguage>()
+let cssLoaded = false
+
+export const loadHighlightJs = async (
+  languages: HighlightLanguage[] = []
+): Promise<HLJSApi | null> => {
+  if (!import.meta.client) {
+    return null
+  }
+
+  if (!highlighterPromise) {
+    highlighterPromise = import('highlight.js/lib/core').then(async (module) => {
+      const hljs = module.default
+
+      if (!cssLoaded) {
+        await import('highlight.js/styles/github-dark.css')
+        cssLoaded = true
+      }
+
+      return hljs
+    })
+  }
+
+  const hljs = await highlighterPromise
+
+  await Promise.all(
+    languages.map(async (language) => {
+      if (registeredLanguages.has(language)) {
+        return
+      }
+
+      if (!hljs.getLanguage(language)) {
+        const { default: loader } = await languageLoaders[language]()
+        hljs.registerLanguage(language, loader)
+      }
+
+      registeredLanguages.add(language)
+    })
+  )
+
+  return hljs
+}


### PR DESCRIPTION
## Summary
- add a shared highlight.js loader utility that registers required languages and imports the theme once
- switch ecoscore page and product admin section to rely on the shared loader with client-side dynamic imports to keep rendering consistent

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459f604988832bbafee061d545c951)