### PR TITLE
Define isDesktop before SEO head setup

### DIFF
--- a/frontend/app/pages/[categorySlug]/index.vue
+++ b/frontend/app/pages/[categorySlug]/index.vue
@@ -538,6 +538,10 @@ const initialIsDesktop = useState<boolean>(
 
 const isHydrated = ref(false)
 
+const isDesktop = computed(() =>
+  isHydrated.value ? display.lgAndUp.value : initialIsDesktop.value
+)
+
 onMounted(() => {
   isHydrated.value = true
 })
@@ -796,10 +800,6 @@ const { data: sortOptionsData, execute: loadSortOptions } = useLazyAsyncData(
 
 const filterOptions = computed(() => filterOptionsData.value ?? null)
 const sortOptions = computed(() => sortOptionsData.value ?? null)
-
-const isDesktop = computed(() =>
-  isHydrated.value ? display.lgAndUp.value : initialIsDesktop.value
-)
 const filtersDrawer = ref(false)
 
 const FILTERS_VISIBILITY_STORAGE_KEY = 'category-page-filters-collapsed'


### PR DESCRIPTION
## Summary
- move the isDesktop computation ahead of head configuration
- keep hero image preload logic intact for SEO

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945bcf098a8832bb728cc3b319f519a)