### PR TITLE
Add vendor chunking to Nuxt Vite build

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -112,6 +112,16 @@ process.env.NUXT_STATIC_MAIN_PAGE_ROUTES = JSON.stringify(STATIC_MAIN_PAGE_ROUTE
 
 const localeDomains = buildI18nLocaleDomains()
 
+const VENDOR_CHUNK_MATCHERS = [
+  { pattern: /[\\/]node_modules[\\/]echarts[\\/]/, chunkName: 'vendor-echarts' },
+  { pattern: /[\\/]node_modules[\\/]vue-echarts[\\/]/, chunkName: 'vendor-echarts' },
+  { pattern: /[\\/]node_modules[\\/]date-fns[\\/]/, chunkName: 'vendor-date-fns' },
+  { pattern: /[\\/]node_modules[\\/]vuetify[\\/]/, chunkName: 'vendor-vuetify' },
+  { pattern: /[\\/]node_modules[\\/]@vueuse[\\/]/, chunkName: 'vendor-vueuse' },
+  { pattern: /[\\/]node_modules[\\/]@vue-pdf-viewer[\\/]/, chunkName: 'vendor-pdf-viewer' },
+  { pattern: /[\\/]node_modules[\\/]vue-pdf-embed[\\/]/, chunkName: 'vendor-pdf-viewer' },
+]
+
 export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   srcDir: 'app',
@@ -290,6 +300,17 @@ export default defineNuxtConfig({
           ]
         : []),
     ],
+    build: {
+      chunkSizeWarningLimit: 3000,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            const matchedChunk = VENDOR_CHUNK_MATCHERS.find(({ pattern }) => pattern.test(id))
+            return matchedChunk?.chunkName
+          },
+        },
+      },
+    },
   },
 
   build: {


### PR DESCRIPTION
## Summary
- add Vite manual chunk matchers to group echarts, date-fns, vuetify, vueuse, and pdf viewer dependencies into stable vendor bundles
- raise the Vite chunk size warning limit to reflect the larger vendor bundles after manual chunking

## Testing
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c23f67b0832bb1ba9fcd6e5d185b)