### PR TITLE
Lazy load hCaptcha components

### DIFF
--- a/frontend/app/components/domains/contact/ContactFormCard.vue
+++ b/frontend/app/components/domains/contact/ContactFormCard.vue
@@ -107,38 +107,48 @@
                   />
                 </v-col>
 
-                <v-col cols="12">
-                  <div class="contact-form__captcha">
-                    <VueHcaptcha
-                      v-if="hasSiteKey"
-                      ref="captchaRef"
-                      :sitekey="siteKey"
-                      :language="captchaLocale"
-                      :theme="captchaTheme"
-                      @verify="handleCaptchaVerify"
-                      @expired="handleCaptchaExpired"
-                      @error="handleCaptchaError"
-                    />
-                    <div
-                      v-else
-                      class="contact-form__captcha-placeholder"
-                      aria-hidden="true"
-                    >
-                      <v-icon
-                        icon="mdi-shield-alert-outline"
-                        size="36"
-                        color="primary"
-                      />
+                  <v-col cols="12">
+                    <div class="contact-form__captcha">
+                      <ClientOnly v-if="hasSiteKey">
+                        <VueHcaptcha
+                          ref="captchaRef"
+                          :sitekey="siteKey"
+                          :language="captchaLocale"
+                          :theme="captchaTheme"
+                          @verify="handleCaptchaVerify"
+                          @expired="handleCaptchaExpired"
+                          @error="handleCaptchaError"
+                        />
+                        <template #fallback>
+                          <div class="contact-form__captcha-placeholder" aria-hidden="true">
+                            <v-icon
+                              icon="mdi-shield-alert-outline"
+                              size="36"
+                              color="primary"
+                            />
+                          </div>
+                        </template>
+                      </ClientOnly>
+                      <div
+                        v-else
+                        class="contact-form__captcha-placeholder"
+                        aria-hidden="true"
+                      >
+                        <v-icon
+                          icon="mdi-shield-alert-outline"
+                          size="36"
+                          color="primary"
+                        />
+                      </div>
+                      <p
+                        v-if="captchaError"
+                        class="contact-form__captcha-error"
+                        role="alert"
+                      >
+                        {{ captchaError }}
+                      </p>
                     </div>
-                    <p
-                      v-if="captchaError"
-                      class="contact-form__captcha-error"
-                      role="alert"
-                    >
-                      {{ captchaError }}
-                    </p>
-                  </div>
-                </v-col>
+                  </v-col>
 
                 <v-col cols="12">
                   <div class="contact-form__actions">
@@ -175,9 +185,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
 import { useTheme } from 'vuetify'
 import { VForm } from 'vuetify/components'
 
@@ -202,6 +211,7 @@ const emit = defineEmits<{
 
 const { t, locale } = useI18n()
 const theme = useTheme()
+const VueHcaptcha = defineAsyncComponent(() => import('@hcaptcha/vue3-hcaptcha'))
 const formRef = ref<InstanceType<typeof VForm> | null>(null)
 const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 

--- a/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
+++ b/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
@@ -111,16 +111,26 @@
 
           <v-col cols="12">
             <div class="feedback-form__captcha">
-              <VueHcaptcha
-                v-if="hasSiteKey"
-                ref="captchaRef"
-                :sitekey="siteKey"
-                :language="captchaLocale"
-                :theme="captchaTheme"
-                @verify="handleCaptchaVerify"
-                @expired="handleCaptchaExpired"
-                @error="handleCaptchaError"
-              />
+              <ClientOnly v-if="hasSiteKey">
+                <VueHcaptcha
+                  ref="captchaRef"
+                  :sitekey="siteKey"
+                  :language="captchaLocale"
+                  :theme="captchaTheme"
+                  @verify="handleCaptchaVerify"
+                  @expired="handleCaptchaExpired"
+                  @error="handleCaptchaError"
+                />
+                <template #fallback>
+                  <div class="feedback-form__captcha-placeholder" aria-hidden="true">
+                    <v-icon
+                      icon="mdi-shield-alert-outline"
+                      size="36"
+                      color="primary"
+                    />
+                  </div>
+                </template>
+              </ClientOnly>
               <div
                 v-else
                 class="feedback-form__captcha-placeholder"
@@ -172,10 +182,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useTheme } from 'vuetify'
 import { VForm } from 'vuetify/components'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
 
 export interface FeedbackFormSubmitPayload {
   type: string
@@ -225,6 +234,7 @@ const emit = defineEmits<{
 }>()
 
 const theme = useTheme()
+const VueHcaptcha = defineAsyncComponent(() => import('@hcaptcha/vue3-hcaptcha'))
 const formRef = ref<InstanceType<typeof VForm> | null>(null)
 const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -336,9 +336,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, ref, watch } from 'vue'
 import type { PropType } from 'vue'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
 import { useI18n } from 'vue-i18n'
 import { useTheme } from 'vuetify'
 import { format } from 'date-fns'
@@ -391,6 +390,7 @@ const props = defineProps({
 
 const { locale, t } = useI18n()
 const theme = useTheme()
+const VueHcaptcha = defineAsyncComponent(() => import('@hcaptcha/vue3-hcaptcha'))
 
 const review = ref<ReviewContent | null>(normalizeReview(props.initialReview))
 const createdMs = ref<number | null>(props.reviewCreatedAt ?? null)

--- a/frontend/app/plugins/hcaptcha.client.ts
+++ b/frontend/app/plugins/hcaptcha.client.ts
@@ -1,5 +1,0 @@
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
-
-export default defineNuxtPlugin(nuxtApp => {
-  nuxtApp.vueApp.component('VueHcaptcha', VueHcaptcha)
-})

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -116,6 +116,7 @@ const VENDOR_CHUNK_MATCHERS = [
   { pattern: /[\\/]node_modules[\\/]echarts[\\/]/, chunkName: 'vendor-echarts' },
   { pattern: /[\\/]node_modules[\\/]vue-echarts[\\/]/, chunkName: 'vendor-echarts' },
   { pattern: /[\\/]node_modules[\\/]date-fns[\\/]/, chunkName: 'vendor-date-fns' },
+  { pattern: /[\\/]node_modules[\\/]@hcaptcha[\\/]vue3-hcaptcha[\\/]/, chunkName: 'vendor-hcaptcha' },
   { pattern: /[\\/]node_modules[\\/]vuetify[\\/]/, chunkName: 'vendor-vuetify' },
   { pattern: /[\\/]node_modules[\\/]@vueuse[\\/]/, chunkName: 'vendor-vueuse' },
   { pattern: /[\\/]node_modules[\\/]@vue-pdf-viewer[\\/]/, chunkName: 'vendor-pdf-viewer' },


### PR DESCRIPTION
## Summary
- remove the global hCaptcha plugin registration
- lazy-load VueHcaptcha directly in the form components behind ClientOnly wrappers
- add a dedicated Vite vendor chunk for @hcaptcha/vue3-hcaptcha

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945df86c81c832b902ff8542cd9ae40)