### PR TITLE
Optimize vendor chunking and lazy-load heavy UI blocks

### DIFF
--- a/frontend/app/components/domains/contact/ContactFormCard.vue
+++ b/frontend/app/components/domains/contact/ContactFormCard.vue
@@ -175,11 +175,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
 import { useTheme } from 'vuetify'
 import { VForm } from 'vuetify/components'
+
+const VueHcaptcha = defineAsyncComponent(async () => {
+  const module = await import('@hcaptcha/vue3-hcaptcha')
+  return module.default
+})
+
+type VueHcaptchaComponent = (typeof import('@hcaptcha/vue3-hcaptcha'))['default']
 
 export interface ContactFormPayload {
   name: string
@@ -203,7 +209,7 @@ const emit = defineEmits<{
 const { t, locale } = useI18n()
 const theme = useTheme()
 const formRef = ref<InstanceType<typeof VForm> | null>(null)
-const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
+const captchaRef = ref<InstanceType<VueHcaptchaComponent> | null>(null)
 
 const name = ref('')
 const email = ref('')

--- a/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
+++ b/frontend/app/components/domains/feedback/FeedbackSubmissionForm.vue
@@ -172,10 +172,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { useTheme } from 'vuetify'
 import { VForm } from 'vuetify/components'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
+
+const VueHcaptcha = defineAsyncComponent(async () => {
+  const module = await import('@hcaptcha/vue3-hcaptcha')
+  return module.default
+})
+
+type VueHcaptchaComponent = (typeof import('@hcaptcha/vue3-hcaptcha'))['default']
 
 export interface FeedbackFormSubmitPayload {
   type: string
@@ -226,7 +232,7 @@ const emit = defineEmits<{
 
 const theme = useTheme()
 const formRef = ref<InstanceType<typeof VForm> | null>(null)
-const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
+const captchaRef = ref<InstanceType<VueHcaptchaComponent> | null>(null)
 
 const author = ref(props.defaultAuthor)
 const titleInput = ref('')

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -336,9 +336,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onBeforeUnmount, ref, watch } from 'vue'
 import type { PropType } from 'vue'
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
 import { useI18n } from 'vue-i18n'
 import { useTheme } from 'vuetify'
 import { format } from 'date-fns'
@@ -392,6 +391,13 @@ const props = defineProps({
 const { locale, t } = useI18n()
 const theme = useTheme()
 
+const VueHcaptcha = defineAsyncComponent(async () => {
+  const module = await import('@hcaptcha/vue3-hcaptcha')
+  return module.default
+})
+
+type VueHcaptchaComponent = (typeof import('@hcaptcha/vue3-hcaptcha'))['default']
+
 const review = ref<ReviewContent | null>(normalizeReview(props.initialReview))
 const createdMs = ref<number | null>(props.reviewCreatedAt ?? null)
 const requesting = ref(false)
@@ -400,7 +406,7 @@ const status = ref<ReviewGenerationStatus | null>(null)
 const pollHandle = ref<number | null>(null)
 const showCaptcha = ref(false)
 const captchaToken = ref<string | null>(null)
-const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
+const captchaRef = ref<InstanceType<VueHcaptchaComponent> | null>(null)
 const descriptionRef = ref<HTMLElement | null>(null)
 
 watch(

--- a/frontend/app/pages/[categorySlug]/[...guideSlug].vue
+++ b/frontend/app/pages/[categorySlug]/[...guideSlug].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, defineAsyncComponent, ref } from 'vue'
 import GuideStickySidebar from '~/components/category/guides/GuideStickySidebar.vue'
-import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import type {
   BlogPostDto,
@@ -19,6 +18,7 @@ const normaliseSlug = (value: string | null | undefined) =>
 
 definePageMeta({
   path: '/:categorySlug/:guideSlug([A-Za-z][A-Za-z0-9-]*)',
+  lazy: true,
   validate(route) {
     const raw = route.params.guideSlug
     const slug = Array.isArray(raw) ? raw.join('/') : String(raw ?? '')
@@ -52,6 +52,11 @@ definePageMeta({
 
 const route = useRoute()
 const { selectCategoryBySlug } = useCategories()
+
+const XwikiFullPageRenderer = defineAsyncComponent(async () => {
+  const module = await import('~/components/cms/XwikiFullPageRenderer.vue')
+  return module.default
+})
 
 const categorySlug = computed(() => String(route.params.categorySlug ?? ''))
 

--- a/frontend/app/pages/xwiki-fullpage.vue
+++ b/frontend/app/pages/xwiki-fullpage.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { matchLocalizedWikiRouteByPath } from '~~/shared/utils/localized-routes'
 
 const route = useRoute()
+
+definePageMeta({
+  lazy: true,
+})
+
+const XwikiFullPageRenderer = defineAsyncComponent(async () => {
+  const module = await import('~/components/cms/XwikiFullPageRenderer.vue')
+  return module.default
+})
 
 const matchedRoute = computed(() => matchLocalizedWikiRouteByPath(route.path))
 

--- a/frontend/app/plugins/hcaptcha.client.ts
+++ b/frontend/app/plugins/hcaptcha.client.ts
@@ -1,5 +1,11 @@
-import VueHcaptcha from '@hcaptcha/vue3-hcaptcha'
+import { defineAsyncComponent } from 'vue'
 
 export default defineNuxtPlugin(nuxtApp => {
-  nuxtApp.vueApp.component('VueHcaptcha', VueHcaptcha)
+  nuxtApp.vueApp.component(
+    'VueHcaptcha',
+    defineAsyncComponent(async () => {
+      const module = await import('@hcaptcha/vue3-hcaptcha')
+      return module.default
+    })
+  )
 })

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -118,6 +118,10 @@ const VENDOR_CHUNK_MATCHERS = [
   { pattern: /[\\/]node_modules[\\/]date-fns[\\/]/, chunkName: 'vendor-date-fns' },
   { pattern: /[\\/]node_modules[\\/]vuetify[\\/]/, chunkName: 'vendor-vuetify' },
   { pattern: /[\\/]node_modules[\\/]@vueuse[\\/]/, chunkName: 'vendor-vueuse' },
+  { pattern: /[\\/]node_modules[\\/]@hcaptcha[\\/]vue3-hcaptcha[\\/]/, chunkName: 'vendor-hcaptcha' },
+  { pattern: /[\\/]node_modules[\\/]highlight\.js[\\/]/, chunkName: 'vendor-highlight' },
+  { pattern: /[\\/]node_modules[\\/]markdown-it[\\/]/, chunkName: 'vendor-markdown' },
+  { pattern: /[\\/]node_modules[\\/]vue3-picture-swipe[\\/]/, chunkName: 'vendor-gallery' },
   { pattern: /[\\/]node_modules[\\/]@vue-pdf-viewer[\\/]/, chunkName: 'vendor-pdf-viewer' },
   { pattern: /[\\/]node_modules[\\/]vue-pdf-embed[\\/]/, chunkName: 'vendor-pdf-viewer' },
 ]


### PR DESCRIPTION
## Summary
- split additional heavy libraries (hcaptcha, highlight.js, markdown-it, vue3-picture-swipe) into dedicated vendor chunks
- lazy-load wiki pages and hCaptcha consumers via async components to defer rare dependencies
- ensure wiki routes are marked lazy to hydrate only when visited

## Testing
- pnpm lint (passes with existing warning in ReleaseAccordion.vue)
- pnpm test (fails: vitest session stayed queued with 0 tests before exiting)
- pnpm generate
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945df9adeb4832b8dc57db06b5c8480)