### PR TITLE
Improve vendor chunking and lazy loading

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -165,8 +165,6 @@ import ProductSummaryNavigation from '~/components/product/ProductSummaryNavigat
 import ProductHero from '~/components/product/ProductHero.vue'
 import type { ProductHeroBreadcrumb } from '~/components/product/ProductHero.vue'
 import ProductAttributesSection from '~/components/product/ProductAttributesSection.vue'
-import ProductDocumentationSection from '~/components/product/ProductDocumentationSection.vue'
-import ProductAdminSection from '~/components/product/ProductAdminSection.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useAuth } from '~/composables/useAuth'
 import { useDisplay } from 'vuetify'
@@ -185,6 +183,12 @@ const ProductPriceSection = defineAsyncComponent(
 )
 const ProductAlternatives = defineAsyncComponent(
   () => import('~/components/product/impact/ProductAlternatives.vue')
+)
+const ProductDocumentationSection = defineAsyncComponent(
+  () => import('~/components/product/ProductDocumentationSection.vue')
+)
+const ProductAdminSection = defineAsyncComponent(
+  () => import('~/components/product/ProductAdminSection.vue')
 )
 
 const route = useRoute()

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -150,11 +150,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
+import { computed, defineAsyncComponent, type PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
-import ProductHeroGallery from '~/components/product/ProductHeroGallery.vue'
 import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
 import {
   MAX_COMPARE_ITEMS,
@@ -177,6 +176,10 @@ export interface ProductHeroBreadcrumb {
   title: string
   link?: string
 }
+
+const ProductHeroGallery = defineAsyncComponent(
+  () => import('~/components/product/ProductHeroGallery.vue')
+)
 
 const props = defineProps({
   product: {

--- a/frontend/app/pages/[categorySlug]/[...guideSlug].vue
+++ b/frontend/app/pages/[categorySlug]/[...guideSlug].vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, defineAsyncComponent, ref } from 'vue'
 import GuideStickySidebar from '~/components/category/guides/GuideStickySidebar.vue'
-import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
 import { useCategories } from '~/composables/categories/useCategories'
 import type {
   BlogPostDto,
@@ -11,6 +10,10 @@ import type {
 } from '~~/shared/api-client'
 import { matchProductRouteFromSegments } from '~~/shared/utils/_product-route'
 
+const XwikiFullPageRenderer = defineAsyncComponent(
+  () => import('~/components/cms/XwikiFullPageRenderer.vue')
+)
+
 const normaliseSlug = (value: string | null | undefined) =>
   value
     ?.trim()
@@ -19,6 +22,7 @@ const normaliseSlug = (value: string | null | undefined) =>
 
 definePageMeta({
   path: '/:categorySlug/:guideSlug([A-Za-z][A-Za-z0-9-]*)',
+  lazy: true,
   validate(route) {
     const raw = route.params.guideSlug
     const slug = Array.isArray(raw) ? raw.join('/') : String(raw ?? '')

--- a/frontend/app/pages/[categorySlug]/ecoscore.vue
+++ b/frontend/app/pages/[categorySlug]/ecoscore.vue
@@ -702,6 +702,8 @@ import { loadHighlightJs } from '~/utils/highlight-loader'
 import { createError, useRequestURL, useRoute, useSeoMeta } from '#imports'
 import { useCategories } from '~/composables/categories/useCategories'
 
+definePageMeta({ lazy: true })
+
 const route = useRoute()
 const requestURL = useRequestURL()
 const { t, locale } = useI18n()

--- a/frontend/app/pages/xwiki-fullpage.vue
+++ b/frontend/app/pages/xwiki-fullpage.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import XwikiFullPageRenderer from '~/components/cms/XwikiFullPageRenderer.vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { matchLocalizedWikiRouteByPath } from '~~/shared/utils/localized-routes'
 
 const route = useRoute()
+
+definePageMeta({ lazy: true })
+
+const XwikiFullPageRenderer = defineAsyncComponent(
+  () => import('~/components/cms/XwikiFullPageRenderer.vue')
+)
 
 const matchedRoute = computed(() => matchLocalizedWikiRouteByPath(route.path))
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -117,10 +117,13 @@ const VENDOR_CHUNK_MATCHERS = [
   { pattern: /[\\/]node_modules[\\/]vue-echarts[\\/]/, chunkName: 'vendor-echarts' },
   { pattern: /[\\/]node_modules[\\/]date-fns[\\/]/, chunkName: 'vendor-date-fns' },
   { pattern: /[\\/]node_modules[\\/]@hcaptcha[\\/]vue3-hcaptcha[\\/]/, chunkName: 'vendor-hcaptcha' },
+  { pattern: /[\\/]node_modules[\\/]highlight\.js[\\/]/, chunkName: 'vendor-highlight' },
+  { pattern: /[\\/]node_modules[\\/]markdown-it[\\/]/, chunkName: 'vendor-markdown' },
   { pattern: /[\\/]node_modules[\\/]vuetify[\\/]/, chunkName: 'vendor-vuetify' },
   { pattern: /[\\/]node_modules[\\/]@vueuse[\\/]/, chunkName: 'vendor-vueuse' },
   { pattern: /[\\/]node_modules[\\/]@vue-pdf-viewer[\\/]/, chunkName: 'vendor-pdf-viewer' },
   { pattern: /[\\/]node_modules[\\/]vue-pdf-embed[\\/]/, chunkName: 'vendor-pdf-viewer' },
+  { pattern: /[\\/]node_modules[\\/]vue3-picture-swipe[\\/]/, chunkName: 'vendor-gallery' },
 ]
 
 export default defineNuxtConfig({


### PR DESCRIPTION
## Summary
- add dedicated vendor chunk rules for heavy libraries like highlight.js, markdown-it, and vue3-picture-swipe
- lazy load wiki pages, product galleries, and documentation/admin sections to defer seldom-used bundles
- mark rarely visited routes as lazy to reduce initial payloads

## Testing
- pnpm build
- pnpm lint
- pnpm test --run *(fails: product-uncategorized.spec.ts timeout; run interrupted to avoid extended execution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e8970cbc832bbb6dd71400123f8d)