### PR TITLE
Lazy-load vue-pdf-embed styles with component

### DIFF
--- a/frontend/app/components/product/ProductDocumentationSection.vue
+++ b/frontend/app/components/product/ProductDocumentationSection.vue
@@ -208,13 +208,19 @@ import {
 import { useI18n } from 'vue-i18n'
 import type { ProductPdfDto } from '~~/shared/api-client'
 
-import 'vue-pdf-embed/dist/styles/annotationLayer.css'
-import 'vue-pdf-embed/dist/styles/textLayer.css'
-
 type VuePdfEmbedComponent = (typeof import('vue-pdf-embed'))['default']
 
 const VuePdfEmbed = defineAsyncComponent<VuePdfEmbedComponent>(async () => {
-  const module = await import('vue-pdf-embed')
+  if (!import.meta.client) {
+    return () => null
+  }
+
+  const [module] = await Promise.all([
+    import('vue-pdf-embed'),
+    import('vue-pdf-embed/dist/styles/annotationLayer.css'),
+    import('vue-pdf-embed/dist/styles/textLayer.css'),
+  ])
+
   return module.default
 })
 


### PR DESCRIPTION
## Summary
- load vue-pdf-embed and its layer styles together via client-only async component loader so styles ship only with the documentation viewer
- keep the suspense fallback active while the PDF component and worker assets resolve

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fd3acd10832282c2f329e6c0482d)