### PR TITLE
Switch Vuetify icons to mdi SVG set

### DIFF
--- a/frontend/config/theme/icons.ts
+++ b/frontend/config/theme/icons.ts
@@ -1,0 +1,81 @@
+import { computed, defineComponent, h } from 'vue'
+import type { JSXComponent, PropType } from 'vue'
+
+import type { IconAliases, IconProps, IconSet, IconValue } from 'vuetify'
+import { VComponentIcon, VSvgIcon } from 'vuetify/components'
+import { aliases as mdiIconAliases } from 'vuetify/iconsets/mdi-svg'
+
+import * as mdiIcons from '@mdi/js'
+
+const toPascalCase = (value: string) =>
+  value
+    .split('-')
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join('')
+
+const resolveMdiIcon = (icon: string): IconValue => {
+  if (icon.startsWith('svg:')) {
+    return icon.slice(4)
+  }
+
+  const cleaned = icon.replace(/^mdi:/, '')
+  const directMatch = (mdiIcons as Record<string, string>)[cleaned]
+
+  if (directMatch) {
+    return directMatch
+  }
+
+  const normalized = cleaned.startsWith('mdi-') ? cleaned.slice(4) : cleaned
+  const candidate = `mdi${toPascalCase(normalized)}`
+  const resolvedIcon = (mdiIcons as Record<string, string>)[candidate]
+
+  return resolvedIcon ?? icon
+}
+
+const resolveIconValue = (icon: IconValue) => {
+  if (typeof icon === 'string') {
+    return resolveMdiIcon(icon)
+  }
+
+  return icon
+}
+
+const MdiSvgIcon = defineComponent({
+  name: 'Open4GoodsMdiSvgIcon',
+  props: {
+    icon: {
+      type: [String, Array, Object, Function] as PropType<IconValue>,
+      required: true,
+    },
+    tag: {
+      type: [String, Object, Function] as PropType<IconProps['tag'] | JSXComponent>,
+      default: 'svg',
+    },
+  },
+  setup(props, { attrs }) {
+    const resolvedIcon = computed(() => resolveIconValue(props.icon))
+
+    return () => {
+      const icon = resolvedIcon.value
+
+      if (!icon) {
+        return null
+      }
+
+      if (typeof icon === 'string' || Array.isArray(icon)) {
+        return h(VSvgIcon, { ...attrs, icon, tag: props.tag })
+      }
+
+      return h(VComponentIcon, { ...attrs, icon, tag: props.tag })
+    }
+  },
+})
+
+export const mdiSvgAliases: IconAliases = {
+  ...mdiIconAliases,
+}
+
+export const mdiSvg: IconSet = {
+  component: MdiSvgIcon,
+}

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,7 @@ import { APP_ROUTES_SITEMAP_KEY, SITEMAP_PATH_PREFIX } from './shared/utils/site
 import { LOCALIZED_ROUTE_PATHS, LOCALIZED_WIKI_PATHS, buildI18nPagesConfig } from './shared/utils/localized-routes'
 import { collectStaticPageRouteNames } from './scripts/static-main-page-routes'
 import { vuetifyPalettes } from './config/theme/palettes'
+import { mdiSvg, mdiSvgAliases } from './config/theme/icons'
 
 const APP_PAGES_DIR = fileURLToPath(new URL('./app/pages', import.meta.url))
 const manifestFile = new URL('./app/public/site.webmanifest', import.meta.url)
@@ -242,6 +243,13 @@ export default defineNuxtConfig({
   // Themes palettes are now defined in /frontend/config/theme/palettes.ts
   vuetify: {
     vuetifyOptions: {
+      icons: {
+        defaultSet: 'mdiSvg',
+        aliases: mdiSvgAliases,
+        sets: {
+          mdiSvg,
+        },
+      },
       theme: {
         defaultTheme: 'light',
         themes: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@capacitor/core": "^8.0.0",
     "@hcaptcha/vue3-hcaptcha": "^1.3.0",
-    "@mdi/font": "^7.4.47",
+    "@mdi/js": "^7.4.47",
     "@nuxt/icon": "2.1.1",
     "@nuxt/image": "2.0.0",
     "@pinia/nuxt": "^0.11.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
       '@hcaptcha/vue3-hcaptcha':
         specifier: ^1.3.0
         version: 1.3.0(vue@3.5.26(typescript@5.9.3))
-      '@mdi/font':
+      '@mdi/js':
         specifier: ^7.4.47
         version: 7.4.47
       '@nuxt/icon':
@@ -1998,8 +1998,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@mdi/font@7.4.47':
-    resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
+  '@mdi/js@7.4.47':
+    resolution: {integrity: sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==}
 
   '@miyaneee/rollup-plugin-json5@1.2.0':
     resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
@@ -11562,7 +11562,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mdi/font@7.4.47': {}
+  '@mdi/js@7.4.47': {}
 
   '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.53.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- add a reusable mdiSvg icon set that resolves `mdi-*` names via @mdi/js and registers Vuetify aliases
- configure Vuetify to use the SVG icon set by default and remove the @mdi/font dependency
- refresh the lockfile to drop font assets from the bundle

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945fd76e5248322b5bfc30d6ba4f71a)