### PR TITLE
Enable payload extraction for Nuxt payloads

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -162,7 +162,7 @@ export default defineNuxtConfig({
   },
 
   experimental: {
-    payloadExtraction: false,
+    payloadExtraction: true,
   },
 
   typescript: {


### PR DESCRIPTION
## Summary
- enable Nuxt experimental payload extraction for smaller client payloads

## Testing
- pnpm build
- pnpm exec nuxi analyze --no-serve *(fails: Invalid string length from @clack/prompts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946606f2f88832ba5470297af758589)