### PR TITLE
Refactor auth helpers to update store locally

### DIFF
--- a/frontend/app/pages/auth/login.vue
+++ b/frontend/app/pages/auth/login.vue
@@ -30,6 +30,7 @@
 
 <script setup lang="ts">
 import { authService } from '~~/shared/api-client/services/auth.services'
+import { useAuthStore } from '~/stores/useAuthStore'
 
 const username = ref('')
 const password = ref('')
@@ -38,6 +39,7 @@ const error = ref('')
 const valid = ref(true)
 const router = useRouter()
 const route = useRoute()
+const authStore = useAuthStore()
 
 const canonicalUrl = useCanonicalUrl()
 
@@ -90,7 +92,11 @@ const onSubmit = async () => {
   loading.value = true
   error.value = ''
   try {
-    await authService.login(username.value, password.value)
+    const { authState } = await authService.login(
+      username.value,
+      password.value
+    )
+    authStore.$patch(authState)
     await router.replace(resolveRedirectTarget())
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Login failed'

--- a/frontend/app/plugins/auth-init.server.ts
+++ b/frontend/app/plugins/auth-init.server.ts
@@ -1,4 +1,5 @@
 import { authService } from '~~/shared/api-client/services/auth.services'
+import { useAuthStore } from '~/stores/useAuthStore'
 
 /**
  * Hydrates the authentication store on app startup using the token cookie.
@@ -7,5 +8,7 @@ export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig()
   const token = useCookie<string | null>(config.public.tokenCookieName)
 
-  authService.syncAuthState(token.value)
+  const authStore = useAuthStore()
+
+  authStore.$patch(authService.decodeAuthStateFromToken(token.value))
 })

--- a/frontend/app/plugins/auth-refresh.client.ts
+++ b/frontend/app/plugins/auth-refresh.client.ts
@@ -1,5 +1,6 @@
 import { jwtDecode } from 'jwt-decode'
 import { authService } from '~~/shared/api-client/services/auth.services'
+import { useAuthStore } from '~/stores/useAuthStore'
 
 /**
  * Periodically checks the access token and refreshes it when expired.
@@ -7,13 +8,15 @@ import { authService } from '~~/shared/api-client/services/auth.services'
 export default defineNuxtPlugin(() => {
   const config = useRuntimeConfig()
   const token = useCookie<string | null>(config.public.tokenCookieName)
+  const authStore = useAuthStore()
 
   const checkExpiration = async () => {
     if (!token.value) return
     try {
       const { exp } = jwtDecode<{ exp?: number }>(token.value)
       if (exp && exp * 1000 < Date.now()) {
-        await authService.refresh()
+        const { authState } = await authService.refresh()
+        authStore.$patch(authState)
       }
     } catch (err) {
       console.error('Failed to decode JWT', err)

--- a/frontend/app/stores/useAuthStore.ts
+++ b/frontend/app/stores/useAuthStore.ts
@@ -1,4 +1,6 @@
+import { authService } from '~~/shared/api-client/services/auth.services'
 import { defineStore } from 'pinia'
+import { useAuthCookies } from '~/utils/authCookies'
 
 interface AuthState {
   roles: string[]
@@ -17,9 +19,15 @@ export const useAuthStore = defineStore('auth', {
   },
   actions: {
     async logout() {
-      const { authService } =
-        await import('~~/shared/api-client/services/auth.services')
-      await authService.logout()
+      const { tokenCookie, refreshCookie } = useAuthCookies()
+
+      try {
+        await authService.logout()
+      } finally {
+        this.$reset()
+        tokenCookie.value = null
+        refreshCookie.value = null
+      }
     },
   },
 })

--- a/frontend/shared/api-client/services/auth.services.spec.ts
+++ b/frontend/shared/api-client/services/auth.services.spec.ts
@@ -18,7 +18,23 @@ vi.stubGlobal('$fetch', fetchMock)
 
 let authService: (typeof import('./auth.services'))['authService']
 
-describe('AuthService.logout', () => {
+describe('authService helpers', () => {
+  beforeEach(async () => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(undefined)
+    vi.resetModules()
+    ;({ authService } = await import('./auth.services'))
+  })
+
+  it('calls the logout endpoint without mutating state', async () => {
+    await authService.logout()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/auth/logout', { method: 'POST' })
+  })
+})
+
+describe('useAuthStore.logout', () => {
   beforeEach(async () => {
     setActivePinia(createPinia())
     fetchMock.mockReset()
@@ -37,7 +53,7 @@ describe('AuthService.logout', () => {
       username: 'john',
     })
 
-    await authService.logout()
+    await authStore.logout()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith('/auth/logout', { method: 'POST' })

--- a/frontend/shared/api-client/services/auth.services.ts
+++ b/frontend/shared/api-client/services/auth.services.ts
@@ -2,8 +2,6 @@
  * Authentication service handling login and token refresh calls.
  */
 import { jwtDecode } from 'jwt-decode'
-import { useAuthStore } from '~/stores/useAuthStore'
-import { useAuthCookies } from '~/utils/authCookies'
 
 interface JwtPayload {
   roles?: string[]
@@ -11,90 +9,72 @@ interface JwtPayload {
   sub?: string
 }
 
-export class AuthService {
-  /**
-   * Hydrates the auth store from the access token cookie.
-   */
-  syncAuthState(tokenValue: string | null) {
-    if (import.meta.client) {
-      // The httpOnly cookie is not exposed to the browser, therefore we keep the state provided by SSR.
-      return
-    }
-    const authStore = useAuthStore()
+export interface AuthTokens {
+  accessToken: string
+  refreshToken: string
+}
 
-    if (tokenValue) {
-      try {
-        const decoded = jwtDecode<JwtPayload>(tokenValue)
-        authStore.$patch({
-          roles: decoded.roles ?? [],
-          isLoggedIn: true,
-          username: decoded.username ?? decoded.sub ?? null,
-        })
-      } catch (err) {
-        console.error('Failed to decode JWT', err)
-        authStore.$patch({ roles: [], isLoggedIn: false, username: null })
-      }
-    } else {
-      authStore.$patch({ roles: [], isLoggedIn: false, username: null })
-    }
+export interface AuthStatePayload {
+  roles: string[]
+  isLoggedIn: boolean
+  username: string | null
+}
+
+const decodeAuthStateFromToken = (tokenValue: string | null): AuthStatePayload => {
+  if (!tokenValue) {
+    return { roles: [], isLoggedIn: false, username: null }
   }
 
-  async login(username: string, password: string) {
-    const tokens = await $fetch<{ accessToken: string; refreshToken: string }>(
-      '/auth/login',
-      {
-        method: 'POST',
-        body: { username, password },
-        credentials: 'include',
-      }
-    )
-    // Decode the access token and update the store reactively
-    const decoded = jwtDecode<JwtPayload>(tokens.accessToken)
-    const authStore = useAuthStore()
-    authStore.$patch({
+  try {
+    const decoded = jwtDecode<JwtPayload>(tokenValue)
+
+    return {
       roles: decoded.roles ?? [],
       isLoggedIn: true,
       username: decoded.username ?? decoded.sub ?? null,
-    })
-    return tokens
-  }
-
-  /**
-   * Request a new access token using the refresh token cookie.
-   */
-  async refresh() {
-    const tokens = await $fetch<{ accessToken: string; refreshToken: string }>(
-      '/auth/refresh',
-      {
-        method: 'POST',
-        credentials: 'include',
-      }
-    )
-    // Decode the refreshed access token and patch the auth store
-    const decoded = jwtDecode<JwtPayload>(tokens.accessToken)
-    const authStore = useAuthStore()
-    authStore.$patch({
-      roles: decoded.roles ?? [],
-      isLoggedIn: true,
-      username: decoded.username ?? decoded.sub ?? null,
-    })
-    return tokens
-  }
-
-  async logout() {
-    const authStore = useAuthStore()
-    const { tokenCookie, refreshCookie } = useAuthCookies()
-
-    try {
-      await $fetch('/auth/logout', {
-        method: 'POST',
-      })
-    } finally {
-      authStore.$reset()
-      tokenCookie.value = null
-      refreshCookie.value = null
     }
+  } catch (err) {
+    console.error('Failed to decode JWT', err)
+    return { roles: [], isLoggedIn: false, username: null }
   }
 }
 
-export const authService = new AuthService()
+const login = async (username: string, password: string) => {
+  const tokens = await $fetch<AuthTokens>('/auth/login', {
+    method: 'POST',
+    body: { username, password },
+    credentials: 'include',
+  })
+
+  return {
+    tokens,
+    authState: decodeAuthStateFromToken(tokens.accessToken),
+  }
+}
+
+/**
+ * Request a new access token using the refresh token cookie.
+ */
+const refresh = async () => {
+  const tokens = await $fetch<AuthTokens>('/auth/refresh', {
+    method: 'POST',
+    credentials: 'include',
+  })
+
+  return {
+    tokens,
+    authState: decodeAuthStateFromToken(tokens.accessToken),
+  }
+}
+
+const logout = async () =>
+  $fetch('/auth/logout', {
+    method: 'POST',
+  })
+
+export const authService = {
+  decodeAuthStateFromToken,
+  login,
+  refresh,
+  logout,
+}


### PR DESCRIPTION
## Summary
- refactor auth service helpers to return decoded auth state without mutating the store
- update login flow, refresh plugin, and server init to patch auth store locally
- statically import auth helpers in the auth store and update logout handling and tests

## Testing
- pnpm vitest run shared/api-client/services/auth.services.spec.ts
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694661ca3228832bb057da5dee8182bf)