### PR TITLE
Refine release badges and layout

### DIFF
--- a/frontend/app/components/domains/releases/LatestReleaseBadge.vue
+++ b/frontend/app/components/domains/releases/LatestReleaseBadge.vue
@@ -38,12 +38,13 @@ const handleClick = (event: Event) => {
     :href="props.scrollTarget"
     class="latest-release-badge"
     :class="{ 'latest-release-badge--dense': props.dense }"
+    data-testid="latest-release-badge"
     :role="props.scrollTarget ? 'link' : undefined"
     :aria-label="badgeAriaLabel"
     @click="handleClick"
     @keydown.enter.prevent="handleClick"
   >
-    <span class="latest-release-badge__label">{{ badgeLabel }}</span>
+    <span class="latest-release-badge__pill">{{ badgeLabel }}</span>
     <span class="latest-release-badge__value">{{ latestName }}</span>
   </a>
 </template>
@@ -51,21 +52,21 @@ const handleClick = (event: Event) => {
 <style scoped lang="sass">
 .latest-release-badge
   display: inline-flex
-  align-items: stretch
+  align-items: center
   gap: 10px
-  padding: 6px 12px 6px 0
-  border-radius: 999px
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.16)
-  background: linear-gradient(90deg, rgba(var(--v-theme-surface-default), 0.85), rgba(var(--v-theme-surface-muted), 0.9))
-  color: rgb(var(--v-theme-on-surface))
+  padding: 6px 12px
+  border-radius: 12px
+  border: 1px solid #d0d7de
+  background: linear-gradient(180deg, #f6f8fa, #eaeef2)
+  color: #24292f
   text-decoration: none
-  box-shadow: 0 6px 20px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  box-shadow: inset 0 1px 0 #ffffff, 0 1px 0 rgba(0, 0, 0, 0.04)
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease
   width: fit-content
 
   &:hover
-    border-color: rgba(var(--v-theme-primary), 0.4)
-    box-shadow: 0 10px 26px rgba(var(--v-theme-shadow-primary-600), 0.18)
+    border-color: #afb8c1
+    box-shadow: inset 0 1px 0 #ffffff, 0 4px 12px rgba(0, 0, 0, 0.08)
     transform: translateY(-1px)
 
   &:active
@@ -75,23 +76,27 @@ const handleClick = (event: Event) => {
     padding-block: 4px
     gap: 8px
 
-  &__label
+  &__pill
     display: inline-flex
     align-items: center
-    gap: 6px
+    gap: 8px
     padding: 6px 12px
     border-radius: 999px
-    background: rgba(var(--v-theme-primary), 0.14)
-    color: rgb(var(--v-theme-primary))
+    background: linear-gradient(180deg, #2ea043, #238636)
+    color: #fff
     font-weight: 800
     letter-spacing: 0.08em
     text-transform: uppercase
     font-size: 0.75rem
+    border: 1px solid #1f6f3d
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2)
 
   &__value
     display: inline-flex
     align-items: center
     font-weight: 700
     letter-spacing: 0.01em
-    padding-right: 6px
+    padding-right: 4px
+    color: #24292f
+    white-space: nowrap
 </style>

--- a/frontend/app/components/domains/releases/ReleaseAccordion.vue
+++ b/frontend/app/components/domains/releases/ReleaseAccordion.vue
@@ -55,31 +55,41 @@
         class="release-accordion__panel"
       >
         <v-expansion-panel-title class="release-accordion__title" hide-actions>
-          <template #default="{ expanded: isExpanded }">
+          <template #default="{ expanded: isExpanded, toggle }">
             <div class="release-accordion__title-content">
               <div class="release-accordion__meta">
-                <span class="release-accordion__eyebrow">
-                  {{ formatPublishedDate(release.publishedAt) }}
-                </span>
+                <div class="release-accordion__date-row">
+                  <span class="release-accordion__eyebrow">
+                    {{ formatPublishedDate(release.publishedAt) }}
+                  </span>
+                </div>
                 <span class="release-accordion__name">{{ release.name }}</span>
               </div>
 
               <div class="release-accordion__actions">
-                <v-chip
+                <span
                   v-if="index === 0"
-                  color="primary"
-                  size="small"
-                  variant="flat"
-                  density="comfortable"
-                  class="release-accordion__latest-chip"
+                  class="release-accordion__latest-badge"
+                  role="status"
                 >
-                  {{ t('releases.latest') }}
-                </v-chip>
+                  <span class="release-accordion__badge-dot" aria-hidden="true" />
+                  <span class="release-accordion__badge-label">
+                    {{ t('releases.latest') }}
+                  </span>
+                </span>
 
-                <v-icon
-                  icon="mdi-chevron-down"
-                  class="release-accordion__icon"
-                  :class="{ 'release-accordion__icon--expanded': isExpanded }"
+                <v-btn
+                  variant="text"
+                  color="primary"
+                  density="comfortable"
+                  class="release-accordion__toggle"
+                  :aria-label="
+                    isExpanded
+                      ? t('releases.actions.collapse')
+                      : t('releases.actions.expand')
+                  "
+                  :icon="isExpanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                  @click.stop="toggle"
                 />
               </div>
             </div>
@@ -156,21 +166,26 @@ const formatPublishedDate = (isoDate: string): string => {
   &__title-content
     display: flex
     justify-content: space-between
-    align-items: center
-    gap: 12px
+    align-items: flex-start
+    gap: 16px
+    flex-wrap: wrap
 
   &__actions
     display: flex
     align-items: center
-    gap: 12px
-
-  &__latest-chip
-    font-weight: 700
+    gap: 10px
+    flex-shrink: 0
 
   &__meta
     display: flex
     flex-direction: column
     gap: 6px
+    min-width: 0
+
+  &__date-row
+    display: flex
+    align-items: center
+    gap: 8px
 
   &__eyebrow
     text-transform: uppercase
@@ -182,13 +197,33 @@ const formatPublishedDate = (isoDate: string): string => {
     font-weight: 700
     font-size: 1.05rem
     color: rgb(var(--v-theme-on-surface))
+    word-break: break-word
 
-  &__icon
-    color: rgba(var(--v-theme-on-surface), 0.6)
-    transition: transform 0.2s ease
+  &__latest-badge
+    display: inline-flex
+    align-items: center
+    gap: 8px
+    padding: 6px 12px
+    border-radius: 999px
+    border: 1px solid #d0d7de
+    background: linear-gradient(180deg, #f6f8fa, #eaeef2)
+    box-shadow: inset 0 1px 0 #ffffff, 0 1px 0 rgba(0, 0, 0, 0.04)
+    color: #24292f
+    font-weight: 700
+    font-size: 0.85rem
 
-  &__icon--expanded
-    transform: rotate(180deg)
+  &__badge-dot
+    width: 8px
+    height: 8px
+    border-radius: 50%
+    background: #2da44e
+    box-shadow: 0 0 0 2px rgba(45, 164, 78, 0.2)
+
+  &__badge-label
+    white-space: nowrap
+
+  &__toggle
+    color: rgba(var(--v-theme-on-surface), 0.72)
 
   &__content
     padding: 10px 4px 20px

--- a/frontend/app/pages/releases/index.vue
+++ b/frontend/app/pages/releases/index.vue
@@ -15,7 +15,7 @@
       </template>
     </OpendataHero>
 
-    <v-container class="releases-page__content" fluid>
+    <v-container class="releases-page__content" max-width="1040">
       <div :id="faqAnchorId" class="releases-page__anchor" aria-hidden="true" />
       <h2 class="releases-page__section-title">
         {{ t('releases.faq.title') }}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2325,6 +2325,10 @@
       "latest": "Latest version",
       "title": "Release overview"
     },
+    "actions": {
+      "expand": "Show release details",
+      "collapse": "Hide release details"
+    },
     "latest": "Latest",
     "latestLabel": "Latest release: {name}",
     "loading": "Loading release notes…",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2326,6 +2326,10 @@
       "latest": "Version la plus récente",
       "title": "Vue d'ensemble des versions"
     },
+    "actions": {
+      "expand": "Afficher le détail de la version",
+      "collapse": "Masquer le détail de la version"
+    },
     "latest": "Dernière",
     "latestLabel": "Dernière version : {name}",
     "loading": "Chargement des notes de version…",


### PR DESCRIPTION
## Summary
- restyle latest release badges with a GitHub-inspired pill design and reposition accordion controls
- constrain the releases page content container for a narrower layout
- add localized labels for expanding or collapsing release details

## Testing
- pnpm lint
- pnpm vitest run --passWithNoTests --dir app/components/domains/releases
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946635c4fa4832ba20e2cdf6c1c8206)