### PR TITLE
Refine releases layout and accessibility

### DIFF
--- a/frontend/app/components/domains/releases/ReleaseAccordion.vue
+++ b/frontend/app/components/domains/releases/ReleaseAccordion.vue
@@ -65,7 +65,7 @@
               </div>
             </div>
           </template>
-          <template #actions="{ expanded: isExpanded, toggle }">
+          <template #actions="{ expanded: isExpanded }">
             <div class="release-accordion__actions">
               <v-chip
                 v-if="index === 0"
@@ -88,7 +88,6 @@
                     ? t('releases.actions.collapse', { name: release.name })
                     : t('releases.actions.expand', { name: release.name })
                 "
-                @click.stop="toggle"
               >
                 <v-icon
                   icon="mdi-chevron-down"

--- a/frontend/app/components/domains/releases/ReleaseAccordion.vue
+++ b/frontend/app/components/domains/releases/ReleaseAccordion.vue
@@ -54,8 +54,8 @@
         :value="release.slug"
         class="release-accordion__panel"
       >
-        <v-expansion-panel-title class="release-accordion__title" hide-actions>
-          <template #default="{ expanded: isExpanded }">
+        <v-expansion-panel-title class="release-accordion__title">
+          <template #default>
             <div class="release-accordion__title-content">
               <div class="release-accordion__meta">
                 <span class="release-accordion__eyebrow">
@@ -63,25 +63,39 @@
                 </span>
                 <span class="release-accordion__name">{{ release.name }}</span>
               </div>
+            </div>
+          </template>
+          <template #actions="{ expanded: isExpanded, toggle }">
+            <div class="release-accordion__actions">
+              <v-chip
+                v-if="index === 0"
+                color="primary"
+                size="small"
+                variant="flat"
+                density="comfortable"
+                class="release-accordion__latest-chip"
+              >
+                {{ t('releases.latest') }}
+              </v-chip>
 
-              <div class="release-accordion__actions">
-                <v-chip
-                  v-if="index === 0"
-                  color="primary"
-                  size="small"
-                  variant="flat"
-                  density="comfortable"
-                  class="release-accordion__latest-chip"
-                >
-                  {{ t('releases.latest') }}
-                </v-chip>
-
+              <v-btn
+                icon
+                variant="text"
+                color="on-surface"
+                class="release-accordion__toggle"
+                :aria-label="
+                  isExpanded
+                    ? t('releases.actions.collapse', { name: release.name })
+                    : t('releases.actions.expand', { name: release.name })
+                "
+                @click.stop="toggle"
+              >
                 <v-icon
                   icon="mdi-chevron-down"
                   class="release-accordion__icon"
                   :class="{ 'release-accordion__icon--expanded': isExpanded }"
                 />
-              </div>
+              </v-btn>
             </div>
           </template>
         </v-expansion-panel-title>

--- a/frontend/app/pages/releases/index.vue
+++ b/frontend/app/pages/releases/index.vue
@@ -15,7 +15,7 @@
       </template>
     </OpendataHero>
 
-    <v-container class="releases-page__content" fluid>
+    <v-container class="releases-page__content">
       <div :id="faqAnchorId" class="releases-page__anchor" aria-hidden="true" />
       <h2 class="releases-page__section-title">
         {{ t('releases.faq.title') }}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2327,6 +2327,10 @@
     },
     "latest": "Latest",
     "latestLabel": "Latest release: {name}",
+    "actions": {
+      "expand": "Show details for version {name}",
+      "collapse": "Hide details for version {name}"
+    },
     "loading": "Loading release notes…",
     "empty": "Release notes will arrive soon.",
     "errors": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2328,6 +2328,10 @@
     },
     "latest": "Dernière",
     "latestLabel": "Dernière version : {name}",
+    "actions": {
+      "expand": "Afficher les détails de la version {name}",
+      "collapse": "Masquer les détails de la version {name}"
+    },
     "loading": "Chargement des notes de version…",
     "empty": "Les notes de version seront publiées bientôt.",
     "errors": {


### PR DESCRIPTION
## Summary
- repositioned release accordion header to separate metadata from actions and added explicit toggle controls
- localized expand/collapse labels for release toggles
- narrowed the releases page container to use the standard width

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69466d48bdf4832ba41ba29b20abfec0)