### PR TITLE
Improve accessibility layout container spacing

### DIFF
--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -86,8 +86,16 @@
     color: #ffffff!important
 
 :root.accessibility-layout.accessibility-layout--wide
+    --accessibility-wide-gap: clamp(24px, 4vw, 40px)
+
     .v-main
         :is(.v-container, .container, .cms-page__container--container)
-            max-width: min(1480px, calc(100% - 48px))
+            max-width: calc(100% - (var(--accessibility-wide-gap) * 2))
             width: 100%
-            padding-inline: clamp(16px, 3vw, 32px)
+            margin-inline: auto
+            padding-inline: var(--accessibility-wide-gap)
+
+        :is(.home-section__inner, .home-solution__inner, .home-card-showcase__container)
+            max-width: calc(100% - (var(--accessibility-wide-gap) * 2))
+            width: 100%
+            margin-inline: auto

--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -87,13 +87,7 @@
 
 :root.accessibility-layout.accessibility-layout--wide
     .v-main
-        .v-container,
-        .container
-            max-width: min(1320px, calc(100% - 48px))
-            width: 100%
-            padding-inline: clamp(16px, 3vw, 32px)
-
-        .cms-page__container--container
-            max-width: min(1320px, calc(100% - 48px))
+        :is(.v-container, .container, .cms-page__container--container)
+            max-width: min(1480px, calc(100% - 48px))
             width: 100%
             padding-inline: clamp(16px, 3vw, 32px)

--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -85,15 +85,14 @@
     background-image: linear-gradient(to left, rgb(var(--v-theme-primary)), rgb(var(--v-theme-secondary)))!important
     color: #ffffff!important
 
-:root.accessibility-layout
-    .v-container
-        max-width: 100% !important
-        width: 100%
-
+:root.accessibility-layout.accessibility-layout--wide
+    .v-container,
     .container
-        max-width: 100% !important
+        max-width: min(1320px, calc(100% - 48px))
         width: 100%
+        padding-inline: clamp(16px, 3vw, 32px)
 
     .cms-page__container--container
-        max-width: 100% !important
-        width: 100% !important
+        max-width: min(1320px, calc(100% - 48px))
+        width: 100%
+        padding-inline: clamp(16px, 3vw, 32px)

--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -86,13 +86,14 @@
     color: #ffffff!important
 
 :root.accessibility-layout.accessibility-layout--wide
-    .v-container,
-    .container
-        max-width: min(1320px, calc(100% - 48px))
-        width: 100%
-        padding-inline: clamp(16px, 3vw, 32px)
+    .v-main
+        .v-container,
+        .container
+            max-width: min(1320px, calc(100% - 48px))
+            width: 100%
+            padding-inline: clamp(16px, 3vw, 32px)
 
-    .cms-page__container--container
-        max-width: min(1320px, calc(100% - 48px))
-        width: 100%
-        padding-inline: clamp(16px, 3vw, 32px)
+        .cms-page__container--container
+            max-width: min(1320px, calc(100% - 48px))
+            width: 100%
+            padding-inline: clamp(16px, 3vw, 32px)

--- a/frontend/app/components/shared/menus/ZoomToggle.vue
+++ b/frontend/app/components/shared/menus/ZoomToggle.vue
@@ -14,9 +14,7 @@
         :aria-pressed="isZoomed"
         @click="toggleZoom"
       >
-        <v-icon
-          :icon="isZoomed ? 'mdi-face-woman' : 'mdi-face-woman-outline'"
-        />
+        <v-icon icon="mdi-sunglasses" />
       </v-btn>
     </template>
     {{

--- a/frontend/app/utils/accessibilityLayout.ts
+++ b/frontend/app/utils/accessibilityLayout.ts
@@ -1,5 +1,5 @@
 export const ACCESSIBILITY_LAYOUT_CLASS = 'accessibility-layout'
-export const ACCESSIBILITY_LAYOUT_FLUID_CLASS = 'accessibility-layout--fluid'
+export const ACCESSIBILITY_LAYOUT_WIDE_CLASS = 'accessibility-layout--wide'
 
 export const applyAccessibilityLayout = (isZoomed: boolean) => {
   if (typeof document === 'undefined') {
@@ -10,5 +10,5 @@ export const applyAccessibilityLayout = (isZoomed: boolean) => {
 
   rootElement.style.fontSize = isZoomed ? '120%' : ''
   rootElement.classList.toggle(ACCESSIBILITY_LAYOUT_CLASS, isZoomed)
-  rootElement.classList.toggle(ACCESSIBILITY_LAYOUT_FLUID_CLASS, isZoomed)
+  rootElement.classList.toggle(ACCESSIBILITY_LAYOUT_WIDE_CLASS, isZoomed)
 }


### PR DESCRIPTION
## Summary
- rename the fluid accessibility layout class to a wide layout marker toggled with zoom mode
- adjust accessibility layout container sizing and padding to keep margins, including CMS containers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694684cd0168832b8c3df7aab6de56ed)