### PR TITLE
Add pulse animation to nudge corner icon

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -35,6 +35,7 @@ const props = withDefaults(
   }>(),
   {
     eyebrow: undefined,
+    subtitle: undefined,
     primaryCta: undefined,
     educationCard: undefined,
     fluid: false,

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import NudgeToolWizard from './NudgeToolWizard.vue'
@@ -44,8 +45,9 @@ vi.mock('~/utils/_nudge-tool-filters', () => ({
 }))
 vi.mock('@vueuse/core', () => ({
   useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
-  useElementSize: () => ({ height: { value: 100 } }),
+  useElementSize: () => ({ height: ref(100), width: ref(0) }),
   useTransition: (source: unknown) => source,
+  usePreferredReducedMotion: () => ({ value: false }),
 }))
 
 describe('NudgeToolWizard', () => {


### PR DESCRIPTION
## Summary
- add randomized pulse animation with accessibility controls for the nudge wizard corner icon
- pause pulse on hover/focus, respect reduced motion, and expose style tokens for animation timing
- update supporting mocks and defaults to keep tests and lint rules passing

## Testing
- pnpm lint
- pnpm vitest run components/nudge-tool/NudgeToolWizard.spec.ts
- pnpm build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a6fc8490832baecd1c49331d1c09)