### PR TITLE
Add localized home hero title subtitle

### DIFF
--- a/frontend/app/components/domains/opendata/OpendataHero.vue
+++ b/frontend/app/components/domains/opendata/OpendataHero.vue
@@ -35,6 +35,7 @@ const props = withDefaults(
   }>(),
   {
     eyebrow: undefined,
+    subtitle: undefined,
     primaryCta: undefined,
     educationCard: undefined,
     fluid: false,

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -199,6 +199,45 @@ const heroSubtitleOptions = computed<string[]>(() => {
   return heroSubtitleFallback.value ? [heroSubtitleFallback.value] : []
 })
 
+const heroTitleSubtitleFallback = computed(() => {
+  const legacySubtitle = String(t('home.hero.titleSubtitle')).trim()
+
+  if (!legacySubtitle || legacySubtitle === 'home.hero.titleSubtitle') {
+    return ''
+  }
+
+  return legacySubtitle
+})
+
+const heroTitleSubtitleOptions = computed<string[]>(() => {
+  const titleSubtitles = tm('home.hero.titleSubtitle') as unknown
+  const subtitleConfig: HeroSubtitleConfig | undefined =
+    !Array.isArray(titleSubtitles) &&
+    typeof titleSubtitles === 'object' &&
+    titleSubtitles != null
+      ? (titleSubtitles as HeroSubtitleConfig)
+      : undefined
+
+  const defaultSubtitles = normalizeHeroSubtitles(
+    Array.isArray(titleSubtitles) ? titleSubtitles : subtitleConfig?.default
+  )
+
+  const eventSubtitles = normalizeHeroSubtitles(
+    subtitleConfig?.events?.[activeEventPack.value]
+  )
+
+  const normalizedSubtitles =
+    eventSubtitles.length > 0 ? eventSubtitles : defaultSubtitles
+
+  if (normalizedSubtitles.length > 0) {
+    return normalizedSubtitles
+  }
+
+  return heroTitleSubtitleFallback.value
+    ? [heroTitleSubtitleFallback.value]
+    : []
+})
+
 const heroSubtitleSeed = useState<number | null>(
   'home-hero-subtitle-seed',
   () => null
@@ -211,6 +250,20 @@ if (heroSubtitleSeed.value == null) {
 const heroSubtitle = computed(() => {
   const subtitles = heroSubtitleOptions.value
   const fallback = heroSubtitleFallback.value
+
+  if (!subtitles.length) {
+    return fallback
+  }
+
+  const normalizedIndex = Math.floor(heroSubtitleSeed.value * subtitles.length) %
+    subtitles.length
+
+  return subtitles[normalizedIndex] ?? fallback
+})
+
+const heroTitleSubtitle = computed(() => {
+  const subtitles = heroTitleSubtitleOptions.value
+  const fallback = heroTitleSubtitleFallback.value
 
   if (!subtitles.length) {
     return fallback
@@ -427,6 +480,9 @@ useHead({
             <h1 id="home-hero-title" class="home-hero__title">
               {{ t('home.hero.title') }}
             </h1>
+            <p v-if="heroTitleSubtitle" class="home-hero__title-subtitle">
+              {{ heroTitleSubtitle }}
+            </p>
           </v-col>
         </v-row>
         <v-row justify="center">
@@ -689,6 +745,13 @@ useHead({
   margin: 0
   color: #ffffff
   text-shadow: rgb(var(--v-theme-primary)) 1px 0 10px
+
+.home-hero__title-subtitle
+  margin: clamp(0.65rem, 1.8vw, 1rem) auto 0
+  max-width: 28ch
+  color: rgba(var(--v-theme-surface-default), 0.94)
+  font-size: clamp(1rem, 2.4vw, 1.4rem)
+  line-height: 1.4
 
 .home-hero__search
   display: flex

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -43,6 +43,19 @@
     "hero": {
       "eyebrow": "Responsible shopping",
       "title": "Responsible choices aren’t a luxury",
+      "titleSubtitle": {
+        "default": [
+          "Buy better. Spend smarter."
+        ],
+        "events": {
+          "christmas": [
+            "Find gifts that respect your values and your budget."
+          ],
+          "sdg": [
+            "Everyday shopping aligned with the Sustainable Development Goals."
+          ]
+        }
+      },
       "subtitles": {
         "default": [
           "Save time, stay true to your values. Compare effortlessly, choose freely.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -43,6 +43,19 @@
     "hero": {
       "eyebrow": "",
       "title": "Acheter mieux. Sans dépenser plus.",
+      "titleSubtitle": {
+        "default": [
+          "Acheter mieux. Sans dépenser plus."
+        ],
+        "events": {
+          "christmas": [
+            "Des idées cadeaux qui respectent tes valeurs et ton budget."
+          ],
+          "sdg": [
+            "Des achats du quotidien alignés sur les Objectifs de développement durable."
+          ]
+        }
+      },
       "subtitles": {
         "default": [
           "Gagne du temps. Choisis librement.",


### PR DESCRIPTION
## Summary
- add a localized home-hero title subtitle with event-pack overrides and deterministic selection
- render the subtitle under the hero title with styling tweaks
- extend hero translations and fix a missing default prop to satisfy linting

## Testing
- pnpm lint
- pnpm vitest run components/home/sections/HomeHeroSection.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a98f9b10832b8470ef7ffb3671cd)