### PR TITLE
Add event-pack aware home i18n and documentation

### DIFF
--- a/frontend/app/components/home/sections/HomeCtaSection.vue
+++ b/frontend/app/components/home/sections/HomeCtaSection.vue
@@ -4,6 +4,8 @@ import SearchSuggestField, {
   type CategorySuggestionItem,
   type ProductSuggestionItem,
 } from '~/components/search/SearchSuggestField.vue'
+import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
+import { useEventPackI18n } from '~/composables/useEventPackI18n'
 
 type Emits = {
   'update:searchQuery': [value: string]
@@ -25,11 +27,18 @@ const props = withDefaults(
 
 const emit = defineEmits<Emits>()
 
-const { t } = useI18n()
+const { t, te } = useI18n()
 
 const { categoriesLandingUrl, minSuggestionQueryLength } = toRefs(props)
 
 const searchQueryValue = computed(() => props.searchQuery)
+
+const activeEventPack = useSeasonalEventPack()
+const packI18n = useEventPackI18n(activeEventPack)
+
+const resolveSearchString = (path: string, fallbackKey: string) =>
+  packI18n.resolveString(path, { fallbackKeys: [fallbackKey] }) ??
+  (te(fallbackKey) ? String(t(fallbackKey)) : '')
 
 const handleSubmit = () => {
   emit('submit')
@@ -68,9 +77,24 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
               <SearchSuggestField
                 :model-value="searchQueryValue"
                 class="home-hero__search-input"
-                :label="t('home.hero.search.label')"
-                :placeholder="t('home.hero.search.placeholder')"
-                :aria-label="t('home.hero.search.ariaLabel')"
+                :label="
+                  resolveSearchString(
+                    'hero.search.label',
+                    'home.hero.search.label'
+                  )
+                "
+                :placeholder="
+                  resolveSearchString(
+                    'hero.search.placeholder',
+                    'home.hero.search.placeholder'
+                  )
+                "
+                :aria-label="
+                  resolveSearchString(
+                    'hero.search.ariaLabel',
+                    'home.hero.search.ariaLabel'
+                  )
+                "
                 :min-chars="minSuggestionQueryLength"
                 @update:model-value="handleUpdate"
                 @submit="handleSubmit"
@@ -82,13 +106,13 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
                     class="home-hero__search-submit nudger_degrade-defaut"
                     icon="mdi-arrow-right"
                     variant="flat"
-                    color="primary"
-                    size="small"
-                    type="submit"
-                    :aria-label="t('home.cta.searchSubmit')"
-                  />
-                </template>
-              </SearchSuggestField>
+                  color="primary"
+                  size="small"
+                  type="submit"
+                  :aria-label="t('home.cta.searchSubmit')"
+                />
+              </template>
+            </SearchSuggestField>
             </form>
             <div class="home-cta__actions">
               <div class="home-cta__links">

--- a/frontend/app/composables/useEventPackI18n.ts
+++ b/frontend/app/composables/useEventPackI18n.ts
@@ -1,0 +1,137 @@
+import { computed, toValue, type MaybeRef } from 'vue'
+
+import { DEFAULT_EVENT_PACK, type EventPackName } from '~~/config/theme/assets'
+
+const BASE_KEY = 'home.events'
+
+type ResolveOptions = {
+  fallbackKeys?: string[]
+}
+
+type VariantOptions = ResolveOptions & {
+  randomize?: boolean
+  stateKey?: string
+}
+
+const toFlatPath = (path: string | string[]) =>
+  Array.isArray(path) ? path.join('.') : path
+
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+    .filter(Boolean)
+}
+
+export const useEventPackI18n = (packName: MaybeRef<EventPackName>) => {
+  const { tm, te } = useI18n()
+
+  const variantSeeds = useState<Record<string, number>>(
+    'event-pack-variant-seeds',
+    () => ({})
+  )
+
+  const buildKey = (path: string, pack: EventPackName) =>
+    `${BASE_KEY}.${pack}.${path}`
+
+  const resolveRaw = (path: string | string[], options?: ResolveOptions) => {
+    const normalizedPath = toFlatPath(path)
+    const pack = toValue(packName)
+
+    const packKey = buildKey(normalizedPath, pack)
+
+    if (te(packKey)) {
+      return tm(packKey)
+    }
+
+    const defaultKey = buildKey(normalizedPath, DEFAULT_EVENT_PACK)
+
+    if (te(defaultKey)) {
+      return tm(defaultKey)
+    }
+
+    for (const key of options?.fallbackKeys ?? []) {
+      if (te(key)) {
+        return tm(key)
+      }
+    }
+
+    return undefined
+  }
+
+  const pickVariant = (key: string, values: string[]): string | undefined => {
+    if (values.length === 0) {
+      return undefined
+    }
+
+    if (!variantSeeds.value[key]) {
+      variantSeeds.value[key] = Math.random()
+    }
+
+    const seed = variantSeeds.value[key]
+    const index = Math.floor(seed * values.length) % values.length
+
+    return values[index]
+  }
+
+  const resolveString = (
+    path: string | string[],
+    options?: ResolveOptions
+  ): string | undefined => {
+    const raw = resolveRaw(path, options)
+
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim()
+      return trimmed.length > 0 ? trimmed : undefined
+    }
+
+    return undefined
+  }
+
+  const resolveStringVariant = (
+    path: string | string[],
+    options?: VariantOptions
+  ): string | undefined => {
+    const raw = resolveRaw(path, options)
+    const normalizedPath = toFlatPath(path)
+
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim()
+      return trimmed.length > 0 ? trimmed : undefined
+    }
+
+    const variants = toStringArray(raw)
+    const shouldRandomize = options?.randomize ?? true
+
+    if (!shouldRandomize) {
+      return variants[0]
+    }
+
+    const stateKey = options?.stateKey ?? normalizedPath
+    return pickVariant(stateKey, variants)
+  }
+
+  const resolveList = <T = unknown>(
+    path: string | string[],
+    options?: ResolveOptions
+  ): T[] => {
+    const raw = resolveRaw(path, options)
+
+    if (!Array.isArray(raw)) {
+      return []
+    }
+
+    return raw as T[]
+  }
+
+  return {
+    resolveRaw,
+    resolveString,
+    resolveStringVariant,
+    resolveList,
+    packKey: computed(() => toValue(packName)),
+  }
+}

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -3,6 +3,52 @@ import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { defineComponent, h, ref, computed } from 'vue'
 
 const messages: Record<string, unknown> = {
+  'home.events.default.hero.search.label': 'Search for a product',
+  'home.events.default.hero.search.placeholder': 'Search a product',
+  'home.events.default.hero.search.ariaLabel': 'Search input',
+  'home.events.default.hero.search.cta': 'NUDGER',
+  'home.events.default.hero.search.helper': '50M references',
+  'home.events.default.hero.search.helpersTitle':
+    'Shop with intention. Compare for impact.',
+  'home.events.default.hero.search.helpers': [
+    {
+      icon: '🌿',
+      label: 'A unique eco assessment',
+      segments: [{ text: 'A unique eco assessment' }],
+    },
+    {
+      icon: '🏷️',
+      label: 'Best prices',
+      segments: [
+        { text: 'Pay the right price with' },
+        { text: '{partnersLink}', to: '/partners' },
+      ],
+    },
+    {
+      icon: '🛡️',
+      label: 'Independent & open',
+      segments: [{ text: 'Independent & open' }],
+    },
+    {
+      icon: '⚡',
+      label: '50M references',
+      segments: [{ text: '50M references' }],
+    },
+  ],
+  'home.events.default.hero.search.partnerLinkLabel':
+    '{formattedCount} partner | {formattedCount} partners',
+  'home.events.default.hero.search.partnerLinkFallback': 'our partners',
+  'home.events.default.hero.eyebrow': 'Responsible shopping',
+  'home.events.default.hero.title': 'Responsible choices are not a luxury',
+  'home.events.default.hero.subtitles': [
+    'Save time, stay true to your values.',
+    'Shop smarter without compromise.',
+  ],
+  'home.events.default.hero.titleSubtitle': ['Buy better. Spend smarter.'],
+  'home.events.default.hero.imageAlt': 'Hero illustration',
+  'home.events.default.hero.iconAlt': 'Hero icon',
+  'home.events.default.hero.context.ariaLabel':
+    'Hero context card summarising Nudger’s promise',
   'home.hero.search.label': 'Search for a product',
   'home.hero.search.placeholder': 'Search a product',
   'home.hero.search.ariaLabel': 'Search input',
@@ -311,6 +357,7 @@ mockNuxtImport('useI18n', () => () => ({
     return translate(key, resolvedParams, count)
   },
   tm: (key: string) => messages[key],
+  te: (key: string) => Boolean(messages[key]),
   locale: localeRef,
   availableLocales: ['fr-FR', 'en-US'],
 }))

--- a/frontend/docs/event-packs.md
+++ b/frontend/docs/event-packs.md
@@ -1,0 +1,108 @@
+# Event packs – localization & assets (frontend)
+
+This document explains how event packs drive both assets (parallaxes, themed visuals) and **localized copy** for the home page. Packs are resolved by name (e.g. `default`, `christmas`, `sdg`) and fall back to `default` when a field is missing.
+
+## I18n structure
+
+All pack-aware strings live under `home.events.<pack>.*`. The `default` branch contains the baseline values. Example (trimmed):
+
+```jsonc
+{
+  "home": {
+    "events": {
+      "default": {
+        "hero": {
+          "eyebrow": "Responsible shopping",
+          "title": "Responsible choices aren’t a luxury",
+          "titleSubtitle": ["Buy better. Spend smarter."],
+          "subtitles": [
+            "Save time, stay true to your values. Compare effortlessly, choose freely.",
+            "Shop smarter without compromise. Nudger balances planet and price."
+          ],
+          "search": {
+            "label": "Search for a product",
+            "placeholder": "Search a product (e.g. television, smartphone…)",
+            "ariaLabel": "Search for a responsible product",
+            "cta": "NUDGER",
+            "helpersTitle": "Shop with intention. Compare for impact.",
+            "helpers": [
+              { "icon": "🌿", "segments": [{ "text": "A unique ecological assessment", "to": "/impact-score" }] }
+            ],
+            "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
+            "partnerLinkFallback": "our partners"
+          },
+          "context": {
+            "ariaLabel": "Hero context card summarising Nudger’s promise"
+          },
+          "iconAlt": "Nudger PWA launcher icon",
+          "imageAlt": "Illustration of the Nudger comparison experience..."
+        }
+      },
+      "christmas": {
+        "hero": {
+          "titleSubtitle": ["Find gifts that respect your values and your budget."],
+          "subtitles": [
+            "Give with intention this season. Compare prices and impact in one place."
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Keys you can override per pack (non-exhaustive):
+
+- `hero.title`, `hero.eyebrow`, `hero.titleSubtitle`, `hero.subtitles`
+- `hero.search.*` (label, placeholder, aria, CTA, `helpersTitle`, `helpers`, partner link strings)
+- `hero.context.*`
+- `hero.iconAlt`, `hero.imageAlt`
+
+## Fallback rules
+
+1. Try `home.events.<activePack>.<path>`.
+2. Fallback to `home.events.default.<path>`.
+3. Optional extra fallback keys can be provided per call (legacy `home.hero.*` is kept as a safety net).
+
+## Rendering-time randomisation
+
+Lists (e.g. `hero.subtitles`, `hero.titleSubtitle`) are randomised **per render**. Seeds are stored in `useState('event-pack-variant-seeds')` with a deterministic key, so SSR and CSR remain consistent for a given render.
+
+- Use `resolveStringVariant(path, { stateKey })` to pick one entry from a list.
+- Use `resolveList(path)` to fetch arrays (e.g. helpers).
+
+## Consuming pack-aware strings
+
+Use the composable `useEventPackI18n(packName)`:
+
+```ts
+const activePack = useSeasonalEventPack()
+const packI18n = useEventPackI18n(activePack)
+
+const heroTitle = computed(() =>
+  packI18n.resolveString('hero.title', { fallbackKeys: ['home.hero.title'] })
+)
+
+const heroSubtitle = computed(() =>
+  packI18n.resolveStringVariant('hero.subtitles', {
+    stateKey: 'home-hero-subtitles',
+    fallbackKeys: ['home.hero.subtitles']
+  })
+)
+
+const helpers = computed(() =>
+  packI18n.resolveList('hero.search.helpers', {
+    fallbackKeys: ['home.hero.search.helpers']
+  })
+)
+```
+
+Functions provided:
+
+- `resolveString(path, { fallbackKeys? })` → string | undefined
+- `resolveStringVariant(path, { stateKey?, randomize?, fallbackKeys? })` → string | undefined (handles lists)
+- `resolveList<T>(path, { fallbackKeys? })` → `T[]`
+
+## Alignment with assets
+
+Event pack names mirror the asset packs in `config/theme/assets.ts` (`eventParallaxPacks`). Select the active pack via `useSeasonalEventPack`, then pass it to both the asset resolver (`useThemedParallaxBackgrounds`) and the i18n resolver (`useEventPackI18n`) to keep visuals and text in sync.

--- a/frontend/docs/fr/event-packs.md
+++ b/frontend/docs/fr/event-packs.md
@@ -1,0 +1,106 @@
+# Packs événementiels – localisation & assets (frontend)
+
+Ce document décrit comment les packs événementiels pilotent à la fois les assets (parallaxes, visuels) et les textes localisés de la page d’accueil. Les noms de packs (`default`, `christmas`, `sdg`, …) sont partagés avec les ressources graphiques et héritent toujours de `default` quand une clé est absente.
+
+## Structure i18n
+
+Toutes les chaînes dépendantes d’un pack vivent sous `home.events.<pack>.*`. La branche `default` contient les valeurs de base. Exemple (extrait) :
+
+```jsonc
+{
+  "home": {
+    "events": {
+      "default": {
+        "hero": {
+          "eyebrow": "Responsable",
+          "title": "Acheter mieux. Sans dépenser plus.",
+          "titleSubtitle": ["Acheter mieux. Sans dépenser plus."],
+          "subtitles": [
+            "Gagne du temps. Choisis librement.",
+            "Consomme mieux sans payer plus."
+          ],
+          "search": {
+            "label": "Tu sais déjà ce que tu cherches ?",
+            "placeholder": "Recherchez un produit ou une catégorie",
+            "helpersTitle": "Offre avec intention. Compare avec impact.",
+            "helpers": [
+              { "icon": "🌿", "segments": [{ "text": "Une évaluation écologique", "to": "/impact-score" }] }
+            ],
+            "partnerLinkLabel": "{formattedCount} partenaire | {formattedCount} partenaires",
+            "partnerLinkFallback": "nos partenaires"
+          },
+          "context": {
+            "ariaLabel": "Carte contexte du héros présentant la promesse Nudger"
+          },
+          "iconAlt": "Icône du lanceur de l'application Nudger",
+          "imageAlt": "Illustration du comparateur Nudger..."
+        }
+      },
+      "christmas": {
+        "hero": {
+          "titleSubtitle": ["Des idées cadeaux qui respectent tes valeurs."],
+          "subtitles": [
+            "Offre avec intention : compare prix et impact avant d'emballer."
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Champs surchargés par pack (liste ouverte) :
+
+- `hero.title`, `hero.eyebrow`, `hero.titleSubtitle`, `hero.subtitles`
+- `hero.search.*` (label, placeholder, aria, CTA, `helpersTitle`, `helpers`, chaînes de lien partenaire)
+- `hero.context.*`
+- `hero.iconAlt`, `hero.imageAlt`
+
+## Règles de fallback
+
+1. Chercher `home.events.<packActif>.<chemin>`.
+2. Revenir à `home.events.default.<chemin>`.
+3. Facultatif : clés de secours passées en option (les anciennes `home.hero.*` sont conservées en dernier recours).
+
+## Tirage aléatoire au rendu
+
+Les listes (`hero.subtitles`, `hero.titleSubtitle`, etc.) sont tirées **à chaque rendu**. Les seeds sont stockées dans `useState('event-pack-variant-seeds')` avec une clé déterministe pour rester cohérent entre SSR et client pour une même vue.
+
+- `resolveStringVariant(path, { stateKey })` choisit une entrée dans une liste.
+- `resolveList(path)` récupère les tableaux (ex. helpers).
+
+## Consommation côté code
+
+Utilisez `useEventPackI18n(packName)` :
+
+```ts
+const activePack = useSeasonalEventPack()
+const packI18n = useEventPackI18n(activePack)
+
+const heroTitle = computed(() =>
+  packI18n.resolveString('hero.title', { fallbackKeys: ['home.hero.title'] })
+)
+
+const heroSubtitle = computed(() =>
+  packI18n.resolveStringVariant('hero.subtitles', {
+    stateKey: 'home-hero-subtitles',
+    fallbackKeys: ['home.hero.subtitles']
+  })
+)
+
+const helpers = computed(() =>
+  packI18n.resolveList('hero.search.helpers', {
+    fallbackKeys: ['home.hero.search.helpers']
+  })
+)
+```
+
+API disponible :
+
+- `resolveString(path, { fallbackKeys? })` → string | undefined
+- `resolveStringVariant(path, { stateKey?, randomize?, fallbackKeys? })` → string | undefined (gère les listes)
+- `resolveList<T>(path, { fallbackKeys? })` → `T[]`
+
+## Alignement avec les assets
+
+Les noms de pack sont identiques à ceux des assets dans `config/theme/assets.ts` (`eventParallaxPacks`). Sélectionnez le pack actif via `useSeasonalEventPack`, puis réutilisez-le pour les assets (`useThemedParallaxBackgrounds`) et les textes (`useEventPackI18n`) afin de garder visuels et contenus synchronisés.

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -35,6 +35,108 @@
     }
   },
   "home": {
+    "events": {
+      "default": {
+        "hero": {
+          "eyebrow": "Responsible shopping",
+          "title": "Responsible choices aren’t a luxury",
+          "titleSubtitle": [
+            "Buy better. Spend smarter."
+          ],
+          "subtitles": [
+            "Save time, stay true to your values. Compare effortlessly, choose freely.",
+            "Shop smarter without compromise. Nudger balances planet and price.",
+            "Find the responsible choice faster. Trusted data, transparent insights."
+          ],
+          "iconAlt": "Nudger PWA launcher icon",
+          "imageAlt": "Illustration of the Nudger comparison experience with product cards and impact charts.",
+          "search": {
+            "label": "Search for a product",
+            "placeholder": "Search a product (e.g. television, smartphone…)",
+            "ariaLabel": "Search for a responsible product",
+            "cta": "NUDGER",
+            "helper": "Independent comparator powered by open data.",
+            "helpersTitle": "Shop with intention. Compare for impact.",
+            "helpers": [
+              {
+                "icon": "🌿",
+                "label": "A unique ecological and environmental assessment",
+                "segments": [
+                  {
+                    "text": "A unique ecological assessment",
+                    "to": "/impact-score"
+                  },
+                  {
+                    "text": " and environmental review"
+                  }
+                ]
+              },
+              {
+                "icon": "🏷️",
+                "label": "The best prices on the market",
+                "segments": [
+                  {
+                    "text": "Stay smart on prices with"
+                  },
+                  {
+                    "text": "{partnersLink}",
+                    "to": "/partners"
+                  }
+                ]
+              },
+              {
+                "icon": "🛡️",
+                "label": "Independent comparator, open-source software and open data",
+                "segments": [
+                  {
+                    "text": "Independent comparator, "
+                  },
+                  {
+                    "text": "open-source software",
+                    "to": "/opensource"
+                  },
+                  {
+                    "text": " and "
+                  },
+                  {
+                    "text": "open data",
+                    "to": "/opendata"
+                  }
+                ]
+              }
+            ],
+            "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
+            "partnerLinkFallback": "our partners"
+          },
+          "context": {
+            "cornerLabel": "Impact digest",
+            "cornerTooltip": "Key highlights from Nudger’s methodology",
+            "ariaLabel": "Hero context card summarising Nudger’s promise"
+          }
+        }
+      },
+      "christmas": {
+        "hero": {
+          "titleSubtitle": [
+            "Find gifts that respect your values and your budget."
+          ],
+          "subtitles": [
+            "Give with intention this season. Compare prices and impact in one place.",
+            "Find gifts that respect your values and your budget."
+          ]
+        }
+      },
+      "sdg": {
+        "hero": {
+          "titleSubtitle": [
+            "Everyday shopping aligned with the Sustainable Development Goals."
+          ],
+          "subtitles": [
+            "Small choices, global goals. Discover products aligned with the SDGs."
+          ]
+        }
+      }
+    },
     "seo": {
       "title": "Nudger – Responsible shopping made easy",
       "description": "Compare the environmental impact and prices of over 50 million products with Nudger.",
@@ -81,6 +183,7 @@
         "ariaLabel": "Search for a responsible product",
         "cta": "NUDGER",
         "helper": "Independent comparator powered by open data.",
+        "helpersTitle": "Shop with intention. Compare for impact.",
         "helpers": [
           {
             "icon": "🌿",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -35,13 +35,115 @@
     }
   },
   "home": {
+    "events": {
+      "default": {
+        "hero": {
+          "eyebrow": "Comparateur responsable",
+          "title": "Acheter mieux. Sans dépenser plus.",
+          "titleSubtitle": [
+            "Acheter mieux. Sans dépenser plus."
+          ],
+          "subtitles": [
+            "Gagne du temps. Choisis librement.",
+            "Consomme mieux sans payer plus. Nudger équilibre planète et budget.",
+            "Trouve rapidement des produits alignés avec tes valeurs, grâce à des données transparentes."
+          ],
+          "iconAlt": "Icône du lanceur de l'application Nudger",
+          "imageAlt": "Illustration du comparateur Nudger affichant des cartes produits et des graphiques d’impact.",
+          "search": {
+            "label": "Tu sais déjà ce que tu cherches ?",
+            "placeholder": "Recherchez un produit ou une catégorie",
+            "ariaLabel": "Rechercher un produit responsable",
+            "cta": "NUDGER",
+            "helper": "Comparateur indépendant et open data.",
+            "helpersTitle": "Offre avec intention. Compare avec impact.",
+            "helpers": [
+              {
+                "icon": "🌿",
+                "label": "Une évaluation écologique et environnementale unique",
+                "segments": [
+                  {
+                    "text": "Une évaluation écologique",
+                    "to": "/impact-score"
+                  },
+                  {
+                    "text": " et environnementale unique"
+                  }
+                ]
+              },
+              {
+                "icon": "🛡️",
+                "label": "100% indépendant, logiciel libre et données ouvertes",
+                "segments": [
+                  {
+                    "text": "100% indépendant, "
+                  },
+                  {
+                    "text": "logiciel libre",
+                    "to": "/opensource"
+                  },
+                  {
+                    "text": " et "
+                  },
+                  {
+                    "text": "données ouvertes",
+                    "to": "/opendata"
+                  }
+                ]
+              },
+              {
+                "icon": "🏷️",
+                "label": "Sans se faire avoir sur les prix",
+                "segments": [
+                  {
+                    "text": "Sans se faire avoir sur les prix avec"
+                  },
+                  {
+                    "text": "{partnersLink}",
+                    "to": "/partenaires"
+                  }
+                ]
+              }
+            ],
+            "partnerLinkLabel": "{formattedCount} partenaire | {formattedCount} partenaires",
+            "partnerLinkFallback": "nos partenaires"
+          },
+          "context": {
+            "cornerLabel": "Résumé impact",
+            "cornerTooltip": "Les points forts de la méthodologie Nudger",
+            "ariaLabel": "Carte contexte du héros présentant la promesse Nudger"
+          }
+        }
+      },
+      "christmas": {
+        "hero": {
+          "titleSubtitle": [
+            "Des idées cadeaux qui respectent tes valeurs et ton budget."
+          ],
+          "subtitles": [
+            "Offre avec intention : compare prix et impact avant d'emballer.",
+            "Des idées cadeaux qui respectent tes valeurs et ton budget."
+          ]
+        }
+      },
+      "sdg": {
+        "hero": {
+          "titleSubtitle": [
+            "Des achats du quotidien alignés sur les Objectifs de développement durable."
+          ],
+          "subtitles": [
+            "Des choix du quotidien alignés sur les Objectifs de développement durable."
+          ]
+        }
+      }
+    },
     "seo": {
       "title": "Nudger – Consommer responsable n’est pas un luxe",
       "description": "Comparez l’impact environnemental et les prix de plus de 50 millions de produits grâce à Nudger. Faites des choix responsables pour votre budget et la planète.",
       "imageAlt": "Illustration du tableau de bord Nudger présentant des scores d’impact et des prix."
     },
     "hero": {
-      "eyebrow": "",
+      "eyebrow": "Comparateur responsable",
       "title": "Acheter mieux. Sans dépenser plus.",
       "titleSubtitle": {
         "default": [
@@ -81,6 +183,7 @@
         "ariaLabel": "Rechercher un produit responsable",
         "cta": "NUDGER",
         "helper": "Comparateur indépendant et open data.",
+        "helpersTitle": "Offre avec intention. Compare avec impact.",
         "helpers": [
           {
             "icon": "🌿",


### PR DESCRIPTION
## Summary
- add a pack-aware i18n resolver and wire the home hero/CTA to resolve texts per event pack with default fallbacks
- restructure home locale files under `home.events.<pack>` (including helper titles) for EN/FR and seed deterministic subtitle selection in tests
- document the event pack localisation model in English and French

## Testing
- pnpm lint
- CI=1 pnpm vitest run components/home/sections/HomeHeroSection.spec.ts
- CI=1 pnpm vitest run pages/index.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486154847083229d927035e306e751)