### PR TITLE
Add agent workflow endpoint for GitHub issues

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AgentController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AgentController.java
@@ -1,0 +1,115 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.io.IOException;
+
+import org.kohsuke.github.GHFileNotFoundException;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentErrorResponseDto;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentStatusDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.AgentService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing agent workflow state backed by GitHub issues and branches.
+ */
+@RestController
+@RequestMapping("/agents")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Agents", description = "Suivi des workflows d'agents automatisés.")
+public class AgentController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentController.class);
+
+    private final AgentService agentService;
+
+    public AgentController(AgentService agentService) {
+        this.agentService = agentService;
+    }
+
+    /**
+     * Return the workflow status and branch URL associated with the given GitHub issue.
+     *
+     * @param issueId        GitHub issue identifier
+     * @param domainLanguage localisation hint propagated to the response header
+     * @return workflow state and branch URL if available
+     */
+    @GetMapping("/{issueId}")
+    @Operation(
+            summary = "Récupérer l'état d'un agent",
+            description = "Expose l'état du workflow pour un ticket GitHub et la branche associée si elle existe.",
+            parameters = {
+                    @Parameter(name = "issueId", in = ParameterIn.PATH, required = true,
+                            description = "Identifiant GitHub de l'issue suivie.",
+                            schema = @Schema(type = "string", example = "128")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Langue de domaine (future localisation).",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "État trouvé",
+                            headers = @Header(name = "X-Locale", description = "Locale résolue.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AgentStatusDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Identifiant invalide",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AgentErrorResponseDto.class))),
+                    @ApiResponse(responseCode = "404", description = "Issue inconnue",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AgentErrorResponseDto.class))),
+                    @ApiResponse(responseCode = "502", description = "Erreur GitHub",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AgentErrorResponseDto.class)))
+            }
+    )
+    public ResponseEntity<?> getAgentStatus(@PathVariable("issueId") String issueId,
+                                            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        try {
+            AgentStatusDto status = agentService.getAgentStatus(issueId);
+            return ResponseEntity.ok()
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(status);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.warn("Invalid issue id '{}': {}", issueId, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new AgentErrorResponseDto("L'identifiant d'issue doit être numérique."));
+        } catch (GHFileNotFoundException ex) {
+            LOGGER.warn("Issue {} not found on GitHub", issueId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new AgentErrorResponseDto("Issue inconnue ou inaccessible."));
+        } catch (IOException ex) {
+            LOGGER.error("GitHub error while reading issue {}: {}", issueId, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .cacheControl(CacheControl.noCache())
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .body(new AgentErrorResponseDto("Erreur lors de la récupération des données GitHub."));
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentErrorResponseDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentErrorResponseDto.java
@@ -1,0 +1,14 @@
+package org.open4goods.nudgerfrontapi.dto.agent;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Error payload returned when an agent status cannot be resolved.
+ *
+ * @param message Human readable description of the problem
+ */
+public record AgentErrorResponseDto(
+        @Schema(description = "Message décrivant l'erreur rencontrée.",
+                example = "Issue inconnue ou inaccessible.")
+        String message) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentStatusDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentStatusDto.java
@@ -1,0 +1,24 @@
+package org.open4goods.nudgerfrontapi.dto.agent;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Public contract exposing the status of an automated agent working on a GitHub issue.
+ *
+ * @param issueId       GitHub issue identifier used to track the agent progress
+ * @param workflowState Current workflow state inferred from GitHub objects
+ * @param branchUrl     URL of the working branch if it exists
+ */
+public record AgentStatusDto(
+        @Schema(description = "Identifiant de l'issue GitHub suivie.", example = "128")
+        String issueId,
+
+        @Schema(description = "État courant du workflow de l'agent.",
+                implementation = AgentWorkflowState.class)
+        AgentWorkflowState workflowState,
+
+        @Schema(description = "URL de la branche associée si elle existe.",
+                example = "https://github.com/open4goods/open4goods/tree/issue-128",
+                nullable = true, format = "uri")
+        String branchUrl) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentWorkflowState.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/agent/AgentWorkflowState.java
@@ -1,0 +1,46 @@
+package org.open4goods.nudgerfrontapi.dto.agent;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Lifecycle steps for an automated contribution agent.
+ */
+@Schema(description = "Cycle de vie d'un agent automatisé autour d'une issue GitHub.")
+public enum AgentWorkflowState {
+
+    /**
+     * A request has been received but no issue was created yet.
+     */
+    @Schema(description = "Requête reçue mais pas encore transformée en issue GitHub.")
+    REQUESTED,
+
+    /**
+     * The GitHub issue has been created.
+     */
+    @Schema(description = "Issue GitHub créée.")
+    ISSUE_CREATED,
+
+    /**
+     * A working branch dedicated to the issue exists.
+     */
+    @Schema(description = "Branche de travail créée pour l'issue.")
+    BRANCH_CREATED,
+
+    /**
+     * A pull request is open for the branch.
+     */
+    @Schema(description = "Pull request ouverte pour revue.")
+    IN_REVIEW,
+
+    /**
+     * The pull request has been merged.
+     */
+    @Schema(description = "Pull request fusionnée.")
+    MERGED,
+
+    /**
+     * The effort ended without a merge (issue or PR closed).
+     */
+    @Schema(description = "Issue ou pull request fermée sans merge.")
+    CLOSED
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AgentService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AgentService.java
@@ -1,0 +1,116 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestQueryBuilder;
+import org.kohsuke.github.GHRepository;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentStatusDto;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentWorkflowState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service responsible for mapping GitHub issues/branches to an agent workflow status.
+ */
+@Service
+public class AgentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AgentService.class);
+
+    private final GHRepository repository;
+
+    public AgentService(GHRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Retrieve the workflow status for the given GitHub issue.
+     *
+     * @param issueId GitHub issue identifier supplied by the client
+     * @return agent status including branch URL (if any) and workflow state
+     * @throws IOException when GitHub communication fails
+     * @throws IllegalArgumentException when the issue id cannot be parsed
+     */
+    public AgentStatusDto getAgentStatus(String issueId) throws IOException {
+        int issueNumber = parseIssueNumber(issueId);
+        GHIssue issue = repository.getIssue(issueNumber);
+
+        Optional<String> branchName = findBranch(issueNumber);
+        Optional<GHPullRequest> pullRequest = findPullRequest(branchName);
+
+        AgentWorkflowState workflowState = resolveWorkflowState(issue, pullRequest, branchName);
+        String branchUrl = branchName.map(this::buildBranchUrl).orElse(null);
+
+        return new AgentStatusDto(issueId, workflowState, branchUrl);
+    }
+
+    private int parseIssueNumber(String issueId) {
+        try {
+            return Integer.parseInt(issueId);
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Issue id must be a number", ex);
+        }
+    }
+
+    private Optional<String> findBranch(int issueNumber) throws IOException {
+        String issueToken = String.valueOf(issueNumber);
+        Map<String, GHBranch> branches = repository.getBranches();
+        return branches.keySet().stream()
+                .filter(name -> name.contains(issueToken))
+                .findFirst();
+    }
+
+    private Optional<GHPullRequest> findPullRequest(Optional<String> branchName) throws IOException {
+        if (branchName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        GHPullRequestQueryBuilder query = repository.queryPullRequests()
+                .state(GHIssueState.ALL)
+                .head(branchName.get());
+
+        return query.list()
+                .toList()
+                .stream()
+                .findFirst();
+    }
+
+    private AgentWorkflowState resolveWorkflowState(GHIssue issue,
+                                                    Optional<GHPullRequest> pullRequest,
+                                                    Optional<String> branchName) throws IOException {
+        if (pullRequest.isPresent()) {
+            GHPullRequest pr = pullRequest.get();
+            if (Boolean.TRUE.equals(pr.isMerged())) {
+                return AgentWorkflowState.MERGED;
+            }
+            if (pr.getState() == GHIssueState.OPEN) {
+                return AgentWorkflowState.IN_REVIEW;
+            }
+            return AgentWorkflowState.CLOSED;
+        }
+
+        if (issue.getState() == GHIssueState.CLOSED) {
+            return AgentWorkflowState.CLOSED;
+        }
+
+        if (branchName.isPresent()) {
+            return AgentWorkflowState.BRANCH_CREATED;
+        }
+
+        LOGGER.debug("No branch or pull request found for issue {}, returning ISSUE_CREATED state", issue.getNumber());
+        return AgentWorkflowState.ISSUE_CREATED;
+    }
+
+    private String buildBranchUrl(String branchName) {
+        URL repositoryUrl = repository.getHtmlUrl();
+        return repositoryUrl == null ? null : repositoryUrl.toString() + "/tree/" + branchName;
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/AgentServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/AgentServiceTest.java
@@ -1,0 +1,142 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestQueryBuilder;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentStatusDto;
+import org.open4goods.nudgerfrontapi.dto.agent.AgentWorkflowState;
+
+@ExtendWith(MockitoExtension.class)
+class AgentServiceTest {
+
+    private static final String ISSUE_ID = "42";
+    private static final int ISSUE_NUMBER = 42;
+    private static final String BRANCH_NAME = "feature/issue-42";
+
+    @Mock
+    private GHRepository repository;
+    @Mock
+    private org.kohsuke.github.GHIssue issue;
+    @Mock
+    private GHPullRequest pullRequest;
+    @Mock
+    private GHPullRequestQueryBuilder pullRequestQueryBuilder;
+    @Mock
+    private PagedIterable<GHPullRequest> pullRequests;
+
+    private AgentService agentService;
+
+    @BeforeEach
+    void setUp() {
+        agentService = new AgentService(repository);
+    }
+
+    @Test
+    void shouldExposeMergedStateWhenPullRequestMerged() throws Exception {
+        stubIssueWithRepositoryUrl(GHIssueState.OPEN);
+        stubBranch();
+        stubPullRequest(List.of(pullRequest));
+        when(pullRequest.isMerged()).thenReturn(true);
+
+        AgentStatusDto status = agentService.getAgentStatus(ISSUE_ID);
+
+        assertThat(status.workflowState()).isEqualTo(AgentWorkflowState.MERGED);
+        assertThat(status.branchUrl()).endsWith(BRANCH_NAME);
+    }
+
+    @Test
+    void shouldExposeInReviewWhenPullRequestOpen() throws Exception {
+        stubIssueWithRepositoryUrl(GHIssueState.OPEN);
+        stubBranch();
+        stubPullRequest(List.of(pullRequest));
+        when(pullRequest.isMerged()).thenReturn(false);
+        when(pullRequest.getState()).thenReturn(GHIssueState.OPEN);
+
+        AgentStatusDto status = agentService.getAgentStatus(ISSUE_ID);
+
+        assertThat(status.workflowState()).isEqualTo(AgentWorkflowState.IN_REVIEW);
+    }
+
+    @Test
+    void shouldExposeBranchCreatedWhenBranchExistsWithoutPullRequest() throws Exception {
+        stubIssueWithRepositoryUrl(GHIssueState.OPEN);
+        stubBranch();
+        stubPullRequest(Collections.emptyList());
+
+        AgentStatusDto status = agentService.getAgentStatus(ISSUE_ID);
+
+        assertThat(status.workflowState()).isEqualTo(AgentWorkflowState.BRANCH_CREATED);
+        assertThat(status.branchUrl()).endsWith(BRANCH_NAME);
+    }
+
+    @Test
+    void shouldExposeClosedWhenIssueClosedWithoutBranch() throws Exception {
+        stubIssue(GHIssueState.CLOSED);
+        when(repository.getBranches()).thenReturn(Collections.emptyMap());
+
+        AgentStatusDto status = agentService.getAgentStatus(ISSUE_ID);
+
+        assertThat(status.workflowState()).isEqualTo(AgentWorkflowState.CLOSED);
+        assertThat(status.branchUrl()).isNull();
+    }
+
+    @Test
+    void shouldExposeIssueCreatedWhenNothingElseFound() throws Exception {
+        stubIssue(GHIssueState.OPEN);
+        when(repository.getBranches()).thenReturn(Collections.emptyMap());
+
+        AgentStatusDto status = agentService.getAgentStatus(ISSUE_ID);
+
+        assertThat(status.workflowState()).isEqualTo(AgentWorkflowState.ISSUE_CREATED);
+        assertThat(status.branchUrl()).isNull();
+    }
+
+    @Test
+    void shouldRejectNonNumericIssueId() {
+        assertThatThrownBy(() -> agentService.getAgentStatus("abc"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private void stubIssue(GHIssueState state) throws Exception {
+        when(repository.getIssue(ISSUE_NUMBER)).thenReturn(issue);
+        lenient().when(issue.getState()).thenReturn(state);
+    }
+
+    private void stubIssueWithRepositoryUrl(GHIssueState state) throws Exception {
+        stubIssue(state);
+        when(repository.getHtmlUrl()).thenReturn(new URL("https://github.com/open4good/open4goods"));
+    }
+
+    private void stubBranch() throws Exception {
+        Map<String, org.kohsuke.github.GHBranch> branches = new HashMap<>();
+        branches.put(BRANCH_NAME, mock(org.kohsuke.github.GHBranch.class));
+        when(repository.getBranches()).thenReturn(branches);
+    }
+
+    private void stubPullRequest(List<GHPullRequest> prs) throws Exception {
+        when(repository.queryPullRequests()).thenReturn(pullRequestQueryBuilder);
+        when(pullRequestQueryBuilder.state(GHIssueState.ALL)).thenReturn(pullRequestQueryBuilder);
+        when(pullRequestQueryBuilder.head(BRANCH_NAME)).thenReturn(pullRequestQueryBuilder);
+        when(pullRequestQueryBuilder.list()).thenReturn(pullRequests);
+        when(pullRequests.toList()).thenReturn(prs);
+    }
+}


### PR DESCRIPTION
## Summary
- add agent workflow DTOs including the new `workflowState` field and optional branch URL
- implement a GitHub-backed `AgentService` and `GET /agents/{issueId}` endpoint to expose branch and status information
- cover the workflow mapping with unit tests to guard the GitHub state resolution

## Testing
- mvn -pl front-api -am test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486a6b6b588322a9293b95f54e1243)