### PR TITLE
Add floating nudge wizard on product page

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2102,6 +2102,10 @@
       "alternatives": "Alternatives",
       "price": "Pricing"
     },
+    "nudge": {
+      "fabAriaLabel": "Open the Nudger assistant for this category",
+      "fabLabel": "Need tailored help?"
+    },
     "price": {
       "condition": {
         "new": "New",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2102,6 +2102,10 @@
       "alternatives": "Alternatives",
       "price": "Prix"
     },
+    "nudge": {
+      "fabAriaLabel": "Ouvrir l'assistant Nudger pour cette catégorie",
+      "fabLabel": "Besoin d'aide personnalisée ?"
+    },
     "price": {
       "condition": {
         "new": "Neuf",


### PR DESCRIPTION
## Summary
- add a floating action button on product pages that opens the Nudge tool wizard with the current category context
- internationalize the FAB labels and adjust page styles for the new floating control
- extend the uncategorized product page test coverage to verify wizard availability when a category is present

## Testing
- pnpm lint
- pnpm vitest run pages/product-uncategorized.spec.ts
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69486ca0319c8322a9a890b1068732f3)