### PR TITLE
Use Vuetify SVG icons

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -7,6 +7,7 @@ import type { ManifestOptions } from 'vite-plugin-pwa'
 
 import VueDevTools from 'vite-plugin-vue-devtools'
 import { VueMcp } from 'vite-plugin-vue-mcp'
+import { aliases, mdi } from 'vuetify/iconsets/mdi-svg'
 
 import xwikiSandboxPrefixerOptions from './config/postcss/xwiki-sandbox-prefixer-options.js'
 import { DEFAULT_NUXT_LOCALE, buildI18nLocaleDomains } from './shared/utils/domain-language'
@@ -242,6 +243,13 @@ export default defineNuxtConfig({
   // Themes palettes are now defined in /frontend/config/theme/palettes.ts
   vuetify: {
     vuetifyOptions: {
+      icons: {
+        defaultSet: 'mdiSvg',
+        aliases,
+        sets: {
+          mdiSvg: mdi,
+        },
+      },
       theme: {
         defaultTheme: 'light',
         themes: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@capacitor/core": "^8.0.0",
     "@hcaptcha/vue3-hcaptcha": "^1.3.0",
-    "@mdi/font": "^7.4.47",
     "@nuxt/icon": "2.1.1",
     "@nuxt/image": "2.0.0",
     "@pinia/nuxt": "^0.11.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@hcaptcha/vue3-hcaptcha':
         specifier: ^1.3.0
         version: 1.3.0(vue@3.5.26(typescript@5.9.3))
-      '@mdi/font':
-        specifier: ^7.4.47
-        version: 7.4.47
       '@nuxt/icon':
         specifier: 2.1.1
         version: 2.1.1(magicast@0.5.1)(vite@7.2.7(@types/node@25.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.3))
@@ -2012,9 +2009,6 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@mdi/font@7.4.47':
-    resolution: {integrity: sha512-43MtGpd585SNzHZPcYowu/84Vz2a2g31TvPMTm9uTiCSWzaheQySUcSyUH/46fPnuPQWof2yd0pGBtzee/IQWw==}
 
   '@miyaneee/rollup-plugin-json5@1.2.0':
     resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
@@ -11622,8 +11616,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@mdi/font@7.4.47': {}
 
   '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.53.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- configure Vuetify to use the mdi SVG icon set
- remove the unused `@mdi/font` dependency now that the SVG set is used

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487f5bd4888322a348b64bc86a6a6a)