### PR TITLE
Randomize welcome icon pulse scale and easing

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolWelcomeIcon.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWelcomeIcon.vue
@@ -25,16 +25,38 @@ const IDLE_MAX = 5000
 const PULSE_ITERATIONS_MIN = 1
 const PULSE_ITERATIONS_MAX = 3
 const ZOOM_DURATION_MS = 300
-const ZOOM_SCALE = 1.15
+const ZOOM_SCALE_MIN = 1.05
+const ZOOM_SCALE_MAX = 1.25
+const EASE_IN_OUT = 'cubic-bezier(0.42, 0, 0.58, 1)'
+
+const interpolate = (start: number, end: number, ratio: number) =>
+  start + (end - start) * ratio
+
+const easingForScale = (scaleValue: number) => {
+  const ratio = (scaleValue - ZOOM_SCALE_MIN) / (ZOOM_SCALE_MAX - ZOOM_SCALE_MIN)
+
+  // Starts at the current easing (ease-in-out) and gradually eases out more
+  // aggressively as the scale increases for a softer landing.
+  const x1 = interpolate(0.42, 0.25, ratio)
+  const y1 = interpolate(0, 1, ratio)
+  const x2 = interpolate(0.58, 0.5, ratio)
+  const y2 = interpolate(1, 1, ratio)
+
+  return `cubic-bezier(${x1.toFixed(3)}, ${y1.toFixed(3)}, ${x2.toFixed(3)}, ${y2.toFixed(3)})`
+}
+
+const randomScale = () =>
+  Number((ZOOM_SCALE_MIN + Math.random() * (ZOOM_SCALE_MAX - ZOOM_SCALE_MIN)).toFixed(3))
 
 const isHovered = ref(false)
 const reducedMotion = usePreferredReducedMotion()
 const scale = ref(1)
+const easing = ref(EASE_IN_OUT)
 
 // -- Styles --
 const iconStyle = computed(() => ({
   transform: `scale(${scale.value})`,
-  transition: `transform ${ZOOM_DURATION_MS}ms ease-in-out`,
+  transition: `transform ${ZOOM_DURATION_MS}ms ${easing.value}`,
   cursor: 'default',
   // Ensure we don't overflow parent if it's tight
   maxWidth: '100%',
@@ -57,6 +79,12 @@ const randomInt = (min: number, max: number) =>
 
 const scheduleIdle = () => {
   clearTimers()
+  if (reducedMotion.value === 'reduce') {
+    scale.value = 1
+    easing.value = EASE_IN_OUT
+    return
+  }
+
   const delay = randomInt(IDLE_MIN, IDLE_MAX)
   idleTimer = setTimeout(() => {
     startPulseSequence()
@@ -64,6 +92,12 @@ const scheduleIdle = () => {
 }
 
 const startPulseSequence = () => {
+  if (reducedMotion.value === 'reduce') {
+    scale.value = 1
+    easing.value = EASE_IN_OUT
+    return
+  }
+
   const iterations = randomInt(PULSE_ITERATIONS_MIN, PULSE_ITERATIONS_MAX)
   runPulse(iterations)
 }
@@ -72,6 +106,7 @@ const runPulse = (remaining: number) => {
   // Guard clauses
   if (isHovered.value || reducedMotion.value === 'reduce') {
     scale.value = 1
+    easing.value = EASE_IN_OUT
     return
   }
 
@@ -81,7 +116,9 @@ const runPulse = (remaining: number) => {
   }
 
   // Zoom In
-  scale.value = ZOOM_SCALE
+  const nextScale = randomScale()
+  easing.value = easingForScale(nextScale)
+  scale.value = nextScale
 
   // Schedule Zoom Out
   pulseTimer = setTimeout(() => {
@@ -108,6 +145,7 @@ watch([isHovered, reducedMotion], ([hover, reduced]) => {
   if (hover || reduced === 'reduce') {
     clearTimers()
     scale.value = 1
+    easing.value = EASE_IN_OUT
   } else {
     scheduleIdle()
   }


### PR DESCRIPTION
## Summary
- add per-pulse randomized scale between 1.05 and 1.25
- vary easing curve with the chosen scale and default to the existing ease-in-out for the smallest pulse
- respect reduced motion preference by skipping animations and resetting easing when disabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694898de3350832b96193e02fb6d8a06)