### PR TITLE
Add live reports and version card to opensource page

### DIFF
--- a/frontend/app/pages/opensource/index.vue
+++ b/frontend/app/pages/opensource/index.vue
@@ -9,6 +9,95 @@
       :info-card="heroInfoCard"
     />
 
+    <v-container class="opensource-live" fluid>
+      <v-row class="g-4" align="stretch">
+        <v-col cols="12" md="4">
+          <v-card class="opensource-version-card h-100" color="surface-glass">
+            <v-card-title class="d-flex align-center justify-space-between">
+              <div class="text-body-1 text-uppercase font-weight-medium">
+                {{ t('opensource.live.version.title') }}
+              </div>
+              <v-chip color="primary" variant="tonal" size="small">
+                {{ t('opensource.live.version.status') }}
+              </v-chip>
+            </v-card-title>
+            <v-card-text>
+              <div class="text-h4 font-weight-bold">
+                {{ currentVersion }}
+              </div>
+              <div class="text-body-2 mt-2 text-medium-emphasis">
+                {{ t('opensource.live.version.subtitle') }}
+              </div>
+              <v-divider class="my-4" />
+              <div class="d-flex align-center ga-3">
+                <v-icon icon="mdi-source-repository" color="primary" size="32" />
+                <span class="text-body-2">
+                  {{ t('opensource.live.version.description') }}
+                </span>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+
+        <v-col cols="12" md="8">
+          <v-card class="opensource-reports-card h-100" color="surface-glass">
+            <v-card-title class="d-flex flex-column align-start">
+              <div class="text-overline text-uppercase">
+                {{ t('opensource.live.eyebrow') }}
+              </div>
+              <div class="text-h6 font-weight-bold">
+                {{ t('opensource.live.title') }}
+              </div>
+              <div class="text-body-2 text-medium-emphasis">
+                {{ t('opensource.live.subtitle') }}
+              </div>
+            </v-card-title>
+
+            <v-tabs
+              v-model="activeReportTab"
+              align-tabs="center"
+              bg-color="primary"
+              stacked
+              grow
+            >
+              <v-tab
+                v-for="report in liveReportTabs"
+                :key="report.value"
+                :value="report.value"
+              >
+                <v-icon :icon="report.icon" size="28" class="mb-1" />
+                {{ report.label }}
+              </v-tab>
+            </v-tabs>
+
+            <v-tabs-window v-model="activeReportTab">
+              <v-tabs-window-item
+                v-for="report in liveReportTabs"
+                :key="report.value"
+                :value="report.value"
+              >
+                <v-card flat>
+                  <v-card-text>
+                    <div class="text-body-2 text-medium-emphasis mb-3">
+                      {{ report.description }}
+                    </div>
+                    <div class="opensource-report-frame">
+                      <iframe
+                        :src="report.src"
+                        :title="report.label"
+                        loading="lazy"
+                        referrerpolicy="no-referrer"
+                      />
+                    </div>
+                  </v-card-text>
+                </v-card>
+              </v-tabs-window-item>
+            </v-tabs-window>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+
     <OpensourcePillarsSection
       :eyebrow="t('opensource.pillars.eyebrow')"
       :title="t('opensource.pillars.title')"
@@ -36,7 +125,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import OpensourceHero from '~/components/domains/opensource/OpensourceHero.vue'
 import OpensourcePillarsSection from '~/components/domains/opensource/OpensourcePillarsSection.vue'
@@ -123,6 +212,8 @@ definePageMeta({
 const { t, locale, availableLocales } = useI18n()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
+const currentVersion = 'v0.9.8'
+const activeReportTab = ref('frontend-coverage')
 
 const heroCtas = computed<HeroCtaDisplay[]>(() => [
   {
@@ -271,6 +362,30 @@ const opendataCallout = computed<OpendataCalloutDisplay>(() => ({
   ctaAriaLabel: `${String(t('opensource.resources.opendata.cta.label'))} : ${String(t('opensource.resources.opendata.cta.ariaLabel'))}`,
 }))
 
+const liveReportTabs = computed(() => [
+  {
+    value: 'frontend-coverage',
+    icon: 'mdi-vuejs',
+    label: String(t('opensource.live.tabs.frontend.title')),
+    description: String(t('opensource.live.tabs.frontend.description')),
+    src: '/reports/test-coverage/frontend/index.html',
+  },
+  {
+    value: 'backend-coverage',
+    icon: 'mdi-alpha-b-box-outline',
+    label: String(t('opensource.live.tabs.backend.title')),
+    description: String(t('opensource.live.tabs.backend.description')),
+    src: '/reports/test-coverage/backend/index.html',
+  },
+  {
+    value: 'maven-site',
+    icon: 'mdi-cog-outline',
+    label: String(t('opensource.live.tabs.maven.title')),
+    description: String(t('opensource.live.tabs.maven.description')),
+    src: '/public/reports/maven-site/index.html',
+  },
+])
+
 const canonicalUrl = computed(() =>
   new URL(
     resolveLocalizedRoutePath('opensource', locale.value),
@@ -341,4 +456,24 @@ useHead(() => ({
 .opensource-page
   display: flex
   flex-direction: column
+
+.opensource-live
+  padding-top: 24px
+
+.opensource-version-card
+  .v-card-title
+    gap: 8px
+
+.opensource-report-frame
+  position: relative
+  border-radius: 12px
+  overflow: hidden
+  min-height: 420px
+  background: rgba(var(--v-theme-surface-muted), 0.24)
+
+  iframe
+    border: 0
+    width: 100%
+    height: 100%
+
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1676,6 +1676,31 @@
       "subtitle": "Code, data and governance are transparent so anyone can audit and improve Nudger.",
       "title": "We build a commons for responsible shopping"
     },
+    "live": {
+      "eyebrow": "Live from the code",
+      "subtitle": "Quality dashboards are updated after each pipeline so you can explore the latest metrics.",
+      "tabs": {
+        "backend": {
+          "description": "Back-end coverage and mutations to validate the stability of services and domain logic.",
+          "title": "Backend coverage"
+        },
+        "frontend": {
+          "description": "Client-side tests covering navigation, composables and shared components.",
+          "title": "Frontend coverage"
+        },
+        "maven": {
+          "description": "Generated Maven site aggregating project reports, dependencies and code quality checks.",
+          "title": "Maven site"
+        }
+      },
+      "title": "Fresh quality reports at a glance",
+      "version": {
+        "description": "Latest tagged release deployed to our environments.",
+        "status": "Current",
+        "subtitle": "Tracking the deployed version helps align community discussions and bug reports.",
+        "title": "Current version"
+      }
+    },
     "pillars": {
       "cards": {
         "community": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1676,6 +1676,31 @@
       "subtitle": "Découvrez les coulisses de Nudger : notre code est ouvert pour que chacun puisse apprendre, comprendre et améliorer Nudger.",
       "title": "Open Source"
     },
+    "live": {
+      "eyebrow": "En direct du code",
+      "subtitle": "Les tableaux de bord sont mis à jour après chaque pipeline pour consulter les métriques en temps réel.",
+      "tabs": {
+        "backend": {
+          "description": "Couverture et mutations back-end pour valider la stabilité des services et du domaine.",
+          "title": "Couverture backend"
+        },
+        "frontend": {
+          "description": "Tests côté client couvrant la navigation, les composables et les composants partagés.",
+          "title": "Couverture frontend"
+        },
+        "maven": {
+          "description": "Site Maven généré regroupant rapports, dépendances et contrôles qualité.",
+          "title": "Site Maven"
+        }
+      },
+      "title": "Des rapports de qualité toujours frais",
+      "version": {
+        "description": "Dernière release taggée déployée sur nos environnements.",
+        "status": "En ligne",
+        "subtitle": "Suivre la version déployée facilite les échanges communautaires et les rapports de bugs.",
+        "title": "Version actuelle"
+      }
+    },
     "pillars": {
       "cards": {
         "community": {


### PR DESCRIPTION
## Summary
- add a live section on the open source page with version card and tabbed embeds for quality reports
- wire the tabs to frontend coverage, backend coverage, and Maven site iframes with Vuetify icons
- localize the new copy in English and French and adjust styling for the new embeds

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a7f12ea0832b944b97e7dbfd920f)