### PR TITLE
Integrate agent Q&A into FAQ experience

### DIFF
--- a/frontend/app/components/home/sections/HomeFaqSection.vue
+++ b/frontend/app/components/home/sections/HomeFaqSection.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
 import TextContent from '~/components/domains/content/TextContent.vue'
+import AgentPromptInput from '@/components/agent/AgentPromptInput.vue'
+import { useAgent } from '@/composables/useAgent'
+import type {
+  AgentActivityDto,
+  AgentRequestDto,
+  AgentRequestDtoPromptVisibilityEnum,
+  AgentRequestDtoTypeEnum,
+  AgentRequestResponseDto,
+  AgentTemplateDto,
+} from '~~/shared/api-client/services/agents.services'
+import type { DomainLanguage } from '~~/app/types/agent'
 
 type FaqItem = {
   question: string
@@ -7,11 +19,151 @@ type FaqItem = {
   blocId: string
 }
 
+type AgentFaqAppendPayload = Pick<FaqItem, 'question' | 'answer'>
+
+type LastAgentResult = {
+  question: string
+  issueUrl?: string
+  previewUrl?: string
+  status?: string
+  visibility?: string
+}
+
 const props = defineProps<{
   items: FaqItem[]
 }>()
 
-const { t } = useI18n()
+const emit = defineEmits<{
+  (event: 'append-faq', item: AgentFaqAppendPayload): void
+}>()
+
+const { t, locale } = useI18n()
+const { listTemplates, submitRequest, listActivity } = useAgent()
+
+const template = ref<AgentTemplateDto | null>(null)
+const submitting = ref(false)
+const lastResult = ref<LastAgentResult | null>(null)
+
+const localeCode = computed(() => locale.value.split('-')[0] as DomainLanguage)
+
+const hasPanels = computed(() => props.items.length > 0)
+
+const lastResultLink = computed(
+  () => lastResult.value?.previewUrl || lastResult.value?.issueUrl || ''
+)
+
+const decorateAnswer = (
+  prompt: string,
+  response: AgentRequestResponseDto
+): string => {
+  const link = response.previewUrl || response.issueUrl
+  if (link) {
+    return t('home.faq.agent.dynamicAnswerWithLink', { link })
+  }
+
+  if (response.workflowState) {
+    return t('home.faq.agent.dynamicAnswerWithState', {
+      state: response.workflowState,
+    })
+  }
+
+  return t('home.faq.agent.dynamicAnswerPending', { question: prompt })
+}
+
+const appendAgentFaq = (payload: AgentFaqAppendPayload) => {
+  emit('append-faq', payload)
+}
+
+const pickLatestPublicQuestion = (activities: AgentActivityDto[]) =>
+  activities.find(
+    activity =>
+      activity.type === 'QUESTION' &&
+      activity.promptVisibility === 'PUBLIC' &&
+      Boolean(activity.promptSummary)
+  )
+
+const loadAgentContext = async () => {
+  try {
+    const [templates, activities] = await Promise.all([
+      listTemplates(localeCode.value),
+      listActivity(localeCode.value),
+    ])
+
+    template.value =
+      templates.find(item => item.id === 'question') ?? templates.at(0) ?? null
+
+    const lastQuestion = pickLatestPublicQuestion(activities)
+    if (lastQuestion) {
+      lastResult.value = {
+        question:
+          lastQuestion.promptSummary ||
+          t('home.faq.agent.preview.questionFallback'),
+        issueUrl: lastQuestion.issueUrl,
+        status: lastQuestion.status,
+        visibility: lastQuestion.promptVisibility,
+      }
+    }
+  } catch (error) {
+    console.error('Failed to load agent context', error)
+  }
+}
+
+onMounted(loadAgentContext)
+
+async function handleSubmit({
+  prompt,
+  isPrivate,
+  attributeValues,
+  captchaToken,
+}: {
+  prompt: string
+  isPrivate: boolean
+  attributeValues: Record<string, unknown>
+  captchaToken?: string
+}) {
+  if (!template.value) {
+    return
+  }
+
+  const trimmedPrompt = prompt.trim()
+
+  if (!trimmedPrompt) {
+    return
+  }
+
+  submitting.value = true
+  try {
+    const request: AgentRequestDto = {
+      type: 'QUESTION' as unknown as AgentRequestDtoTypeEnum,
+      promptUser: trimmedPrompt,
+      promptTemplateId: template.value.id,
+      promptVisibility: isPrivate
+        ? AgentRequestDtoPromptVisibilityEnum.Private
+        : AgentRequestDtoPromptVisibilityEnum.Public,
+      attributeValues,
+      captchaToken,
+    }
+
+    const response = await submitRequest(request, localeCode.value)
+
+    lastResult.value = {
+      question: trimmedPrompt,
+      issueUrl: response.issueUrl,
+      previewUrl: response.previewUrl,
+      status: response.workflowState,
+      visibility: response.promptVisibility,
+    }
+
+    appendAgentFaq({
+      question: trimmedPrompt,
+      answer: decorateAnswer(trimmedPrompt, response),
+    })
+  } catch (error) {
+    console.error('Failed to submit question', error)
+  } finally {
+    submitting.value = false
+  }
+}
 </script>
 
 <template>
@@ -25,6 +177,7 @@ const { t } = useI18n()
           {{ t('home.faq.subtitle') }}
         </p>
         <v-expansion-panels
+          v-if="hasPanels"
           class="home-faq__panels"
           multiple
           variant="accordion"
@@ -43,6 +196,99 @@ const { t } = useI18n()
             </v-expansion-panel-text>
           </v-expansion-panel>
         </v-expansion-panels>
+
+        <v-card class="home-faq__agent-card" elevation="0">
+          <div class="home-faq__agent-header">
+            <p class="home-faq__agent-eyebrow">
+              {{ t('home.faq.agent.eyebrow') }}
+            </p>
+            <h3 class="home-faq__agent-title">
+              {{ t('home.faq.agent.title') }}
+            </h3>
+            <p class="home-faq__agent-subtitle">
+              {{ t('home.faq.agent.subtitle') }}
+            </p>
+          </div>
+
+          <div class="home-faq__agent-form">
+            <AgentPromptInput
+              v-if="template"
+              :template-name="template.name"
+              :attributes="template.attributes"
+              :can-toggle-visibility="!template.publicPromptHistory"
+              :default-public="template.publicPromptHistory"
+              :loading="submitting"
+              @submit="handleSubmit"
+            />
+            <v-skeleton-loader
+              v-else
+              type="article, actions"
+              class="home-faq__agent-skeleton"
+            />
+          </div>
+
+          <v-divider class="my-6" />
+
+          <div class="home-faq__agent-preview">
+            <div class="home-faq__agent-preview-header">
+              <span class="home-faq__agent-preview-eyebrow">
+                {{ t('home.faq.agent.preview.eyebrow') }}
+              </span>
+              <p class="home-faq__agent-preview-title">
+                {{ t('home.faq.agent.preview.title') }}
+              </p>
+              <p class="home-faq__agent-preview-subtitle">
+                {{ t('home.faq.agent.preview.subtitle') }}
+              </p>
+            </div>
+
+            <div class="home-faq__agent-preview-body">
+              <div class="home-faq__agent-preview-question">
+                <v-icon
+                  icon="mdi-robot-happy-outline"
+                  color="primary"
+                  class="mr-2"
+                />
+                <div>
+                  <p class="text-caption text-medium-emphasis mb-1">
+                    {{ t('home.faq.agent.preview.label') }}
+                  </p>
+                  <p class="text-body-1 font-weight-medium mb-1">
+                    {{
+                      lastResult?.question ||
+                      t('home.faq.agent.preview.questionFallback')
+                    }}
+                  </p>
+                  <p class="text-caption text-medium-emphasis">
+                    {{
+                      lastResult?.status
+                        ? t('home.faq.agent.preview.status', {
+                            status: lastResult?.status,
+                          })
+                        : t('home.faq.agent.preview.statusPending')
+                    }}
+                  </p>
+                </div>
+              </div>
+
+              <div class="home-faq__agent-preview-actions">
+                <v-btn
+                  :disabled="!lastResultLink"
+                  color="primary"
+                  variant="tonal"
+                  :href="lastResultLink || undefined"
+                  :aria-disabled="!lastResultLink"
+                  target="_blank"
+                >
+                  {{ t('home.faq.agent.preview.cta') }}
+                </v-btn>
+                <p class="text-caption text-medium-emphasis">
+                  {{ t('home.faq.agent.preview.helper') }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </v-card>
       </div>
     </v-container>
   </section>
@@ -61,7 +307,7 @@ const { t } = useI18n()
   margin: 0 auto
   display: flex
   flex-direction: column
-  gap: clamp(0.875rem, 2vw, 1.25rem);
+  gap: clamp(0.875rem, 2vw, 1.5rem)
 
 .home-section__header
   max-width: 760px
@@ -83,9 +329,102 @@ const { t } = useI18n()
   font-size: 1.05rem
 
 .home-faq__panel-text
-  //background: rgba(var(--v-theme-surface-primary-080), 0.4)
   background: rgb(var(--v-theme-surface-default))
 
 .home-faq__text-content
   padding-block: 0.5rem
+
+.home-faq__agent-card
+  border-radius: clamp(1.25rem, 3vw, 1.75rem)
+  padding: clamp(1.25rem, 2.5vw, 2rem)
+  border: 1px solid rgba(var(--v-theme-primary), 0.2)
+  background: linear-gradient(145deg, rgba(var(--v-theme-surface-primary-080), 0.4), rgba(var(--v-theme-surface-default), 0.9))
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.05)
+  display: flex
+  flex-direction: column
+  gap: clamp(1rem, 2vw, 1.5rem)
+
+.home-faq__agent-header
+  display: flex
+  flex-direction: column
+  gap: 0.35rem
+  text-align: left
+
+.home-faq__agent-eyebrow
+  display: inline-flex
+  align-items: center
+  gap: 0.5rem
+  padding: 0.35rem 0.75rem
+  background: rgba(var(--v-theme-primary), 0.08)
+  color: rgb(var(--v-theme-primary))
+  border-radius: 999px
+  font-weight: 600
+  font-size: 0.9rem
+  width: fit-content
+
+.home-faq__agent-title
+  font-size: clamp(1.2rem, 2.8vw, 1.5rem)
+  margin: 0
+
+.home-faq__agent-subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  max-width: 720px
+
+.home-faq__agent-form
+  width: 100%
+
+.home-faq__agent-skeleton
+  width: 100%
+
+.home-faq__agent-preview
+  display: grid
+  gap: clamp(0.5rem, 1vw, 0.75rem)
+
+.home-faq__agent-preview-header
+  display: flex
+  flex-direction: column
+  gap: 0.25rem
+
+.home-faq__agent-preview-eyebrow
+  font-size: 0.85rem
+  font-weight: 600
+  color: rgb(var(--v-theme-primary))
+
+.home-faq__agent-preview-title
+  margin: 0
+  font-weight: 600
+  font-size: 1.05rem
+
+.home-faq__agent-preview-subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.home-faq__agent-preview-body
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-faq__agent-preview-question
+  display: flex
+  gap: 0.75rem
+  align-items: flex-start
+  padding: 0.75rem 1rem
+  border-radius: 0.75rem
+  background: rgba(var(--v-theme-surface-primary-050), 0.7)
+
+.home-faq__agent-preview-actions
+  display: flex
+  align-items: center
+  gap: 0.75rem
+  flex-wrap: wrap
+
+@media (min-width: 960px)
+  .home-faq__agent-preview-body
+    flex-direction: row
+    justify-content: space-between
+    align-items: center
+
+  .home-faq__agent-preview-actions
+    justify-content: flex-end
 </style>

--- a/frontend/app/composables/useAgent.ts
+++ b/frontend/app/composables/useAgent.ts
@@ -6,8 +6,12 @@ import type {
 } from '~~/shared/api-client/services/agents.services'
 
 export const useAgent = () => {
-  async function listTemplates(): Promise<AgentTemplateDto[]> {
-    return await $fetch<AgentTemplateDto[]>('/api/agents/templates')
+  async function listTemplates(
+    domainLanguage?: string
+  ): Promise<AgentTemplateDto[]> {
+    return await $fetch<AgentTemplateDto[]>('/api/agents/templates', {
+      params: { domainLanguage },
+    })
   }
 
   async function submitRequest(
@@ -19,13 +23,20 @@ export const useAgent = () => {
     })
   }
 
-  async function listActivity(): Promise<AgentActivityDto[]> {
-    return await $fetch<AgentActivityDto[]>('/api/agents/activity')
+  async function listActivity(
+    domainLanguage?: string
+  ): Promise<AgentActivityDto[]> {
+    return await $fetch<AgentActivityDto[]>('/api/agents/activity', {
+      params: { domainLanguage },
+    })
   }
 
-  async function getMailto(agentId: string): Promise<string> {
+  async function getMailto(
+    agentId: string,
+    domainLanguage?: string
+  ): Promise<string> {
     return await $fetch<string>('/api/agents/mailto', {
-      params: { agentId },
+      params: { agentId, domainLanguage },
     })
   }
 

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -187,6 +187,22 @@ const messages: Record<string, unknown> = {
     'Yes, refreshed regularly with quality checks.',
   'home.faq.items.suggestProduct.question': 'How can I suggest a product?',
   'home.faq.items.suggestProduct.answer': 'Use our dedicated contact form.',
+  'home.faq.agent.eyebrow': 'Your AI result here',
+  'home.faq.agent.title': 'Ask your question, we’ll pin it to the FAQ',
+  'home.faq.agent.subtitle': 'Your question and the AI result will show below.',
+  'home.faq.agent.dynamicAnswerWithLink': 'See the detailed AI answer: {link}',
+  'home.faq.agent.dynamicAnswerWithState': 'Answer in progress ({state}).',
+  'home.faq.agent.dynamicAnswerPending': 'Thanks! Your question is in queue.',
+  'home.faq.agent.preview.eyebrow': 'Live AI feed',
+  'home.faq.agent.preview.title': 'Latest AI answer',
+  'home.faq.agent.preview.subtitle': 'The freshest public question appears here.',
+  'home.faq.agent.preview.label': 'Latest question',
+  'home.faq.agent.preview.status': 'Status: {status}',
+  'home.faq.agent.preview.statusPending': 'Status pending',
+  'home.faq.agent.preview.cta': 'Open the result',
+  'home.faq.agent.preview.helper': 'Opens the last public response',
+  'home.faq.agent.preview.questionFallback':
+    'Your AI question will surface here.',
   'home.cta.title': 'Ready to buy better without overspending?',
   'home.cta.subtitle': 'Restart a search or explore the analysed offers.',
   'home.cta.button': 'Start a search',
@@ -382,7 +398,24 @@ const affiliationPartnersMock = [
   { id: 'partner-3', name: 'Partner 3' },
 ]
 
-const fetchSpy = vi.fn().mockResolvedValue(affiliationPartnersMock)
+const fetchSpy = vi.fn((url: string) => {
+  if (typeof url === 'string' && url.includes('/api/agents/templates')) {
+    return Promise.resolve([
+      {
+        id: 'question',
+        name: 'Question',
+        attributes: [],
+        publicPromptHistory: true,
+      },
+    ])
+  }
+
+  if (typeof url === 'string' && url.includes('/api/agents/activity')) {
+    return Promise.resolve([])
+  }
+
+  return Promise.resolve(affiliationPartnersMock)
+})
 
 vi.stubGlobal('$fetch', fetchSpy)
 
@@ -457,6 +490,26 @@ const SearchSuggestFieldStub = defineComponent({
         onInput,
         onKeydown,
       })
+  },
+})
+
+const AgentPromptInputStub = defineComponent({
+  name: 'AgentPromptInputStub',
+  emits: ['submit'],
+  setup(_props, { emit }) {
+    const onClick = () =>
+      emit('submit', {
+        prompt: 'stub question',
+        isPrivate: false,
+        attributeValues: {},
+      })
+
+    return () =>
+      h(
+        'button',
+        { class: 'agent-prompt-input-stub', type: 'button', onClick },
+        'Ask agent'
+      )
   },
 })
 
@@ -546,6 +599,7 @@ const mountHomePage = async () => {
         VBtn: VBtnStub,
         VTextField: VTextFieldStub,
         SearchSuggestField: SearchSuggestFieldStub,
+        AgentPromptInput: AgentPromptInputStub,
         VImg: VImgStub,
         VDivider: simpleStub('hr'),
         VExpansionPanels: simpleStub('div'),

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -15,7 +15,6 @@ import HomeBlogSection from '~/components/home/sections/HomeBlogSection.vue'
 import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSection.vue'
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
 import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
-import HomeAgentSection from '~/components/home/sections/HomeAgentSection.vue'
 import ParallaxWidget from '~/components/shared/ui/ParallaxWidget.vue'
 import type {
   CategorySuggestionItem,
@@ -340,17 +339,31 @@ const faqItems = computed(() => [
   },
 ])
 
+type FaqItem = { question: string; answer: string }
+
+const userFaqEntries = ref<FaqItem[]>([])
+
+const allFaqItems = computed(() => [...faqItems.value, ...userFaqEntries.value])
+
 const faqPanels = computed(() =>
-  faqItems.value.map((item, index) => ({
+  allFaqItems.value.map((item, index) => ({
     ...item,
     blocId: `HOME:FAQ:${index + 1}`,
   }))
 )
 
+const handleAgentFaqAppend = (item: FaqItem) => {
+  if (!item.question?.trim()) {
+    return
+  }
+
+  userFaqEntries.value = [...userFaqEntries.value, item]
+}
+
 const faqJsonLd = computed(() => ({
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
-  mainEntity: faqItems.value.map(item => ({
+  mainEntity: allFaqItems.value.map(item => ({
     '@type': 'Question',
     name: item.question,
     acceptedAnswer: {
@@ -831,14 +844,12 @@ useHead(() => ({
               >
                 <v-fade-transition :disabled="shouldReduceMotion">
                   <div v-show="animatedSections.faq">
-                    <HomeFaqSection :items="faqPanels" />
+                    <HomeFaqSection
+                      :items="faqPanels"
+                      @append-faq="handleAgentFaqAppend"
+                    />
                   </div>
                 </v-fade-transition>
-              </div>
-
-              <!-- Ask Agent Section -->
-              <div class="home-page__section">
-                <HomeAgentSection />
               </div>
 
               <div

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -467,6 +467,25 @@
           "question": "How can I suggest a product?",
           "answer": "Use our dedicated contact form."
         }
+      },
+      "agent": {
+        "eyebrow": "Your AI result here 😉",
+        "title": "Ask your question, we’ll pin it to the FAQ",
+        "subtitle": "Share your request, we’ll answer with frugal AI and surface it below for everyone.",
+        "dynamicAnswerWithLink": "See the detailed AI answer: {link}",
+        "dynamicAnswerWithState": "We’re crafting the answer ({state}).",
+        "dynamicAnswerPending": "Thanks! Your question is in the queue.",
+        "preview": {
+          "eyebrow": "Live AI feed",
+          "title": "Latest AI answer",
+          "subtitle": "The freshest public question appears here.",
+          "label": "Latest question",
+          "status": "Status: {status}",
+          "statusPending": "Status pending",
+          "cta": "Open the result",
+          "helper": "Opens the last public response in a new tab",
+          "questionFallback": "Your AI question will surface here."
+        }
       }
     },
     "roundedCards": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -470,6 +470,25 @@
           "question": "Comment suggérer un produit ?",
           "answer": "Via notre formulaire de contact dédié."
         }
+      },
+      "agent": {
+        "eyebrow": "Ton résultat IA ici 😉",
+        "title": "Pose ta question, on l’affiche dans la FAQ",
+        "subtitle": "Envoie ta demande, on répond avec une IA frugale et on affiche le résultat juste en dessous.",
+        "dynamicAnswerWithLink": "Découvre la réponse détaillée : {link}",
+        "dynamicAnswerWithState": "Réponse en cours ({state}).",
+        "dynamicAnswerPending": "Merci ! Ta question est dans la file.",
+        "preview": {
+          "eyebrow": "Flux IA en direct",
+          "title": "Dernière réponse IA",
+          "subtitle": "La dernière question publique apparaît ici.",
+          "label": "Dernière question",
+          "status": "Statut : {status}",
+          "statusPending": "Statut en attente",
+          "cta": "Ouvrir le résultat",
+          "helper": "Ouvre la dernière réponse publique dans un nouvel onglet",
+          "questionFallback": "Ta question IA s’affichera ici."
+        }
       }
     },
     "roundedCards": {


### PR DESCRIPTION
## Summary
- embed the agent question form and live result preview directly under the homepage FAQ
- append submitted questions back into the FAQ list and structured FAQ data with refreshed copy and styling
- add translations and test stubs to support the new FAQ + agent experience

## Testing
- pnpm fast *(fails: existing lint errors in unrelated pages — see PageHeader/opensource/partners/team lint output)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69491b421eb08322ad1b903e176d521c)