### PR TITLE
Add shared multimodal embedding support

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -302,8 +302,8 @@ public class ApiConfig {
 
 
 	@Bean
-	ImageEmbeddingService imageEmbeddingService () {
-		return new DjlImageEmbeddingService();
+	ImageEmbeddingService imageEmbeddingService(ApiProperties apiProperties) {
+		return new DjlImageEmbeddingService(apiProperties);
 	}
 	@Bean
 	ResourceCompletionService resourceCompletionService(ImageMagickService imageService, VerticalsConfigService verticalConfigService, ResourceService resourceService, ProductRepository dataRepository, ApiProperties apiProperties, ImageEmbeddingService imageEmbeddingService) {

--- a/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
@@ -646,14 +646,58 @@ public class ApiProperties {
 	}
 
 	public static class EmbeddingConfig {
-		private String modelPath = "/opt/open4goods/models/distilcamembert-base";
+		/**
+		 * Multimodal (text + image) model loaded through DJL (HuggingFace provider).
+		 * Default: multilingual CLIP.
+		 */
+		private String multimodalModelUrl = "djl://ai.djl.huggingface.pytorch/sentence-transformers/clip-ViT-B-32-multilingual-v1";
 
-		public String getModelPath() {
-			return modelPath;
+		/**
+		 * Text-only embedding model for improved semantic search.
+		 * Default: multilingual E5.
+		 */
+		private String textModelUrl = "djl://ai.djl.huggingface.pytorch/intfloat/multilingual-e5-base";
+
+		/**
+		 * Expected embedding dimension for both text and image vectors.
+		 */
+		private int embeddingDimension = 512;
+
+		/**
+		 * Target input size for vision models.
+		 */
+		private int imageInputSize = 224;
+
+		public String getMultimodalModelUrl() {
+			return multimodalModelUrl;
 		}
 
-		public void setModelPath(String modelPath) {
-			this.modelPath = modelPath;
+		public void setMultimodalModelUrl(String multimodalModelUrl) {
+			this.multimodalModelUrl = multimodalModelUrl;
+		}
+
+		public String getTextModelUrl() {
+			return textModelUrl;
+		}
+
+		public void setTextModelUrl(String textModelUrl) {
+			this.textModelUrl = textModelUrl;
+		}
+
+		public int getEmbeddingDimension() {
+			return embeddingDimension;
+		}
+
+		public void setEmbeddingDimension(int embeddingDimension) {
+			this.embeddingDimension = embeddingDimension;
+		}
+
+		public int getImageInputSize() {
+			return imageInputSize;
+		}
+
+		public void setImageInputSize(int imageInputSize) {
+			this.imageInputSize = imageInputSize;
 		}
 	}
 

--- a/model/src/main/java/org/open4goods/model/product/Product.java
+++ b/model/src/main/java/org/open4goods/model/product/Product.java
@@ -181,9 +181,9 @@ public class Product implements Standardisable {
 	private EcoScoreRanking ranking = new EcoScoreRanking();
 
 	/**
-	 * Text embedding vector for semantic search (DistilCamemBERT = 768 dims)
+	 * Multimodal embedding vector for semantic search (CLIP = 512 dims)
 	 */
-	@Field(type = FieldType.Dense_Vector, dims = 768)
+	@Field(type = FieldType.Dense_Vector, dims = 512)
 	private float[] embedding;
 
 	//////////////////// :

--- a/model/src/main/resources/product-mappings.json
+++ b/model/src/main/resources/product-mappings.json
@@ -158,6 +158,12 @@
       "type": "keyword",
       "index": true
     },
+    "embedding": {
+      "type": "dense_vector",
+      "dims": 512,
+      "index": true,
+      "similarity": "cosine"
+    },
 
     "externalIds": {
       "type": "object",
@@ -263,7 +269,34 @@
     },
     "resources": {
       "type": "object",
-      "enabled": false
+      "dynamic": "false",
+      "properties": {
+        "url": {
+          "type": "keyword",
+          "index": false
+        },
+        "resourceType": {
+          "type": "keyword"
+        },
+        "imageInfo": {
+          "properties": {
+            "width": {
+              "type": "integer",
+              "index": false
+            },
+            "height": {
+              "type": "integer",
+              "index": false
+            },
+            "embedding": {
+              "type": "dense_vector",
+              "dims": 512,
+              "index": true,
+              "similarity": "cosine"
+            }
+          }
+        }
+      }
     },
     "bestsScores": {
       "type": "object",
@@ -330,13 +363,13 @@
         "upcType": {
           "type": "keyword",
           "index": false
+        },
+        "embedding": {
+          "type": "dense_vector",
+          "dims": 512,
+          "index": true,
+          "similarity": "cosine"
         }
-      },
-      "embedding": {
-        "type": "dense_vector",
-        "dims": 768,
-        "index": true,
-        "similarity": "cosine"
       }
     }
   }


### PR DESCRIPTION
## Summary
- configure embedding properties for shared multilingual CLIP and text-only models, and inject them into the DJL text/image embedding services
- broaden name aggregation embedding text with brand/model/offer names and add unit coverage for the builder and embedding hook
- update product Elasticsearch mappings to index multimodal vectors for products and image resources

## Testing
- mvn -pl api -am -Dtest=NamesAggregationServiceTest -Dsurefire.failIfNoSpecifiedTests=false test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694941396524832287a9689e17d6db11)