### PR TITLE
Fix Maven build failure in CI pipeline

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,11 +13,19 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - name: Claude Code Action Official
-        uses: anthropics/claude-code-action@v1
-
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Install unzip (required for Claude Code Action)
+        run: |
+          if ! command -v unzip &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y unzip
+          fi
+
+      - name: Claude Code Action Official
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
- Move checkout step before claude-code-action (was incorrectly first)
- Add unzip installation for self-hosted runner (required by Bun setup)
- Add anthropic_api_key secret parameter to claude-code-action

## Summary

- [ ] Linked issue / context: 
- [ ] Scope owned by `gh` (PR body) vs MCP (comments/labels) confirmed

## Validation

- [ ] `pnpm lint` (frontend)
- [ ] `pnpm test --run` (frontend)
- [ ] `pnpm generate` (frontend)
- [ ] `pnpm test:visual` or visual evidence attached (screenshots/traces) — optional; do not block CI
- [ ] `mvn --offline -pl front-api -am clean install` (if backend touched)
- [ ] `scripts/dev-doctor.sh` reviewed (toolchain and env vars)

## Visual evidence

- Link to Playwright report / screenshots:

## Auth / tokens

- [ ] `GH_TOKEN` configured for gh CLI (repo + workflow + pull_request:write)
- [ ] `MCP_GITHUB_TOKEN` configured for MCP GitHub (comment/labels only)
