### PR TITLE
feat: template-aware agent contact fallback

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/MailTemplateProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/MailTemplateProperties.java
@@ -1,0 +1,79 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Configuration holder for reusable mail templates used by the contact flow.
+ * <p>
+ * Templates can be shared across the application (agents, contact forms, etc.)
+ * and are resolved at runtime based on the domain language. Values are
+ * provided through the {@code front.mail-templates} configuration namespace.
+ * </p>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "front.mail-templates")
+public class MailTemplateProperties {
+
+    @Schema(description = "Collection of mail templates available to the contact service.")
+    private List<MailTemplate> templates;
+
+    public List<MailTemplate> getTemplates() {
+        return templates;
+    }
+
+    public void setTemplates(List<MailTemplate> templates) {
+        this.templates = templates;
+    }
+
+    public static class MailTemplate {
+        @Schema(description = "Unique identifier used to resolve the template.", example = "agent-feedback")
+        private String id;
+
+        @Schema(description = "Recipient email override for this template.", example = "team@nudger.fr")
+        private String to;
+
+        @Schema(description = "Localized subject lines keyed by language tag.")
+        private Map<String, String> subject;
+
+        @Schema(description = "Localized message body keyed by language tag.")
+        private Map<String, String> body;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getTo() {
+            return to;
+        }
+
+        public void setTo(String to) {
+            this.to = to;
+        }
+
+        public Map<String, String> getSubject() {
+            return subject;
+        }
+
+        public void setSubject(Map<String, String> subject) {
+            this.subject = subject;
+        }
+
+        public Map<String, String> getBody() {
+            return body;
+        }
+
+        public void setBody(Map<String, String> body) {
+            this.body = body;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ContactController.java
@@ -50,7 +50,7 @@ public class ContactController {
     @PostMapping
     @Operation(
             summary = "Submit a contact message",
-            description = "Verify captcha token and forward the message to the support mailbox.",
+            description = "Verify captcha token and forward the message to the support mailbox. Supports optional template identifiers to prefill the subject and body.",
             parameters = {
                     @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
                             description = "Language driving localisation of textual fields (future use).",
@@ -76,7 +76,7 @@ public class ContactController {
                                                      @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
                                                      HttpServletRequest httpRequest) {
         try {
-            contactService.submit(request, IpUtils.getIp(httpRequest));
+            contactService.submit(request, IpUtils.getIp(httpRequest), domainLanguage);
             return ResponseEntity.ok()
                     .cacheControl(CacheControl.noCache())
                     .header("X-Locale", domainLanguage.languageTag())

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/contact/ContactRequestDto.java
@@ -30,5 +30,20 @@ public record ContactRequestDto(
         @JsonProperty("h-captcha-response")
         @Schema(name = "h-captcha-response", description = "Token returned by the hCaptcha widget.",
                 example = "10000000-aaaa-bbbb-cccc-000000000001")
-        String captchaResponse) {
+        String captchaResponse,
+
+        @Schema(description = "Identifier of the mail template to use for composing the email.", example = "agent-question")
+        String templateId,
+
+        @Schema(description = "Optional subject override when the template is not available.", example = "[Agent] Nouvelle demande")
+        String subject,
+
+        @Schema(description = "Frontend route from which the request originates.", example = "/prompt")
+        String sourceRoute,
+
+        @Schema(description = "Component or page identifier initiating the request.", example = "AgentPromptInput")
+        String sourceComponent,
+
+        @Schema(description = "Human readable page title that initiated the request.", example = "Espace Agents IA")
+        String sourcePage) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ContactService.java
@@ -1,9 +1,16 @@
 package org.open4goods.nudgerfrontapi.service;
 
+import java.util.Optional;
+
 import org.open4goods.nudgerfrontapi.config.properties.ContactProperties;
+import org.open4goods.nudgerfrontapi.config.properties.MailTemplateProperties;
+import org.open4goods.nudgerfrontapi.config.properties.MailTemplateProperties.MailTemplate;
 import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.captcha.service.HcaptchaService;
 import org.springframework.stereotype.Service;
+
+import org.springframework.util.StringUtils;
 
 /**
  * Service orchestrating contact form submissions: captcha verification and email dispatching.
@@ -19,12 +26,14 @@ public class ContactService {
 
     private final ContactMailService contactMailService;
     private final ContactProperties contactProperties;
+    private final MailTemplateProperties mailTemplateProperties;
     private final HcaptchaService hcaptchaService;
 
     public ContactService(ContactMailService contactMailService, ContactProperties contactProperties,
-            HcaptchaService hcaptchaService) {
+            MailTemplateProperties mailTemplateProperties, HcaptchaService hcaptchaService) {
         this.contactMailService = contactMailService;
         this.contactProperties = contactProperties;
+        this.mailTemplateProperties = mailTemplateProperties;
         this.hcaptchaService = hcaptchaService;
     }
 
@@ -33,12 +42,59 @@ public class ContactService {
      *
      * @param request contact request payload
      * @param clientIp IP address reported by the caller
+     * @param domainLanguage locale hint used to select template translations
      * @throws Exception when captcha verification or email dispatch fails
      */
-    public void submit(ContactRequestDto request, String clientIp) throws Exception {
+    public void submit(ContactRequestDto request, String clientIp, DomainLanguage domainLanguage) throws Exception {
         hcaptchaService.verifyRecaptcha(clientIp, request.captchaResponse());
-        // Prefix the subject to keep a consistent format in the shared inbox.
-        contactMailService.send(contactProperties.getEmail(), request.message(), SUBJECT_PREFIX + request.name(),
-                request.email());
+
+        String targetEmail = contactProperties.getEmail();
+        String subject = SUBJECT_PREFIX + request.name();
+        String body = request.message();
+
+        Optional<MailTemplate> resolvedTemplate = resolveTemplate(request.templateId());
+
+        if (resolvedTemplate.isPresent()) {
+            MailTemplate template = resolvedTemplate.get();
+            if (StringUtils.hasText(template.getTo())) {
+                targetEmail = template.getTo();
+            }
+            subject = renderTemplateValue(template.getSubject(), request, subject, domainLanguage);
+            body = renderTemplateValue(template.getBody(), request, body, domainLanguage);
+        } else if (StringUtils.hasText(request.subject())) {
+            subject = request.subject();
+        }
+
+        contactMailService.send(targetEmail, body, subject, request.email());
+    }
+
+    private Optional<MailTemplate> resolveTemplate(String templateId) {
+        if (!StringUtils.hasText(templateId) || mailTemplateProperties.getTemplates() == null) {
+            return Optional.empty();
+        }
+        return mailTemplateProperties.getTemplates().stream()
+                .filter(template -> templateId.equals(template.getId()))
+                .findFirst();
+    }
+
+    private String renderTemplateValue(java.util.Map<String, String> localizedValues, ContactRequestDto request,
+            String fallback, DomainLanguage domainLanguage) {
+        if (localizedValues == null || localizedValues.isEmpty()) {
+            return fallback;
+        }
+        String languageKey = domainLanguage.languageTag();
+        String chosen = Optional.ofNullable(localizedValues.get(languageKey))
+                .or(() -> Optional.ofNullable(localizedValues.get(languageKey.split("-")[0])))
+                .or(() -> Optional.ofNullable(localizedValues.get("en")))
+                .orElse(localizedValues.values().iterator().next());
+
+        return chosen
+                .replace("{{name}}", request.name())
+                .replace("{{email}}", request.email())
+                .replace("{{message}}", request.message())
+                .replace("{{sourceRoute}}", Optional.ofNullable(request.sourceRoute()).orElse(""))
+                .replace("{{sourceComponent}}", Optional.ofNullable(request.sourceComponent()).orElse(""))
+                .replace("{{sourcePage}}", Optional.ofNullable(request.sourcePage()).orElse(""))
+                .replace("{{subject}}", Optional.ofNullable(request.subject()).orElse(""));
     }
 }

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -246,6 +246,31 @@
       "description": "Recipient email address for contact form submissions."
     },
     {
+      "name": "front.mail-templates.templates",
+      "type": "java.util.List",
+      "description": "Collection of reusable mail templates available to the contact service."
+    },
+    {
+      "name": "front.mail-templates.templates[].id",
+      "type": "java.lang.String",
+      "description": "Unique identifier of the mail template."
+    },
+    {
+      "name": "front.mail-templates.templates[].to",
+      "type": "java.lang.String",
+      "description": "Optional recipient override for the template."
+    },
+    {
+      "name": "front.mail-templates.templates[].subject",
+      "type": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Localized subject lines keyed by language tag."
+    },
+    {
+      "name": "front.mail-templates.templates[].body",
+      "type": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Localized body content keyed by language tag."
+    },
+    {
       "name": "front.partners.ecosystem.partners",
       "type": "java.util.List",
       "description": "Configured ecosystem partners displayed on the public site."

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ContactServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ContactServiceTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.open4goods.nudgerfrontapi.config.properties.ContactProperties;
 import org.open4goods.nudgerfrontapi.dto.contact.ContactRequestDto;
+import org.open4goods.nudgerfrontapi.config.properties.MailTemplateProperties;
+import org.open4goods.nudgerfrontapi.config.properties.MailTemplateProperties.MailTemplate;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.captcha.service.HcaptchaService;
 
 /**
@@ -18,6 +21,7 @@ class ContactServiceTest {
 
     private ContactMailService contactMailService;
     private ContactProperties contactProperties;
+    private MailTemplateProperties mailTemplateProperties;
     private HcaptchaService hcaptchaService;
     private ContactService contactService;
 
@@ -26,15 +30,25 @@ class ContactServiceTest {
         contactMailService = mock(ContactMailService.class);
         contactProperties = new ContactProperties();
         contactProperties.setEmail("contact@nudger.fr");
+        mailTemplateProperties = new MailTemplateProperties();
         hcaptchaService = mock(HcaptchaService.class);
-        contactService = new ContactService(contactMailService, contactProperties, hcaptchaService);
+        contactService = new ContactService(contactMailService, contactProperties, mailTemplateProperties, hcaptchaService);
     }
 
     @Test
     void submitShouldVerifyCaptchaAndSendEmail() throws Exception {
-        ContactRequestDto request = new ContactRequestDto("Jean", "jean@example.com", "Bonjour", "token");
+        ContactRequestDto request = new ContactRequestDto(
+                "Jean",
+                "jean@example.com",
+                "Bonjour",
+                "token",
+                null,
+                null,
+                null,
+                null,
+                null);
 
-        contactService.submit(request, "127.0.0.1");
+        contactService.submit(request, "127.0.0.1", DomainLanguage.fr);
 
         verify(hcaptchaService).verifyRecaptcha("127.0.0.1", "token");
         verify(contactMailService).send("contact@nudger.fr", "Bonjour", "nudger.fr > Message de Jean",
@@ -42,12 +56,48 @@ class ContactServiceTest {
     }
 
     @Test
+    void submitShouldUseTemplateWhenAvailable() throws Exception {
+        MailTemplate template = new MailTemplate();
+        template.setId("agent-question");
+        template.setTo("agents@nudger.fr");
+        template.setSubject(java.util.Map.of("fr", "Sujet {{name}}", "en", "Subject {{name}}"));
+        template.setBody(java.util.Map.of("fr", "Corps {{message}}", "en", "Body {{message}}"));
+        mailTemplateProperties.setTemplates(java.util.List.of(template));
+
+        ContactRequestDto request = new ContactRequestDto(
+                "Marie",
+                "marie@example.com",
+                "Bonjour",
+                "token",
+                "agent-question",
+                null,
+                "/prompt",
+                "AgentPromptInput",
+                "Espace Agents"
+        );
+
+        contactService.submit(request, "10.0.0.1", DomainLanguage.fr);
+
+        verify(hcaptchaService).verifyRecaptcha("10.0.0.1", "token");
+        verify(contactMailService).send("agents@nudger.fr", "Corps Bonjour", "Sujet Marie", "marie@example.com");
+    }
+
+    @Test
     void submitShouldPropagateExceptions() throws Exception {
-        ContactRequestDto request = new ContactRequestDto("Jane", "jane@example.com", "Salut", "token");
+        ContactRequestDto request = new ContactRequestDto(
+                "Jane",
+                "jane@example.com",
+                "Salut",
+                "token",
+                null,
+                null,
+                null,
+                null,
+                null);
         doThrow(new Exception("smtp error")).when(contactMailService)
                 .send("contact@nudger.fr", "Salut", "nudger.fr > Message de Jane", "jane@example.com");
 
-        assertThrows(Exception.class, () -> contactService.submit(request, "192.168.0.1"));
+        assertThrows(Exception.class, () -> contactService.submit(request, "192.168.0.1", DomainLanguage.fr));
         verify(hcaptchaService).verifyRecaptcha("192.168.0.1", "token");
     }
 }

--- a/frontend/app/components/agent/AgentPromptInput.vue
+++ b/frontend/app/components/agent/AgentPromptInput.vue
@@ -81,11 +81,10 @@
           {{ $t('agents.promptInput.emailDescription') }}
         </p>
         <v-btn
-          :href="fallbackMailto"
-          target="_blank"
           variant="outlined"
           size="small"
           color="primary"
+          @click="emitFallbackContact"
           >{{ $t('agents.promptInput.openEmail') }}</v-btn
         >
       </div>
@@ -137,6 +136,14 @@ const emit = defineEmits<{
       captchaToken?: string
     }
   ): void
+  (
+    e: 'fallback-contact',
+    payload: {
+      prompt: string
+      attributeValues: Record<string, unknown>
+      captchaToken?: string
+    }
+  ): void
   (e: 'cancel'): void
 }>()
 
@@ -169,6 +176,17 @@ function submit() {
     isPrivate: isPrivate.value,
     attributeValues: attributeValues.value,
     captchaToken: captchaToken.value || undefined,
+  })
+}
+
+function emitFallbackContact() {
+  if (!prompt.value.trim()) {
+    return
+  }
+  emit('fallback-contact', {
+    prompt: prompt.value,
+    attributeValues: attributeValues.value,
+    captchaToken: siteKey.value ? captchaToken.value || undefined : undefined,
   })
 }
 </script>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2805,10 +2805,12 @@
       "required": "Request cannot be empty",
       "private": "Make my prompt private",
       "privateDescription": "The issue will be public, but your prompt text will be hidden.",
-      "email": "Prefer email?",
-      "emailDescription": "You can use your default email client instead.",
-      "openEmail": "Open Email Client",
-      "details": "Additional Details"
+      "email": "Prefer something quieter?",
+      "emailDescription": "We will send your request through the Contact Service with a prefilled email.",
+      "openEmail": "Send via Contact Service",
+      "details": "Additional Details",
+      "noAttributes": "No additional information provided.",
+      "anonymousName": "Nudger User"
     },
     "submission": {
       "success": "Request Submitted!",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2812,10 +2812,12 @@
       "required": "La demande ne peut pas être vide",
       "private": "Rendre ma demande privée",
       "privateDescription": "Le ticket sera public, mais votre texte original sera masqué.",
-      "email": "Vous préférez envoyer un email ?",
-      "emailDescription": "Vous pouvez utiliser votre client de messagerie par défaut.",
-      "openEmail": "Ouvrir mon email",
-      "details": "Détails supplémentaires"
+      "email": "Vous êtes timides ?",
+      "emailDescription": "Nous envoyons votre demande au Contact Service avec un email prérempli.",
+      "openEmail": "Envoyer via Contact Service",
+      "details": "Détails supplémentaires",
+      "noAttributes": "Aucune information complémentaire fournie.",
+      "anonymousName": "Utilisateur Nudger"
     },
     "submission": {
       "success": "Demande envoyée !",

--- a/frontend/server/api/contact.post.ts
+++ b/frontend/server/api/contact.post.ts
@@ -9,6 +9,11 @@ interface ContactFormPayload {
   email?: string
   message?: string
   hCaptchaResponse?: string
+  templateId?: string
+  subject?: string
+  sourceRoute?: string
+  sourceComponent?: string
+  sourcePage?: string
 }
 
 const EMAIL_PATTERN =
@@ -28,6 +33,11 @@ export default defineEventHandler(
     const email = sanitizeInput(String(body.email ?? ''))
     const message = sanitizeInput(String(body.message ?? ''))
     const hCaptchaResponse = sanitizeInput(String(body.hCaptchaResponse ?? ''))
+    const templateId = sanitizeInput(String(body.templateId ?? ''))
+    const subject = sanitizeInput(String(body.subject ?? ''))
+    const sourceRoute = sanitizeInput(String(body.sourceRoute ?? ''))
+    const sourceComponent = sanitizeInput(String(body.sourceComponent ?? ''))
+    const sourcePage = sanitizeInput(String(body.sourcePage ?? ''))
 
     if (!name) {
       throw createError({
@@ -79,6 +89,11 @@ export default defineEventHandler(
         email,
         message,
         hCaptchaResponse,
+        templateId: templateId || undefined,
+        subject: subject || undefined,
+        sourceRoute: sourceRoute || undefined,
+        sourceComponent: sourceComponent || undefined,
+        sourcePage: sourcePage || undefined,
       })
     } catch (error) {
       const backendError = await extractBackendErrorDetails(error)

--- a/frontend/shared/api-client/models/ContactRequestDto.ts
+++ b/frontend/shared/api-client/models/ContactRequestDto.ts
@@ -43,6 +43,36 @@ export interface ContactRequestDto {
      * @memberof ContactRequestDto
      */
     hCaptchaResponse: string;
+    /**
+     * Identifier of the mail template to use for composing the email.
+     * @type {string}
+     * @memberof ContactRequestDto
+     */
+    templateId?: string | null;
+    /**
+     * Optional subject override when the template is not available.
+     * @type {string}
+     * @memberof ContactRequestDto
+     */
+    subject?: string | null;
+    /**
+     * Frontend route from which the request originates.
+     * @type {string}
+     * @memberof ContactRequestDto
+     */
+    sourceRoute?: string | null;
+    /**
+     * Component or page identifier initiating the request.
+     * @type {string}
+     * @memberof ContactRequestDto
+     */
+    sourceComponent?: string | null;
+    /**
+     * Human readable page title that initiated the request.
+     * @type {string}
+     * @memberof ContactRequestDto
+     */
+    sourcePage?: string | null;
 }
 
 /**
@@ -70,6 +100,11 @@ export function ContactRequestDtoFromJSONTyped(json: any, ignoreDiscriminator: b
         'email': json['email'],
         'message': json['message'],
         'hCaptchaResponse': json['h-captcha-response'],
+        'templateId': json['templateId'] == null ? null : json['templateId'],
+        'subject': json['subject'] == null ? null : json['subject'],
+        'sourceRoute': json['sourceRoute'] == null ? null : json['sourceRoute'],
+        'sourceComponent': json['sourceComponent'] == null ? null : json['sourceComponent'],
+        'sourcePage': json['sourcePage'] == null ? null : json['sourcePage'],
     };
 }
 
@@ -88,6 +123,10 @@ export function ContactRequestDtoToJSONTyped(value?: ContactRequestDto | null, i
         'email': value['email'],
         'message': value['message'],
         'h-captcha-response': value['hCaptchaResponse'],
+        'templateId': value['templateId'],
+        'subject': value['subject'],
+        'sourceRoute': value['sourceRoute'],
+        'sourceComponent': value['sourceComponent'],
+        'sourcePage': value['sourcePage'],
     };
 }
-


### PR DESCRIPTION
## Summary
- add reusable mail template configuration and make contact service template-aware with domain language rendering
- extend contact DTOs, server route, and API client to forward template/context metadata for agent fallback submissions
- refresh agent prompt fallback UI copy and route the CTA through the contact service with prefilled context

## Testing
- ✅ `pnpm lint`
- ⚠️ `mvn --offline -pl front-api -am test` *(fails in offline mode because `com.h2database:h2:2.3.232` is missing locally; requires online resolution)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949481a2bd08322bea316ba4df0424e)