### PR TITLE
Remove GTIN embedding mapping from product index

### DIFF
--- a/model/src/main/resources/product-mappings.json
+++ b/model/src/main/resources/product-mappings.json
@@ -363,12 +363,6 @@
         "upcType": {
           "type": "keyword",
           "index": false
-        },
-        "embedding": {
-          "type": "dense_vector",
-          "dims": 512,
-          "index": true,
-          "similarity": "cosine"
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove the GTIN info dense_vector mapping from product-mappings to drop unused embeddings

## Testing
- mvn --offline -pl model test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694afcb5743c832297757ab1b9203047)