### PR TITLE
Add semantic vector search pipeline

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -277,9 +277,10 @@ public class ApiConfig {
 
 
 	@Bean
-	SearchService searchService(@Autowired ProductRepository aggregatedDataRepository, @Autowired String logsFolder) {
-		return new SearchService(aggregatedDataRepository, logsFolder);
-	}
+    SearchService searchService(@Autowired ProductRepository aggregatedDataRepository, @Autowired String logsFolder,
+                    @Autowired DjlTextEmbeddingService textEmbeddingService) {
+            return new SearchService(aggregatedDataRepository, logsFolder, textEmbeddingService);
+    }
 
 	@Bean
         BrandService brandService(@Autowired RemoteFileCachingService rfc, @Autowired SerialisationService serialisationService) throws Exception {

--- a/api/src/main/java/org/open4goods/api/services/completion/text/DjlTextEmbeddingService.java
+++ b/api/src/main/java/org/open4goods/api/services/completion/text/DjlTextEmbeddingService.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
 import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.commons.services.TextEmbeddingService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +22,7 @@ import ai.djl.repository.zoo.ZooModel;
 import ai.djl.training.util.ProgressBar;
 
 @Service
-public class DjlTextEmbeddingService {
+public class DjlTextEmbeddingService implements TextEmbeddingService {
 
     private static final Logger logger = LoggerFactory.getLogger(DjlTextEmbeddingService.class);
 
@@ -48,6 +49,7 @@ public class DjlTextEmbeddingService {
      * @param text
      * @return normalized embedding vector
      */
+    @Override
     public float[] embed(String text) {
         float[] vector = embedWithModel(textModel, text);
         if (vector != null) {

--- a/commons/src/main/java/org/open4goods/commons/services/SearchService.java
+++ b/commons/src/main/java/org/open4goods/commons/services/SearchService.java
@@ -19,6 +19,7 @@ import org.open4goods.model.product.ProductCondition;
 import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.SubsetCriteria;
 import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.commons.services.TextEmbeddingService;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,10 +74,12 @@ public class SearchService {
 
 	public static final String MISSING_BUCKET = "ES-UNKNOWN";
 
-        private ProductRepository aggregatedDataRepository;
+        private final ProductRepository aggregatedDataRepository;
+        private final TextEmbeddingService embeddingService;
 
-        public SearchService(ProductRepository aggregatedDataRepository, String logsFolder) {
+        public SearchService(ProductRepository aggregatedDataRepository, String logsFolder, TextEmbeddingService embeddingService) {
                 this.aggregatedDataRepository = aggregatedDataRepository;
+                this.embeddingService = embeddingService;
         }
 
         /**
@@ -285,352 +288,346 @@ public class SearchService {
 	 */
 	//TODO : Why 
 	// @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
-	public VerticalSearchResponse verticalSearch(VerticalConfig vertical, VerticalSearchRequest request) {
+	        public VerticalSearchResponse verticalSearch(VerticalConfig vertical, VerticalSearchRequest request) {
 
-		VerticalSearchResponse vsr = new VerticalSearchResponse();
+                VerticalSearchResponse vsr = new VerticalSearchResponse();
 
-		List<AttributeConfig> customAttrFilters = vertical.verticalFilters().stream().filter(Objects::nonNull).toList();
+                List<AttributeConfig> customAttrFilters = vertical.verticalFilters().stream().filter(Objects::nonNull).toList();
 
-		Criteria criterias = new Criteria("vertical").is(vertical.getId())
-				.and(aggregatedDataRepository.getRecentPriceQuery())
-				;
-		
-		// Filtering on brand if in this disposition
-		if (request.getBrandsSubset() != null) {
-			if (request.getBrandsSubset().getCriterias().size() == 1) {
-				SubsetCriteria cr = request.getBrandsSubset().getCriterias().getFirst();
-				criterias.and(new Criteria(cr.getField()).is(cr.getValue()));
-			}
-		}
-		
-		// Adding the filter on excluded if set
-		if (request.getExcludedFilters().size()>0) {
-			criterias.and(new Criteria("excludedCauses").in(request.getExcludedFilters()) );	
-		} else 	if (!request.isExcluded()) {
-			criterias.and(new Criteria("excluded").is(false));
-		}
-		
+                Criteria criterias = buildVerticalCriteria(vertical, request);
 
-		// Adding custom numeric filters
-//		Criteria optional
-		for (NumericRangeFilter filter : request.getNumericFilters()) {
+                NativeQueryBuilder esQuery = new NativeQueryBuilder().withQuery(new CriteriaQuery(criterias));
 
-		    if (!filter.isAllowEmptyValues()) {
-		        // Strict "and" filtering for the range
-		        Criteria rangeCriteria = new Criteria(filter.getKey())
-		            .greaterThanEqual(filter.getMinValue())
-		            .lessThanEqual(filter.getMaxValue());
+                Pageable pageable = resolvePageable(request);
+                esQuery = esQuery.withPageable(pageable);
 
-		        criterias.and(rangeCriteria);
-		    } else {
-		        // Allow items where the field is not present OR within the range
-		    	criterias.subCriteria(new Criteria().or(filter.getKey()).exists().not()
-		    			.or(filter.getKey())
-			            .greaterThanEqual(filter.getMinValue())
-			            .lessThanEqual(filter.getMaxValue()));
-		    }
-		}
+                // Adding standard aggregations
+                esQuery = esQuery
+        //                              .withAggregation("min_price",   Aggregation.of(a -> a.min(ta -> ta.field("price.minPrice.price"))))
+        //                              .withAggregation("max_price",   Aggregation.of(a -> a.max(ta -> ta.field("price.minPrice.price"))))
+        //                              .withAggregation("min_offers",  Aggregation.of(a -> a.min(ta -> ta.field("offersCount"))))
+        //                              .withAggregation("max_offers",  Aggregation.of(a -> a.max(ta -> ta.field("offersCount"))))
+                                .withAggregation("conditions",  Aggregation.of(a -> a.terms(ta -> ta.field("price.conditions").missing(MISSING_BUCKET).size(3)))        )
+                                .withAggregation("trend",       Aggregation.of(a -> a.terms(ta -> ta.field("price.trend").size(3)))     )
+                                .withAggregation("excludedCauses",      Aggregation.of(a -> a.terms(ta -> ta.field("excludedCauses").size(20))) )
+                                .withAggregation("brands",      Aggregation.of(a -> a.terms(ta -> ta.field("attributes.referentielAttributes.BRAND").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))  )
+                                .withAggregation("country",     Aggregation.of(a -> a.terms(ta -> ta.field("gtinInfos.country").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))       )
 
 
-		// Adding custom checkbox filters
-		for (Entry<String, Set<String>> filter : request.getTermsFilter().entrySet()) {
-			
-			// If we must show the missing, and if several clauses, we need a OR condition
-			if (filter.getValue().size() > 1 &&  filter.getValue().contains(MISSING_BUCKET)) {
-		    	criterias.subCriteria(new Criteria().or(filter.getKey()).exists().not()
-		    			.or(filter.getKey()).in(filter.getValue()))  ;
-			} else {
-				if (filter.getValue().contains(MISSING_BUCKET)) {
-					criterias.and(new Criteria(filter.getKey()).exists().not());					
-				} else {
-					
-//					// TODO : dirty hack
-//					if ("price.trend".equals(filter.getKey())) {
-//						criterias.and(new Criteria(filter.getKey()).is((filter.getValue().stream().findAny().orElse(null))));
-//					} else {
-						criterias.and(new Criteria(filter.getKey()).in(filter.getValue()) );
-//					}
-				}
-				
-			}
-			
-		}
+                                ;
+                ////
+                // Sort order
+                /////
 
-		/////////////////////////////////
-		// Adding subset hard filtering
-		/////////////////////////////////
-		
-		request.getSubsets().forEach(subset -> {
-			subset.getCriterias().forEach(criteria -> {
-				switch (criteria.getOperator()) {
-				case LOWER_THAN: {
-					criterias.and(new Criteria(criteria.getField()).lessThanEqual(Double.valueOf(criteria.getValue())));
-					break;
-				}
-				case GREATER_THAN: {
-					criterias.and(new Criteria(criteria.getField()).greaterThanEqual(Double.valueOf( criteria.getValue())));					
-					break;
-				}
-				case EQUALS: {
-					criterias.and(new Criteria(criteria.getField()).is(criteria.getValue()));
+                if (request.getSortField() != null) {
+                    SortOrder order = request.getSortOrder().equalsIgnoreCase("DESC") ? SortOrder.Desc : SortOrder.Asc;
 
-					break;
-				}
-				
-				
-				
-				default:
-					throw new IllegalArgumentException("Unexpected value: " + criteria.getOperator());
-				}
-				
-			});
-		});
-		
-		
-		
-		// Setting the query
-		NativeQueryBuilder esQuery = new NativeQueryBuilder().withQuery(new CriteriaQuery(criterias));
+                    SortOptions sortOptions = new SortOptions.Builder()
+                        .field(new FieldSort.Builder()
+                            .field(request.getSortField())
+                            .order(order)
+                            .unmappedType(FieldType.Float) // or "keyword"/"long" depending on the field
+                            .missing("_last")
+                            .build())
+                        .build();
 
-		// Pagination
-		if (null != request.getPageNumber() && null != request.getPageSize()) {
-			esQuery = esQuery .withPageable(PageRequest.of(request.getPageNumber(), request.getPageSize()));
-		} else {
-			//TODO(p3,conf) : default pageNumber from conf
-			esQuery = esQuery .withPageable(PageRequest.of(0, 100));
-		}
+                    esQuery = esQuery.withSort(sortOptions);
+                }
+
+                // Adding custom attributes terms filters aggregations
+                for (AttributeConfig attrConfig : customAttrFilters) {
+                    esQuery = esQuery
+                                    .withAggregation(attrConfig.getKey(),   Aggregation.of(a -> a.terms(ta -> ta.field("attributes.indexed."+attrConfig.getKey()+".value").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))        );
+                }
+
+                // Adding custom range aggregations
+                for (NumericRangeFilter filter: request.getNumericFilters()) {
+                    esQuery = esQuery
+                    .withAggregation("min_"+filter.getKey(),        Aggregation.of(a -> a.min(ta -> ta.field(filter.getKey()))))
+                    .withAggregation("max_"+filter.getKey(),        Aggregation.of(a -> a.max(ta -> ta.field(filter.getKey()))))
+                    .withAggregation("missing_"+filter.getKey(),    Aggregation.of(a -> a.missing(ta -> ta.field(filter.getKey()))))
+                    .withAggregation("interval_"+filter.getKey(),
+                                Aggregation.of(a -> a.histogram(h -> h.field(filter.getKey())
+                                        .interval(filter.getIntervalSize())
+                                        .minDocCount(1)) // Ensure empty buckets are excluded
+                                    ))
+                    ;
+                }
+
+                SearchHits<Product> results;
+                try {
+                        results = aggregatedDataRepository.search(esQuery.build(),ProductRepository.MAIN_INDEX_NAME);
+                } catch (Exception e) {
+
+                        if (e instanceof UncategorizedElasticsearchException) {
+                            Throwable cause = e.getCause();
+                            if (cause instanceof ElasticsearchException ee) {
+                                LOGGER.error ("Elasticsearch error: " + ee.response());
+                            }
+                        }
+
+                        throw e;
+                }
 
 
-		// Adding standard aggregations
-		esQuery = esQuery
-//				.withAggregation("min_price", 	Aggregation.of(a -> a.min(ta -> ta.field("price.minPrice.price"))))
-//				.withAggregation("max_price", 	Aggregation.of(a -> a.max(ta -> ta.field("price.minPrice.price"))))
-//				.withAggregation("min_offers", 	Aggregation.of(a -> a.min(ta -> ta.field("offersCount"))))
-//				.withAggregation("max_offers", 	Aggregation.of(a -> a.max(ta -> ta.field("offersCount"))))
-				.withAggregation("conditions", 	Aggregation.of(a -> a.terms(ta -> ta.field("price.conditions").missing(MISSING_BUCKET).size(3)))	)
-				.withAggregation("trend", 	Aggregation.of(a -> a.terms(ta -> ta.field("price.trend").size(3)))	)
-				.withAggregation("excludedCauses", 	Aggregation.of(a -> a.terms(ta -> ta.field("excludedCauses").size(20)))	)				
-				.withAggregation("brands", 	Aggregation.of(a -> a.terms(ta -> ta.field("attributes.referentielAttributes.BRAND").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))	)
-				.withAggregation("country", 	Aggregation.of(a -> a.terms(ta -> ta.field("gtinInfos.country").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))	)
-				
-				
-				;
-		////
-		// Sort order
-		/////
-
-		if (request.getSortField() != null) {
-		    SortOrder order = request.getSortOrder().equalsIgnoreCase("DESC") ? SortOrder.Desc : SortOrder.Asc;
-
-		    SortOptions sortOptions = new SortOptions.Builder()
-		        .field(new FieldSort.Builder()
-		            .field(request.getSortField())
-		            .order(order)
-		            .unmappedType(FieldType.Float) // or "keyword"/"long" depending on the field
-		            .missing("_last")
-		            .build())
-		        .build();
-
-		    esQuery = esQuery.withSort(sortOptions);
-		}
-
-		// Adding custom attributes terms filters aggregations
-		for (AttributeConfig attrConfig : customAttrFilters) {
-			esQuery = esQuery
-					.withAggregation(attrConfig.getKey(), 	Aggregation.of(a -> a.terms(ta -> ta.field("attributes.indexed."+attrConfig.getKey()+".value").missing(MISSING_BUCKET).size(AGGREGATION_BUCKET_SIZE)  ))	);
-		}
-		
-		// Adding custom range aggregations
-		for (NumericRangeFilter filter: request.getNumericFilters()) {
-			esQuery = esQuery
-			.withAggregation("min_"+filter.getKey(),  	Aggregation.of(a -> a.min(ta -> ta.field(filter.getKey()))))
-			.withAggregation("max_"+filter.getKey(), 	Aggregation.of(a -> a.max(ta -> ta.field(filter.getKey()))))
-			.withAggregation("missing_"+filter.getKey(), 	Aggregation.of(a -> a.missing(ta -> ta.field(filter.getKey()))))
-			.withAggregation("interval_"+filter.getKey(), 
-				    Aggregation.of(a -> a.histogram(h -> h.field(filter.getKey())
-				            .interval(filter.getIntervalSize()) 
-				            .minDocCount(1)) // Ensure empty buckets are excluded
-				        ))
-//			 .withAggregation("range_" + filter.getKey(),
-//				        Aggregation.of(a -> a.range(r -> r
-//				            .field(filter.getKey())
-//				            .ranges(
-//				            	// TODO : From conf
-//				                // Fine-grained range for lower values
-//				                AggregationRange.of(r1 -> r1.key("0-500").from("0").to("500")),
-//				                AggregationRange.of(r2 -> r2.key("500-1500").from("500").to("1500")),
-//				                // Medium steps for mid-range values
-//				                AggregationRange.of(r3 -> r3.key("1500-5000").from("1500").to("5000")),
-//				                // Larger steps for higher values
-//				                AggregationRange.of(r4 -> r4.key("5000-10000").from("5000").to("10000")),
-//				                AggregationRange.of(r5 -> r5.key("10000+").from("10000")
-//				                )
-//				            )
-//				        ))
-//				    )
-			;		
-		}
-				
-		SearchHits<Product> results;
-		try {
-			results = aggregatedDataRepository.search(esQuery.build(),ProductRepository.MAIN_INDEX_NAME);
-		} catch (Exception e) {
-			
-			if (e instanceof UncategorizedElasticsearchException) {
-			    Throwable cause = e.getCause();
-			    if (cause instanceof ElasticsearchException ee) {
-			        LOGGER.error ("Elasticsearch error: " + ee.response());
-			    }
-			}
-
-			throw e;
-		}
+                // Handling aggregations results if relevant
+                //NOTE(gof) : this cast is not nice...
+                ElasticsearchAggregations aggregations = (ElasticsearchAggregations)results.getAggregations();
 
 
-		// Handling aggregations results if relevant
-		//NOTE(gof) : this cast is not nice...
-		ElasticsearchAggregations aggregations = (ElasticsearchAggregations)results.getAggregations();
+                ///////
+                // Numeric aggregations
+                ///////
+                MinAggregate minPrice = aggregations.get("min_price.minPrice.price").aggregation().getAggregate().min();
+                MaxAggregate maxPrice = aggregations.get("max_price.minPrice.price").aggregation().getAggregate().max();
+                MaxAggregate maxOffers = aggregations.get("max_offersCount").aggregation().getAggregate().max();
+                MinAggregate minOffers = aggregations.get("min_offersCount").aggregation().getAggregate().min();
+                //
+                vsr.setMaxPrice(maxPrice.value());
+                vsr.setMinPrice(minPrice.value());
+                vsr.setMaxOffers(Double.valueOf(maxOffers.value()).intValue());
+                vsr.setMinOffers(Double.valueOf(minOffers.value()).intValue());
 
 
-		///////
-		// Numeric aggregations
-		///////
-		MinAggregate minPrice = aggregations.get("min_price.minPrice.price").aggregation().getAggregate().min();
-		MaxAggregate maxPrice = aggregations.get("max_price.minPrice.price").aggregation().getAggregate().max();
-		MaxAggregate maxOffers = aggregations.get("max_offersCount").aggregation().getAggregate().max();
-		MinAggregate minOffers = aggregations.get("min_offersCount").aggregation().getAggregate().min();
-		//
-		vsr.setMaxPrice(maxPrice.value());
-		vsr.setMinPrice(minPrice.value());
-		vsr.setMaxOffers(Double.valueOf(maxOffers.value()).intValue());
-		vsr.setMinOffers(Double.valueOf(minOffers.value()).intValue());
+
+                // Adding custom range aggregations
+                for (NumericRangeFilter filter: request.getNumericFilters()) {
+
+                        MinAggregate min = aggregations.get("min_"+filter.getKey()).aggregation().getAggregate().min();
+                        MaxAggregate max= aggregations.get("max_"+filter.getKey()).aggregation().getAggregate().max();
+                        MissingAggregate missing = aggregations.get("missing_"+filter.getKey()).aggregation().getAggregate().missing();
+                        HistogramAggregate priceHistogram = aggregations.get("interval_" + filter.getKey()).aggregation().getAggregate().histogram();
+
+                        List<NumericBucket> priceBuckets = new ArrayList<>();
+                        for (HistogramBucket bucket : priceHistogram.buckets().array()) {
+                            priceBuckets.add(new NumericBucket(bucket.key()+"", bucket.docCount()));
+                        }
 
 
-		
-		// Adding custom range aggregations
-		for (NumericRangeFilter filter: request.getNumericFilters()) {
-			
-			MinAggregate min = aggregations.get("min_"+filter.getKey()).aggregation().getAggregate().min();
-			MaxAggregate max= aggregations.get("max_"+filter.getKey()).aggregation().getAggregate().max();
-			MissingAggregate missing = aggregations.get("missing_"+filter.getKey()).aggregation().getAggregate().missing();
-			HistogramAggregate priceHistogram = aggregations.get("interval_" + filter.getKey()).aggregation().getAggregate().histogram();
-			
-			List<NumericBucket> priceBuckets = new ArrayList<>();
-			for (HistogramBucket bucket : priceHistogram.buckets().array()) {
-			    priceBuckets.add(new NumericBucket(bucket.key()+"", bucket.docCount()));
-			}
-			
-			
-//			RangeAggregate priceAgg =  aggregations.get("range_" + filter.getKey()).aggregation().getAggregate().range();
-//			for (RangeBucket rb : priceAgg.buckets().array()) {
-//				 priceBuckets.add(new PriceBucket(rb.key()+"", rb.docCount()));
-//			}
-//			
-			NumericRangeFilter nrf = new NumericRangeFilter();
-			nrf.setMaxValue(max.value());
-			nrf.setMinValue(min.value());
-			nrf.setPriceBuckets(priceBuckets);
-			nrf.setUnknown(missing.docCount());
-			
-			vsr.getNumericFilters().put(filter.getKey(), nrf);
-			
-		}
-		
-		
-		///////
-		// Price trend
-		///////
+                        NumericRangeFilter nrf = new NumericRangeFilter();
+                        nrf.setMaxValue(max.value());
+                        nrf.setMinValue(min.value());
+                        nrf.setPriceBuckets(priceBuckets);
+                        nrf.setUnknown(missing.docCount());
 
-		LongTermsAggregate productSate  =  aggregations.get("trend").aggregation().getAggregate().lterms();
-		for (LongTermsBucket b :   productSate.buckets().array()) {
-			
-			if (b.key() == -1) {
-				vsr.setPriceDecreasing(b.docCount());
-			}
-		}
-		
-		///////
-		// Item condition
-		///////
+                        vsr.getNumericFilters().put(filter.getKey(), nrf);
 
-		StringTermsAggregate priceTrend  =  aggregations.get("conditions").aggregation().getAggregate().sterms();
-		for (StringTermsBucket b :   priceTrend.buckets().array()) {
-			vsr.getConditions().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
-		}
-		vsr.getConditions().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
+                }
 
 
-		///////
-		// Brands
-		///////
+                ///////
+                // Price trend
+                ///////
 
-		StringTermsAggregate brands  =  aggregations.get("brands").aggregation().getAggregate().sterms() ;
-		for (StringTermsBucket b :   brands.buckets().array()) {
-			vsr.getBrands().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
-		}
-		vsr.getBrands().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
+                LongTermsAggregate productSate  =  aggregations.get("trend").aggregation().getAggregate().lterms();
+                for (LongTermsBucket b :   productSate.buckets().array()) {
 
-		///////
-		// Countries
-		///////
+                        if (b.key() == -1) {
+                                vsr.setPriceDecreasing(b.docCount());
+                        }
+                }
 
-		StringTermsAggregate countries  =  aggregations.get("country").aggregation().getAggregate().sterms() ;
-		for (StringTermsBucket bucket : countries.buckets().array()) {
-			vsr.getCountries().add (new VerticalFilterTerm(bucket.key().stringValue(), bucket.docCount()));
-		}
-		vsr.getCountries().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
+                ///////
+                // Item condition
+                ///////
 
-		///////
-		// excluded
-		///////
-
-		StringTermsAggregate excluded  =  aggregations.get("excludedCauses").aggregation().getAggregate().sterms() ;
-		for (StringTermsBucket b :   excluded.buckets().array()) {
-			vsr.getExcluded().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
-		}
-		vsr.getExcluded().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
-
-		
-		//////////////
-		/// Attr filters
-		//////////////
+                StringTermsAggregate priceTrend  =  aggregations.get("conditions").aggregation().getAggregate().sterms();
+                for (StringTermsBucket b :   priceTrend.buckets().array()) {
+                        vsr.getConditions().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
+                }
+                vsr.getConditions().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
 
 
-		//		// Handling custom filters aggregations
-		for (AttributeConfig attrConfig : customAttrFilters) {
-			StringTermsAggregate agg  =  aggregations.get(attrConfig.getKey()).aggregation().getAggregate().sterms() ;
-			vsr.getCustomFilters().put(attrConfig, new ArrayList<>());
-			for (StringTermsBucket bucket : agg.buckets().array()) {
+                ///////
+                // Brands
+                ///////
 
-				if (!bucket.key().stringValue().equals(MISSING_BUCKET)) {
-					vsr.getCustomFilters().get(attrConfig).add (new VerticalFilterTerm(bucket.key().stringValue(), bucket.docCount()));
-				} else {
-					vsr.getCustomFilters().get(attrConfig).add (new VerticalFilterTerm(MISSING_BUCKET, bucket.docCount()));
-				}
-			}
+                StringTermsAggregate brands  =  aggregations.get("brands").aggregation().getAggregate().sterms() ;
+                for (StringTermsBucket b :   brands.buckets().array()) {
+                        vsr.getBrands().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
+                }
+                vsr.getBrands().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
 
-			if (attrConfig.getAttributeValuesOrdering().equals(org.open4goods.model.vertical.Order.COUNT ) ) {
-				vsr.getCustomFilters().get(attrConfig).sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
-			}
-			else {
-				vsr.getCustomFilters().get(attrConfig).sort(Comparator.comparing(VerticalFilterTerm::getText));
-			}
+                ///////
+                // Countries
+                ///////
 
-		}
+                StringTermsAggregate countries  =  aggregations.get("country").aggregation().getAggregate().sterms() ;
+                for (StringTermsBucket bucket : countries.buckets().array()) {
+                        vsr.getCountries().add (new VerticalFilterTerm(bucket.key().stringValue(), bucket.docCount()));
+                }
+                vsr.getCountries().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
 
-		// Setting the response
-		vsr.setTotalResults(results.getTotalHits());
-		vsr.setData(results.get().map(SearchHit::getContent).toList());
+                ///////
+                // excluded
+                ///////
 
-		vsr.setVerticalConfig(vertical);
-		vsr.setRequest(request);
-		String queryString = StringUtils.join(criterias.getCriteriaChain(), "\n-> ");
-		LOGGER.info("Searching in vertical {} : {} results for query \n-> {}", vertical.getId(), vsr.getTotalResults(), queryString);
-//		verticalstatsLogger.info("Searching in vertical {} : {}",vertical.getId(), request.toString());
+                StringTermsAggregate excluded  =  aggregations.get("excludedCauses").aggregation().getAggregate().sterms() ;
+                for (StringTermsBucket b :   excluded.buckets().array()) {
+                        vsr.getExcluded().add (new VerticalFilterTerm(b.key().stringValue(), b.docCount()));
+                }
+                vsr.getExcluded().sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
 
-		return vsr;
-	}
 
-    public String sanitize(String q) {
+                //////////////
+                /// Attr filters
+                //////////////
+
+
+                //              // Handling custom filters aggregations
+                for (AttributeConfig attrConfig : customAttrFilters) {
+                        StringTermsAggregate agg  =  aggregations.get(attrConfig.getKey()).aggregation().getAggregate().sterms() ;
+                        vsr.getCustomFilters().put(attrConfig, new ArrayList<>());
+                        for (StringTermsBucket bucket : agg.buckets().array()) {
+
+                                if (!bucket.key().stringValue().equals(MISSING_BUCKET)) {
+                                        vsr.getCustomFilters().get(attrConfig).add (new VerticalFilterTerm(bucket.key().stringValue(), bucket.docCount()));
+                                } else {
+                                        vsr.getCustomFilters().get(attrConfig).add (new VerticalFilterTerm(MISSING_BUCKET, bucket.docCount()));
+                                }
+                        }
+
+                        if (attrConfig.getAttributeValuesOrdering().equals(org.open4goods.model.vertical.Order.COUNT ) ) {
+                                vsr.getCustomFilters().get(attrConfig).sort((o1, o2) -> o2.getCount().compareTo(o1.getCount()));
+                        }
+                        else {
+                                vsr.getCustomFilters().get(attrConfig).sort(Comparator.comparing(VerticalFilterTerm::getText));
+                        }
+
+                }
+
+                // Setting the response
+                vsr.setTotalResults(results.getTotalHits());
+                vsr.setData(results.get().map(SearchHit::getContent).toList());
+                vsr.setFrom((int) pageable.getOffset());
+                vsr.setTo((int) pageable.getOffset() + vsr.getData().size());
+
+                vsr.setVerticalConfig(vertical);
+                vsr.setRequest(request);
+                String queryString = StringUtils.join(criterias.getCriteriaChain(), " -> ");
+                LOGGER.info("Searching in vertical {} : {} results for query -> {}", vertical.getId(), vsr.getTotalResults(), queryString);
+
+                return vsr;
+            }
+
+            public VerticalSearchResponse verticalSemanticSearch(VerticalConfig vertical, VerticalSearchRequest request, String query) {
+                VerticalSearchResponse response = new VerticalSearchResponse();
+                response.setVerticalConfig(vertical);
+                response.setRequest(request);
+
+        String sanitized = sanitize(query);
+        float[] vector = embeddingService.embed(sanitized);
+                if (vector == null || vector.length == 0) {
+                    response.setTotalResults(0L);
+                    response.setFrom(0);
+                    response.setTo(0);
+                    response.setData(List.of());
+                    return response;
+                }
+
+                Criteria criterias = buildVerticalCriteria(vertical, request);
+                Pageable pageable = resolvePageable(request);
+                int knnLimit = Math.max(pageable.getPageSize() * (pageable.getPageNumber() + 1), pageable.getPageSize());
+
+                SearchHits<Product> results = aggregatedDataRepository.knnSearchByEmbedding(vector, criterias, knnLimit);
+
+                List<Product> products = results.getSearchHits().stream()
+                        .skip(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .map(SearchHit::getContent)
+                        .toList();
+
+                response.setTotalResults(results.getTotalHits());
+                response.setFrom((int) pageable.getOffset());
+                response.setTo((int) pageable.getOffset() + products.size());
+                response.setData(products);
+        LOGGER.info("Semantic search in vertical {} : {} results for query {}", vertical.getId(), response.getTotalResults(), sanitized);
+        return response;
+    }
+
+            private Criteria buildVerticalCriteria(VerticalConfig vertical, VerticalSearchRequest request) {
+                Criteria criterias = new Criteria("vertical").is(vertical.getId())
+                        .and(aggregatedDataRepository.getRecentPriceQuery());
+
+                if (request.getBrandsSubset() != null && request.getBrandsSubset().getCriterias().size() == 1) {
+                        SubsetCriteria cr = request.getBrandsSubset().getCriterias().getFirst();
+                        criterias.and(new Criteria(cr.getField()).is(cr.getValue()));
+                }
+
+                if (request.getExcludedFilters().size() > 0) {
+                        criterias.and(new Criteria("excludedCauses").in(request.getExcludedFilters()) );
+                } else  if (!request.isExcluded()) {
+                        criterias.and(new Criteria("excluded").is(false));
+                }
+
+                for (NumericRangeFilter filter : request.getNumericFilters()) {
+
+                    if (!filter.isAllowEmptyValues()) {
+                        Criteria rangeCriteria = new Criteria(filter.getKey())
+                            .greaterThanEqual(filter.getMinValue())
+                            .lessThanEqual(filter.getMaxValue());
+
+                        criterias.and(rangeCriteria);
+                    } else {
+                        criterias.subCriteria(new Criteria().or(filter.getKey()).exists().not()
+                                        .or(filter.getKey())
+                                    .greaterThanEqual(filter.getMinValue())
+                                    .lessThanEqual(filter.getMaxValue()));
+                    }
+                }
+
+                for (Entry<String, Set<String>> filter : request.getTermsFilter().entrySet()) {
+
+                        if (filter.getValue().size() > 1 &&  filter.getValue().contains(MISSING_BUCKET)) {
+                        criterias.subCriteria(new Criteria().or(filter.getKey()).exists().not()
+                                        .or(filter.getKey()).in(filter.getValue()))  ;
+                        } else {
+                                if (filter.getValue().contains(MISSING_BUCKET)) {
+                                        criterias.and(new Criteria(filter.getKey()).exists().not());
+                                } else {
+                                        criterias.and(new Criteria(filter.getKey()).in(filter.getValue()) );
+                                }
+
+                        }
+
+                }
+
+                request.getSubsets().forEach(subset -> {
+                        subset.getCriterias().forEach(criteria -> {
+                                switch (criteria.getOperator()) {
+                                case LOWER_THAN: {
+                                        criterias.and(new Criteria(criteria.getField()).lessThanEqual(Double.valueOf(criteria.getValue())));
+                                        break;
+                                }
+                                case GREATER_THAN: {
+                                        criterias.and(new Criteria(criteria.getField()).greaterThanEqual(Double.valueOf( criteria.getValue())));
+                                        break;
+                                }
+                                case EQUALS: {
+                                        criterias.and(new Criteria(criteria.getField()).is(criteria.getValue()));
+
+                                        break;
+                                }
+
+
+
+                                default:
+                                        throw new IllegalArgumentException("Unexpected value: " + criteria.getOperator());
+                                }
+
+                        });
+                });
+
+                return criterias;
+            }
+
+            private Pageable resolvePageable(VerticalSearchRequest request) {
+                if (null != request.getPageNumber() && null != request.getPageSize()) {
+                        return PageRequest.of(request.getPageNumber(), request.getPageSize());
+                }
+                return PageRequest.of(0, 100);
+            }
+public String sanitize(String q) {
             if (q == null) {
                     return "";
             }

--- a/commons/src/main/java/org/open4goods/commons/services/TextEmbeddingService.java
+++ b/commons/src/main/java/org/open4goods/commons/services/TextEmbeddingService.java
@@ -1,0 +1,16 @@
+package org.open4goods.commons.services;
+
+/**
+ * Simple contract for components able to generate embedding vectors for free text inputs.
+ */
+public interface TextEmbeddingService
+{
+
+    /**
+     * Generates an embedding vector for the provided text.
+     *
+     * @param text the text to embed
+     * @return a normalised embedding vector or {@code null} when the text cannot be embedded
+     */
+    float[] embed(String text);
+}

--- a/commons/src/test/java/org/open4goods/commons/services/SearchServiceTest.java
+++ b/commons/src/test/java/org/open4goods/commons/services/SearchServiceTest.java
@@ -1,0 +1,94 @@
+package org.open4goods.commons.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.commons.model.dto.VerticalSearchRequest;
+import org.open4goods.commons.model.dto.VerticalSearchResponse;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest
+{
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private TextEmbeddingService textEmbeddingService;
+
+    @Mock
+    private SearchHits<Product> searchHits;
+
+    @Mock
+    private SearchHit<Product> searchHit;
+
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp()
+    {
+        searchService = new SearchService(productRepository, "logs", textEmbeddingService);
+        lenient().when(productRepository.getRecentPriceQuery()).thenReturn(new Criteria("offersCount").greaterThan(0));
+    }
+
+    @Test
+    void verticalSemanticSearchReturnsEmptyWhenEmbeddingMissing()
+    {
+        when(textEmbeddingService.embed("query")).thenReturn(null);
+
+        VerticalSearchResponse response = searchService.verticalSemanticSearch(new VerticalConfig(), new VerticalSearchRequest(), "query");
+
+        assertThat(response.getTotalResults()).isZero();
+        assertThat(response.getData()).isEmpty();
+        verifyNoInteractions(productRepository);
+    }
+
+    @Test
+    void verticalSemanticSearchDelegatesToRepository()
+    {
+        VerticalConfig verticalConfig = new VerticalConfig();
+        verticalConfig.setId("phones");
+
+        VerticalSearchRequest request = new VerticalSearchRequest();
+        request.setPageNumber(0);
+        request.setPageSize(1);
+
+        when(textEmbeddingService.embed("query")).thenReturn(new float[] {0.3f, 0.4f});
+
+        Product product = new Product();
+        when(searchHit.getContent()).thenReturn(product);
+        when(searchHits.getSearchHits()).thenReturn(List.of(searchHit));
+        when(searchHits.getTotalHits()).thenReturn(1L);
+
+        ArgumentCaptor<Criteria> criteriaCaptor = ArgumentCaptor.forClass(Criteria.class);
+        when(productRepository.knnSearchByEmbedding(any(), criteriaCaptor.capture(), anyInt())).thenReturn(searchHits);
+
+        VerticalSearchResponse response = searchService.verticalSemanticSearch(verticalConfig, request, "query");
+
+        assertThat(response.getData()).containsExactly(product);
+        assertThat(response.getFrom()).isZero();
+        assertThat(response.getTo()).isEqualTo(1);
+        assertThat(response.getTotalResults()).isEqualTo(1L);
+
+        Criteria criteria = criteriaCaptor.getValue();
+        assertThat(criteria.getCriteriaChain().stream().anyMatch(c -> "vertical".equals(c.getField().getName()))).isTrue();
+        assertThat(criteria.getCriteriaChain().stream().anyMatch(c -> "offersCount".equals(c.getField().getName()))).isTrue();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/TextEmbeddingConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/TextEmbeddingConfig.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import org.open4goods.commons.services.TextEmbeddingService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TextEmbeddingConfig
+{
+    @Bean
+    @ConditionalOnMissingBean(TextEmbeddingService.class)
+    TextEmbeddingService textEmbeddingService()
+    {
+        return text -> null;
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -33,6 +33,7 @@ import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterField;
 import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.verticals.VerticalsConfigService;
+import org.open4goods.commons.services.TextEmbeddingService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
@@ -70,13 +71,16 @@ class SearchServiceTest {
     @Mock
     private ApiProperties apiProperties;
 
+    @Mock
+    private TextEmbeddingService textEmbeddingService;
+
     private SearchService searchService;
 
     @BeforeEach
     void setUp() {
         lenient().when(apiProperties.getResourceRootPath()).thenReturn("https://assets.nudger.test");
         lenient().when(repository.expirationClause()).thenReturn(0L);
-        searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties);
+        searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties, textEmbeddingService);
     }
 
     @Test

--- a/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
+++ b/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
@@ -1,19 +1,52 @@
 package org.open4goods.services.productrepository.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch._types.KnnSearch;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.open4goods.model.product.Product;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.test.util.ReflectionTestUtils;
 
-class ProductRepositoryTest {
+@ExtendWith(MockitoExtension.class)
+class ProductRepositoryTest
+{
+
+    @Mock
+    private ElasticsearchOperations elasticsearchOperations;
+
+    @Mock
+    private SearchHits<Product> searchHits;
+
+    private ProductRepository repository;
+
+    @BeforeEach
+    void setUp()
+    {
+        repository = new ProductRepository();
+        ReflectionTestUtils.setField(repository, "elasticsearchOperations", elasticsearchOperations);
+    }
 
     @Test
-    void computeMissingIdsUsesStringKeysFromExistingResults() {
+    void computeMissingIdsUsesStringKeysFromExistingResults()
+    {
         Map<String, Product> cachedResults = new HashMap<>();
         Product cachedProduct = new Product();
         cachedProduct.setId(123L);
@@ -22,5 +55,33 @@ class ProductRepositoryTest {
         Set<String> missingIds = ProductRepository.computeMissingIds(List.of(123L, 456L), cachedResults);
 
         assertThat(missingIds).containsExactlyInAnyOrder("456");
+    }
+
+    @Test
+    void knnSearchByEmbeddingAddsGuardrailsToQuery()
+    {
+        when(elasticsearchOperations.search(any(org.springframework.data.elasticsearch.core.query.Query.class), eq(Product.class), eq(ProductRepository.CURRENT_INDEX))).thenReturn(searchHits);
+
+        Criteria baseCriteria = new Criteria("vertical").is("phones");
+        repository.knnSearchByEmbedding(new float[] {0.1f, 0.2f}, baseCriteria, 3);
+
+        ArgumentCaptor<NativeQuery> queryCaptor = ArgumentCaptor.forClass(NativeQuery.class);
+        verify(elasticsearchOperations).search(queryCaptor.capture(), eq(Product.class), eq(ProductRepository.CURRENT_INDEX));
+
+        NativeQuery submittedQuery = queryCaptor.getValue();
+        KnnSearch knnSearch = submittedQuery.getKnnSearches().getFirst();
+
+        assertThat(knnSearch.k()).isEqualTo(3);
+        assertThat(knnSearch.queryVector()).containsExactly(0.1f, 0.2f);
+        assertThat(knnSearch.filter()).isEmpty();
+        assertThat(submittedQuery.getPageable().getPageSize()).isEqualTo(3);
+    }
+
+    @Test
+    void knnSearchByEmbeddingRejectsEmptyVectors()
+    {
+        assertThatThrownBy(() -> repository.knnSearchByEmbedding(new float[0], new Criteria("vertical"), 2))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("Embedding vector must not be empty");
     }
 }


### PR DESCRIPTION
## Summary
- add text embedding service abstraction and wire semantic search through commons and front API
- implement product repository KNN search guardrails and expose semantic endpoint with embedding computation
- update tests to cover semantic search flows and repository guardrails

## Testing
- mvn -pl commons test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0691abbc8322a8e5920813f8bf79)