### PR TITLE
Handle disabled categories on product cards

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.spec.ts
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.spec.ts
@@ -107,12 +107,15 @@ let pinia: Pinia
 let i18n: I18n
 let vuetify: VuetifyInstance
 
-const mountGrid = async (products: ProductDto[]) => {
+const mountGrid = async (
+  products: ProductDto[],
+  extraProps: Record<string, unknown> = {}
+) => {
   const module = await import('./CategoryProductCardGrid.vue')
   const CategoryProductCardGrid = module.default
 
   return mount(CategoryProductCardGrid, {
-    props: { products },
+    props: { products, ...extraProps },
     global: {
       plugins: [pinia, i18n, vuetify],
       stubs: {
@@ -242,6 +245,20 @@ describe('CategoryProductCardGrid', () => {
     expect(store.items).toHaveLength(1)
 
     expect((secondButton.element as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('applies disabled styling and nofollow links when requested', async () => {
+    const product = buildProduct({ fullSlug: '/products/demo' })
+    const wrapper = await mountGrid([product], {
+      isCategoryDisabled: true,
+      nofollowLinks: true,
+    })
+
+    const card = wrapper.get('.category-product-card-grid__card')
+    expect(card.classes()).toContain(
+      'category-product-card-grid__card--disabled'
+    )
+    expect(card.attributes('rel')).toBe('nofollow')
   })
 
   it('renders new and occasion badges side by side without condition text', async () => {

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -4,6 +4,7 @@
     :class="[
       `category-product-card-grid--size-${cardSize}`,
       `category-product-card-grid--variant-${variant}`,
+      { 'category-product-card-grid--disabled': isDisabledCategory },
     ]"
     dense
   >
@@ -25,14 +26,20 @@
         :offers-count-label="offersCountLabel(product)"
         :untitled-label="$t('category.products.untitledProduct')"
         :not-rated-label="$t('category.products.notRated')"
+        :disabled="isDisabledCategory"
+        :link-rel="linkRel"
       />
       <v-card
         v-else
         class="category-product-card-grid__card"
+        :class="{
+          'category-product-card-grid__card--disabled': isDisabledCategory,
+        }"
         rounded="xl"
         elevation="2"
         hover
         :to="productLink(product)"
+        :rel="linkRel"
       >
         <div class="category-product-card-grid__compare">
           <CategoryProductCompareToggle :product="product" size="compact" />
@@ -176,6 +183,8 @@ const props = defineProps<{
   variant?: 'classic' | 'compact-tile'
   maxAttributes?: number
   showAttributeIcons?: boolean
+  isCategoryDisabled?: boolean
+  nofollowLinks?: boolean
 }>()
 
 const { t, n } = useI18n()
@@ -223,6 +232,10 @@ const cardSize = computed(() => props.size ?? 'comfortable')
 const variant = computed(() => props.variant ?? 'classic')
 const maxAttributes = computed(() => props.maxAttributes)
 const showAttributeIcons = computed(() => props.showAttributeIcons ?? true)
+const isDisabledCategory = computed(() => props.isCategoryDisabled ?? false)
+const linkRel = computed(() =>
+  props.nofollowLinks ? 'nofollow' : undefined
+)
 
 const resolveImage = (product: ProductDto) => {
   return (
@@ -391,6 +404,13 @@ const offerBadges = (product: ProductDto): OfferBadge[] => {
 .category-product-card-grid
   margin: 0
 
+  &--disabled
+    .category-product-card-grid__card,
+    .product-tile-card
+      filter: grayscale(1)
+      opacity: 0.6
+
+  
   &__card
     height: 100%
     display: flex
@@ -402,6 +422,10 @@ const offerBadges = (product: ProductDto): OfferBadge[] => {
     &:hover
       transform: translateY(-4px)
       box-shadow: 0 16px 30px rgba(21, 46, 73, 0.08)
+
+    &--disabled
+      filter: grayscale(1)
+      opacity: 0.6
 
   &__image
     border-top-left-radius: inherit

--- a/frontend/app/components/category/products/ProductTileCard.vue
+++ b/frontend/app/components/category/products/ProductTileCard.vue
@@ -1,10 +1,12 @@
 <template>
   <v-card
     class="product-tile-card"
+    :class="{ 'product-tile-card--disabled': disabled }"
     rounded="xl"
     elevation="2"
     hover
     :to="productLink"
+    :rel="linkRel"
   >
     <div class="product-tile-card__wrapper">
       <div class="product-tile-card__media">
@@ -124,6 +126,8 @@ const props = withDefaults(
     offersCountLabel: string
     untitledLabel: string
     notRatedLabel: string
+    disabled?: boolean
+    linkRel?: string
   }>(),
   {
     attributes: () => [],
@@ -131,6 +135,8 @@ const props = withDefaults(
     offerBadges: () => [],
     imageSrc: undefined,
     productLink: undefined,
+    disabled: false,
+    linkRel: undefined,
   }
 )
 
@@ -156,6 +162,15 @@ const hasAttributes = computed(() => props.attributes.length > 0)
   display: flex;
   text-decoration: none;
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4);
+
+  &--disabled {
+    filter: grayscale(1);
+    opacity: 0.7;
+
+    .product-tile-card__image :deep(img) {
+      filter: grayscale(1);
+    }
+  }
 
   &__wrapper {
     display: flex;

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -349,13 +349,6 @@ const heroTitle = computed(
     }) ?? ''
 )
 
-const heroDescriptionTitle = computed(
-  () =>
-    packI18n.resolveString('hero.search.helpersTitle', {
-      fallbackKeys: ['home.hero.search.helpersTitle'],
-    }) ?? ''
-)
-
 const handleHeroImageLoad = () => {
   isHeroImageLoaded.value = true
 }

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -618,6 +618,9 @@ const categoryDisplayName = computed(
     category.value?.verticalHomeDescription ??
     siteName.value
 )
+const shouldRestrictCategoryProducts = computed(
+  () => category.value?.enabled === false && !isLoggedIn.value
+)
 const canonicalUrl = computed(() =>
   new URL(route.path, requestURL.origin).toString()
 )
@@ -1663,7 +1666,15 @@ const viewComponentProps = computed(() => {
     }
   }
 
-  return base
+  if (viewMode.value === 'list') {
+    return base
+  }
+
+  return {
+    ...base,
+    isCategoryDisabled: shouldRestrictCategoryProducts.value,
+    nofollowLinks: shouldRestrictCategoryProducts.value,
+  }
 })
 
 const loadingProducts = ref(false)


### PR DESCRIPTION
## Summary
- allow category resolution to fall back to disabled entries when resolving by slug and cover the behavior in tests
- add disabled/nofollow handling to category product cards while keeping logged-in users unaffected, including tile styling
- pass category disablement down from CategoryPage and clean up an unused home hero computed

## Testing
- pnpm lint
- pnpm vitest run app/composables/categories/useCategories.spec.ts app/components/category/products/CategoryProductCardGrid.spec.ts --reporter=basic
- pnpm generate *(fails: missing app/components/domains/opendata/OpendataHero.vue referenced from releases page)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b4bda5a8883229e933aab08490b42)