### PR TITLE
Add animated home hero subtitle

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -8,6 +8,7 @@ import SearchSuggestField, {
 } from '~/components/search/SearchSuggestField.vue'
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
+import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import { useHeroBackgroundAsset } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
 import {
@@ -426,6 +427,13 @@ useHead({
             <p v-if="heroTitleSubtitle" class="home-hero__title-subtitle">
               {{ heroTitleSubtitle }}
             </p>
+            <AnimatedSubtitle
+              class="home-hero__title-animated-subtitle"
+              i18n-key="home.hero.subtitle"
+              animation="fade"
+              :delay="500"
+              :duration-ms="420"
+            />
           </v-col>
         </v-row>
         <v-row justify="center">
@@ -716,6 +724,13 @@ useHead({
   color: rgba(var(--v-theme-surface-default), 0.94)
   font-size: clamp(1rem, 2.4vw, 1.4rem)
   line-height: 1.4
+
+.home-hero__title-animated-subtitle
+  margin: clamp(0.5rem, 1.6vw, 0.85rem) auto 0
+  max-width: 30ch
+  font-size: clamp(0.95rem, 2.2vw, 1.2rem)
+  line-height: 1.4
+  color: rgba(var(--v-theme-surface-default), 0.9)
 
 .home-hero__search
   display: flex

--- a/frontend/app/components/shared/ui/AnimatedSubtitle.vue
+++ b/frontend/app/components/shared/ui/AnimatedSubtitle.vue
@@ -1,0 +1,188 @@
+<template>
+  <component
+    :is="tag"
+    v-if="isVisible && resolvedText"
+    class="animated-subtitle"
+    :class="animationClass"
+    :style="animationStyle"
+    v-bind="$attrs"
+  >
+    {{ resolvedText }}
+  </component>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+type AnimationPreset = 'fade' | 'fade-up' | 'fade-down' | 'fade-scale' | 'fade-blur'
+
+type I18nValues = Record<string, string | number>
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(
+  defineProps<{
+    i18nKey?: string
+    text?: string
+    values?: I18nValues
+    delay?: number
+    durationMs?: number
+    animation?: AnimationPreset | string
+    tag?: keyof HTMLElementTagNameMap
+  }>(),
+  {
+    i18nKey: undefined,
+    text: undefined,
+    values: undefined,
+    delay: 0,
+    durationMs: 420,
+    animation: 'fade',
+    tag: 'p',
+  }
+)
+
+const { t } = useI18n()
+
+const isVisible = ref(false)
+let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+const resolvedText = computed(() => {
+  if (props.text && props.text.trim().length > 0) {
+    return props.text
+  }
+
+  if (props.i18nKey) {
+    return t(props.i18nKey, props.values)
+  }
+
+  return ''
+})
+
+const animationClass = computed(() => {
+  if (!props.animation) {
+    return null
+  }
+
+  return `animated-subtitle--${props.animation}`
+})
+
+const animationStyle = computed(() => ({
+  '--animated-subtitle-duration': `${props.durationMs}ms`,
+}))
+
+const reveal = () => {
+  if (timeoutId) {
+    clearTimeout(timeoutId)
+  }
+
+  timeoutId = setTimeout(() => {
+    isVisible.value = true
+  }, Math.max(props.delay ?? 0, 0))
+}
+
+onMounted(() => {
+  reveal()
+})
+
+onBeforeUnmount(() => {
+  if (timeoutId) {
+    clearTimeout(timeoutId)
+    timeoutId = null
+  }
+})
+</script>
+
+<style scoped>
+.animated-subtitle {
+  margin: 0;
+  animation-duration: var(--animated-subtitle-duration, 420ms);
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
+  opacity: 0;
+}
+
+.animated-subtitle--fade {
+  animation-name: animated-subtitle-fade;
+}
+
+.animated-subtitle--fade-up {
+  animation-name: animated-subtitle-fade-up;
+}
+
+.animated-subtitle--fade-down {
+  animation-name: animated-subtitle-fade-down;
+}
+
+.animated-subtitle--fade-scale {
+  animation-name: animated-subtitle-fade-scale;
+}
+
+.animated-subtitle--fade-blur {
+  animation-name: animated-subtitle-fade-blur;
+}
+
+@keyframes animated-subtitle-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes animated-subtitle-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes animated-subtitle-fade-down {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes animated-subtitle-fade-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes animated-subtitle-fade-blur {
+  from {
+    opacity: 0;
+    filter: blur(6px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animated-subtitle {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    filter: none;
+  }
+}
+</style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -187,7 +187,7 @@
         "Shop smarter without compromise. Nudger balances planet and price.",
         "Find the responsible choice faster. Trusted data, transparent insights."
       ],
-      "subtitle": "Save time, stay true to your values. Compare effortlessly, choose freely.",
+      "subtitle": "Yes, it's possible.",
       "iconAlt": "Nudger PWA launcher icon",
       "imageAlt": "Illustration of the Nudger comparison experience with product cards and impact charts.",
       "search": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -296,7 +296,7 @@
         "Consomme mieux sans payer plus. Nudger équilibre planète et budget.",
         "Trouve rapidement des produits alignés avec tes valeurs, grâce à des données transparentes."
       ],
-      "subtitle": "Gagne du temps. Choisis librement.",
+      "subtitle": "Et oui, c'est possible.",
       "iconAlt": "Icône du lanceur de l'application Nudger",
       "imageAlt": "Illustration du comparateur Nudger affichant des cartes produits et des graphiques d’impact.",
       "search": {


### PR DESCRIPTION
### Motivation
- Improve the homepage hero by introducing a subtle, reusable animated subtitle that is revealed after hydration to avoid SSR flashing.
- Provide a configurable component that supports multiple animation presets and timing so other pages can reuse the effect.
- Keep localization in-component by allowing an `i18n` key to be passed as a prop so translations are resolved where the component is used.
- Respect accessibility by honoring `prefers-reduced-motion` and allowing consumers to control duration and delay via props.

### Description
- Add `AnimatedSubtitle.vue` to `app/components/shared/ui/` which accepts `i18nKey`, `text`, `values`, `delay`, `durationMs`, `animation` and `tag` props and reveals the text on `onMounted`.
- Implement several animation presets (`fade`, `fade-up`, `fade-down`, `fade-scale`, `fade-blur`) and CSS keyframes with `prefers-reduced-motion` handling in the component.
- Wire the new component into `HomeHeroSection.vue` and render the localized subtitle using `i18n-key="home.hero.subtitle"` with `:delay="500"` and `animation="fade"`.
- Update the `home.hero.subtitle` translations in `en-US.json` and `fr-FR.json` to the new messages used by the component.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm test` and the test suite passed (329 tests passed).
- Ran `pnpm generate` to build and prerender the app and the generation completed successfully.
- A visual smoke check was captured (screenshot) showing the delayed subtitle reveal on the home page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea0ffd688832bb1e5c57fb1cc166c)