### PR TITLE
Fix layout spacing under main menu

### DIFF
--- a/frontend/app/components/domains/home/hero/The-main-menu-container.vue
+++ b/frontend/app/components/domains/home/hero/The-main-menu-container.vue
@@ -8,9 +8,9 @@ const handleToggleDrawer = () => emit('toggle-drawer')
 
 <template>
   <v-app-bar app flat color="surface-default" class="main-menu-app-bar">
-    <v-container fluid class="py-0 mt-2">
+    <v-container fluid class="py-0">
       <div class="d-flex align-center w-100">
-        <v-app-bar-title class="d-flex align-center mt-sm">
+        <v-app-bar-title class="d-flex align-center">
           <the-main-logo />
         </v-app-bar-title>
         <v-spacer />

--- a/frontend/app/layouts/default.spec.ts
+++ b/frontend/app/layouts/default.spec.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import DefaultLayout from './default.vue'
+
+const drawerState = ref(false)
+
+vi.mock('#imports', () => ({
+  useState: vi.fn(() => drawerState),
+  useRoute: vi.fn(() => ({ name: 'home' })),
+  useDevice: vi.fn(() => ({ isMobileOrTablet: false })),
+  useDisplay: vi.fn(() => ({ mdAndDown: { value: false } })),
+}))
+
+vi.mock('vuetify/lib/framework.mjs', () => ({
+  useDisplay: () => ({ mdAndDown: { value: false } }),
+  DisplaySymbol: Symbol.for('vuetify:display'),
+}))
+
+const stubs = {
+  ClientOnly: {
+    template: '<div><slot /></div>',
+  },
+  PageLoadingOverlay: {
+    template: '<div data-testid="loading-overlay" />',
+  },
+  TheMainMenuContainer: {
+    template: '<div data-testid="main-menu" />',
+  },
+  TheMainFooter: {
+    template: '<footer><slot /></footer>',
+  },
+  TheMainFooterContent: {
+    template: '<div data-testid="footer-content" />',
+  },
+  CategoryComparePanel: {
+    template: '<div data-testid="compare-panel" />',
+  },
+  PwaOfflineNotice: {
+    template: '<div data-testid="offline-notice" />',
+  },
+  PwaInstallPrompt: {
+    template: '<div data-testid="install-prompt" />',
+  },
+  VApp: {
+    template: '<div><slot /></div>',
+  },
+  VMain: {
+    template: '<main data-testid="layout-main" v-bind="$attrs"><slot /></main>',
+  },
+  VNavigationDrawer: {
+    template: '<aside><slot /></aside>',
+  },
+}
+
+describe('default layout', () => {
+  it('applies layout padding class to the main area', () => {
+    const wrapper = mount(DefaultLayout, {
+      global: {
+        stubs,
+      },
+      slots: {
+        default: '<div data-testid="page-slot" />',
+      },
+    })
+
+    const main = wrapper.get('[data-testid="layout-main"]')
+
+    expect(main.classes()).toContain('layout-main-content')
+  })
+})

--- a/frontend/app/layouts/default.vue
+++ b/frontend/app/layouts/default.vue
@@ -27,7 +27,7 @@
       </template>
     </ClientOnly>
 
-    <v-main>
+    <v-main class="layout-main-content">
       <slot />
     </v-main>
 
@@ -80,6 +80,14 @@ watch(
 </script>
 
 <style scoped lang="sass">
+
+.layout-main-content
+  padding-top: calc(var(--v-layout-top, 64px) + env(safe-area-inset-top))
+  background-color: transparent
+
+  @media (max-width: 959px)
+    padding-top: calc(var(--v-layout-top, 56px) + env(safe-area-inset-top))
+
 .pre-hydration-app-bar-spacer
   height: 64px
 


### PR DESCRIPTION
## Summary
- ensure the default layout reserves space beneath the sticky main menu via top padding and SSR-safe spacer
- adjust the main menu container spacing so the app bar sits flush without encroaching on page content
- add a layout unit test to guarantee the main content area keeps the padding class applied

## Testing
- pnpm lint
- pnpm vitest run app/layouts/default.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f95c8d788322af774252b1dcb50e)