### PR TITLE
Expose disabled categories to clients and adjust disabled UX

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/CategoriesController.java
@@ -96,14 +96,14 @@ public class CategoriesController {
     @GetMapping
     @Operation(
             summary = "List categories",
-            description = "Return vertical configurations optionally filtered by their enabled status.",
+            description = "Return vertical configurations. The enabled flag is exposed but not filtered server-side.",
             parameters = {
                     @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
                             description = "Language driving localisation of textual fields (future use).",
                             schema = @Schema(implementation = DomainLanguage.class)),
                     @Parameter(name = "onlyEnabled", in = ParameterIn.QUERY, required = false,
-                            description = "When true, only return verticals flagged as enabled.",
-                            schema = @Schema(type = "boolean", defaultValue = "true"))
+                            description = "Deprecated: retained for backward compatibility. All verticals are returned regardless of this flag.",
+                            schema = @Schema(type = "boolean", defaultValue = "false"))
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "Categories returned",
@@ -116,8 +116,8 @@ public class CategoriesController {
     @Cacheable(cacheNames = CacheConstants.FOREVER_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public ResponseEntity<List<VerticalConfigDto>> categories(
             @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
-            @RequestParam(name = "onlyEnabled", defaultValue = "true") boolean onlyEnabled) {
-        List<VerticalConfigDto> body = verticalsConfigService.getConfigsWithoutDefault(onlyEnabled).stream()
+            @RequestParam(name = "onlyEnabled", defaultValue = "false") boolean onlyEnabled) {
+        List<VerticalConfigDto> body = verticalsConfigService.getConfigsWithoutDefault().stream()
                 .map(config -> categoryMappingService.toVerticalConfigDto(config, domainLanguage))
                 .filter(Objects::nonNull)
                 .toList();

--- a/frontend/app/components/domains/home/sections/The-section-items-slide.vue
+++ b/frontend/app/components/domains/home/sections/The-section-items-slide.vue
@@ -18,7 +18,7 @@ const { categories, fetchCategories } = useCategories()
 
 const { pending } = await useAsyncData(
   'home-categories-slide',
-  () => fetchCategories(true), // Only enabled categories
+  () => fetchCategories(),
   { server: true, immediate: true }
 )
 

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
@@ -16,6 +16,9 @@ vi.mock('vuetify', () => ({
 vi.mock('~/composables/categories/useCategories', () => ({
   useCategories: () => ({ fetchCategories: vi.fn().mockResolvedValue([]) }),
 }))
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({ isLoggedIn: { value: false } }),
+}))
 vi.mock('~/components/nudge-tool/NudgeWizardHeader.vue', () => ({
   default: { template: '<div class="header-stub"></div>' },
 }))

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -152,6 +152,7 @@
 <script setup lang="ts">
 import { useDebounceFn, useElementSize } from '@vueuse/core'
 import { useCategories } from '~/composables/categories/useCategories'
+import { useAuth } from '~/composables/useAuth'
 import NudgeWizardHeader from '~/components/nudge-tool/NudgeWizardHeader.vue'
 import NudgeToolAnimatedIcon from '~/components/nudge-tool/NudgeToolAnimatedIcon.vue'
 import type { CornerSize } from '~/components/shared/cards/RoundedCornerCard.vue'
@@ -197,6 +198,7 @@ const accentCornerOffsets: Record<CornerSize, string> = {
 }
 
 const { t } = useI18n()
+const { isLoggedIn } = useAuth()
 
 const { fetchCategories } = useCategories()
 
@@ -311,6 +313,7 @@ const steps = computed<WizardStep[]>(() => {
     props: {
       categories: categories.value,
       selectedCategoryId: selectedCategoryId.value,
+      isAuthenticated: isLoggedIn.value,
     },
   })
 
@@ -540,7 +543,7 @@ const hydrateCategories = async () => {
     return
   }
 
-  const result = await fetchCategories(true)
+  const result = await fetchCategories()
   categories.value = result
 }
 

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -636,6 +636,9 @@ const seoDescription = computed(
     category.value?.verticalHomeDescription ??
     ''
 )
+const robotsContent = computed(() =>
+  shouldRestrictCategoryProducts.value ? 'noindex, nofollow' : undefined
+)
 const ogTitle = computed(
   () => category.value?.verticalMetaOpenGraphTitle ?? seoTitle.value
 )
@@ -667,6 +670,12 @@ useSeoMeta({
   ogLocale: () => ogLocale.value,
   ogImageAlt: () => category.value?.verticalHomeTitle ?? siteName.value,
 })
+
+useHead(() => ({
+  meta: robotsContent.value
+    ? [{ name: 'robots', content: robotsContent.value }]
+    : [],
+}))
 
 useHead(() => ({
   meta: [

--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -731,6 +731,9 @@ const canonicalPath = computed(() => {
 const canonicalUrl = computed(() =>
   new URL(canonicalPath.value, requestURL.origin).toString()
 )
+const productRobotsContent = computed(() =>
+  categoryDetail.value?.enabled === false ? 'noindex, nofollow' : undefined
+)
 
 const resolvedProductImageSource = computed(() => {
   const galleryImages = product.value?.resources?.images ?? []
@@ -765,6 +768,12 @@ useSeoMeta({
   ogImage: () => ogImageUrl.value,
   ogImageAlt: () => ogImageAlt.value,
 })
+
+useHead(() => ({
+  meta: productRobotsContent.value
+    ? [{ name: 'robots', content: productRobotsContent.value }]
+    : [],
+}))
 
 useHead(() => ({
   link: [{ rel: 'canonical', href: canonicalUrl.value }],

--- a/frontend/app/composables/categories/useCategories.ts
+++ b/frontend/app/composables/categories/useCategories.ts
@@ -70,15 +70,16 @@ export const useCategories = () => {
 
   /**
    * Fetch categories from the backend proxy
-   * @param onlyEnabled - Filter only enabled categories
    */
   const fetchCategories = async (
-    onlyEnabled: boolean = true
+    options?: { forceRefresh?: boolean }
   ): Promise<VerticalConfigDto[]> => {
-    const cacheKey = `list-${onlyEnabled}`
+    const forceRefresh = options?.forceRefresh ?? false
+    const cacheKey = 'list-all'
     const cachedCategories = categoriesListCache.value[cacheKey]
 
     if (
+      !forceRefresh &&
       cachedCategories &&
       Date.now() - cachedCategories.timestamp < TWO_HOURS_MS
     ) {
@@ -93,7 +94,6 @@ export const useCategories = () => {
       const headers = buildRequestHeaders()
       const response = await $fetch<VerticalConfigDto[]>('/api/categories', {
         ...(headers ? { headers } : {}),
-        params: { onlyEnabled },
       })
 
       categories.value = response ?? []
@@ -129,13 +129,13 @@ export const useCategories = () => {
     error.value = null
 
     if (categories.value.length === 0) {
-      await fetchCategories(true)
+      await fetchCategories()
     }
 
     let matchingCategory = findCategoryBySlug(slug)
 
     if (!matchingCategory) {
-      await fetchCategories(false)
+      await fetchCategories({ forceRefresh: true })
       matchingCategory = findCategoryBySlug(slug)
     }
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -215,7 +215,7 @@ useAsyncData(
   'home-heavy-data',
   async () => {
     if (rawCategories.value.length === 0) {
-      await fetchCategories(true)
+      await fetchCategories()
     }
 
     if (paginatedArticles.value.length === 0) {

--- a/frontend/docs/server/api-integration-template.md
+++ b/frontend/docs/server/api-integration-template.md
@@ -322,7 +322,7 @@ const { categories, loading, error, fetchCategories } = useCategories()
 // Fetch categories on component mount
 await useAsyncData(
   'home-categories-slide',
-  () => fetchCategories(true), // Only enabled categories
+  () => fetchCategories(),
   { server: true, immediate: true }
 )
 

--- a/frontend/shared/api-client/services/categories.services.ts
+++ b/frontend/shared/api-client/services/categories.services.ts
@@ -31,15 +31,12 @@ export const useCategoriesService = (domainLanguage: DomainLanguage) => {
   }
 
   /**
-   * Fetch categories optionally filtered by enabled status
-   * @param onlyEnabled - Filter only enabled categories
+   * Fetch categories. The enabled flag is exposed for client-side handling only.
    * @returns Promise<VerticalConfigDto[]>
    */
-  const getCategories = async (
-    onlyEnabled?: boolean
-  ): Promise<VerticalConfigDto[]> => {
+  const getCategories = async (): Promise<VerticalConfigDto[]> => {
     try {
-      return await resolveApi().categories1({ domainLanguage, onlyEnabled })
+      return await resolveApi().categories1({ domainLanguage })
     } catch (error) {
       console.error('Error fetching categories:', error)
       throw error


### PR DESCRIPTION
## Summary
- Return all categories from the API and Nuxt server route while keeping documentation in sync
- Update category composable/service and UI to fetch all categories, handle disabled states, and add robots noindex for disabled verticals
- Refresh nudge tool interactions and tests so disabled categories are rendered but blocked unless authenticated

## Testing
- pnpm test
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950faf0802c83228cf1965325dc244e)