### PR TITLE
Enhance ImpactScore layout options

### DIFF
--- a/frontend/app/components/shared/ui/ImpactScore.spec.ts
+++ b/frontend/app/components/shared/ui/ImpactScore.spec.ts
@@ -66,7 +66,7 @@ describe('ImpactScore', () => {
     },
   }
 
-  it('renders badge mode by default', () => {
+  it('renders combined mode by default with chip and stars', () => {
     const wrapper = mount(ImpactScore, {
       props: {
         score: 4,
@@ -75,8 +75,9 @@ describe('ImpactScore', () => {
       global: globalOptions,
     })
 
+    expect(wrapper.find('.impact-score-combined').exists()).toBe(true)
     expect(wrapper.findComponent(VChipStub).exists()).toBe(true)
-    expect(wrapper.find('.impact-score').exists()).toBe(false) // .impact-score class is on the div for stars mode
+    expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
     expect(wrapper.text()).toContain('16 / 20') // (4/5)*20 = 16
 
     // Check tooltip text
@@ -153,5 +154,24 @@ describe('ImpactScore', () => {
     expect(wrapper.findComponent(VChipStub).exists()).toBe(true)
     expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
     expect(wrapper.text()).toContain('16 / 20')
+  })
+
+  it('supports vertical layout and toggleable elements', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 3,
+        max: 5,
+        mode: 'combined',
+        layout: 'vertical',
+        showScore: false,
+        showStars: true,
+      },
+      global: globalOptions,
+    })
+
+    const combined = wrapper.find('.impact-score-combined')
+    expect(combined.classes()).toContain('impact-score-combined--vertical')
+    expect(wrapper.findComponent(VChipStub).exists()).toBe(false)
+    expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- make the combined chip + stars view the default ImpactScore layout and add layout/show toggles for score and stars
- refresh ImpactScore styling tokens for horizontal and vertical arrangements while keeping theme-based colors
- extend ImpactScore unit tests for the new default, visibility toggles, and vertical orientation

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951185f114c8322aa2e7d916ebdf83d)