### PR TITLE
Update FAQ content and impact CTA

### DIFF
--- a/frontend/app/components/home/sections/HomeFaqSection.vue
+++ b/frontend/app/components/home/sections/HomeFaqSection.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import TextContent from '~/components/domains/content/TextContent.vue'
+import { useLocalePath } from '#i18n'
 
 type FaqItem = {
   question: string
   answer: string
   blocId: string
+  isImpactScore?: boolean
+  ctaLabel?: string
+  ctaAria?: string
 }
 
 const props = defineProps<{
@@ -13,6 +16,8 @@ const props = defineProps<{
 }>()
 
 const hasPanels = computed(() => props.items.length > 0)
+const localePath = useLocalePath()
+const impactScorePath = computed(() => localePath('/impact-score'))
 </script>
 
 <template>
@@ -36,12 +41,19 @@ const hasPanels = computed(() => props.items.length > 0)
               <h3 class="home-faq__panel-title">{{ panel.question }}</h3>
             </v-expansion-panel-title>
             <v-expansion-panel-text class="home-faq__panel-text">
-              <TextContent
-                class="home-faq__text-content"
-                :bloc-id="panel.blocId"
-                :fallback-text="panel.answer"
-                :ipsum-length="panel.answer.length"
-              />
+              <!-- eslint-disable-next-line vue/no-v-html -->
+              <div class="home-faq__answer" v-html="panel.answer" />
+              <div v-if="panel.isImpactScore && panel.ctaLabel" class="home-faq__cta-wrapper">
+                <v-btn
+                  class="home-faq__cta"
+                  color="primary"
+                  variant="tonal"
+                  :to="impactScorePath"
+                  :aria-label="panel.ctaAria || panel.ctaLabel"
+                >
+                  {{ panel.ctaLabel }}
+                </v-btn>
+              </div>
             </v-expansion-panel-text>
           </v-expansion-panel>
         </v-expansion-panels>
@@ -87,6 +99,21 @@ const hasPanels = computed(() => props.items.length > 0)
 .home-faq__panel-text
   background: rgb(var(--v-theme-surface-default))
 
-.home-faq__text-content
+.home-faq__answer
   padding-block: 0.5rem
+  display: flex
+  flex-direction: column
+  gap: 0.375rem
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+  ul
+    padding-left: 1.25rem
+    margin: 0
+
+.home-faq__cta-wrapper
+  margin-top: 0.5rem
+
+.home-faq__cta
+  width: fit-content
+  font-weight: 600
 </style>

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -172,21 +172,20 @@ const messages: Record<string, unknown> = {
   'home.faq.title': 'FAQ',
   'home.faq.subtitle': 'Quick answers to the most common questions.',
   'home.faq.items.free.question': 'Is Nudger free?',
-  'home.faq.items.free.answer': 'Yes, searching is free to use.',
+  'home.faq.items.free.answer':
+    'Yes, Nudger is completely free for you!<br/><br/>We earn money through affiliate partnerships. That means we receive a commission when you click Nudger offers and complete your purchase with our partner merchants.<br/><br/>It\'s the same model used by comparison sites and it never changes the price of the products you see on Nudger.',
   'home.faq.items.account.question': 'Do I need an account?',
-  'home.faq.items.account.answer': 'No for searching; an account is optional.',
-  'home.faq.items.categories.question': 'Which categories are covered?',
-  'home.faq.items.categories.answer':
-    'Electronics & Appliances today, more to come.',
+  'home.faq.items.account.answer':
+    "<b>Not at all!</b><br/>Every feature is available without creating an account on our platform.<br/>That's how we protect your privacy, too.",
   'home.faq.items.impactScore.question':
     'How do you calculate the Impact Score?',
   'home.faq.items.impactScore.answer':
-    'Five weighted criteria + lean AI, fully open methodology.',
+    'This is where Nudger shines.<br/><br/>We aim to guide you through the realm of possibilities rather than provide absolute judgments.<br/><ul><li>We analyse every data point we have related to ecological and societal impact.</li><li>We compare products against each other using our Impact Score.</li><li>Advanced AI systems adjust how each criterion is weighted.</li></ul>And the whole process stays fully transparent.',
+  'home.faq.items.impactScore.cta': 'Learn more',
+  'home.faq.items.impactScore.ctaAria': 'Open the detailed Impact Score page',
   'home.faq.items.dataFreshness.question': 'Are the data kept up to date?',
   'home.faq.items.dataFreshness.answer':
-    'Yes, refreshed regularly with quality checks.',
-  'home.faq.items.suggestProduct.question': 'How can I suggest a product?',
-  'home.faq.items.suggestProduct.answer': 'Use our dedicated contact form.',
+    'Yes, our product data is refreshed <b>twice a day</b> to track offer changes as closely as possible.',
   'home.faq.agent.eyebrow': 'Your AI result here',
   'home.faq.agent.title': 'Ask your question, we’ll pin it to the FAQ',
   'home.faq.agent.subtitle': 'Your question and the AI result will show below.',
@@ -574,16 +573,6 @@ const HomeBlogCarouselStub = defineComponent({
   },
 })
 
-const TextContentStub = defineComponent({
-  name: 'TextContentStub',
-  props: {
-    fallbackText: { type: String, default: '' },
-  },
-  setup(props) {
-    return () => h('div', { class: 'text-content-stub' }, props.fallbackText)
-  },
-})
-
 const mountHomePage = async () => {
   const component = (await import('./index.vue')).default
   return mountSuspended(component, {
@@ -609,7 +598,6 @@ const mountHomePage = async () => {
         VExpansionPanelText: simpleStub('div'),
         NuxtLink: NuxtLinkStub,
         HomeBlogCarousel: HomeBlogCarouselStub,
-        TextContent: TextContentStub,
       },
     },
   })
@@ -673,7 +661,7 @@ describe('Home page', () => {
       '@type': 'FAQPage',
     })
     expect(Array.isArray(json?.mainEntity)).toBe(true)
-    expect(json?.mainEntity).toHaveLength(6)
+    expect(json?.mainEntity).toHaveLength(4)
     expect(json?.mainEntity[0]).toMatchObject({
       '@type': 'Question',
       acceptedAnswer: { '@type': 'Answer' },

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -322,20 +322,15 @@ const faqItems = computed(() => [
     answer: String(t('home.faq.items.account.answer')),
   },
   {
-    question: String(t('home.faq.items.categories.question')),
-    answer: String(t('home.faq.items.categories.answer')),
-  },
-  {
     question: String(t('home.faq.items.impactScore.question')),
     answer: String(t('home.faq.items.impactScore.answer')),
+    ctaLabel: String(t('home.faq.items.impactScore.cta')),
+    ctaAria: String(t('home.faq.items.impactScore.ctaAria')),
+    isImpactScore: true,
   },
   {
     question: String(t('home.faq.items.dataFreshness.question')),
     answer: String(t('home.faq.items.dataFreshness.answer')),
-  },
-  {
-    question: String(t('home.faq.items.suggestProduct.question')),
-    answer: String(t('home.faq.items.suggestProduct.answer')),
   },
 ])
 

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -407,36 +407,30 @@
         }
       }
     },
-    "faq": {
-      "title": "FAQ",
-      "subtitle": "Quick answers to the most common questions.",
-      "items": {
-        "free": {
-          "question": "Is Nudger free?",
-          "answer": "Yes, searching is free to use."
-        },
-        "account": {
-          "question": "Do I need an account?",
-          "answer": "No for searching; an account is optional if you want lists or alerts."
-        },
-        "categories": {
-          "question": "Which categories are covered?",
-          "answer": "Electronics & Appliances today, more to come."
-        },
-        "impactScore": {
-          "question": "How do you calculate the Impact Score?",
-          "answer": "Five weighted criteria + lean AI, fully open methodology."
-        },
-        "dataFreshness": {
-          "question": "Are the data kept up to date?",
-          "answer": "Yes, refreshed regularly with quality checks."
-        },
-        "suggestProduct": {
-          "question": "How can I suggest a product?",
-          "answer": "Use our dedicated contact form."
-        }
+  "faq": {
+    "title": "FAQ",
+    "subtitle": "Quick answers to the most common questions.",
+    "items": {
+      "free": {
+        "question": "Is Nudger free?",
+        "answer": "Yes, Nudger is completely free for you!<br/><br/>We earn money through affiliate partnerships. That means we receive a commission when you click Nudger offers and complete your purchase with our partner merchants.<br/><br/>It's the same model used by comparison sites and it never changes the price of the products you see on Nudger."
       },
-      "agent": {
+      "account": {
+        "question": "Do I need an account?",
+        "answer": "<b>Not at all!</b><br/>Every feature is available without creating an account on our platform.<br/>That's how we protect your privacy, too."
+      },
+      "impactScore": {
+        "question": "How do you calculate the Impact Score?",
+        "answer": "This is where Nudger shines.<br/><br/>We aim to guide you through the realm of possibilities rather than provide absolute judgments.<br/><ul><li>We analyse every data point we have related to ecological and societal impact.</li><li>We compare products against each other using our Impact Score.</li><li>Advanced AI systems adjust how each criterion is weighted.</li></ul>And the whole process stays fully transparent.",
+        "cta": "Learn more",
+        "ctaAria": "Open the detailed Impact Score page"
+      },
+      "dataFreshness": {
+        "question": "Are the data kept up to date?",
+        "answer": "Yes, our product data is refreshed <b>twice a day</b> to track offer changes as closely as possible."
+      }
+    },
+    "agent": {
         "eyebrow": "Your AI result here 😉",
         "title": "Ask your question, we’ll pin it to the FAQ",
         "subtitle": "Share your request, we’ll answer with frugal AI and surface it below for everyone.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -517,36 +517,30 @@
         }
       }
     },
-    "faq": {
-      "title": "FAQ",
-      "subtitle": "Les réponses rapides aux questions fréquentes.",
-      "items": {
-        "free": {
-          "question": "Nudger est-il gratuit ?",
-          "answer": "Oui, la recherche est libre d’accès."
-        },
-        "account": {
-          "question": "Besoin d’un compte ?",
-          "answer": "Non pour rechercher ; compte optionnel si vous souhaitez listes ou alertes."
-        },
-        "categories": {
-          "question": "Quelles catégories ?",
-          "answer": "Électronique & Électroménager aujourd’hui, extensions à venir."
-        },
-        "impactScore": {
-          "question": "Comment calculez-vous l’Impact Score ?",
-          "answer": "5 critères pondérés + IA sobre, méthode ouverte et auditée."
-        },
-        "dataFreshness": {
-          "question": "Les données sont-elles à jour ?",
-          "answer": "Oui, mises à jour régulières avec contrôles qualité."
-        },
-        "suggestProduct": {
-          "question": "Comment suggérer un produit ?",
-          "answer": "Via notre formulaire de contact dédié."
-        }
+  "faq": {
+    "title": "FAQ",
+    "subtitle": "Les réponses rapides aux questions fréquentes.",
+    "items": {
+      "free": {
+        "question": "Nudger est-il gratuit ?",
+        "answer": "Oui, Nudger est complètement gratuit pour vous !<br/><br/>Nous gagnons de l'argent grâce au système d'affiliation. Cela signifie que nous touchons une rétro-commission quand vous cliquez sur les offres de Nudger et que vous finalisez vos achats chez nos commerçants partenaires.<br/><br/>C'est le même principe que celui utilisé par les comparateurs en ligne, et cela n'influence en rien le prix des produits disponibles sur Nudger."
       },
-      "agent": {
+      "account": {
+        "question": "Besoin d’un compte ?",
+        "answer": "<b>Pas du tout !</b><br/>L'intégralité de nos fonctionnalités est disponible sans que vous ayez besoin de créer de compte sur notre plateforme.<br/>C'est ça aussi le respect de la vie privée."
+      },
+      "impactScore": {
+        "question": "Comment calculez-vous l’Impact Score ?",
+        "answer": "C'est là-dessus que Nudger se distingue.<br/><br/>Nous cherchons à vous orienter au mieux dans l'univers des possibles, pas à faire de l'évaluation de façon absolue.<br/><ul><li>Nous analysons toutes les données à notre disposition ayant un rapport avec l'impact écologique et sociétal.</li><li>Nous classons ensuite les produits les uns par rapport aux autres à l'aide de notre Impact Score.</li><li>Des systèmes d'IA avancés ajustent la pondération des différents critères.</li></ul>Et tout cela est entièrement transparent.",
+        "cta": "En savoir plus",
+        "ctaAria": "Ouvrir la page dédiée à l'Impact Score"
+      },
+      "dataFreshness": {
+        "question": "Les données sont-elles à jour ?",
+        "answer": "Oui, nos données produits sont mises à jour <b>deux fois par jour</b> pour refléter au mieux les évolutions des offres."
+      }
+    },
+    "agent": {
         "eyebrow": "Ton résultat IA ici 😉",
         "title": "Pose ta question, on l’affiche dans la FAQ",
         "subtitle": "Envoie ta demande, on répond avec une IA frugale et on affiche le résultat juste en dessous.",


### PR DESCRIPTION
## Summary
- update home FAQ entries to new localized copy and remove deprecated questions
- add localized Impact Score CTA button in the FAQ panel and render HTML answers directly
- refresh home page tests and FAQ data mappings for the streamlined list

## Testing
- pnpm fast

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511d08b19c8322904989bd6f8ab083)