### PR TITLE
Add subtitles and tooltips to nudge wizard steps

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
@@ -75,6 +75,11 @@ describe('NudgeToolWizard', () => {
           VWindow: { template: '<div><slot /></div>' },
           VWindowItem: { template: '<div><slot /></div>', props: ['value'] },
           VSpacer: true,
+          VTooltip: {
+            props: ['text', 'location'],
+            template:
+              '<div class="v-tooltip-stub"><slot name="activator" :props="{}" /><slot /></div>',
+          },
           // We keep VStepper stubbed but check its props if possible,
           // or we can use a component that renders keys
           VStepper: {

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.vue
@@ -106,20 +106,29 @@
         class="nudge-wizard__progress-bubbles"
         :style="footerOffsetStyle"
       >
-        <v-btn
+        <v-tooltip
           v-for="step in progressSteps"
           :key="step.key"
-          class="nudge-wizard__progress-bubble"
-          :variant="step.key === activeStepKey ? 'flat' : 'text'"
-          :color="step.key === activeStepKey ? 'primary' : undefined"
-          :aria-label="step.title"
-          :disabled="!canAccessStep(step.key)"
-          icon
-          size="44"
-          @click="() => handleProgressClick(step.key)"
+          location="top"
+          :text="step.title"
         >
-          <span class="nudge-wizard__progress-index">{{ step.index }}</span>
-        </v-btn>
+          <template #activator="{ props: tooltipProps }">
+            <span class="nudge-wizard__progress-bubble-wrapper" v-bind="tooltipProps">
+              <v-btn
+                class="nudge-wizard__progress-bubble"
+                :variant="step.key === activeStepKey ? 'flat' : 'text'"
+                :color="step.key === activeStepKey ? 'primary' : undefined"
+                :aria-label="step.title"
+                :disabled="!canAccessStep(step.key)"
+                icon
+                size="44"
+                @click="() => handleProgressClick(step.key)"
+              >
+                <span class="nudge-wizard__progress-index">{{ step.index }}</span>
+              </v-btn>
+            </span>
+          </template>
+        </v-tooltip>
       </div>
       <div class="nudge-wizard__footer-actions">
         <v-btn
@@ -323,6 +332,7 @@ const steps = computed<WizardStep[]>(() => {
       component: NudgeToolStepScores,
       title: t('nudge-tool.steps.scores.title'),
       subtitle: t('nudge-tool.steps.scores.subtitle'),
+      icon: 'mdi-leaf-circle-outline',
       props: {
         modelValue: selectedScores.value,
         scores: nudgeConfig.value?.scores ?? [],
@@ -336,6 +346,7 @@ const steps = computed<WizardStep[]>(() => {
     component: NudgeToolStepCondition,
     title: t('nudge-tool.steps.condition.title'),
     subtitle: t('nudge-tool.steps.condition.subtitle'),
+    icon: 'mdi-compare-horizontal',
     props: { modelValue: condition.value },
     onUpdate: (value: ProductConditionSelection) => {
       condition.value = value
@@ -572,20 +583,13 @@ const isNextDisabled = computed(() => {
 const canAccessStep = (stepKey: string) =>
   visitedStepKeys.value.includes(stepKey)
 
-const progressSteps = computed(() => {
-  if (activeStepKey.value === 'category') {
-    return []
-  }
-
-  return steps.value
-    .filter(step => step.key !== 'category')
-    .filter(step => visitedStepKeys.value.includes(step.key))
-    .map((step, index) => ({
-      key: step.key,
-      title: step.title,
-      index: index + 1,
-    }))
-})
+const progressSteps = computed(() =>
+  steps.value.map((step, index) => ({
+    key: step.key,
+    title: step.title,
+    index: index + 1,
+  }))
+)
 
 const handleProgressClick = (stepKey: string) => {
   if (!canAccessStep(stepKey)) {
@@ -927,6 +931,10 @@ const cornerIconDimensions = computed(() => {
     gap: 10px;
     align-items: center;
     flex-wrap: wrap;
+  }
+
+  &__progress-bubble-wrapper {
+    display: inline-flex;
   }
 
   &__progress-bubble {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2685,7 +2685,7 @@
       },
       "scores": {
         "title": "Your ecological priorities",
-        "subtitle": ""
+        "subtitle": "Not mandatory, but that's what we're here for."
       },
       "recommendations": {
         "title": "Our picks for you",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2800,7 +2800,7 @@
       },
       "scores": {
         "title": "Tes priorités écologiques",
-        "subtitle": ""
+        "subtitle": "C'est pas obligé. Mais on est quand même là pour ça."
       },
       "recommendations": {
         "title": "Nos propositions",


### PR DESCRIPTION
## Summary
- add localized subtitle and mdi icons to scores and condition steps
- show all wizard steps in progress bubbles with tooltips for titles
- stub Vuetify tooltip in wizard spec to keep tests stable

## Testing
- pnpm fast *(fails: long-running suite with existing warnings; interrupted after multiple queued specs)*
- pnpm vitest run app/components/nudge-tool/NudgeToolWizard.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952437ad8ec83229bbc8a1b63a40e99)