### PR TITLE
Improve nudge wizard navigation and card behavior

### DIFF
--- a/frontend/app/components/shared/cards/RoundedCornerCard.vue
+++ b/frontend/app/components/shared/cards/RoundedCornerCard.vue
@@ -84,7 +84,9 @@ const { t } = useI18n()
 const heroBackgroundAsset = useHeroBackgroundAsset()
 
 const isInteractive = computed(() => props.selectable && !props.disabled)
-const tabIndex = computed(() => (props.disabled ? -1 : 0))
+const tabIndex = computed(() =>
+  isInteractive.value && !props.disabled ? 0 : -1
+)
 const ariaPressed = computed(() =>
   isInteractive.value ? String(props.selected) : undefined
 )
@@ -174,6 +176,42 @@ const handleKeyDown = (event: KeyboardEvent) => {
   }
 }
 
+const cardListeners = computed(() => {
+  if (!isInteractive.value) {
+    return {
+      mouseenter: () => {
+        isHovered.value = false
+      },
+      mouseleave: () => {
+        isHovered.value = false
+      },
+      focusin: () => {
+        isHovered.value = false
+      },
+      focusout: () => {
+        isHovered.value = false
+      },
+    }
+  }
+
+  return {
+    click: handleSelect,
+    keydown: handleKeyDown,
+    mouseenter: () => {
+      isHovered.value = true
+    },
+    mouseleave: () => {
+      isHovered.value = false
+    },
+    focusin: () => {
+      isHovered.value = true
+    },
+    focusout: () => {
+      isHovered.value = false
+    },
+  }
+})
+
 const cardAriaLabel = computed(
   () => props.ariaLabel || props.title || props.subtitle || undefined
 )
@@ -205,12 +243,7 @@ const hasHeader = computed(() =>
     :aria-disabled="ariaDisabled"
     :aria-label="cardAriaLabel"
     :ripple="isInteractive"
-    @click="handleSelect"
-    @keydown="handleKeyDown"
-    @mouseenter="isHovered = true"
-    @mouseleave="isHovered = false"
-    @focusin="isHovered = true"
-    @focusout="isHovered = false"
+    v-on="cardListeners"
   >
     <div
       class="rounded-card__corner"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2660,7 +2660,8 @@
       "continue": "Continue",
       "seeAll": "See all recommendations",
       "previous": "Previous",
-      "next": "Next"
+      "next": "Next",
+      "viewCategoryResults": "Open {category} with your filters"
     },
     "wizard": {
       "welcome": "Welcome!"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2775,7 +2775,8 @@
       "continue": "Continuer",
       "seeAll": "Voir toutes les recommandations",
       "previous": "Précédent",
-      "next": "Suivant"
+      "next": "Suivant",
+      "viewCategoryResults": "Ouvrir {category} avec vos filtres"
     },
     "wizard": {
       "welcome": "🤘"


### PR DESCRIPTION
## Summary
- disable RoundedCornerCard interactivity when the card is not selectable so non-clickable surfaces no longer show hover link affordances
- wire the nudge wizard corner summary to navigate to the selected category page with the current filter hash and localized label
- style the corner CTA button and add i18n strings for the new navigation hint

## Testing
- pnpm test
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69524de65da08322b28320729cd24e0f)