### PR TITLE
Add open data item counts to stats endpoint

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/StatsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/StatsController.java
@@ -42,7 +42,7 @@ public class StatsController {
     @GetMapping("/categories")
     @Operation(
             summary = "Get categories statistics",
-            description = "Return aggregated statistics about vertical category mappings and affiliation partners.",
+            description = "Return aggregated statistics about vertical category mappings, affiliation partners and available OpenData items.",
             parameters = {
                     @io.swagger.v3.oas.annotations.Parameter(name = "domainLanguage", in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY, required = true,
                             description = "Language driving localisation of textual fields (future use).",

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDatasetDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/opendata/OpenDataDatasetDto.java
@@ -16,6 +16,9 @@ public record OpenDataDatasetDto(
         @Schema(description = "Number of rows in the dataset formatted using the requested locale.", example = "150\u00a0000")
         String recordCount,
 
+        @Schema(description = "Raw number of rows in the dataset.", example = "1500000")
+        long recordCountValue,
+
         @Schema(description = "Last update timestamp formatted using the requested locale.",
                 example = "12 mars 2024, 10:15:42", nullable = true)
         String lastUpdated,

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
@@ -10,5 +10,11 @@ public record CategoriesStatsDto(
         int enabledVerticalConfigs,
 
         @Schema(description = "Number of affiliation partners available for price comparison.", example = "18")
-        Integer affiliationPartnersCount
+        Integer affiliationPartnersCount,
+
+        @Schema(description = "Total number of GTIN items available in the OpenData exports.", example = "1250000")
+        long gtinOpenDataItemsCount,
+
+        @Schema(description = "Total number of ISBN items available in the OpenData exports.", example = "870000")
+        long isbnOpenDataItemsCount
 ) { }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingService.java
@@ -145,6 +145,7 @@ public class OpenDataMappingService {
         return new OpenDataDatasetDto(
                 type,
                 formatInteger(recordCount, locale),
+                recordCount,
                 formatTimestamp(file, locale),
                 formatDataSize(safeLength(file), locale),
                 buildDownloadUrl(relativeDownloadPath),

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/OpenDataMappingServiceTest.java
@@ -1,0 +1,48 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.opendata.OpenDataDatasetDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.services.opendata.config.OpenDataConfig;
+import org.open4goods.services.opendata.service.OpenDataService;
+
+class OpenDataMappingServiceTest {
+
+    @Test
+    void gtinDatasetIncludesRawRecordCount() throws Exception {
+        OpenDataService openDataService = mock(OpenDataService.class);
+        OpenDataConfig openDataConfig = mock(OpenDataConfig.class);
+        ApiProperties apiProperties = mock(ApiProperties.class);
+
+        File datasetFile = File.createTempFile("gtin-dataset", ".zip");
+        datasetFile.deleteOnExit();
+        try (FileOutputStream outputStream = new FileOutputStream(datasetFile)) {
+            outputStream.write("data".getBytes());
+        }
+
+        given(openDataService.totalItemsGTIN()).willReturn(9_876L);
+        given(openDataConfig.gtinZipFile()).willReturn(datasetFile);
+        given(apiProperties.getResourceRootPath()).willReturn("https://static.example");
+
+        OpenDataMappingService service = new OpenDataMappingService(openDataService, openDataConfig, apiProperties);
+
+        OpenDataDatasetDto dto = service.gtin(DomainLanguage.en);
+
+        Locale locale = Locale.forLanguageTag(DomainLanguage.en.languageTag());
+        String expectedFormattedCount = NumberFormat.getIntegerInstance(locale).format(9_876L);
+
+        assertThat(dto.recordCount()).isEqualTo(expectedFormattedCount);
+        assertThat(dto.recordCountValue()).isEqualTo(9_876L);
+        assertThat(dto.downloadUrl()).isEqualTo("https://static.example/opendata/gtin-open-data.zip");
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
@@ -4,10 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+import org.open4goods.model.affiliation.AffiliationPartner;
 import org.open4goods.nudgerfrontapi.dto.stats.CategoriesStatsDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
 import org.open4goods.services.serialisation.service.SerialisationService;
+import org.open4goods.services.opendata.service.OpenDataService;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -22,7 +26,8 @@ class StatsServiceTest {
     void categoriesCountsEnabledVerticalConfigs() throws Exception {
         SerialisationService serialisationService = new SerialisationService();
         ResourcePatternResolver resolver = mock(ResourcePatternResolver.class);
-        AffiliationPartnerService partnerSrvice = mock(AffiliationPartnerService.class);
+        AffiliationPartnerService partnerService = mock(AffiliationPartnerService.class);
+        OpenDataService openDataService = mock(OpenDataService.class);
 
         Resource defaultResource = resource("_default.yml", DEFAULT_YAML);
         Resource enabledResource = resource("enabled.yml", ENABLED_YAML);
@@ -31,12 +36,18 @@ class StatsServiceTest {
         given(resolver.getResource("classpath:/verticals/_default.yml")).willReturn(defaultResource);
         given(resolver.getResources("classpath:/verticals/*.yml"))
                 .willReturn(new Resource[]{defaultResource, enabledResource, disabledResource});
+        given(openDataService.totalItemsGTIN()).willReturn(1_234L);
+        given(openDataService.totalItemsISBN()).willReturn(567L);
+        given(partnerService.getPartners()).willReturn(List.of(mock(AffiliationPartner.class), mock(AffiliationPartner.class)));
 
-        StatsService service = new StatsService(serialisationService, resolver, partnerSrvice);
+        StatsService service = new StatsService(serialisationService, resolver, partnerService, openDataService);
 
         CategoriesStatsDto dto = service.categories(DomainLanguage.fr);
 
         assertThat(dto.enabledVerticalConfigs()).isEqualTo(1);
+        assertThat(dto.affiliationPartnersCount()).isEqualTo(2);
+        assertThat(dto.gtinOpenDataItemsCount()).isEqualTo(1_234L);
+        assertThat(dto.isbnOpenDataItemsCount()).isEqualTo(567L);
     }
 
     private Resource resource(String filename, String yaml) {


### PR DESCRIPTION
## Summary
- extend stats DTOs to expose affiliation partner and OpenData item counts
- include raw OpenData dataset record totals in dataset responses and mapping logic
- add unit tests covering stats aggregation and OpenData mapping outputs

## Testing
- mvn -s ../settings.xml clean install *(fails: dependency resolution blocked by 403 from maven.xwiki.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695385048e188322bfb46c1b3203c109)