### PR TITLE
Add device-specific scan and voice controls to search

### DIFF
--- a/frontend/app/components/home/sections/HomeCtaSection.vue
+++ b/frontend/app/components/home/sections/HomeCtaSection.vue
@@ -96,6 +96,12 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
                   )
                 "
                 :min-chars="minSuggestionQueryLength"
+                :enable-scan="true"
+                :scan-mobile="true"
+                :scan-desktop="false"
+                :enable-voice="true"
+                :voice-mobile="true"
+                :voice-desktop="true"
                 @update:model-value="handleUpdate"
                 @submit="handleSubmit"
                 @select-category="handleCategorySelect"

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -469,6 +469,12 @@ useHead({
                         })
                       "
                       :min-chars="minSuggestionQueryLength"
+                      :enable-scan="true"
+                      :scan-mobile="true"
+                      :scan-desktop="false"
+                      :enable-voice="true"
+                      :voice-mobile="true"
+                      :voice-desktop="true"
                       @update:model-value="updateSearchQuery"
                       @submit="handleSubmit"
                       @select-category="handleCategorySelect"

--- a/frontend/app/components/search/SearchSuggestField.spec.ts
+++ b/frontend/app/components/search/SearchSuggestField.spec.ts
@@ -26,6 +26,10 @@ vi.mock('vue-i18n', () => ({
           'Align the barcode within the frame.',
         'search.suggestions.scanner.loading': 'Preparing camera…',
         'search.suggestions.scanner.error': 'Camera unavailable.',
+        'search.suggestions.voice.startLabel': 'Start voice search',
+        'search.suggestions.voice.stopLabel': 'Stop voice search',
+        'search.suggestions.voice.unsupported': 'Voice unavailable',
+        'search.suggestions.voice.error': 'Voice error',
       }
 
       const template = messages[key] ?? key
@@ -227,6 +231,50 @@ describe('SearchSuggestField', () => {
     vi.unstubAllGlobals()
   })
 
+  it('does not fetch suggestions when disabled', async () => {
+    const wrapper = await mount(SearchSuggestField, {
+      props: {
+        modelValue: '',
+        label: 'Search',
+        placeholder: 'Search products',
+        ariaLabel: 'Search products',
+        minChars: 2,
+        enableSuggest: false,
+      },
+      global: {
+        stubs: {
+          VHover: VHoverStub,
+          VAutocomplete: VAutocompleteStub,
+          VListItem: createStub('div'),
+          VAvatar: createStub('div'),
+          VImg: createStub('img'),
+          VIcon: createStub('span'),
+          VBtn: createStub('button'),
+          VCard: createStub('div'),
+          VDialog: VDialogStub,
+          ImpactScore: createStub('div'),
+          PwaBarcodeScanner: PwaBarcodeScannerStub,
+        },
+        components: {
+          ClientOnly: defineComponent({
+            name: 'ClientOnlyStub',
+            setup(_, { slots }) {
+              return () => (slots.default ? slots.default() : [])
+            },
+          }),
+        },
+      },
+    })
+
+    const autocomplete = wrapper.getComponent(VAutocompleteStub)
+    autocomplete.vm.$emit('update:search', 'tv')
+    await wrapper.vm.$nextTick()
+    vi.advanceTimersByTime(350)
+    await flushPromises()
+
+    expect(globalThis.$fetch).not.toHaveBeenCalled()
+  })
+
   it('fetches suggestions when the value meets the minimum length', async () => {
     const wrapper = await mountField()
     const autocomplete = wrapper.getComponent(VAutocompleteStub)
@@ -370,6 +418,15 @@ describe('SearchSuggestField', () => {
     const wrapper = await mountField()
 
     expect(wrapper.find('[data-test="search-scanner-button"]').exists()).toBe(
+      true
+    )
+  })
+
+  it('renders the voice button on mobile when enabled', async () => {
+    displayMock.smAndDown.value = true
+    const wrapper = await mountField()
+
+    expect(wrapper.find('[data-test="search-voice-button"]').exists()).toBe(
       true
     )
   })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1875,6 +1875,12 @@
         "loading": "Preparing the camera…",
         "helper": "Align the barcode within the frame to search automatically.",
         "error": "We couldn't access your camera. Please enter the GTIN manually."
+      },
+      "voice": {
+        "startLabel": "Start voice search",
+        "stopLabel": "Stop voice search",
+        "unsupported": "Voice search is not available on this device.",
+        "error": "We couldn't capture your voice. Try again or type your query."
       }
     },
     "groups": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1923,6 +1923,12 @@
         "loading": "Initialisation de la caméra…",
         "helper": "Alignez le code-barres dans le cadre pour lancer la recherche automatiquement.",
         "error": "Impossible d'accéder à votre caméra. Saisissez le GTIN manuellement."
+      },
+      "voice": {
+        "startLabel": "Démarrer la recherche vocale",
+        "stopLabel": "Arrêter la recherche vocale",
+        "unsupported": "La recherche vocale n'est pas disponible sur cet appareil.",
+        "error": "Nous n'avons pas compris votre voix. Réessayez ou saisissez votre requête."
       }
     },
     "groups": {


### PR DESCRIPTION
## Summary
- add feature toggles for search suggestions, barcode scanning, and voice input with device-specific variants
- integrate a microphone action using the Web Speech API, guarding unsupported environments and extending test coverage
- configure homepage search bars for the requested mobile/desktop combinations and localize new voice strings

## Testing
- pnpm vitest run app/components/search/SearchSuggestField.spec.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953868d0df883229c092d2fcd96bdbd)