### PR TITLE
Add divers aggregate handling for impact details

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -1,0 +1,209 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { computed, defineComponent, h, nextTick } from 'vue'
+import ProductImpactDetailsTable from './ProductImpactDetailsTable.vue'
+import type { ScoreView } from './impact-types'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en-US',
+  messages: {
+    'en-US': {
+      product: {
+        impact: {
+          detailsTitle: 'Impact details',
+          noDetailsAvailable: 'No details',
+          hideDetails: 'Hide details',
+          subscoreDetailsToggle: 'Show details',
+          valueOutOf: '{value} / {max}',
+          tableHeaders: {
+            scoreName: 'Indicator',
+            attributeValue: 'Raw value',
+            scoreValue: 'Score',
+            coefficient: 'Coefficient',
+            lifecycle: 'Lifecycle',
+          },
+          lifecycle: {
+            END_OF_LIFE: 'End of life',
+            EXTRACTION: 'Extraction',
+            MANUFACTURING: 'Manufacturing',
+            TRANSPORTATION: 'Transportation',
+            USE: 'Use',
+          },
+          aggregateScores: {
+            DIVERS: 'Miscellaneous',
+            AGG1: 'Aggregate 1',
+          },
+        },
+      },
+    },
+  },
+})
+
+const VDataTableStub = defineComponent({
+  name: 'VDataTableStub',
+  props: ['headers', 'items', 'itemsPerPage', 'density', 'class', 'hideDefaultFooter'],
+  setup(props, { slots }) {
+    const items = computed(
+      () => (props.items as Array<{ rowType?: string }> | undefined) ?? []
+    )
+
+    return () =>
+      h(
+        'div',
+        { class: 'v-data-table-stub' },
+        items.value.map(item =>
+          h('div', { class: `row row-${item.rowType ?? 'unknown'}` }, [
+            slots['item.label']?.({ item }),
+            slots['item.attributeValue']?.({ item }),
+            slots['item.displayValue']?.({ item }),
+            slots['item.coefficient']?.({ item }),
+            slots['item.lifecycle']?.({ item }),
+          ])
+        ) ?? []
+      )
+  },
+})
+
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  emits: ['click'],
+  setup(_props, { emit, slots }) {
+    return () =>
+      h(
+        'button',
+        {
+          class: 'v-btn-stub',
+          onClick: () => emit('click'),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIconStub',
+  props: ['icon', 'size'],
+  setup(props) {
+    return () => h('span', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VChipStub = defineComponent({
+  name: 'VChipStub',
+  props: ['color', 'size', 'variant'],
+  setup(_props, { slots }) {
+    return () => h('span', { class: 'v-chip-stub' }, slots.default?.())
+  },
+})
+
+const ProductImpactSubscoreRatingStub = defineComponent({
+  name: 'ProductImpactSubscoreRatingStub',
+  props: ['score', 'max', 'size', 'showValue'],
+  setup(props) {
+    return () =>
+      h(
+        'span',
+        { class: 'subscore-rating-stub', 'data-score': props.score },
+        String(props.score ?? '')
+      )
+  },
+})
+
+const ImpactCoefficientBadgeStub = defineComponent({
+  name: 'ImpactCoefficientBadgeStub',
+  props: ['value', 'tooltipParams'],
+  setup(props) {
+    return () =>
+      h('span', { class: 'impact-coefficient-stub' }, String(props.value ?? '—'))
+  },
+})
+
+const mountComponent = (scores: ScoreView[]) =>
+  mount(ProductImpactDetailsTable, {
+    props: { scores },
+    global: {
+      plugins: [i18n],
+      stubs: {
+        'v-data-table': VDataTableStub,
+        'v-btn': VBtnStub,
+        'v-icon': VIconStub,
+        'v-chip': VChipStub,
+        ProductImpactSubscoreRating: ProductImpactSubscoreRatingStub,
+        ImpactCoefficientBadge: ImpactCoefficientBadgeStub,
+      },
+    },
+  })
+
+describe('ProductImpactDetailsTable', () => {
+  it('groups orphan scores into the DIVERS aggregate and keeps groups collapsed', () => {
+    const scores: ScoreView[] = [
+      {
+        id: 'AGG1',
+        label: 'Aggregate 1',
+        relativeValue: 4.5,
+        participateInScores: [],
+      },
+      {
+        id: 'SUB1',
+        label: 'Subscore 1',
+        relativeValue: 3.2,
+        participateInScores: ['AGG1'],
+        participateInACV: ['USE'],
+      },
+      {
+        id: 'ORPHAN',
+        label: 'Orphan score',
+        relativeValue: 2.4,
+        participateInScores: [],
+      },
+    ]
+
+    const wrapper = mountComponent(scores)
+    const vm = wrapper.vm as unknown as {
+      tableItems: Array<{ id: string; rowType: string; displayValue: number | null }>
+      expandedGroups: Set<string>
+    }
+
+    expect(vm.tableItems).toHaveLength(2)
+    const diversRow = vm.tableItems.find(row => row.id === 'DIVERS')
+    expect(diversRow?.rowType).toBe('aggregate')
+    expect(diversRow?.displayValue).toBeCloseTo(2.4)
+    expect(vm.expandedGroups.size).toBe(0)
+  })
+
+  it('duplicates scores across aggregates and computes aggregate values from children when missing', async () => {
+    const scores: ScoreView[] = [
+      {
+        id: 'CHILD',
+        label: 'Child score',
+        relativeValue: 3,
+        participateInScores: ['AGG1', 'AGG2'],
+        aggregates: { AGG2: 4.6 },
+      },
+    ]
+
+    const wrapper = mountComponent(scores)
+    const vm = wrapper.vm as unknown as {
+      tableItems: Array<{ id: string; rowType: string; displayValue: number | null; parentId?: string }>
+      toggleGroup: (id: string) => void
+    }
+
+    const agg1 = vm.tableItems.find(row => row.id === 'AGG1')
+    const agg2 = vm.tableItems.find(row => row.id === 'AGG2')
+
+    expect(agg1?.displayValue).toBeCloseTo(3)
+    expect(agg2?.displayValue).toBeCloseTo(4.6)
+
+    vm.toggleGroup('AGG1')
+    vm.toggleGroup('AGG2')
+    await nextTick()
+
+    const childRows = vm.tableItems.filter(row => row.rowType === 'subscore')
+    expect(childRows).toHaveLength(2)
+    expect(childRows.map(row => row.parentId)).toContain('AGG1')
+    expect(childRows.map(row => row.parentId)).toContain('AGG2')
+    expect(vm.tableItems.find(row => row.id === 'DIVERS')).toBeUndefined()
+  })
+})

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2251,7 +2251,9 @@
         "TRANSPORTATION": "Transport & logistics",
         "USE": "Product use"
       },
-      "aggregateScores": {},
+      "aggregateScores": {
+        "DIVERS": "Miscellaneous"
+      },
       "showDetails": "Show detailed indicators",
       "hideDetails": "Hide detailed indicators",
       "title": "Environmental impact"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2299,7 +2299,9 @@
         "TRANSPORTATION": "Transport & logistique",
         "USE": "Usage du produit"
       },
-      "aggregateScores": {},
+      "aggregateScores": {
+        "DIVERS": "Divers"
+      },
       "showDetails": "Afficher les indicateurs détaillés",
       "hideDetails": "Masquer les indicateurs détaillés",
       "title": "Impact écologique"


### PR DESCRIPTION
## Summary
- group orphan impact subscores into a collapsible "divers" aggregate with translated label
- compute aggregate display values from provided aggregates or child averages when no aggregate score exists
- add unit tests for impact details grouping and register the new translations

## Testing
- pnpm lint
- pnpm test ProductImpactDetailsTable.spec.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539e8a003c8322810f2c5f874d562f)