### PR TITLE
Add contact form prefill and home contact redirect

### DIFF
--- a/frontend/app/components/domains/contact/ContactFormCard.vue
+++ b/frontend/app/components/domains/contact/ContactFormCard.vue
@@ -92,6 +92,21 @@
                 </v-col>
 
                 <v-col cols="12">
+                  <v-text-field
+                    v-model="subject"
+                    :label="t('contact.form.fields.subject.label')"
+                    :placeholder="t('contact.form.fields.subject.placeholder')"
+                    :counter="180"
+                    :rules="subjectRules"
+                    :disabled="submitting"
+                    autocomplete="on"
+                    required
+                    prepend-inner-icon="mdi-form-textbox"
+                    variant="outlined"
+                  />
+                </v-col>
+
+                <v-col cols="12">
                   <v-textarea
                     v-model="message"
                     :label="t('contact.form.fields.message.label')"
@@ -196,6 +211,7 @@ import { VForm } from 'vuetify/components'
 export interface ContactFormPayload {
   name: string
   email: string
+  subject: string
   message: string
   hCaptchaResponse: string
 }
@@ -205,6 +221,8 @@ const props = defineProps<{
   success: boolean
   errorMessage: string | null
   siteKey: string
+  initialSubject?: string
+  initialMessage?: string
 }>()
 
 const emit = defineEmits<{
@@ -222,6 +240,7 @@ const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 
 const name = ref('')
 const email = ref('')
+const subject = ref('')
 const message = ref('')
 const captchaToken = ref('')
 const captchaError = ref<string | null>(null)
@@ -250,6 +269,14 @@ const emailRules = computed(() => [
   (value: string) =>
     emailPattern.test(value?.trim() ?? '') ||
     t('contact.form.errors.email.invalid'),
+])
+
+const subjectRules = computed(() => [
+  (value: string) =>
+    !!value?.trim() || t('contact.form.errors.subject.required'),
+  (value: string) =>
+    (value?.trim().length ?? 0) >= 3 ||
+    t('contact.form.errors.subject.length'),
 ])
 
 const messageRules = computed(() => [
@@ -286,6 +313,7 @@ const resetCaptcha = () => {
 const clearFormFields = () => {
   name.value = ''
   email.value = ''
+  subject.value = ''
   message.value = ''
   formRef.value?.resetValidation()
   resetCaptcha()
@@ -314,10 +342,27 @@ const handleSubmit = async () => {
   emit('submit', {
     name: name.value.trim(),
     email: email.value.trim(),
+    subject: subject.value.trim(),
     message: message.value.trim(),
     hCaptchaResponse: captchaToken.value,
   })
 }
+
+watch(
+  () => props.initialSubject,
+  value => {
+    subject.value = value?.trim() ?? ''
+  },
+  { immediate: true }
+)
+
+watch(
+  () => props.initialMessage,
+  value => {
+    message.value = value?.trim() ?? ''
+  },
+  { immediate: true }
+)
 
 watch(
   () => props.success,

--- a/frontend/app/pages/contact/index.vue
+++ b/frontend/app/pages/contact/index.vue
@@ -95,6 +95,8 @@
       :submitting="submitting"
       :success="success"
       :error-message="formError"
+      :initial-subject="initialSubject"
+      :initial-message="initialMessage"
       @submit="handleFormSubmit"
       @reset-feedback="handleResetFeedback"
     />
@@ -127,6 +129,7 @@ definePageMeta({
 })
 
 const { t, locale, availableLocales } = useI18n()
+const route = useRoute()
 const runtimeConfig = useRuntimeConfig()
 const requestURL = useRequestURL()
 const localePath = useLocalePath()
@@ -136,6 +139,30 @@ const siteKey = computed(() => runtimeConfig.public.hcaptchaSiteKey ?? '')
 const submitting = ref(false)
 const success = ref(false)
 const formError = ref<string | null>(null)
+
+const MAX_SUBJECT_LENGTH = 180
+const MAX_MESSAGE_LENGTH = 1200
+
+const normalizePrefillValue = (value: unknown, maxLength: number) => {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return ''
+  }
+
+  return trimmed.slice(0, maxLength)
+}
+
+const initialSubject = computed(() =>
+  normalizePrefillValue(route.query.subject, MAX_SUBJECT_LENGTH)
+)
+const initialMessage = computed(() =>
+  normalizePrefillValue(route.query.message, MAX_MESSAGE_LENGTH)
+)
 
 const linkedinUrl = computed(() => String(t('siteIdentity.links.linkedin')))
 

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -43,6 +43,7 @@ const requestURL = useRequestURL()
 const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const searchQuery = ref('')
+const contactRedirectMessage = ref('')
 
 const MIN_SUGGESTION_QUERY_LENGTH = 2
 
@@ -132,6 +133,7 @@ type AnimatedSectionKey =
   | 'blog'
   | 'objections'
   | 'faq'
+  | 'contactRedirect'
   | 'cta'
 
 const prefersReducedMotion = usePreferredReducedMotion()
@@ -146,6 +148,7 @@ const animatedSections = reactive<Record<AnimatedSectionKey, boolean>>({
   blog: false,
   objections: false,
   faq: false,
+  contactRedirect: false,
   cta: false,
 })
 
@@ -210,6 +213,11 @@ const sanitizeBlogSummary = (value: unknown) =>
 
 const hasRenderableImage = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0
+
+const contactRedirectSubject = computed(() =>
+  toTrimmedString(t('home.contactRedirect.prefilledSubject'))
+)
+const CONTACT_REDIRECT_MAX_LENGTH = 400
 
 useAsyncData(
   'home-heavy-data',
@@ -633,6 +641,30 @@ const handleProductSuggestion = (suggestion: ProductSuggestionItem) => {
   navigateToSearch(suggestion.title)
 }
 
+const handleContactRedirect = () => {
+  const sanitizedMessage = toTrimmedString(contactRedirectMessage.value).slice(
+    0,
+    CONTACT_REDIRECT_MAX_LENGTH
+  )
+
+  const query: Record<string, string> = {}
+
+  if (contactRedirectSubject.value) {
+    query.subject = contactRedirectSubject.value
+  }
+
+  if (sanitizedMessage) {
+    query.message = sanitizedMessage
+  }
+
+  router.push(
+    localePath({
+      name: 'contact',
+      query: Object.keys(query).length ? query : undefined,
+    })
+  )
+}
+
 const seoTitle = computed(() => String(t('home.seo.title')))
 
 const seoDescription = computed(() => String(t('home.seo.description')))
@@ -836,6 +868,82 @@ useHead(() => ({
               </div>
 
               <div
+                v-intersect="createIntersectHandler('contactRedirect')"
+                class="home-page__section"
+              >
+                <v-slide-y-transition :disabled="shouldReduceMotion">
+                  <div v-show="animatedSections.contactRedirect">
+                    <section
+                      class="home-contact-redirect"
+                      aria-labelledby="home-contact-redirect-heading"
+                    >
+                      <v-card
+                        class="home-contact-redirect__card"
+                        elevation="10"
+                        rounded="xl"
+                        variant="flat"
+                        color="surface-primary-050"
+                      >
+                        <div class="home-contact-redirect__content">
+                          <div class="home-contact-redirect__texts">
+                            <p class="home-contact-redirect__eyebrow">
+                              {{ t('home.contactRedirect.eyebrow') }}
+                            </p>
+                            <h3
+                              id="home-contact-redirect-heading"
+                              class="home-contact-redirect__title"
+                            >
+                              {{ t('home.contactRedirect.title') }}
+                            </h3>
+                            <p class="home-contact-redirect__subtitle">
+                              {{ t('home.contactRedirect.subtitle') }}
+                            </p>
+                          </div>
+
+                          <v-form
+                            class="home-contact-redirect__form"
+                            @submit.prevent="handleContactRedirect"
+                          >
+                            <v-text-field
+                              v-model="contactRedirectMessage"
+                              :label="t('home.contactRedirect.inputLabel')"
+                              :placeholder="t('home.contactRedirect.placeholder')"
+                              :counter="CONTACT_REDIRECT_MAX_LENGTH"
+                              prepend-inner-icon="mdi-help-circle-outline"
+                              variant="outlined"
+                              hide-details="auto"
+                              clearable
+                              color="primary"
+                            />
+                            <div class="home-contact-redirect__actions">
+                              <v-btn
+                                type="submit"
+                                color="primary"
+                                size="large"
+                                prepend-icon="mdi-arrow-right"
+                              >
+                                {{ t('home.contactRedirect.cta') }}
+                              </v-btn>
+                              <v-btn
+                                :to="localePath({ name: 'contact' })"
+                                variant="text"
+                                color="primary"
+                              >
+                                {{ t('home.contactRedirect.secondaryCta') }}
+                              </v-btn>
+                            </div>
+                            <p class="home-contact-redirect__helper">
+                              {{ t('home.contactRedirect.helper') }}
+                            </p>
+                          </v-form>
+                        </div>
+                      </v-card>
+                    </section>
+                  </div>
+                </v-slide-y-transition>
+              </div>
+
+              <div
                 v-intersect="createIntersectHandler('cta')"
                 class="home-page__section"
               >
@@ -899,4 +1007,63 @@ useHead(() => ({
 
 .home-page__section
   width: 100%
+
+.home-contact-redirect__card
+  border: 1px solid rgb(var(--v-theme-surface-primary-080))
+  background: linear-gradient(135deg, rgba(var(--v-theme-surface-glass), 0.35) 0%, rgb(var(--v-theme-surface-default)) 100%)
+
+.home-contact-redirect__content
+  display: grid
+  grid-template-columns: 1fr
+  gap: 1.25rem
+  align-items: center
+  padding: clamp(1.5rem, 4vw, 2.25rem)
+
+.home-contact-redirect__texts
+  display: flex
+  flex-direction: column
+  gap: 0.5rem
+
+.home-contact-redirect__eyebrow
+  align-self: flex-start
+  padding: 0.3rem 0.9rem
+  border-radius: 999px
+  background: rgb(var(--v-theme-surface-primary-120))
+  color: rgb(var(--v-theme-primary))
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  font-weight: 700
+  font-size: 0.85rem
+  margin: 0
+
+.home-contact-redirect__title
+  font-size: clamp(1.6rem, 3vw, 2rem)
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+.home-contact-redirect__subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-size: 1.05rem
+  line-height: 1.5
+
+.home-contact-redirect__form
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-contact-redirect__actions
+  display: flex
+  gap: 0.75rem
+  flex-wrap: wrap
+  align-items: center
+
+.home-contact-redirect__helper
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-strong), 0.72)
+  font-size: 0.95rem
+
+@media (min-width: 960px)
+  .home-contact-redirect__content
+    grid-template-columns: 1.1fr 1fr
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -431,24 +431,35 @@
       }
     },
     "agent": {
-        "eyebrow": "Your AI result here 😉",
-        "title": "Ask your question, we’ll pin it to the FAQ",
-        "subtitle": "Share your request, we’ll answer with frugal AI and surface it below for everyone.",
-        "dynamicAnswerWithLink": "See the detailed AI answer: {link}",
-        "dynamicAnswerWithState": "We’re crafting the answer ({state}).",
-        "dynamicAnswerPending": "Thanks! Your question is in the queue.",
-        "preview": {
-          "eyebrow": "Live AI feed",
-          "title": "Latest AI answer",
-          "subtitle": "The freshest public question appears here.",
-          "label": "Latest question",
-          "status": "Status: {status}",
-          "statusPending": "Status pending",
-          "cta": "Open the result",
-          "helper": "Opens the last public response in a new tab",
-          "questionFallback": "Your AI question will surface here."
-        }
+      "eyebrow": "Your AI result here 😉",
+      "title": "Ask your question, we’ll pin it to the FAQ",
+      "subtitle": "Share your request, we’ll answer with frugal AI and surface it below for everyone.",
+      "dynamicAnswerWithLink": "See the detailed AI answer: {link}",
+      "dynamicAnswerWithState": "We’re crafting the answer ({state}).",
+      "dynamicAnswerPending": "Thanks! Your question is in the queue.",
+      "preview": {
+        "eyebrow": "Live AI feed",
+        "title": "Latest AI answer",
+        "subtitle": "The freshest public question appears here.",
+        "label": "Latest question",
+        "status": "Status: {status}",
+        "statusPending": "Status pending",
+        "cta": "Open the result",
+        "helper": "Opens the last public response in a new tab",
+        "questionFallback": "Your AI question will surface here."
       }
+    },
+    "contactRedirect": {
+      "eyebrow": "Need help?",
+      "title": "Can’t find your answer?",
+      "subtitle": "Type a few words and we’ll take you straight to the contact form.",
+      "inputLabel": "Your request in a few words",
+      "placeholder": "e.g. I need an invoice or product info",
+      "cta": "Go to Contact",
+      "secondaryCta": "Open the Contact page",
+      "helper": "We’ll prefill the contact form to save you time.",
+      "prefilledSubject": "Question from the FAQ"
+    }
     },
     "roundedCards": {
       "eyebrow": "Design system",
@@ -913,6 +924,10 @@
           "invalid": "Please enter a valid email address.",
           "required": "Please enter your email address."
         },
+        "subject": {
+          "length": "Please provide a subject with at least 3 characters.",
+          "required": "Please add a subject to your message."
+        },
         "message": {
           "length": "Your message must be at least 10 characters long.",
           "required": "Please describe your request."
@@ -941,6 +956,10 @@
         "name": {
           "label": "Your name",
           "placeholder": "e.g. Alex Martin"
+        },
+        "subject": {
+          "label": "Subject",
+          "placeholder": "e.g. Question about a product or offer"
         }
       },
       "privacy": "We only use your contact details to answer your request and never share them with third parties.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -496,6 +496,17 @@
           "helper": "Ouvre la dernière réponse publique dans un nouvel onglet",
           "questionFallback": "Ta question IA s’affichera ici."
         }
+      },
+      "contactRedirect": {
+        "eyebrow": "Besoin d’aide ?",
+        "title": "Vous ne trouvez pas votre réponse ?",
+        "subtitle": "Saisissez quelques mots et on vous redirige vers le formulaire de contact.",
+        "inputLabel": "Votre demande en bref",
+        "placeholder": "ex. Je cherche une facture ou une info produit",
+        "cta": "Envoyer vers Contact",
+        "secondaryCta": "Aller à la page Contact",
+        "helper": "Nous pré-remplissons le formulaire de contact pour vous faire gagner du temps.",
+        "prefilledSubject": "Question depuis la FAQ"
       }
     },
     "roundedCards": {
@@ -961,6 +972,10 @@
           "invalid": "Merci de saisir une adresse e-mail valide.",
           "required": "Merci d'indiquer une adresse e-mail."
         },
+        "subject": {
+          "length": "Merci de préciser un objet d'au moins 3 caractères.",
+          "required": "Merci d'ajouter un objet à votre message."
+        },
         "message": {
           "length": "Votre message doit contenir au moins 10 caractères.",
           "required": "Merci de détailler votre demande."
@@ -989,6 +1004,10 @@
         "name": {
           "label": "Votre nom",
           "placeholder": "ex. Alex Martin"
+        },
+        "subject": {
+          "label": "Objet de votre demande",
+          "placeholder": "ex. Question sur un produit ou une offre"
         }
       },
       "privacy": "Vos coordonnées ne sont utilisées que pour répondre à votre message et ne sont jamais partagées.",


### PR DESCRIPTION
## Summary
- add subject support and prefilled values to the contact form, including validation
- read query params on the contact page to initialise subject/message and propagate them to the API payload
- add a post-FAQ contact redirect section on the home page with i18n strings and styling

## Testing
- pnpm lint
- pnpm test
- pnpm generate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a03d5cc88322a885fa8cce736692)