### PR TITLE
chore: bundle documentation resources into deployments

### DIFF
--- a/.github/actions/bundle-doc-resources/action.yml
+++ b/.github/actions/bundle-doc-resources/action.yml
@@ -1,0 +1,28 @@
+name: "Bundle markdown & prompt resources into JARs"
+description: "Stages repository .md/.prompt files and embeds them into provided JARs"
+inputs:
+  jar-paths:
+    description: "Newline-separated list of JAR paths to update"
+    required: false
+    default: ""
+  root-dir:
+    description: "Repository root to scan"
+    required: false
+    default: "."
+  staging-dir:
+    description: "Directory used to stage doc resources before embedding"
+    required: false
+    default: "target/classpath-docs"
+runs:
+  using: "composite"
+  steps:
+    - name: Stage .md and .prompt resources and embed in JARs
+      shell: bash
+      env:
+        JAR_PATHS: ${{ inputs.jar-paths }}
+        ROOT_DIR: ${{ inputs.root-dir }}
+        STAGING_DIR: ${{ inputs.staging-dir }}
+      run: |
+        set -euo pipefail
+        mapfile -t jar_paths_array < <(printf '%s\n' "${JAR_PATHS}" | sed '/^$/d')
+        bash scripts/bundle-doc-resources.sh "${ROOT_DIR}" "${STAGING_DIR}" "${jar_paths_array[@]}"

--- a/.github/workflows/releaseDeployProd.yml
+++ b/.github/workflows/releaseDeployProd.yml
@@ -196,6 +196,15 @@ jobs:
           set -euo pipefail
           mvn -B -ntp -T 1C -DinstallAtEnd=true clean install
 
+      - name: 📚 Bundle markdown/prompt resources into JARs
+        uses: ./.github/actions/bundle-doc-resources
+        with:
+          jar-paths: |
+            admin/target/admin-0.0.1-SNAPSHOT.jar
+            api/target/api-0.0.1-SNAPSHOT.jar
+            ui/target/ui-0.0.1-SNAPSHOT.jar
+            front-api/target/front-api-0.0.1-SNAPSHOT.jar
+
       - name: 🌐 Generate Maven Site (stage)
         shell: bash
         run: |

--- a/.github/workflows/testAndPublishBeta.yml
+++ b/.github/workflows/testAndPublishBeta.yml
@@ -60,9 +60,21 @@ jobs:
 
       ############################################
       # 5. Build and Test with Maven
-      ############################################    
+      ############################################
       - name: Build and Test with Maven
         run: mvn --batch-mode --update-snapshots install
+
+      ############################################
+      # 5b. Bundle markdown/prompt resources into classpath JARs
+      ############################################
+      - name: Bundle markdown/prompt resources
+        uses: ./.github/actions/bundle-doc-resources
+        with:
+          jar-paths: |
+            admin/target/admin-0.0.1-SNAPSHOT.jar
+            api/target/api-0.0.1-SNAPSHOT.jar
+            ui/target/ui-0.0.1-SNAPSHOT.jar
+            front-api/target/front-api-0.0.1-SNAPSHOT.jar
 
       ############################################
       # 6. Deploy JAR Files to Qualification Environment

--- a/scripts/bundle-doc-resources.sh
+++ b/scripts/bundle-doc-resources.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${1:-.}"
+STAGING_DIR="${2:-target/classpath-docs}"
+shift 2 || true
+JAR_PATHS=("$@")
+
+# Normalize staging directory
+mkdir -p "${STAGING_DIR}/docs"
+rm -rf "${STAGING_DIR}/docs"
+mkdir -p "${STAGING_DIR}/docs"
+
+pushd "${ROOT_DIR}" >/dev/null
+
+find_command=(find . \(
+  -path "./.git" -o
+  -path "./.mvn" -o
+  -path "./frontend/node_modules" -o
+  -path "./frontend/.output" -o
+  -path "./frontend/.nuxt" -o
+  -name target -o
+  -name .gradle
+\) -prune -o -type f \( -name "*.md" -o -name "*.prompt" \) -print0)
+
+if ! rsync --version >/dev/null 2>&1; then
+  echo "rsync is required to stage documentation resources" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2046
+"${find_command[@]}" | rsync -a --from0 --files-from=- ./ "${STAGING_DIR}/docs"
+
+popd >/dev/null
+
+if [[ ${#JAR_PATHS[@]} -eq 0 ]]; then
+  echo "No jar paths provided; staging docs only."
+  exit 0
+fi
+
+if ! command -v jar >/dev/null 2>&1; then
+  echo "jar command not found; ensure JDK is installed." >&2
+  exit 1
+fi
+
+for jar_path in "${JAR_PATHS[@]}"; do
+  if [[ ! -f "${jar_path}" ]]; then
+    echo "Warning: jar not found at ${jar_path}; skipping." >&2
+    continue
+  fi
+
+  echo "Embedding documentation resources into ${jar_path}" >&2
+  jar uf "${jar_path}" -C "${STAGING_DIR}" .
+done

--- a/scripts/tests/bundle-doc-resources.test.sh
+++ b/scripts/tests/bundle-doc-resources.test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+cd "${FIXTURE_DIR}"
+
+mkdir -p repo/frontend/docs repo/services/api
+cat > repo/README.md <<'MD'
+# Root doc
+MD
+cat > repo/frontend/docs/guide.md <<'MD'
+# Frontend guide
+MD
+cat > repo/services/api/usage.prompt <<'PR'
+Prompt content
+PR
+
+touch repo/BOGUS.txt
+jar cf repo/sample.jar -C repo BOGUS.txt
+
+cd "${ROOT}"
+
+scripts/bundle-doc-resources.sh "${FIXTURE_DIR}/repo" "${FIXTURE_DIR}/repo/target/classpath-docs" "${FIXTURE_DIR}/repo/sample.jar"
+
+STAGED_DIR="${FIXTURE_DIR}/repo/target/classpath-docs/docs"
+[[ -f "${STAGED_DIR}/README.md" ]] || { echo "README not staged"; exit 1; }
+[[ -f "${STAGED_DIR}/frontend/docs/guide.md" ]] || { echo "guide not staged"; exit 1; }
+[[ -f "${STAGED_DIR}/services/api/usage.prompt" ]] || { echo "prompt not staged"; exit 1; }
+
+if ! jar tf "${FIXTURE_DIR}/repo/sample.jar" | grep -q "docs/README.md"; then
+  echo "Docs not embedded into jar"
+  exit 1
+fi
+if ! jar tf "${FIXTURE_DIR}/repo/sample.jar" | grep -q "docs/frontend/docs/guide.md"; then
+  echo "Nested doc not embedded"
+  exit 1
+fi
+if ! jar tf "${FIXTURE_DIR}/repo/sample.jar" | grep -q "docs/services/api/usage.prompt"; then
+  echo "Prompt not embedded"
+  exit 1
+fi
+
+echo "bundle-doc-resources test passed"


### PR DESCRIPTION
## Summary
- add a reusable composite action to stage markdown/prompt assets and embed them into deployment JARs
- update prod and beta GitHub workflows to package documentation resources alongside build artifacts
- add a shell test to validate documentation bundling behavior

## Testing
- bash scripts/tests/bundle-doc-resources.test.sh
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ac9caba48322ae9da643e2ff30ef)