### PR TITLE
fix: serialize category configs in API

### DIFF
--- a/frontend/server/api/categories/[id].ts
+++ b/frontend/server/api/categories/[id].ts
@@ -1,5 +1,6 @@
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
 import type { VerticalConfigFullDto } from '~~/shared/api-client'
+import { VerticalConfigFullDtoToJSON } from '~~/shared/api-client'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
@@ -26,7 +27,8 @@ export default defineEventHandler(
     const categoriesService = useCategoriesService(domainLanguage)
 
     try {
-      return await categoriesService.getCategoryById(categoryId)
+      const category = await categoriesService.getCategoryById(categoryId)
+      return VerticalConfigFullDtoToJSON(category)
     } catch (error) {
       const backendError = await extractBackendErrorDetails(error)
       console.error(

--- a/frontend/server/api/categories/index.ts
+++ b/frontend/server/api/categories/index.ts
@@ -2,6 +2,7 @@ import { cachedEventHandler } from 'nitropack/runtime/internal/cache'
 import type { H3Event } from 'h3'
 import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
 import type { VerticalConfigDto } from '~~/shared/api-client'
+import { VerticalConfigDtoToJSON } from '~~/shared/api-client'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
@@ -47,7 +48,8 @@ const handler = async (event: H3Event): Promise<VerticalConfigDto[]> => {
   const categoriesService = useCategoriesService(domainLanguage)
 
   try {
-    return await categoriesService.getCategories()
+    const categories = await categoriesService.getCategories()
+    return categories.map(category => VerticalConfigDtoToJSON(category))
   } catch (error) {
     const backendError = await extractBackendErrorDetails(error)
     console.error(


### PR DESCRIPTION
### Motivation
- The category DTOs contain Set-backed fields (e.g. `participateInScores`) that are not JSON-serializable as-is for the frontend. 
- Returning raw generated model instances from server routes can leak non-JSON-friendly values across the server boundary. 
- Convert the DTOs to plain JSON representations to ensure the frontend receives arrays and primitive-friendly structures. 

### Description
- Import and use `VerticalConfigFullDtoToJSON` in `frontend/server/api/categories/[id].ts` to serialize the single category detail response. 
- Import and use `VerticalConfigDtoToJSON` in `frontend/server/api/categories/index.ts` and map the categories list through it so Set fields become arrays. 
- No change to business logic or downstream API calls; the routes still call the same generated OpenAPI services and now return JSON-serializable objects. 

### Testing
- Ran `pnpm lint` against the frontend and the lint step completed successfully. 
- Ran `pnpm test` but the run failed due to unrelated locale file parse errors in `i18n/locales/fr-FR.json` and one failing assertion in `pages/product-uncategorized.spec.ts`, so the full test suite did not complete successfully. 
- Ran `pnpm generate` and the build failed with a JSON parse error caused by merge conflict markers present in `i18n/locales/fr-FR.json`, blocking successful generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954082a5990832ba23558031b1d1c40)