### PR TITLE
Add attribute sourcing audit table to product attributes

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -109,7 +109,10 @@
           :id="sectionIds.attributes"
           class="product-page__section"
         >
-          <ProductAttributesSection :product="product" />
+          <ProductAttributesSection
+            :product="product"
+            :attribute-configs="categoryDetail?.attributesConfig?.configs ?? []"
+          />
         </section>
 
         <section

--- a/frontend/app/components/product/ProductAttributesSection.spec.ts
+++ b/frontend/app/components/product/ProductAttributesSection.spec.ts
@@ -2,7 +2,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createI18n } from 'vue-i18n'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 import type { ProductDto } from '~~/shared/api-client'
 
 const runtimeConfigMock = vi.hoisted(() => ({
@@ -17,6 +17,14 @@ vi.mock('#imports', () => ({
   useRuntimeConfig: () => runtimeConfigMock,
 }))
 
+const isLoggedInRef = ref(false)
+
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({
+    isLoggedIn: isLoggedInRef,
+  }),
+}))
+
 const VCardStub = defineComponent({
   name: 'VCardStub',
   setup(_, { slots }) {
@@ -28,6 +36,42 @@ const VTableStub = defineComponent({
   name: 'VTableStub',
   setup(_, { slots }) {
     return () => h('table', { class: 'v-table-stub' }, slots.default?.())
+  },
+})
+
+const VDataTableStub = defineComponent({
+  name: 'VDataTableStub',
+  props: [
+    'headers',
+    'items',
+    'itemsPerPage',
+    'itemClass',
+    'density',
+    'class',
+  ],
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'div',
+        { class: 'v-data-table-stub' },
+        ((props.items as Array<Record<string, unknown>>) ?? []).map(item => {
+          const rowClass =
+            typeof props.itemClass === 'function'
+              ? props.itemClass(item)
+              : props.itemClass
+
+          return h(
+            'div',
+            { class: ['v-data-table-row-stub', rowClass] },
+            [
+              slots['item.attribute']?.({ item }),
+              slots['item.bestValue']?.({ item }),
+              slots['item.sources']?.({ item }),
+              slots['item.indexed']?.({ item }),
+            ]
+          )
+        })
+      )
   },
 })
 
@@ -140,6 +184,34 @@ const VTextFieldStub = defineComponent({
           onInput,
           type: 'text',
         }),
+      ])
+  },
+})
+
+const VCheckboxStub = defineComponent({
+  name: 'VCheckboxStub',
+  props: {
+    modelValue: { type: Boolean, default: false },
+    label: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const onChange = (event: Event) => {
+      const target = event.target as HTMLInputElement | null
+      emit('update:modelValue', target?.checked ?? false)
+    }
+
+    return () =>
+      h('label', { class: 'v-checkbox-stub' }, [
+        h('input', {
+          class: 'v-checkbox-stub__input',
+          type: 'checkbox',
+          checked: props.modelValue,
+          onChange,
+        }),
+        props.label
+          ? h('span', { class: 'v-checkbox-stub__label' }, props.label)
+          : null,
       ])
   },
 })
@@ -301,6 +373,27 @@ const i18n = createI18n({
           title: 'Technical specifications',
           subtitle: 'Browse every specification and filter with keywords.',
           searchPlaceholder: 'Search a specification',
+          audit: {
+            title: 'Attribute sourcing audit',
+            subtitle:
+              'Compare indexed attributes with their synonyms and data sources.',
+            searchPlaceholder: 'Search attributes',
+            filters: {
+              indexed: 'Indexed',
+              notIndexed: 'Not indexed',
+            },
+            columns: {
+              attribute: 'Attribute',
+              bestValue: 'Best value',
+              sources: 'Sources',
+              indexed: 'Status',
+            },
+            indexed: 'Indexed',
+            notIndexed: 'Not indexed',
+            noBestValue: 'No value',
+            empty: 'No attribute configuration is available yet.',
+            emptyFiltered: 'No attributes match the current filters.',
+          },
           main: {
             title: 'Key specifications',
             identity: {
@@ -357,17 +450,25 @@ const i18n = createI18n({
   },
 })
 
-const mountComponent = async (product: ProductDto) => {
+const mountComponent = async (
+  product: ProductDto,
+  options?: {
+    attributeConfigs?: Array<Record<string, unknown>>
+    isLoggedIn?: boolean
+  }
+) => {
+  isLoggedInRef.value = options?.isLoggedIn ?? false
   const module = await import('./ProductAttributesSection.vue')
   const Component = module.default
 
   const wrapper = await mountSuspended(Component, {
-    props: { product },
+    props: { product, attributeConfigs: options?.attributeConfigs ?? [] },
     global: {
       plugins: [i18n],
       stubs: {
         VCard: VCardStub,
         VTable: VTableStub,
+        VDataTable: VDataTableStub,
         VIcon: VIconStub,
         VChip: VChipStub,
         VTooltip: VTooltipStub,
@@ -375,6 +476,7 @@ const mountComponent = async (product: ProductDto) => {
         VDivider: VDividerStub,
         VImg: VImgStub,
         VTextField: VTextFieldStub,
+        VCheckbox: VCheckboxStub,
         VRow: VRowStub,
         VCol: VColStub,
         VTimeline: VTimelineStub,
@@ -448,5 +550,44 @@ describe('ProductAttributesSection', () => {
     const emptyState = wrapper.find('.product-attributes__empty--detailed')
     expect(emptyState.exists()).toBe(true)
     expect(emptyState.text()).toBe('No specifications match your search.')
+  })
+
+  it('renders the attribute audit table for logged-in users', async () => {
+    const wrapper = await mountComponent(buildProduct(), {
+      isLoggedIn: true,
+      attributeConfigs: [
+        {
+          key: 'weight',
+          name: 'Weight',
+          synonyms: { icecat: new Set(['weight', 'mass']) },
+        },
+        {
+          key: 'depth',
+          name: 'Depth',
+          synonyms: { icecat: new Set(['depth']) },
+        },
+        {
+          key: 'color',
+          name: 'Color',
+          synonyms: { eprel: new Set(['color']) },
+        },
+      ],
+    })
+
+    const rows = wrapper.findAll('.v-data-table-row-stub')
+    expect(rows).toHaveLength(3)
+    expect(wrapper.text()).toContain('Attribute sourcing audit')
+    expect(wrapper.text()).toContain('Weight')
+    expect(wrapper.text()).toContain('Color')
+
+    const matchedRows = wrapper.findAll(
+      '.product-attributes__audit-row--matched'
+    )
+    expect(matchedRows.length).toBeGreaterThanOrEqual(1)
+
+    const unindexedRows = wrapper.findAll(
+      '.product-attributes__audit-row--unindexed'
+    )
+    expect(unindexedRows).toHaveLength(1)
   })
 })

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -118,6 +118,107 @@
       </v-row>
     </div>
 
+    <div
+      v-if="showAuditWidget"
+      class="product-attributes__block product-attributes__block--audit"
+    >
+      <div
+        class="product-attributes__block-header product-attributes__block-header--audit"
+      >
+        <div class="product-attributes__audit-heading">
+          <h3 class="product-attributes__block-title">
+            {{ $t('product.attributes.audit.title') }}
+          </h3>
+          <p class="product-attributes__audit-subtitle">
+            {{ $t('product.attributes.audit.subtitle') }}
+          </p>
+        </div>
+        <div class="product-attributes__audit-controls">
+          <v-text-field
+            v-model="auditSearchTerm"
+            :label="$t('product.attributes.audit.searchPlaceholder')"
+            prepend-inner-icon="mdi-magnify"
+            hide-details
+            clearable
+            class="product-attributes__search product-attributes__search--audit"
+          />
+          <div class="product-attributes__audit-filters">
+            <v-checkbox
+              v-model="showIndexed"
+              :label="$t('product.attributes.audit.filters.indexed')"
+              hide-details
+              density="compact"
+              class="product-attributes__audit-filter"
+            />
+            <v-checkbox
+              v-model="showNotIndexed"
+              :label="$t('product.attributes.audit.filters.notIndexed')"
+              hide-details
+              density="compact"
+              class="product-attributes__audit-filter"
+            />
+          </div>
+        </div>
+      </div>
+
+      <v-data-table
+        v-if="filteredAuditRows.length"
+        :headers="auditHeaders"
+        :items="filteredAuditRows"
+        :items-per-page="auditItemsPerPage"
+        :item-class="auditRowClass"
+        class="product-attributes__audit-table"
+        density="comfortable"
+      >
+        <template #[`item.attribute`]="{ item }">
+          <div class="product-attributes__audit-attribute">
+            <span class="product-attributes__audit-name">
+              {{ item.name }}
+            </span>
+            <span class="product-attributes__audit-key">
+              {{ item.key }}
+            </span>
+          </div>
+        </template>
+        <template #[`item.bestValue`]="{ item }">
+          <ProductAttributeSourcingLabel
+            :value="item.displayValue"
+            :sourcing="item.sourcing"
+            class="product-attributes__audit-value"
+          />
+        </template>
+        <template #[`item.sources`]="{ item }">
+          <span class="product-attributes__audit-count">
+            {{ item.sourceCount }}
+          </span>
+        </template>
+        <template #[`item.indexed`]="{ item }">
+          <v-chip
+            size="small"
+            variant="tonal"
+            :color="item.isIndexed ? 'surface-primary-120' : 'surface-muted'"
+          >
+            {{
+              $t(
+                item.isIndexed
+                  ? 'product.attributes.audit.indexed'
+                  : 'product.attributes.audit.notIndexed'
+              )
+            }}
+          </v-chip>
+        </template>
+      </v-data-table>
+      <p v-else class="product-attributes__empty product-attributes__empty--audit">
+        {{
+          $t(
+            auditHasFilters
+              ? 'product.attributes.audit.emptyFiltered'
+              : 'product.attributes.audit.empty'
+          )
+        }}
+      </p>
+    </div>
+
     <div class="product-attributes__block product-attributes__block--detailed">
       <div
         class="product-attributes__block-header product-attributes__block-header--detailed"
@@ -171,15 +272,18 @@
 import { computed, ref } from 'vue'
 import type { PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '~/composables/useAuth'
 import ProductAttributeSourcingLabel from '~/components/product/attributes/ProductAttributeSourcingLabel.vue'
 import ProductAttributesDetailCard from '~/components/product/attributes/ProductAttributesDetailCard.vue'
 import ProductLifeTimeline from '~/components/product/ProductLifeTimeline.vue'
 import type {
+  AttributeConfigDto,
   ProductAttributeDto,
   ProductAttributeSourceDto,
   ProductAttributesDto,
   ProductDto,
   ProductIndexedAttributeDto,
+  ProductSourcedAttributeDto,
 } from '~~/shared/api-client'
 
 const props = defineProps({
@@ -191,6 +295,10 @@ const props = defineProps({
     type: Object as PropType<ProductAttributesDto | null>,
     default: null,
   },
+  attributeConfigs: {
+    type: Array as PropType<AttributeConfigDto[]>,
+    default: () => [],
+  },
   product: {
     type: Object as PropType<ProductDto | null>,
     default: null,
@@ -199,9 +307,22 @@ const props = defineProps({
 
 const { t, n, locale } = useI18n()
 const runtimeConfig = useRuntimeConfig()
+const { isLoggedIn } = useAuth()
 
 const searchTerm = ref('')
 const hasSearchTerm = computed(() => searchTerm.value.trim().length > 0)
+const auditSearchTerm = ref('')
+const showIndexed = ref(true)
+const showNotIndexed = ref(true)
+
+const auditHasFilters = computed(
+  () =>
+    auditSearchTerm.value.trim().length > 0 ||
+    !showIndexed.value ||
+    !showNotIndexed.value
+)
+
+const showAuditWidget = computed(() => isLoggedIn.value)
 
 const resolvedAttributes = computed<ProductAttributesDto | null>(() => {
   if (props.attributes) {
@@ -330,6 +451,113 @@ const toStringList = (input: unknown): string[] => {
   }
 
   return []
+}
+
+const normalizeAttributeKey = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed.toUpperCase() : null
+}
+
+const normalizeSourcingSources = (
+  sources: ProductAttributeSourceDto['sources'] | null | undefined
+): ProductSourcedAttributeDto[] => {
+  if (!sources) {
+    return []
+  }
+
+  if (Array.isArray(sources)) {
+    return sources.filter(
+      (entry): entry is ProductSourcedAttributeDto => Boolean(entry)
+    )
+  }
+
+  if (sources instanceof Set) {
+    return Array.from(sources).filter(
+      (entry): entry is ProductSourcedAttributeDto => Boolean(entry)
+    )
+  }
+
+  if (sources instanceof Map) {
+    return Array.from(sources.values()).filter(
+      (entry): entry is ProductSourcedAttributeDto => Boolean(entry)
+    )
+  }
+
+  if (typeof sources === 'object') {
+    return Object.values(
+      sources as Record<string, ProductSourcedAttributeDto | null | undefined>
+    ).filter((entry): entry is ProductSourcedAttributeDto => Boolean(entry))
+  }
+
+  return []
+}
+
+const normalizeSynonyms = (
+  synonyms: AttributeConfigDto['synonyms']
+): Array<{ sourceName: string; tokens: string[] }> => {
+  if (!synonyms) {
+    return []
+  }
+
+  return Object.entries(synonyms).reduce<
+    Array<{ sourceName: string; tokens: string[] }>
+  >((accumulator, [sourceName, values]) => {
+    const tokens = toStringList(values)
+    if (!sourceName.trim() || !tokens.length) {
+      return accumulator
+    }
+
+    accumulator.push({ sourceName: sourceName.trim(), tokens })
+    return accumulator
+  }, [])
+}
+
+const buildSynonymSourcing = (
+  synonyms: AttributeConfigDto['synonyms']
+): ProductAttributeSourceDto | null => {
+  const entries = normalizeSynonyms(synonyms)
+  if (!entries.length) {
+    return null
+  }
+
+  const sources = entries.map<ProductSourcedAttributeDto>(entry => ({
+    datasourceName: entry.sourceName,
+    value: entry.tokens.join(', '),
+  }))
+
+  return {
+    bestValue: undefined,
+    conflicts: false,
+    sources: new Set(sources),
+  }
+}
+
+const buildSynonymTokenSet = (
+  synonyms: AttributeConfigDto['synonyms']
+): string[] => {
+  const tokens = normalizeSynonyms(synonyms).flatMap(entry => entry.tokens)
+  return tokens.map(token => token.toLowerCase())
+}
+
+const matchesSynonyms = (
+  tokens: string[],
+  values: Array<string | null | undefined>
+): boolean => {
+  if (!tokens.length) {
+    return false
+  }
+
+  const normalizedValues = values
+    .filter((value): value is string => typeof value === 'string')
+    .map(value => value.toLowerCase())
+
+  return tokens.some(token =>
+    normalizedValues.some(value => value.includes(token))
+  )
 }
 
 interface IdentityDetail {
@@ -503,6 +731,145 @@ const mainAttributes = computed<MainAttributeRow[]>(() => {
     []
   )
 })
+
+interface AuditAttributeRow {
+  key: string
+  name: string
+  displayValue: string
+  bestValue: string | null
+  sourceCount: number
+  sourcing: ProductAttributeSourceDto | null
+  isIndexed: boolean
+  isMatched: boolean
+  searchText: string
+}
+
+const auditHeaders = computed(() => [
+  {
+    title: t('product.attributes.audit.columns.attribute'),
+    key: 'attribute',
+    sortable: true,
+  },
+  {
+    title: t('product.attributes.audit.columns.bestValue'),
+    key: 'bestValue',
+    sortable: false,
+  },
+  {
+    title: t('product.attributes.audit.columns.sources'),
+    key: 'sources',
+    sortable: true,
+  },
+  {
+    title: t('product.attributes.audit.columns.indexed'),
+    key: 'indexed',
+    sortable: true,
+  },
+])
+
+const auditItemsPerPage = 10
+
+const auditRows = computed<AuditAttributeRow[]>(() => {
+  const configs = props.attributeConfigs ?? []
+  const indexedAttributes = resolvedAttributes.value?.indexedAttributes ?? {}
+  const indexedMap = new Map<string, ProductIndexedAttributeDto>()
+
+  Object.entries(indexedAttributes).forEach(([key, attribute]) => {
+    const normalized = normalizeAttributeKey(key)
+    if (normalized) {
+      indexedMap.set(normalized, attribute)
+    }
+  })
+
+  return configs.reduce<AuditAttributeRow[]>((accumulator, config) => {
+    const normalizedKey = normalizeAttributeKey(config.key)
+    if (!normalizedKey) {
+      return accumulator
+    }
+
+    const indexedAttribute = indexedMap.get(normalizedKey)
+    const isIndexed = Boolean(indexedAttribute)
+    const bestValue = formatMainAttributeValue(indexedAttribute)
+    const displayValue =
+      resolveDisplayValue(indexedAttribute, bestValue) ??
+      t('product.attributes.audit.noBestValue')
+
+    const name =
+      config.name?.trim() ||
+      indexedAttribute?.name?.trim() ||
+      normalizedKey
+
+    const synonyms = config.synonyms
+    const synonymSources = buildSynonymSourcing(synonyms)
+    const sourcing = indexedAttribute?.sourcing ?? synonymSources ?? null
+
+    const sourceCount = normalizeSourcingSources(sourcing?.sources).length
+
+    const synonymTokens = buildSynonymTokenSet(synonyms)
+    const indexedSources = normalizeSourcingSources(
+      indexedAttribute?.sourcing?.sources
+    )
+    const matchValues = [
+      indexedAttribute?.name,
+      indexedAttribute?.value,
+      indexedAttribute?.sourcing?.bestValue,
+      ...indexedSources.map(source => source.name),
+      ...indexedSources.map(source => source.value),
+    ]
+
+    const isMatched = isIndexed && matchesSynonyms(synonymTokens, matchValues)
+
+    const searchText = `${name} ${bestValue ?? ''}`.trim().toLowerCase()
+
+    accumulator.push({
+      key: normalizedKey,
+      name,
+      displayValue,
+      bestValue: bestValue ?? null,
+      sourceCount,
+      sourcing,
+      isIndexed,
+      isMatched,
+      searchText,
+    })
+
+    return accumulator
+  }, [])
+})
+
+const filteredAuditRows = computed(() => {
+  const term = auditSearchTerm.value.trim().toLowerCase()
+  const showIndexedValue = showIndexed.value
+  const showNotIndexedValue = showNotIndexed.value
+
+  return auditRows.value.filter(row => {
+    if (row.isIndexed && !showIndexedValue) {
+      return false
+    }
+
+    if (!row.isIndexed && !showNotIndexedValue) {
+      return false
+    }
+
+    if (!term) {
+      return true
+    }
+
+    return row.searchText.includes(term)
+  })
+})
+
+const auditRowClass = (item: AuditAttributeRow) => {
+  if (!item.isIndexed) {
+    return 'product-attributes__audit-row product-attributes__audit-row--unindexed'
+  }
+
+  if (item.isMatched) {
+    return 'product-attributes__audit-row product-attributes__audit-row--matched'
+  }
+
+  return 'product-attributes__audit-row product-attributes__audit-row--indexed'
+}
 
 export interface DetailAttributeView {
   key: string
@@ -819,9 +1186,94 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
   gap: 1rem;
 }
 
+.product-attributes__block-header--audit {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.product-attributes__audit-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.product-attributes__audit-subtitle {
+  margin: 0;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+}
+
+.product-attributes__audit-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-attributes__audit-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.product-attributes__audit-filter {
+  margin: 0;
+}
+
+.product-attributes__audit-table {
+  border-radius: 16px;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.5);
+  background: rgba(var(--v-theme-surface-glass-strong), 0.96);
+}
+
+.product-attributes__audit-attribute {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.product-attributes__audit-name {
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-attributes__audit-key {
+  font-size: 0.8rem;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+}
+
+.product-attributes__audit-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.product-attributes__audit-count {
+  font-weight: 600;
+}
+
+.product-attributes__audit-row {
+  transition: background-color 0.2s ease;
+}
+
+.product-attributes__audit-row--indexed {
+  background: rgba(var(--v-theme-surface-primary-050), 0.5);
+}
+
+.product-attributes__audit-row--matched {
+  background: rgba(var(--v-theme-accent-supporting), 0.15);
+}
+
+.product-attributes__audit-row--unindexed {
+  background: rgba(var(--v-theme-surface-muted), 0.4);
+}
+
 .product-attributes__search {
   width: 100%;
   max-width: 100%;
+}
+
+.product-attributes__search--audit {
+  max-width: 420px;
 }
 
 .product-attributes__detailed-layout {
@@ -858,6 +1310,12 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
   background: rgba(var(--v-theme-surface-primary-050), 0.7);
 }
 
+.product-attributes__empty--audit {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(var(--v-theme-surface-primary-050), 0.7);
+}
+
 .product-attributes__timeline-row {
   margin-top: 1.5rem;
 }
@@ -873,8 +1331,22 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
     justify-content: space-between;
   }
 
+  .product-attributes__block-header--audit {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+  }
+
+  .product-attributes__audit-controls {
+    align-items: flex-end;
+  }
+
   .product-attributes__search {
     max-width: 320px;
+  }
+
+  .product-attributes__search--audit {
+    max-width: 360px;
   }
 }
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2030,6 +2030,26 @@
       "title": "Technical specifications",
       "subtitle": "Browse every specification and filter with keywords.",
       "searchPlaceholder": "Search a specification",
+      "audit": {
+        "title": "Attribute sourcing audit",
+        "subtitle": "Compare indexed attributes with their synonyms and data sources.",
+        "searchPlaceholder": "Search attributes",
+        "filters": {
+          "indexed": "Indexed",
+          "notIndexed": "Not indexed"
+        },
+        "columns": {
+          "attribute": "Attribute",
+          "bestValue": "Best value",
+          "sources": "Sources",
+          "indexed": "Status"
+        },
+        "indexed": "Indexed",
+        "notIndexed": "Not indexed",
+        "noBestValue": "No value",
+        "empty": "No attribute configuration is available yet.",
+        "emptyFiltered": "No attributes match the current filters."
+      },
       "main": {
         "title": "Key specifications",
         "identity": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2078,6 +2078,26 @@
       "title": "Caractéristiques techniques",
       "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
       "searchPlaceholder": "Rechercher une caractéristique",
+      "audit": {
+        "title": "Audit des attributs indexés",
+        "subtitle": "Comparez les attributs indexés avec leurs synonymes et leurs sources.",
+        "searchPlaceholder": "Rechercher des attributs",
+        "filters": {
+          "indexed": "Indexés",
+          "notIndexed": "Non indexés"
+        },
+        "columns": {
+          "attribute": "Attribut",
+          "bestValue": "Meilleure valeur",
+          "sources": "Sources",
+          "indexed": "Statut"
+        },
+        "indexed": "Indexé",
+        "notIndexed": "Non indexé",
+        "noBestValue": "Aucune valeur",
+        "empty": "Aucune configuration d'attribut n'est disponible pour le moment.",
+        "emptyFiltered": "Aucun attribut ne correspond aux filtres actuels."
+      },
       "main": {
         "title": "Caractéristiques principales",
         "identity": {


### PR DESCRIPTION
### Motivation
- Surface category attribute configurations alongside indexed product attributes to help audit sourcing and synonym coverage. 
- Allow reviewers to compare indexed values with synonym-derived sources when an attribute is not indexed. 
- Restrict the audit UI to authenticated users to avoid exposing internal tooling to anonymous visitors.

### Description
- Pass `categoryDetail.attributesConfig.configs` into `ProductAttributesSection` via a new `attribute-configs` prop and wire it in `ProductPage.vue`.
- Add an authenticated audit widget to `ProductAttributesSection.vue` with search, indexed / not-indexed filters, and a `v-data-table` that lists attribute rows and sourcing metadata. 
- Implement normalization and matching helpers (`normalizeAttributeKey`, `normalizeSourcingSources`, `normalizeSynonyms`, `buildSynonymSourcing`, `buildSynonymTokenSet`, `matchesSynonyms`) and compute audit rows that combine indexed sourcing and synonym-derived sources. 
- Use `useAuth()` / `isLoggedIn` to conditionally show the widget, add i18n strings in `en-US.json` and `fr-FR.json`, and update `ProductAttributesSection.spec.ts` with coverage for the new UI and mocked auth/stubs.

### Testing
- Ran `pnpm lint --offline` which failed due to an invalid CLI flag for the current `eslint` configuration. 
- Ran `pnpm lint` which reported existing lint errors (unrelated unused-variable issues in `HomeHeroSection.vue`) and therefore did not fully pass. 
- Ran `pnpm test` which exercised the updated component tests and the suite mostly passed but the test run finished with 2 failing tests (preexisting failures in `components/home/sections/HomeHeroSection.spec.ts`). 
- Ran `pnpm generate` which completed successfully and produced a static build (with a PWA precache glob warning for `**/_payload.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540c44a4a8832ba78b83e3393bdc34)