### PR TITLE
Normalize parallax asset references and simplify i18n entries

### DIFF
--- a/frontend/app/composables/useThemedParallaxBackgrounds.ts
+++ b/frontend/app/composables/useThemedParallaxBackgrounds.ts
@@ -16,6 +16,20 @@ import {
 import { resolveThemeName, type ThemeName } from '~~/shared/constants/theme'
 import { resolveThemedAssetUrl } from './useThemedAsset'
 
+const normalizeParallaxAsset = (value: string): string => {
+  const trimmed = value.trim()
+
+  if (!trimmed || trimmed.startsWith('/') || trimmed.startsWith('http')) {
+    return trimmed
+  }
+
+  if (trimmed.includes('/')) {
+    return trimmed
+  }
+
+  return `parallax/${trimmed}`
+}
+
 const resolveParallaxLayers = (
   assets: ParallaxLayerSource[] | undefined,
   themeName: ThemeName
@@ -27,7 +41,12 @@ const resolveParallaxLayers = (
   return assets
     .map(asset => {
       const source = typeof asset === 'string' ? asset : asset.src
-      const resolved = resolveThemedAssetUrl(source, themeName)
+      const normalized = normalizeParallaxAsset(source)
+      if (!normalized) {
+        return null
+      }
+
+      const resolved = resolveThemedAssetUrl(normalized, themeName)
 
       if (!resolved) {
         return null

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -166,8 +166,10 @@ const resolveAplatSource = (value?: string): string | undefined => {
     return trimmed
   }
 
+  const normalized = trimmed.includes('/') ? trimmed : `parallax/${trimmed}`
+
   return resolveThemedAssetUrl(
-    trimmed,
+    normalized,
     themeName.value,
     seasonalEventPack.value
   )

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -8,12 +8,12 @@
         "favicon": "placeholders/favicon.svg"
       },
       "parallax": {
-        "essentials": "parallax/parallax-placeholder.svg",
-        "features": "parallax/parallax-placeholder.svg",
-        "blog": "parallax/parallax-placeholder.svg",
-        "objections": "parallax/parallax-placeholder.svg",
-        "cta": "parallax/parallax-placeholder.svg",
-        "aplat": "parallax/parallax-aplats.svg"
+        "essentials": "parallax-placeholder.svg",
+        "features": "parallax-placeholder.svg",
+        "blog": "parallax-placeholder.svg",
+        "objections": "parallax-placeholder.svg",
+        "cta": "parallax-placeholder.svg",
+        "aplat": "parallax-aplats.svg"
       },
       "hero": {
         "eyebrow": "Responsible shopping",
@@ -131,12 +131,12 @@
         }
       },
       "parallax": {
-        "essentials": "parallax/parallax-background-bastille-essentials.svg",
-        "features": "parallax/parallax-background-bastille-features.svg",
-        "blog": "parallax/parallax-background-bastille-blog.svg",
-        "objections": "parallax/parallax-background-bastille-objections.svg",
-        "cta": "parallax/parallax-background-bastille-cta.svg",
-        "aplat": "parallax/parallax-aplats.svg"
+        "essentials": "parallax-background-bastille-essentials.svg",
+        "features": "parallax-background-bastille-features.svg",
+        "blog": "parallax-background-bastille-blog.svg",
+        "objections": "parallax-background-bastille-objections.svg",
+        "cta": "parallax-background-bastille-cta.svg",
+        "aplat": "parallax-aplats.svg"
       }
     }
   },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -76,12 +76,12 @@
         "partnersBackground": "placeholders/generated/partners.svg"
       },
       "parallax": {
-        "essentials": "parallax/parallax-background-christmas-essentials.svg",
-        "features": "parallax/parallax-background-christmas-features.svg",
-        "blog": "parallax/parallax-background-christmas-blog.svg",
-        "objections": "parallax/parallax-background-christmas-objections.svg",
-        "cta": "parallax/parallax-background-christmas-cta.svg",
-        "aplat": "parallax/parallax-aplats.svg"
+        "essentials": "parallax-background-christmas-essentials.svg",
+        "features": "parallax-background-christmas-features.svg",
+        "blog": "parallax-background-christmas-blog.svg",
+        "objections": "parallax-background-christmas-objections.svg",
+        "cta": "parallax-background-christmas-cta.svg",
+        "aplat": "parallax-aplats.svg"
       }
     },
     "default": {
@@ -101,12 +101,12 @@
         "partnersBackground": "placeholders/generated/partners.svg"
       },
       "parallax": {
-        "essentials": "parallax/parallax-essentials.svg",
-        "features": "parallax/parallax-features.svg",
-        "blog": "parallax/parallax-blog.svg",
-        "objections": "parallax/parallax-objections.svg",
-        "cta": "parallax/parallax-cta.svg",
-        "aplat": "parallax/parallax-aplats.svg"
+        "essentials": "parallax-essentials.svg",
+        "features": "parallax-features.svg",
+        "blog": "parallax-blog.svg",
+        "objections": "parallax-objections.svg",
+        "cta": "parallax-cta.svg",
+        "aplat": "parallax-aplats.svg"
       },
       "hero": {
         "eyebrow": "Nudger, c'est :",


### PR DESCRIPTION
### Motivation

- Make parallax asset lookup robust to filename-only values by resolving them under the `parallax/` theme folder. 
- Allow the home page parallax "aplat" (decorative SVG) to be provided as a filename-only entry in event packs. 
- Simplify localized event pack entries so they can use short filenames and be resolved consistently by the themed asset resolver.

### Description

- Added `normalizeParallaxAsset` and used it in `useThemedParallaxBackgrounds.ts` so string assets without a path are prefixed with `parallax/` before resolution. 
- Updated `resolveThemedParallaxLayers` to skip empty values and call `resolveThemedAssetUrl` with the normalized path. 
- Updated `resolveAplatSource` in `frontend/app/pages/index.vue` to normalize filename-only `aplat` entries before calling `resolveThemedAssetUrl`. 
- Simplified parallax asset entries in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` to filename-only values (removed the explicit `parallax/` prefix where appropriate).

### Testing

- Ran `pnpm lint`, which failed due to unrelated unused-variable errors in `app/components/home/sections/HomeHeroSection.vue`. 
- Ran `pnpm test`, which executed the Vitest suite but finished with failing tests (some specs passed, the test run terminated after failures). 
- Ran `pnpm generate`, which completed successfully and produced the static output. 
- A headless screenshot attempt (Playwright) failed due to browser launch errors and is not part of the automated test success list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69540e33a7b0832ba6b6dd511490dcbc)