### PR TITLE
Add open-data millions interpolation to home hero helpers

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -28,18 +28,19 @@ const messages: Record<string, unknown> = {
   'packs.default.hero.search.helpers': [
     {
       icon: '🌿',
-      label: 'Une évaluation écologique et environnementale unique',
+      label: "L'impact Score : une évaluation écologique et environnementale unique",
       segments: [
-        { text: 'Une évaluation écologique', to: '/impact-score' },
-        { text: ' et environnementale unique' },
+        { text: "L'impact Score : une" },
+        { text: 'évaluation écologique et environnementale', to: '/impact-score' },
+        { text: ' unique' },
       ],
     },
     {
       icon: '🏷️',
-      label: 'Sans se faire avoir sur les prix',
+      label: '100% indépendant, logiciel libre et {millions}+ produits en données ouvertes',
       segments: [
-        { text: 'Sans se faire avoir sur les prix avec' },
-        { text: '{partnersLink}', to: '/partenaires' },
+        { text: '100% indépendant, logiciel libre et' },
+        { text: '{millions}+ produits en données ouvertes' },
       ],
     },
   ],
@@ -208,6 +209,7 @@ const mountComponent = async (options?: {
       searchQuery: '',
       minSuggestionQueryLength: 2,
       partnersCount: 12,
+      openDataMillions: 42,
     },
     global: {
       stubs: {
@@ -270,17 +272,15 @@ describe('HomeHeroSection', () => {
     expect(impactHelperLink.exists()).toBe(true)
     expect(impactHelperLink.attributes('href')).toBe('/impact-score')
 
-    const partnersHelper = helpers[1]
-    const partnersHelperText = partnersHelper.find('.home-hero__helper-text')
-    const partnersLink = partnersHelper.find('.home-hero__helper-link')
+    const openDataHelper = helpers[1]
+    const openDataHelperText = openDataHelper.find('.home-hero__helper-text')
 
-    expect(partnersHelperText.text()).toContain(
-      'Sans se faire avoir sur les prix avec'
+    expect(openDataHelperText.text()).toContain(
+      '100% indépendant, logiciel libre et'
     )
-    expect(partnersHelperText.text()).toContain('12 partenaires')
-    expect(partnersLink.exists()).toBe(true)
-    expect(partnersLink.attributes('href')).toBe('/partenaires')
-    expect(partnersLink.text()).toContain('12 partenaires')
+    expect(openDataHelperText.text()).toContain(
+      '42+ produits en données ouvertes'
+    )
 
     await wrapper.unmount()
   })

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -13,15 +13,21 @@ const messages: Record<string, unknown> = {
   'packs.default.hero.search.helpers': [
     {
       icon: '🌿',
-      label: 'A unique eco assessment',
-      segments: [{ text: 'A unique eco assessment' }],
+      label: 'Impact Score: a unique ecological and environmental assessment',
+      segments: [
+        { text: 'Impact Score: a' },
+        {
+          text: 'unique ecological and environmental assessment',
+          to: '/impact-score',
+        },
+      ],
     },
     {
       icon: '🏷️',
-      label: 'Best prices',
+      label: '100% independent, open-source, and {millions}+ open-data products',
       segments: [
-        { text: 'Pay the right price with' },
-        { text: '{partnersLink}', to: '/partners' },
+        { text: '100% independent, open-source, and' },
+        { text: '{millions}+ open-data products' },
       ],
     },
     {
@@ -57,15 +63,21 @@ const messages: Record<string, unknown> = {
   'home.hero.search.helpers': [
     {
       icon: '🌿',
-      label: 'A unique eco assessment',
-      segments: [{ text: 'A unique eco assessment' }],
+      label: 'Impact Score: a unique ecological and environmental assessment',
+      segments: [
+        { text: 'Impact Score: a' },
+        {
+          text: 'unique ecological and environmental assessment',
+          to: '/impact-score',
+        },
+      ],
     },
     {
       icon: '🏷️',
-      label: 'Best prices',
+      label: '100% independent, open-source, and {millions}+ open-data products',
       segments: [
-        { text: 'Pay the right price with' },
-        { text: '{partnersLink}', to: '/partners' },
+        { text: '100% independent, open-source, and' },
+        { text: '{millions}+ open-data products' },
       ],
     },
     {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -99,6 +99,24 @@ const heroPartnersCount = computed(() => {
   return affiliationPartners.value?.length ?? 0
 })
 
+const openDataMillions = computed(() => {
+  const gtinCount = categoriesStats.value?.gtinOpenDataItemsCount
+  const isbnCount = categoriesStats.value?.isbnOpenDataItemsCount
+  const resolvedGtinCount =
+    typeof gtinCount === 'number' && Number.isFinite(gtinCount) ? gtinCount : 0
+  const resolvedIsbnCount =
+    typeof isbnCount === 'number' && Number.isFinite(isbnCount) ? isbnCount : 0
+  const totalCount = resolvedGtinCount + resolvedIsbnCount
+
+  if (totalCount <= 0) {
+    return null
+  }
+
+  const roundedMillions = Math.round(totalCount / 1_000_000)
+
+  return roundedMillions > 0 ? roundedMillions : null
+})
+
 const seasonalEventPack = useSeasonalEventPack()
 const packI18n = useEventPackI18n(seasonalEventPack)
 const theme = useTheme()
@@ -774,6 +792,7 @@ useHead(() => ({
         :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
         :verticals="rawCategories"
         :partners-count="heroPartnersCount"
+        :open-data-millions="openDataMillions"
         hero-background-i18n-key="hero.background"
         @submit="handleSearchSubmit"
         @select-category="handleCategorySuggestion"


### PR DESCRIPTION
### Motivation

- Surface the size of the open-data corpus in the home hero helpers by showing a rounded millions value.
- Allow translations/hero helper segments to include an interpolated `{millions}` placeholder that is replaced with a locale-formatted number.
- Wire the displayed value to the aggregated categories stats (GTIN + ISBN open-data counts) so the UI reflects real metrics.
- Refresh hero helper copy to emphasise open-source/open-data messaging and improve the linked segments.

### Description

- Add an optional `openDataMillions?: number` prop to `HomeHeroSection.vue` and support a `{millions}` placeholder via `applyOpenDataMillionsPlaceholder` helper.
- Compute `openDataMillions` in `pages/index.vue` by summing `gtinOpenDataItemsCount` and `isbnOpenDataItemsCount`, then rounding to millions with `Math.round(total / 1_000_000)` and passing the result to the hero component.
- Format the millions value for the current locale using `Intl.NumberFormat` in `HomeHeroSection.vue` before interpolation.
- Update i18n/test fixtures and spec expectations in `HomeHeroSection.spec.ts` and `pages/index.spec.ts` to include the new wording and `{millions}` placeholder and to assert the rendered text.

### Testing

- Ran `pnpm lint` which completed successfully.
- Ran `pnpm test` and the full test suite passed (all tests: `342` tests passed).
- Ran `pnpm generate --offline` to build the site; generation completed successfully but with a non-blocking Workbox warning about a glob pattern that does not match any files.
- Unit tests updated: `frontend/app/components/home/sections/HomeHeroSection.spec.ts` and `frontend/app/pages/index.spec.ts` were refreshed and pass under CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544a0f5e24832ba1179fe4a3e7d501)