### PR TITLE
Add prettyName generation with attribute suffix support

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ProductNamesDto(
         @Schema(description = "H1 title for the requested language", example = "Casque Bluetooth haut de gamme")
         String h1Title,
+        @Schema(description = "Pretty name for the requested language", example = "Télévision Samsung 55 \"")
+        String prettyName,
         @Schema(description = "Meta description aligned with the requested language")
         String metaDescription,
         @Schema(description = "OpenGraph title for social sharing")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -529,6 +529,7 @@ public class ProductMappingService {
         }
         return new ProductNamesDto(
                 resolveLocalisedString(product.getNames().getH1Title(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getPrettyName(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getMetaDescription(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphTitle(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphDescription(), domainLanguage, locale),

--- a/model/src/main/java/org/open4goods/model/product/ProductTexts.java
+++ b/model/src/main/java/org/open4goods/model/product/ProductTexts.java
@@ -7,6 +7,8 @@ public class ProductTexts {
 	private Localisable<String,String> url = new Localisable<>();
 	
 	private Localisable<String,String> h1Title = new Localisable<>();
+
+	private Localisable<String,String> prettyName = new Localisable<>();
 	
 	private Localisable<String,String> metaDescription = new Localisable<>();
 	
@@ -33,6 +35,14 @@ public class ProductTexts {
 
 	public void setH1Title(Localisable<String, String> h1Title) {
 		this.h1Title = h1Title;
+	}
+
+	public Localisable<String, String> getPrettyName() {
+		return prettyName;
+	}
+
+	public void setPrettyName(Localisable<String, String> prettyName) {
+		this.prettyName = prettyName;
 	}
 
 	public Localisable<String, String> getMetaDescription() {

--- a/model/src/main/java/org/open4goods/model/vertical/ProductI18nElements.java
+++ b/model/src/main/java/org/open4goods/model/vertical/ProductI18nElements.java
@@ -10,6 +10,8 @@ public class ProductI18nElements {
 	private PrefixedAttrText url = new PrefixedAttrText();
 	@JsonMerge
 	private PrefixedAttrText h1Title = new PrefixedAttrText();
+	@JsonMerge
+	private PrefixedAttrText prettyName = new PrefixedAttrText();
 
 
 
@@ -80,6 +82,14 @@ public class ProductI18nElements {
 
 	public void setH1Title(PrefixedAttrText h1Title) {
 		this.h1Title = h1Title;
+	}
+
+	public PrefixedAttrText getPrettyName() {
+		return prettyName;
+	}
+
+	public void setPrettyName(PrefixedAttrText prettyName) {
+		this.prettyName = prettyName;
 	}
 
 

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -143,6 +143,12 @@ i18n:
         - BRAND
         - MODEL
         - YEAR
+    prettyName:
+      prefix: "|| TV | Télévision | Téléviseur ||"
+      attrs:
+        - BRAND
+        - DIAGONALE_POUCES
+        - DISPLAY_TECHNOLOGY
     # TODO : Generate short title (for cards restitution, with popular attributes)
 
     ##################################
@@ -188,6 +194,12 @@ i18n:
         - BRAND
         - MODEL
         - YEAR
+    prettyName:
+      prefix: "|| TV | Television ||"
+      attrs:
+        - BRAND
+        - DIAGONALE_POUCES
+        - DISPLAY_TECHNOLOGY
 
     ##################################
     # Vertical page elements


### PR DESCRIPTION
### Motivation
- Introduce a human-friendly "pretty" product name variant that is localisable alongside existing `h1Title`/`url` texts.
- Ensure `prettyName` generation uses vertical templates and includes attribute suffixes configured in the vertical catalog via `AttributeConfig.suffix`.
- Expose the resolved `prettyName` through the front API DTO using the same domain language / i18n resolution as `h1Title` and `url`.
- Provide test coverage for suffix handling to prevent regressions when reading suffixes from vertical configs.

### Description
- Added a `prettyName` localisable field to `ProductTexts` and a `PrefixedAttrText prettyName` to `ProductI18nElements` to hold templates per locale.
- Implemented `prettyName` computation in `NamesAggregationService` with `computePrettyName(...)`, which generates the prefix via `blablaService`, appends attribute values (filtered via `IdHelper.azCharAndDigits`) and resolves attribute suffixes from `VerticalConfig.getAttributesConfig().getAttributeConfigByKey(...)` using `AttributeConfig.getSuffix().i18n(lang)`.
- Exposed `prettyName` in the front API by adding it to `ProductNamesDto` and wiring it in `ProductMappingService` using the same `resolveLocalisedString(...)` logic as other name fields.
- Added `prettyName` templates to `verticals/src/main/resources/verticals/tv.yml` and updated `NamesAggregationServiceTest` to validate suffix handling using the new `AttributesConfig`/`AttributeConfig` suffix values.

### Testing
- Added/updated the unit test `NamesAggregationServiceTest` to assert `prettyName` generation and suffix inclusion for the TV vertical; the test was added to the codebase.
- No automated test suite (Maven or CI) was executed as part of this change set, so no pass/fail results are available.
- No other automated tests were run as part of this PR preparation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69544c0a3c98832bb157028b46e6b8c6)