### PR TITLE
feat(frontend): add homepage photo invitation CTA

### DIFF
--- a/frontend/app/assets/homepage/gain/gain-01.svg
+++ b/frontend/app/assets/homepage/gain/gain-01.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ECFDF3" />
+      <stop offset="100%" stop-color="#E0F2FE" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <circle cx="220" cy="220" r="140" fill="#9AE6B4" opacity="0.9" />
+  <circle cx="430" cy="200" r="120" fill="#7DD3FC" opacity="0.8" />
+  <path
+    d="M140 320 C 240 250, 320 250, 520 300"
+    fill="none"
+    stroke="#0F766E"
+    stroke-width="16"
+    stroke-linecap="round"
+    opacity="0.3"
+  />
+</svg>

--- a/frontend/app/assets/homepage/gain/gain-02.svg
+++ b/frontend/app/assets/homepage/gain/gain-02.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#E0F7FA" />
+      <stop offset="100%" stop-color="#E8F5E9" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <rect x="130" y="120" width="180" height="220" rx="32" fill="#B9FBC0" />
+  <rect x="330" y="90" width="200" height="240" rx="32" fill="#A5D8FF" />
+  <circle cx="320" cy="360" r="68" fill="#D9F99D" />
+</svg>

--- a/frontend/app/assets/homepage/pain/pain-01.svg
+++ b/frontend/app/assets/homepage/pain/pain-01.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F6F1EB" />
+      <stop offset="100%" stop-color="#E8EEF7" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <circle cx="180" cy="200" r="120" fill="#F4B183" opacity="0.8" />
+  <circle cx="420" cy="260" r="150" fill="#9DB7E8" opacity="0.65" />
+  <path
+    d="M120 360 C 200 300, 320 300, 520 360"
+    fill="none"
+    stroke="#2B3A67"
+    stroke-width="18"
+    stroke-linecap="round"
+    opacity="0.25"
+  />
+</svg>

--- a/frontend/app/assets/homepage/pain/pain-02.svg
+++ b/frontend/app/assets/homepage/pain/pain-02.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-hidden="true">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#FDF2F2" />
+      <stop offset="100%" stop-color="#EEF2FF" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <rect x="120" y="110" width="180" height="220" rx="28" fill="#F7C7A8" />
+  <rect x="320" y="140" width="200" height="200" rx="28" fill="#B4C6F0" />
+  <circle cx="260" cy="360" r="70" fill="#FFE2C7" />
+</svg>

--- a/frontend/app/components/home/sections/HomePhotoInvitation.spec.ts
+++ b/frontend/app/components/home/sections/HomePhotoInvitation.spec.ts
@@ -1,0 +1,93 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import HomePhotoInvitation from './HomePhotoInvitation.vue'
+
+const messages: Record<string, string> = {
+  'home.photoInvitation.title': "Et si c'était vous ?",
+  'home.photoInvitation.ariaLabel': 'Proposer votre photo pour Nudger',
+  'home.photoInvitation.contact.subject': 'Proposition de photo pour Nudger',
+  'home.photoInvitation.contact.message':
+    'Bonjour, je propose une photo.',
+  'home.photoInvitation.imageAlt': 'Portrait souriant invitant à participer',
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key,
+  }),
+}))
+
+vi.mock('#i18n', () => ({
+  useLocalePath: () => (name: string) => (name === 'contact' ? '/contact' : ''),
+}))
+
+const createStub = (tag: string, className = '') =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () =>
+        h(
+          tag,
+          { class: [className, attrs.class], ...attrs },
+          slots.default ? slots.default() : []
+        )
+    },
+  })
+
+const NuxtLinkStub = defineComponent({
+  name: 'NuxtLinkStub',
+  props: {
+    to: { type: [String, Object], default: undefined },
+  },
+  setup(props, { slots, attrs }) {
+    return () =>
+      h(
+        'a',
+        {
+          ...attrs,
+          class: ['nuxt-link-stub', attrs.class],
+          'data-to':
+            typeof props.to === 'string'
+              ? props.to
+              : props.to
+                ? JSON.stringify(props.to)
+                : undefined,
+        },
+        slots.default?.()
+      )
+  },
+})
+
+describe('HomePhotoInvitation', () => {
+  it('renders the invitation title and contact link', async () => {
+    const wrapper = await mountSuspended(HomePhotoInvitation, {
+      props: {
+        imageSrc: '/images/example.png',
+      },
+      global: {
+        stubs: {
+          NuxtLink: NuxtLinkStub,
+          VCard: createStub('div'),
+          VImg: createStub('img'),
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain(messages['home.photoInvitation.title'])
+
+    const link = wrapper.find('.nuxt-link-stub')
+    const linkTarget = JSON.parse(link.attributes('data-to')) as {
+      path: string
+      query: { subject: string; message: string }
+    }
+
+    expect(linkTarget).toEqual({
+      path: '/contact',
+      query: {
+        subject: messages['home.photoInvitation.contact.subject'],
+        message: messages['home.photoInvitation.contact.message'],
+      },
+    })
+  })
+})

--- a/frontend/app/components/home/sections/HomePhotoInvitation.vue
+++ b/frontend/app/components/home/sections/HomePhotoInvitation.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useLocalePath } from '#i18n'
+
+const props = withDefaults(
+  defineProps<{
+    imageSrc?: string
+    imageAlt?: string
+  }>(),
+  {
+    imageSrc: '',
+    imageAlt: '',
+  }
+)
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+
+const title = computed(() => t('home.photoInvitation.title'))
+const ariaLabel = computed(() => t('home.photoInvitation.ariaLabel'))
+const contactSubject = computed(() => t('home.photoInvitation.contact.subject'))
+const contactMessage = computed(() => t('home.photoInvitation.contact.message'))
+const resolvedAlt = computed(
+  () => props.imageAlt || t('home.photoInvitation.imageAlt')
+)
+
+const contactLink = computed(() => ({
+  path: localePath('contact'),
+  query: {
+    subject: contactSubject.value,
+    message: contactMessage.value,
+  },
+}))
+</script>
+
+<template>
+  <NuxtLink
+    :to="contactLink"
+    class="home-photo-invitation"
+    :aria-label="ariaLabel"
+  >
+    <v-card
+      class="home-photo-invitation__card"
+      variant="tonal"
+      rounded="xl"
+      elevation="0"
+    >
+      <v-img
+        v-if="props.imageSrc"
+        :src="props.imageSrc"
+        :alt="resolvedAlt"
+        class="home-photo-invitation__image"
+        cover
+        height="220"
+        width="320"
+        loading="lazy"
+      />
+      <div class="home-photo-invitation__content">
+        <p class="home-photo-invitation__title">{{ title }}</p>
+      </div>
+    </v-card>
+  </NuxtLink>
+</template>
+
+<style scoped lang="sass">
+.home-photo-invitation
+  text-decoration: none
+  color: inherit
+  width: min(100%, 360px)
+  display: block
+
+.home-photo-invitation__card
+  background: rgba(var(--v-theme-surface-glass), 0.8)
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.4)
+  transition: transform 0.2s ease, box-shadow 0.2s ease
+
+  &:hover
+    transform: translateY(-4px)
+    box-shadow: 0 18px 32px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
+.home-photo-invitation__image
+  border-bottom: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
+
+.home-photo-invitation__content
+  padding: 1rem 1.25rem 1.25rem
+  text-align: center
+
+.home-photo-invitation__title
+  margin: 0
+  font-size: 1.05rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+</style>

--- a/frontend/app/components/home/sections/HomeProblemsSection.vue
+++ b/frontend/app/components/home/sections/HomeProblemsSection.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import HomePhotoInvitation from './HomePhotoInvitation.vue'
 import HomeSplitSection from './HomeSplitSection.vue'
-import { useThemeAsset } from '~/composables/useThemedAsset'
+import { useRandomHomepageImages } from '~/composables/useRandomHomepageImages'
 
 type ProblemItem = {
   icon: string
@@ -14,17 +15,11 @@ const props = defineProps<{
 
 const { t } = useI18n()
 
+const { painImage } = useRandomHomepageImages()
+
 const sectionTitle = computed(() => t('home.problems.title'))
 const sectionDescription = computed(() => t('home.problems.description'))
-const problemImageAsset = useThemeAsset('problemImage')
-
-const visualImage = computed(() => ({
-  src: problemImageAsset.value || '/images/home/nudger-problem.webp',
-  alt: sectionTitle.value,
-  sizes: '(min-width: 960px) 360px, 70vw',
-  width: 1024,
-  height: 1536,
-}))
+const invitationImageAlt = computed(() => t('home.photoInvitation.imageAlt'))
 </script>
 
 <template>
@@ -33,9 +28,14 @@ const visualImage = computed(() => ({
     class="home-problems"
     :title="sectionTitle"
     :description="sectionDescription"
-    :image="visualImage"
     visual-position="left"
   >
+    <template #visual>
+      <HomePhotoInvitation
+        :image-src="painImage"
+        :image-alt="invitationImageAlt"
+      />
+    </template>
     <v-row class="home-problems__list" dense>
       <v-col
         v-for="item in props.items"

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useThemeAsset } from '~/composables/useThemedAsset'
+import HomePhotoInvitation from './HomePhotoInvitation.vue'
+import { useRandomHomepageImages } from '~/composables/useRandomHomepageImages'
 
 type SolutionBenefit = {
   emoji: string
@@ -13,10 +14,11 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const { gainImage } = useRandomHomepageImages()
 
 const sectionTitle = computed(() => t('home.solution.title'))
 const sectionDescription = computed(() => t('home.solution.description'))
-const solutionImageAsset = useThemeAsset('solutionImage')
+const invitationImageAlt = computed(() => t('home.photoInvitation.imageAlt'))
 </script>
 
 <template>
@@ -61,15 +63,10 @@ const solutionImageAsset = useThemeAsset('solutionImage')
         </v-col>
         <v-col cols="12" md="6" class="home-solution__visual">
           <div class="home-solution__image-wrapper">
-            <img
-              :src="solutionImageAsset || '/images/home/nudger-screaming.webp'"
-              :alt="sectionTitle"
-              class="home-solution__image"
-              sizes="(min-width: 960px) 306px, 60vw"
-              width="1024"
-              height="1536"
-              loading="lazy"
-              decoding="async"
+            <HomePhotoInvitation
+              class="home-solution__invitation"
+              :image-src="gainImage"
+              :image-alt="invitationImageAlt"
             />
           </div>
         </v-col>
@@ -111,12 +108,9 @@ const solutionImageAsset = useThemeAsset('solutionImage')
   justify-content: center
   align-items: center
 
-.home-solution__image
-  width: min(66%, 320px)
-  height: auto
-  display: block
-  transform: rotate(3deg)
-  filter: drop-shadow(0 20px 40px rgba(var(--v-theme-shadow-primary-600), 0.15))
+.home-solution__invitation
+  max-width: 360px
+  width: 100%
 
 .home-solution__list
   margin: 0

--- a/frontend/app/composables/useRandomHomepageImages.ts
+++ b/frontend/app/composables/useRandomHomepageImages.ts
@@ -1,0 +1,35 @@
+const painImages = Object.values(
+  import.meta.glob('~/assets/homepage/pain/*.{png,jpg,jpeg,webp,svg}', {
+    eager: true,
+    import: 'default',
+  })
+) as string[]
+
+const gainImages = Object.values(
+  import.meta.glob('~/assets/homepage/gain/*.{png,jpg,jpeg,webp,svg}', {
+    eager: true,
+    import: 'default',
+  })
+) as string[]
+
+const pickRandomImage = (images: string[], fallback: string) => {
+  if (!images.length) {
+    return fallback
+  }
+
+  return images[Math.floor(Math.random() * images.length)]
+}
+
+export const useRandomHomepageImages = () => {
+  const painImage = useState<string>('home-pain-random-image', () =>
+    pickRandomImage(painImages, '/images/home/nudger-problem.webp')
+  )
+  const gainImage = useState<string>('home-gain-random-image', () =>
+    pickRandomImage(gainImages, '/images/home/nudger-screaming.webp')
+  )
+
+  return {
+    painImage,
+    gainImage,
+  }
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -307,6 +307,15 @@
         }
       }
     },
+    "photoInvitation": {
+      "title": "What if it were you?",
+      "ariaLabel": "Submit your photo for Nudger",
+      "imageAlt": "Smiling portrait invitation",
+      "contact": {
+        "subject": "Photo proposal for Nudger",
+        "message": "Hello,\n\nI would like to submit a photo to appear on Nudger. If it fits, I agree to grant the rights for use on Nudger only.\n\nThanks and have a great day."
+      }
+    },
     "features": {
       "title": "Key features",
       "subtitle": "See what Nudger puts at your fingertips.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -355,6 +355,15 @@
         }
       }
     },
+    "photoInvitation": {
+      "title": "Et si c'était vous ?",
+      "ariaLabel": "Proposer votre photo pour Nudger",
+      "imageAlt": "Portrait souriant invitant à participer",
+      "contact": {
+        "subject": "Proposition de photo pour Nudger",
+        "message": "Bonjour,\n\nJe souhaite proposer une photo pour apparaître sur Nudger. Si elle vous convient, j'accepte de céder mes droits pour une utilisation sur Nudger uniquement.\n\nMerci et belle journée."
+      }
+    },
     "features": {
       "title": "Fonctionnalités clés",
       "subtitle": "Découvrez ce que Nudger met à votre service.",


### PR DESCRIPTION
### Motivation
- Replace static hero visuals with a reusable call-to-action so users can propose photos to appear on the homepage. 
- Surface community content by linking a lightweight invitation component to the `contact` page with prefilled subject and message. 
- Randomise homepage visuals between "pain" and "gain" variants to increase visual variety. 
- Keep theme assets local and easily testable by adding small SVG placeholders for the new image sets.

### Description
- Add a new `HomePhotoInvitation` component that renders a linked card and pre-fills `contact` query params for `subject` and `message`. 
- Add `useRandomHomepageImages` composable to eager-load `~/assets/homepage/{pain,gain}` images and expose `painImage` / `gainImage` state. 
- Replace the previous static visuals in `HomeProblemsSection.vue` and `HomeSolutionSection.vue` with `HomePhotoInvitation` using the random images. 
- Add new homepage assets under `frontend/app/assets/homepage/*`, i18n keys in `frontend/i18n/locales/{fr-FR,en-US}.json`, and a test `HomePhotoInvitation.spec.ts` for the new component.

### Testing
- Ran lint with `pnpm lint` and it completed successfully. 
- Ran the test suite with `pnpm test` (Vitest) and the suites passed (`343` tests passed). 
- Built a static site with `pnpm generate` which completed successfully while emitting a PWA precache glob warning for `_payload.json`. 
- Added and ran a component spec `HomePhotoInvitation.spec.ts` which asserts rendering and correct contact link query parameters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ec1529bc832bad9945c2f55cce72)