### PR TITLE
feat(frontend): add subtle randomized hero background motion

### DIFF
--- a/frontend/app/components/product/ProductHeroBackground.vue
+++ b/frontend/app/components/product/ProductHeroBackground.vue
@@ -6,11 +6,13 @@
       <div
         v-if="resolvedImage"
         class="product-hero-background__image"
+        :class="motionClass"
         :style="imageStyle"
       />
       <div
         v-else-if="fallbackBackgroundSrc"
         class="product-hero-background__image product-hero-background__image--fallback"
+        :class="motionClass"
         :style="fallbackStyle"
       />
     </transition>
@@ -27,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
+import { computed, onMounted, ref, type PropType } from 'vue'
 import type { ProductDto } from '~~/shared/api-client'
 import { useHeroBackgroundAsset } from '~/composables/useThemedAsset'
 
@@ -82,6 +84,15 @@ const imageStyle = computed(() => {
     backgroundImage: `url('${resolvedImage.value}')`,
   }
 })
+
+const motionClass = ref('product-hero-background__image--drift')
+
+onMounted(() => {
+  motionClass.value =
+    Math.random() > 0.5
+      ? 'product-hero-background__image--drift'
+      : 'product-hero-background__image--zoom'
+})
 </script>
 
 <style scoped>
@@ -128,14 +139,58 @@ const imageStyle = computed(() => {
   background-position: center;
   opacity: 0.25; /* "Transparent / Opacified" effect */
   filter: saturate(1.1) blur(3px); /* Shading effect */
-  transform: scale(1.05);
   background-attachment: scroll;
   transition: opacity 0.5s ease;
+  will-change: transform;
 }
 
 .product-hero-background__image--fallback {
   opacity: 0.35;
   filter: saturate(1.15) blur(2px);
+}
+
+.product-hero-background__image--drift {
+  animation: hero-drift 28s ease-in-out infinite alternate;
+}
+
+.product-hero-background__image--zoom {
+  animation: hero-zoom 32s ease-in-out infinite alternate;
+}
+
+@keyframes hero-drift {
+  0% {
+    transform: scale(1.04) translate3d(-1.5%, -1%, 0);
+  }
+  100% {
+    transform: scale(1.08) translate3d(1.5%, 1%, 0);
+  }
+}
+
+@keyframes hero-zoom {
+  0% {
+    transform: scale(1.03);
+  }
+  100% {
+    transform: scale(1.12);
+  }
+}
+
+@media (max-width: 960px) {
+  .product-hero-background__image--drift {
+    animation-duration: 40s;
+  }
+
+  .product-hero-background__image--zoom {
+    animation-duration: 44s;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .product-hero-background__image--drift,
+  .product-hero-background__image--zoom {
+    animation: none;
+    transform: scale(1.02);
+  }
 }
 
 .product-hero-background__grid {


### PR DESCRIPTION
### Motivation
- Make product hero images feel more dynamic by adding a subtle, purely CSS keyframe motion effect.
- Provide two randomized motion variants (drift and zoom) to vary the visual treatment across visits.
- Respect accessibility and user preferences by disabling motion under `prefers-reduced-motion`.
- Slow down the animation on small screens to reduce perceived motion and GPU work.

### Description
- Add a `motionClass` `ref` and `onMounted` randomizer to choose between `product-hero-background__image--drift` and `product-hero-background__image--zoom` and apply it to both resolved and fallback background elements in the template.
- Introduce `@keyframes` for `hero-drift` and `hero-zoom` and corresponding utility classes to start CSS-only animations, and remove the previous static `transform` in favor of `will-change: transform`.
- Add media queries to lengthen animation durations under `@media (max-width: 960px)` and disable animations with a `@media (prefers-reduced-motion: reduce)` rule that falls back to a small static scale.
- Update imports to include `ref` and `onMounted` and wire the new class into the component without changing the image selection logic in `resolvedImage`/`imageStyle`.

### Testing
- Ran `pnpm lint`, which completed with warnings (attribute ordering warnings) but no blocking errors.
- Ran `pnpm test`, and the test suite completed successfully (all tests passed) with unrelated test warnings printed.
- Ran `pnpm generate` (Nuxt generate), which completed successfully but emitted non-blocking warnings (baseline-browser-mapping and Workbox glob pattern).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fa62736c832b986e389c8cb21ea2)