### PR TITLE
Redesign ImpactScore badge, surface attribute sourcing in details, and add aggregate i18n labels

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.spec.ts
@@ -131,6 +131,19 @@ const ImpactCoefficientBadgeStub = defineComponent({
   },
 })
 
+const ProductAttributeSourcingLabelStub = defineComponent({
+  name: 'ProductAttributeSourcingLabelStub',
+  props: ['value', 'sourcing'],
+  setup(props) {
+    return () =>
+      h(
+        'span',
+        { class: 'product-attribute-sourcing-stub' },
+        String(props.value ?? '')
+      )
+  },
+})
+
 const mountComponent = (scores: ScoreView[]) =>
   mount(ProductImpactDetailsTable, {
     props: { scores },
@@ -143,6 +156,7 @@ const mountComponent = (scores: ScoreView[]) =>
         'v-chip': VChipStub,
         ProductImpactSubscoreRating: ProductImpactSubscoreRatingStub,
         ImpactCoefficientBadge: ImpactCoefficientBadgeStub,
+        ProductAttributeSourcingLabel: ProductAttributeSourcingLabelStub,
       },
     },
   })

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -61,7 +61,12 @@
             'impact-details__cell--child': item.rowType === 'subscore',
           }"
         >
-          {{ item.attributeValue }}
+          <ProductAttributeSourcingLabel
+            v-if="item.attributeSourcing"
+            :sourcing="item.attributeSourcing"
+            :value="item.attributeValue"
+          />
+          <span v-else>{{ item.attributeValue }}</span>
         </span>
       </template>
       <template #[`item.displayValue`]="{ item }">
@@ -78,9 +83,6 @@
             size="x-small"
             :show-value="false"
           />
-          <span class="impact-details__value-text">{{
-            formatScoreLabel(item.displayValue)
-          }}</span>
         </div>
       </template>
       <template #[`item.coefficient`]="{ item }">
@@ -130,6 +132,7 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ImpactCoefficientBadge from '~/components/shared/ui/ImpactCoefficientBadge.vue'
+import ProductAttributeSourcingLabel from '~/components/product/attributes/ProductAttributeSourcingLabel.vue'
 import ProductImpactSubscoreRating from './ProductImpactSubscoreRating.vue'
 import type { ScoreView } from './impact-types'
 
@@ -153,6 +156,7 @@ type TableRow = {
   id: string
   label: string
   attributeValue: string
+  attributeSourcing: ScoreView['attributeSourcing']
   displayValue: number | null
   coefficient: number | null
   lifecycle: string[]
@@ -349,6 +353,7 @@ const buildTableRow = (
   id: score.id,
   label: score.label,
   attributeValue: formatAttributeValue(score),
+  attributeSourcing: score.attributeSourcing ?? null,
   displayValue: score.displayValue,
   coefficient: score.coefficient,
   lifecycle: score.participateInACV ?? [],
@@ -397,6 +402,7 @@ const buildAggregateRow = (
   id: aggregateId,
   label: resolveAggregateLabel(aggregateId, aggregateScore),
   attributeValue: '—',
+  attributeSourcing: null,
   displayValue: resolveAggregateDisplayValue(
     aggregateId,
     aggregateScore,
@@ -456,22 +462,6 @@ const toggleGroup = (groupId: string) => {
 
 const isGroupExpanded = (groupId: string) => expandedGroups.value.has(groupId)
 
-const formatScore = (value: number | null) => {
-  if (value == null || Number.isNaN(value)) {
-    return '—'
-  }
-
-  return value.toFixed(1)
-}
-
-const formatScoreLabel = (value: number | null) => {
-  const formatted = formatScore(value)
-  if (formatted === '—') {
-    return formatted
-  }
-
-  return t('product.impact.valueOutOf', { value: formatted, max: 5 })
-}
 </script>
 
 <style scoped>

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.vue
@@ -21,7 +21,7 @@
     </header>
 
     <div class="impact-ecoscore__score">
-      <ImpactScore :score="normalizedScore" :max="5" size="large" show-value />
+      <ImpactScore :score="normalizedScore" :max="5" size="large" />
     </div>
 
     <div v-if="hasDetailContent" class="impact-ecoscore__analysis">

--- a/frontend/app/components/shared/ui/ImpactScore.spec.ts
+++ b/frontend/app/components/shared/ui/ImpactScore.spec.ts
@@ -27,22 +27,6 @@ const VTooltipStub = defineComponent({
   },
 })
 
-const VChipStub = defineComponent({
-  name: 'VChip',
-  props: ['color', 'rounded', 'variant'],
-  setup(props, { slots }) {
-    return () =>
-      h(
-        'div',
-        {
-          class: ['v-chip-stub', props.color ? `bg-${props.color}` : ''],
-          'data-variant': props.variant,
-        },
-        slots.default?.()
-      )
-  },
-})
-
 const VRatingStub = defineComponent({
   name: 'VRating',
   props: ['modelValue', 'length'],
@@ -61,7 +45,6 @@ describe('ImpactScore', () => {
     plugins: [i18n],
     stubs: {
       'v-tooltip': VTooltipStub,
-      'v-chip': VChipStub,
       'v-rating': VRatingStub,
     },
   }
@@ -76,7 +59,7 @@ describe('ImpactScore', () => {
     })
 
     expect(wrapper.find('.impact-score-combined').exists()).toBe(true)
-    expect(wrapper.findComponent(VChipStub).exists()).toBe(true)
+    expect(wrapper.find('.impact-score-badge').exists()).toBe(true)
     expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
     expect(wrapper.text()).toContain('16 / 20') // (4/5)*20 = 16
 
@@ -98,7 +81,7 @@ describe('ImpactScore', () => {
 
     expect(wrapper.find('.impact-score').exists()).toBe(true)
     expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
-    expect(wrapper.findComponent(VChipStub).exists()).toBe(false)
+    expect(wrapper.find('.impact-score-badge').exists()).toBe(false)
   })
 
   it('calculates score out of 20 correctly', () => {
@@ -136,8 +119,8 @@ describe('ImpactScore', () => {
       global: globalOptions,
     })
 
-    const chip = wrapper.findComponent(VChipStub)
-    expect(chip.classes()).toContain('impact-score-badge--large')
+    const badge = wrapper.find('.impact-score-badge')
+    expect(badge.classes()).toContain('impact-score-badge--large')
   })
 
   it('renders combined mode correctly', () => {
@@ -151,7 +134,7 @@ describe('ImpactScore', () => {
     })
 
     expect(wrapper.find('.impact-score-combined').exists()).toBe(true)
-    expect(wrapper.findComponent(VChipStub).exists()).toBe(true)
+    expect(wrapper.find('.impact-score-badge').exists()).toBe(true)
     expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
     expect(wrapper.text()).toContain('16 / 20')
   })
@@ -171,7 +154,20 @@ describe('ImpactScore', () => {
 
     const combined = wrapper.find('.impact-score-combined')
     expect(combined.classes()).toContain('impact-score-combined--vertical')
-    expect(wrapper.findComponent(VChipStub).exists()).toBe(false)
+    expect(wrapper.find('.impact-score-badge').exists()).toBe(false)
     expect(wrapper.findComponent(VRatingStub).exists()).toBe(true)
+  })
+
+  it('supports flat styling on the badge', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 4,
+        flat: true,
+      },
+      global: globalOptions,
+    })
+
+    const badge = wrapper.find('.impact-score-badge')
+    expect(badge.classes()).toContain('impact-score-badge--flat')
   })
 })

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -43,18 +43,18 @@
         :aria-label="tooltipLabel"
         role="img"
       >
-        <v-chip
+        <div
           v-if="shouldDisplayScore"
           class="impact-score-badge"
-          :class="[`impact-score-badge--${size}`]"
-          rounded="pill"
-          variant="flat"
-          :color="badgeColor"
+          :class="[
+            `impact-score-badge--${size}`,
+            { 'impact-score-badge--flat': flat },
+          ]"
         >
           <span class="impact-score-badge__value">
             {{ formattedBadgeScore }}
           </span>
-        </v-chip>
+        </div>
 
         <div v-if="shouldDisplayStars" class="impact-score-combined__rating">
           <v-rating
@@ -76,21 +76,22 @@
       </div>
 
       <!-- Badge Mode -->
-      <v-chip
+      <div
         v-else
         class="impact-score-badge"
-        :class="[`impact-score-badge--${size}`]"
+        :class="[
+          `impact-score-badge--${size}`,
+          { 'impact-score-badge--flat': flat },
+        ]"
         v-bind="activatorProps"
         :aria-label="tooltipLabel"
         role="img"
-        rounded="pill"
-        variant="flat"
-        :color="badgeColor"
+        tabindex="0"
       >
         <span class="impact-score-badge__value">
           {{ formattedBadgeScore }}
         </span>
-      </v-chip>
+      </div>
     </template>
   </v-tooltip>
 </template>
@@ -110,7 +111,9 @@ const props = defineProps({
     default: 5,
   },
   size: {
-    type: String as PropType<'small' | 'medium' | 'large' | 'xlarge'>,
+    type: String as PropType<
+      'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge'
+    >,
     default: 'medium',
   },
   mode: {
@@ -141,6 +144,10 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  flat: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const { t, n } = useI18n()
@@ -170,21 +177,18 @@ const formattedBadgeScore = computed(
     `${n(scoreOutOf20.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 })} / 20`
 )
 
-const badgeColor = computed(() => {
-  // Use a default color if none provided, or map specific ranges if needed.
-  return undefined // heavily rely on CSS class
-})
-
 const ratingSize = computed(() => {
   switch (props.size) {
     case 'small':
-      return 18
+      return 22
     case 'large':
-      return 32
+      return 40
     case 'xlarge':
-      return 48
+      return 56
+    case 'xxlarge':
+      return 64
     default:
-      return 24
+      return 28
   }
 })
 
@@ -242,6 +246,7 @@ const layout = computed(() => props.layout)
 const size = computed(() => props.size)
 const showValue = computed(() => props.showValue)
 const mode = computed(() => props.mode)
+const flat = computed(() => props.flat)
 </script>
 
 <style scoped>
@@ -249,7 +254,7 @@ const mode = computed(() => props.mode)
 .impact-score {
   --impact-score-gap: 0.5rem;
   --impact-score-rating-gap: 0.375rem;
-  --impact-score-value-font-size: 0.95rem;
+  --impact-score-value-font-size: 1rem;
   display: inline-flex;
   align-items: center;
   gap: var(--impact-score-gap);
@@ -265,13 +270,19 @@ const mode = computed(() => props.mode)
 .impact-score--large {
   --impact-score-gap: 0.625rem;
   --impact-score-rating-gap: 0.5rem;
-  --impact-score-value-font-size: 1.05rem;
+  --impact-score-value-font-size: 1.2rem;
 }
 
 .impact-score--xlarge {
   --impact-score-gap: 1rem;
   --impact-score-rating-gap: 0.8rem;
-  --impact-score-value-font-size: 1.6rem;
+  --impact-score-value-font-size: 1.5rem;
+}
+
+.impact-score--xxlarge {
+  --impact-score-gap: 1.1rem;
+  --impact-score-rating-gap: 0.9rem;
+  --impact-score-value-font-size: 1.75rem;
 }
 
 .impact-score__rating :deep(.v-rating__wrapper) {
@@ -290,26 +301,65 @@ const mode = computed(() => props.mode)
 
 /* Badge Style */
 .impact-score-badge {
-  background-color: rgba(var(--v-theme-surface-primary-080), 0.85) !important;
-  color: rgb(var(--v-theme-text-neutral-strong)) !important;
-  font-weight: 600;
-  letter-spacing: 0.03em;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 0.95rem;
+  border-radius: 18px;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.28);
+  background: rgba(var(--v-theme-surface-glass-strong), 0.95);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.impact-score-badge::before {
+  content: '';
+  position: absolute;
+  top: -45%;
+  right: -35%;
+  width: 90%;
+  height: 120%;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-accent-primary-highlight), 0.45),
+    rgba(var(--v-theme-accent-supporting), 0.2)
+  );
+  transform: rotate(-10deg);
+  border-radius: 999px;
+  opacity: 0.8;
+  z-index: 0;
+}
+
+.impact-score-badge--flat {
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .impact-score-badge__value {
-  font-size: 0.95rem;
-}
-
-.impact-score-badge--small .impact-score-badge__value {
-  font-size: 0.85rem;
-}
-
-.impact-score-badge--large .impact-score-badge__value {
+  position: relative;
+  z-index: 1;
   font-size: 1.05rem;
 }
 
+.impact-score-badge--small .impact-score-badge__value {
+  font-size: 0.95rem;
+}
+
+.impact-score-badge--large .impact-score-badge__value {
+  font-size: 1.3rem;
+}
+
 .impact-score-badge--xlarge .impact-score-badge__value {
-  font-size: 1.2rem;
+  font-size: 1.55rem;
+}
+
+.impact-score-badge--xxlarge .impact-score-badge__value {
+  font-size: 1.85rem;
 }
 
 /* Combined Style */
@@ -319,7 +369,7 @@ const mode = computed(() => props.mode)
   --impact-score-combined-gap: 0.75rem;
   --impact-score-stack-gap: 0.6rem;
   --impact-score-rating-gap: 0.375rem;
-  --impact-score-value-font-size: 0.95rem;
+  --impact-score-value-font-size: 1rem;
   gap: var(--impact-score-combined-gap);
   color: rgb(var(--v-theme-text-neutral-strong));
 }
@@ -335,14 +385,21 @@ const mode = computed(() => props.mode)
   --impact-score-combined-gap: 1rem;
   --impact-score-stack-gap: 0.85rem;
   --impact-score-rating-gap: 0.5rem;
-  --impact-score-value-font-size: 1.05rem;
+  --impact-score-value-font-size: 1.2rem;
 }
 
 .impact-score-combined--xlarge {
   --impact-score-combined-gap: 1.25rem;
   --impact-score-stack-gap: 1rem;
   --impact-score-rating-gap: 0.6rem;
-  --impact-score-value-font-size: 1.2rem;
+  --impact-score-value-font-size: 1.4rem;
+}
+
+.impact-score-combined--xxlarge {
+  --impact-score-combined-gap: 1.4rem;
+  --impact-score-stack-gap: 1.2rem;
+  --impact-score-rating-gap: 0.7rem;
+  --impact-score-value-font-size: 1.6rem;
 }
 
 .impact-score-combined--vertical {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2308,7 +2308,11 @@
         "USE": "Product use"
       },
       "aggregateScores": {
-        "DIVERS": "Miscellaneous"
+        "DIVERS": "Miscellaneous",
+        "ENERGY_CONSUMPTION": "Energy consumption",
+        "REPARABILITY": "Repairability",
+        "DURABILITY": "Durability",
+        "ESG": "ESG performance"
       },
       "showDetails": "Show detailed indicators",
       "hideDetails": "Hide detailed indicators",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2335,7 +2335,11 @@
         "USE": "Usage du produit"
       },
       "aggregateScores": {
-        "DIVERS": "Divers"
+        "DIVERS": "Divers",
+        "ENERGY_CONSUMPTION": "Consommation énergétique",
+        "REPARABILITY": "Réparabilité",
+        "DURABILITY": "Durabilité",
+        "ESG": "Performance ESG"
       },
       "showDetails": "Afficher les infos détaillées",
       "hideDetails": "Masquer les indicateurs détaillés",


### PR DESCRIPTION
### Motivation
- Improve visual prominence and theme-safe rendering of the impact badge by introducing a light, diagonal accent ribbon and a flat option that removes the rounded border/shadow. 
- Remove the redundant numeric `/5` display in the main eco-score card while keeping the star tooltip behavior intact. 
- Show attribute sourcing information in the impact details table to make raw-value provenance visible. 
- Add missing aggregate score labels in i18n so grouped aggregates render readable names.

### Description
- Revamped `ImpactScore.vue` to replace the `v-chip` badge with a stylised micro-card, add a diagonal accent pseudo-element, a `flat` prop that removes border/shadow, larger size variants and increased star sizing; preserved tooltip behaviour and badge score-out-of-20 logic. 
- Hid the numeric `/5` in `ProductImpactEcoScoreCard.vue` by removing the `show-value` prop usage and relying on the redesigned badge for display. 
- Extended `ProductImpactDetailsTable.vue` to carry `attributeSourcing` on table rows and render `ProductAttributeSourcingLabel` in the `attributeValue` column, and removed the duplicated inline `/5` label in the subscore column. 
- Updated unit tests and stubs (`ImpactScore.spec.ts`, `ProductImpactDetailsTable.spec.ts`) and added aggregate score names in `en-US.json` and `fr-FR.json`.

### Testing
- Ran `pnpm fast` (lint, tests and build); lint initially flagged an error that was fixed and final run produced only warnings about attribute ordering. 
- Ran `pnpm test --run`; a large portion of the test suite executed and many tests passed (hundreds of unit tests), but the full test run was interrupted to avoid a long CI run (partial success). 
- Ran `pnpm generate` (Nuxt generate); the site built successfully with non-blocking warnings about baseline data and a PWA glob pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69570be840f4832bab1364ddc6d4899e)