### PR TITLE
Improve product SEO metadata, headings and title helpers

### DIFF
--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -178,6 +178,7 @@ import {
   resolvePopularAttributes,
 } from '~/utils/_product-attributes'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
+import { humanizeSlug } from '~/utils/_product-title'
 
 import type {
   AttributeConfigDto,
@@ -216,7 +217,7 @@ const props = defineProps({
   },
 })
 
-const { t, te, n } = useI18n()
+const { t, te, n, locale } = useI18n()
 
 const normalizeString = (value: string | null | undefined) =>
   typeof value === 'string' ? value.trim() : ''
@@ -225,8 +226,14 @@ const fallbackTitle = computed(() => {
   const medium = normalizeString(props.product.names?.h1Title)
   const identity = normalizeString(props.product.identity?.bestName)
   const base = normalizeString(props.product.base?.bestName)
+  const slug = normalizeString(props.product.slug)
+  const gtin = normalizeString(props.product.gtin?.toString())
+  const normalizedSlug = slug ? humanizeSlug(slug, locale.value) : ''
+  const gtinLabel = gtin
+    ? t('product.meta.gtinFallback', { gtin })
+    : ''
 
-  return medium || identity || base || ''
+  return medium || identity || base || normalizedSlug || gtinLabel || ''
 })
 
 const bestName = computed(() => {

--- a/frontend/app/components/product/ProductHeroPricing.vue
+++ b/frontend/app/components/product/ProductHeroPricing.vue
@@ -46,9 +46,9 @@
         <span>{{ priceTrendLabel }}</span>
       </button>
 
-      <h2 class="product-hero__pricing-title">
+      <p class="product-hero__pricing-title">
         {{ $t('product.hero.bestPriceTitle') }}
-      </h2>
+      </p>
     </div>
     <div class="product-hero__price">
       <span class="product-hero__price-value" itemprop="lowPrice">

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -11,9 +11,9 @@
 
       
   <article class="impact-details">
-    <h3 class="impact-details__title">
+    <h4 class="impact-details__title">
       {{ $t('product.impact.detailsTitle') }}
-    </h3>
+    </h4>
     <v-data-table
       v-if="hasRows"
       :headers="headers"

--- a/frontend/app/utils/_product-title.ts
+++ b/frontend/app/utils/_product-title.ts
@@ -1,0 +1,32 @@
+export const capitalizeFirstLetter = (
+  value: string,
+  locale?: string
+): string => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  const [first, ...rest] = Array.from(trimmed)
+
+  return `${first.toLocaleUpperCase(locale)}${rest.join('')}`
+}
+
+export const formatBrandModelTitle = (
+  brand: string,
+  model: string,
+  locale?: string
+): string => {
+  const formattedBrand = capitalizeFirstLetter(brand, locale)
+  const formattedModel = capitalizeFirstLetter(model, locale)
+
+  return [formattedBrand, formattedModel].filter(Boolean).join(' ')
+}
+
+export const humanizeSlug = (slug: string, locale?: string): string => {
+  return slug
+    .split('-')
+    .map(part => capitalizeFirstLetter(part, locale))
+    .join(' ')
+    .trim()
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2012,6 +2012,11 @@
       "cta": "Shop with Nudger",
       "ariaLabel": "Sticky banner promoting responsible shopping"
     },
+    "meta": {
+      "defaultDescription": "Compare {productTitle}{brandModel} on Nudger for pricing, environmental impact, and buying options.",
+      "defaultDescriptionWithVertical": "Compare {productTitle}{brandModel} on Nudger for pricing, environmental impact, and top options in {verticalTitle}.",
+      "gtinFallback": "GTIN {gtin}"
+    },
     "aiReview": {
       "empty": "Summary not requested yet.",
       "errors": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2033,6 +2033,11 @@
       "cta": "Achetez avec Nudger",
       "ariaLabel": "Bannière fixe pour promouvoir un achat responsable"
     },
+    "meta": {
+      "defaultDescription": "Comparez {productTitle}{brandModel} sur Nudger : prix, impact environnemental et options d’achat.",
+      "defaultDescriptionWithVertical": "Comparez {productTitle}{brandModel} sur Nudger : prix, impact environnemental et meilleures options dans {verticalTitle}.",
+      "gtinFallback": "GTIN {gtin}"
+    },
     "aiReview": {
       "empty": "Synthèse non encore demandée.",
       "errors": {


### PR DESCRIPTION
### Motivation
- Improve SEO and UX for product pages by producing clearer meta titles and descriptions that prefer brand/model when available.
- Provide readable fallbacks for uncategorized products using slug and GTIN data to avoid empty or unhelpful titles.
- Ensure heading levels in the product hero and impact details respect a more appropriate semantic hierarchy for accessibility and SEO.

### Description
- Add `frontend/app/utils/_product-title.ts` with `capitalizeFirstLetter`, `formatBrandModelTitle`, and `humanizeSlug` and use them to build consistent brand/model and slug fallbacks (`formatBrandModelTitle`, `humanizeSlug`).
- Update `ProductPage.vue` to prefer a `brandModel` meta title, stronger meta descriptions (using new i18n keys `product.meta.defaultDescription*`), slug/GTIN fallbacks and to prefer internal asset sources for schema images (`schemaImageUrl`).
- Update `ProductHero.vue` and `ProductHeroPricing.vue` to use the new title fallbacks and adjust markup (slug humanization and GTIN label), and change heading tags for SEO: the pricing title changed from `h2` to a `p` and the impact details title in `ProductImpactDetailsTable.vue` changed from `h3` to `h4`.
- Add i18n strings (`en-US.json`, `fr-FR.json`) for the meta description templates and GTIN fallback.

### Testing
- `pnpm test` ran successfully and all unit tests passed (`✅` automated tests completed).
- `pnpm generate --offline` completed successfully producing a static build (`✅` generation succeeded).
- `pnpm lint` ran but reported only warnings (attribute ordering) and is otherwise green; `pnpm lint --offline` is an invalid option in this environment (`⚠️`).
- A Playwright screenshot attempt failed due to Chromium crashing in the container, so no visual screenshot was produced (`⚠️`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957abf72a80832b82ed0800429a848a)