### PR TITLE
Add impact score criteria generation and endpoint

### DIFF
--- a/api/src/main/java/org/open4goods/api/controller/api/VerticalsGenerationController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/VerticalsGenerationController.java
@@ -159,6 +159,18 @@ public class VerticalsGenerationController {
 
 	}
 
+	@GetMapping(path="/{vertical}/impactscore-criterias/")
+	@Operation(summary="Generate the available impact score criterias yaml fragment for a given vertical")
+	@PreAuthorize("hasAuthority('"+RolesConstants.ROLE_ADMIN+"')")
+	@Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+	public String generateImpactScoreCriterias(
+			@PathVariable String vertical,
+			@RequestParam(defaultValue = "10") Integer minCoveragePercent) throws ResourceNotFoundException, IOException {
+
+		VerticalConfig vc = verticalsConfigService.getConfigById(vertical);
+		return verticalsGenService.generateAvailableImpactScoreCriteriasFragment(vc, minCoveragePercent);
+	}
+
 
 
 

--- a/api/src/test/java/org/open4goods/api/services/VerticalsGenerationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/VerticalsGenerationServiceTest.java
@@ -1,0 +1,86 @@
+package org.open4goods.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.api.config.yml.VerticalsGenerationConfig;
+import org.open4goods.icecat.services.IcecatService;
+import org.open4goods.model.vertical.AttributeConfig;
+import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.ImpactScoreConfig;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.services.evaluation.service.EvaluationService;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.services.prompt.service.PromptService;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.open4goods.verticals.GoogleTaxonomyService;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+class VerticalsGenerationServiceTest {
+
+    @Test
+    void generateAvailableImpactScoreCriteriasFragmentIncludesCoverageComments() {
+        VerticalConfig target = verticalConfig("tv");
+        target.setAvailableImpactScoreCriterias(List.of("TARGET_SCORE"));
+
+        VerticalConfig other = verticalConfig("other");
+        AttributeConfig scoreAttribute = new AttributeConfig();
+        scoreAttribute.setKey("SCORE_ATTR");
+        scoreAttribute.setAsScore(true);
+        other.setAttributesConfig(new AttributesConfig(List.of(scoreAttribute)));
+        other.setAvailableImpactScoreCriterias(List.of("SCORE_AVAILABLE"));
+        ImpactScoreConfig impactScoreConfig = new ImpactScoreConfig();
+        impactScoreConfig.setCriteriasPonderation(Map.of("SCORE_PONDER", 0.5));
+        other.setImpactScoreConfig(impactScoreConfig);
+
+        VerticalConfig defaultConfig = verticalConfig("_default");
+        defaultConfig.setAvailableImpactScoreCriterias(List.of("DEFAULT_SCORE"));
+
+        VerticalsConfigService verticalsConfigService = mock(VerticalsConfigService.class);
+        when(verticalsConfigService.getConfigsWithoutDefault()).thenReturn(List.of(target, other));
+        when(verticalsConfigService.getDefaultConfig()).thenReturn(defaultConfig);
+
+        ProductRepository repository = mock(ProductRepository.class);
+        when(repository.countMainIndexHavingVertical("tv")).thenReturn(100L);
+        when(repository.countMainIndexHavingScore("SCORE_ATTR", "tv")).thenReturn(15L);
+        when(repository.countMainIndexHavingScore("SCORE_AVAILABLE", "tv")).thenReturn(10L);
+        when(repository.countMainIndexHavingScore("SCORE_PONDER", "tv")).thenReturn(9L);
+        when(repository.countMainIndexHavingScore("DEFAULT_SCORE", "tv")).thenReturn(50L);
+        when(repository.countMainIndexHavingScore("TARGET_SCORE", "tv")).thenReturn(40L);
+
+        VerticalsGenerationService service = new VerticalsGenerationService(
+                new VerticalsGenerationConfig(),
+                repository,
+                mock(SerialisationService.class),
+                mock(GoogleTaxonomyService.class),
+                verticalsConfigService,
+                mock(ResourcePatternResolver.class),
+                mock(EvaluationService.class),
+                mock(IcecatService.class),
+                mock(PromptService.class));
+
+        String fragment = service.generateAvailableImpactScoreCriteriasFragment(target, 10);
+
+        assertThat(fragment).contains("availableImpactScoreCriterias:");
+        assertThat(fragment).contains("# coverage: 15% (15/100)");
+        assertThat(fragment).contains("- SCORE_ATTR");
+        assertThat(fragment).contains("# coverage: 10% (10/100)");
+        assertThat(fragment).contains("- SCORE_AVAILABLE");
+        assertThat(fragment).contains("# coverage: 50% (50/100)");
+        assertThat(fragment).contains("- DEFAULT_SCORE");
+        assertThat(fragment).doesNotContain("SCORE_PONDER");
+        assertThat(fragment).doesNotContain("TARGET_SCORE");
+    }
+
+    private VerticalConfig verticalConfig(String id) {
+        VerticalConfig config = new VerticalConfig();
+        config.setId(id);
+        return config;
+    }
+}

--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -762,6 +762,18 @@ public class ProductRepository {
                 return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 
+        /**
+         * Count recent products for a specific vertical.
+         *
+         * @param vertical vertical identifier
+         * @return count of recent products with offers for the vertical
+         */
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexHavingVertical(String vertical) {
+                CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery().and(new Criteria("vertical").is(vertical)));
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
         @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
         public Long countMainIndexHavingScore(String scoreName, String vertical) {
                 CriteriaQuery query = new CriteriaQuery(new Criteria("vertical").is(vertical) .and(new Criteria("scores." + scoreName + ".value").exists()));


### PR DESCRIPTION
### Motivation
- Provide a programmatic way to propose available impact score criterias for a vertical by aggregating candidates from other verticals and the default config.
- Surface coverage information so maintainers can choose which criterias meet a minimum coverage threshold against recent products with offers.
- Expose the generation as an admin API endpoint to simplify vertical configuration workflows.

### Description
- Add `generateAvailableImpactScoreCriteriasFragment`, `collectImpactScoreCandidates`, and `addImpactScoreCandidatesFromConfig` to `VerticalsGenerationService` to collect candidate criterias and compute coverage comments.
- Add controller endpoint `GET /{vertical}/impactscore-criterias/` in `VerticalsGenerationController` which calls the new service method and accepts a `minCoveragePercent` parameter.
- Add `ProductRepository.countMainIndexHavingVertical(String)` to count recent products for a given vertical and use it when computing coverage.
- Add unit test `VerticalsGenerationServiceTest` which verifies coverage comments and inclusion/exclusion behavior for generated fragments.

### Testing
- Added unit test `VerticalsGenerationServiceTest#generateAvailableImpactScoreCriteriasFragmentIncludesCoverageComments` that asserts the fragment contains coverage comments and correctly filters criterias by threshold.
- No automated test suite was executed as part of this rollout (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69583fc64c3c832b86808fe143669672)