### PR TITLE
Resolve release directory dynamically

### DIFF
--- a/frontend/server/utils/releases.spec.ts
+++ b/frontend/server/utils/releases.spec.ts
@@ -28,16 +28,19 @@ vi.mock('node:child_process', async importOriginal => {
 
 describe('release utilities', () => {
   let tempRoot: string
-  let releasesDirectory: string
+  let outputReleasesDirectory: string
+  let appReleasesDirectory: string
+  let publicReleasesDirectory: string
   const gitDates = new Map<string, string>()
   let cwdSpy: ReturnType<typeof vi.spyOn>
 
   const writeReleaseNote = async (
     fileName: string,
     publishedAt: string,
-    content: string
+    content: string,
+    directory = outputReleasesDirectory
   ) => {
-    const filePath = path.join(releasesDirectory, fileName)
+    const filePath = path.join(directory, fileName)
     await fs.writeFile(filePath, content)
     gitDates.set(filePath, publishedAt)
   }
@@ -48,11 +51,28 @@ describe('release utilities', () => {
     gitDates.clear()
 
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'releases-'))
-    releasesDirectory = path.join(tempRoot, 'public', 'reports', 'releases')
-    await fs.mkdir(releasesDirectory, { recursive: true })
+    outputReleasesDirectory = path.join(
+      tempRoot,
+      '.output',
+      'public',
+      'reports',
+      'releases'
+    )
+    appReleasesDirectory = path.join(tempRoot, 'app', 'public', 'reports', 'releases')
+    publicReleasesDirectory = path.join(tempRoot, 'public', 'reports', 'releases')
+    await Promise.all([
+      fs.mkdir(outputReleasesDirectory, { recursive: true }),
+      fs.mkdir(appReleasesDirectory, { recursive: true }),
+    ])
 
     await writeReleaseNote('older.md', '2024-11-10T00:00:00.000Z', '# Older')
     await writeReleaseNote('newer.md', '2024-12-15T00:00:00.000Z', '# Newer')
+    await writeReleaseNote(
+      'app.md',
+      '2025-01-01T00:00:00.000Z',
+      '# App',
+      appReleasesDirectory
+    )
 
     execFileMock.mockImplementation(
       (_command, args, _options, callback): ChildProcess => {
@@ -89,6 +109,56 @@ describe('release utilities', () => {
 
     const latestRelease = await getLatestRelease()
     expect(latestRelease?.slug).toBe('newer')
+  })
+
+  it('falls back to app public releases when the build output is missing', async () => {
+    await fs.rm(path.join(tempRoot, '.output'), { recursive: true, force: true })
+    gitDates.clear()
+    await fs.rm(path.join(appReleasesDirectory, 'app.md'), { force: true })
+
+    await writeReleaseNote(
+      'app-older.md',
+      '2024-10-10T00:00:00.000Z',
+      '# App older',
+      appReleasesDirectory
+    )
+    await writeReleaseNote(
+      'app-newer.md',
+      '2024-12-20T00:00:00.000Z',
+      '# App newer',
+      appReleasesDirectory
+    )
+
+    const { getReleaseNotes } = await import('~~/server/utils/releases')
+
+    const releases = await getReleaseNotes()
+
+    expect(releases.map(release => release.slug)).toEqual([
+      'app-newer',
+      'app-older',
+    ])
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to public releases when app public is missing', async () => {
+    await fs.rm(path.join(tempRoot, '.output'), { recursive: true, force: true })
+    await fs.rm(path.join(tempRoot, 'app'), { recursive: true, force: true })
+    await fs.mkdir(publicReleasesDirectory, { recursive: true })
+    gitDates.clear()
+
+    await writeReleaseNote(
+      'public-newer.md',
+      '2024-12-31T00:00:00.000Z',
+      '# Public newer',
+      publicReleasesDirectory
+    )
+
+    const { getLatestRelease } = await import('~~/server/utils/releases')
+
+    const latestRelease = await getLatestRelease()
+
+    expect(latestRelease?.slug).toBe('public-newer')
+    expect(execFileMock).toHaveBeenCalledTimes(1)
   })
 
   it('refreshes the cached release notes when warming the cache', async () => {


### PR DESCRIPTION
### Motivation

- Prioritise the build output releases folder so production finds release notes under `.output/public/reports/releases`.
- Provide robust fallbacks to `app/public/reports/releases` and `public/reports/releases` for dev and legacy layouts.
- Ensure the frontend call that shows the latest release badge can find a non-empty `name` in production by resolving the correct directory.

### Description

- Add `RELEASES_DIRECTORY_CANDIDATES` and a `resolveReleasesDirectory()` helper to pick the first existing releases directory.
- Change `buildReleaseNote` to accept the resolved directory and update `getReleaseNotes()` to read from the resolved path.
- Cache the resolved releases directory and clear `cachedReleasesDirectory` in `warmReleaseCache()` so cache warming re-evaluates the location.
- Update `frontend/server/utils/releases.spec.ts` to cover the `.output`, `app/public`, and `public` fallback scenarios and to simulate git dates.

### Testing

- Ran linter with `pnpm lint`, which completed but reported unrelated `vue/attributes-order` warnings.
- Ran unit tests with `pnpm test`, and the test suite completed successfully (all tests passed).
- Built a production site with `pnpm generate`, which completed successfully and generated `.output/public` (prerender and PWA steps finished with non-blocking warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695850c9b6f8832b935083842b8f6770)