### PR TITLE
Add configurable embedding prefixes and L2 normalization

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -14,6 +14,7 @@ import org.open4goods.api.services.VerticalsGenerationService;
 import org.open4goods.api.services.completion.EprelCompletionService;
 import org.open4goods.api.services.completion.IcecatCompletionService;
 import org.open4goods.api.services.completion.ResourceCompletionService;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
 import org.open4goods.embedding.service.image.DjlImageEmbeddingService;
 import org.open4goods.embedding.service.DjlTextEmbeddingService;
 import org.open4goods.api.services.store.DataFragmentStoreService;
@@ -326,9 +327,10 @@ public class ApiConfig {
 	@Bean
 	AggregationFacadeService realtimeAggregationService(@Autowired EvaluationService evaluationService, StandardiserService standardiserService, AutowireCapableBeanFactory autowireBeanFactory, @Autowired ProductRepository aggregatedDataRepository, ApiProperties apiProperties,
 			@Autowired Gs1PrefixService gs1prefixService, DataSourceConfigService dataSourceConfigService, VerticalsConfigService configService, BarcodeValidationService barcodeValidationService, BrandService brandservice, GoogleTaxonomyService gts, BlablaService blablaService,
-			IcecatService icecatFeatureService, SerialisationService serialisationService, BrandScoreService brandScoreService, DjlTextEmbeddingService embeddingService) {
+			IcecatService icecatFeatureService, SerialisationService serialisationService, BrandScoreService brandScoreService, DjlTextEmbeddingService embeddingService,
+			DjlEmbeddingProperties embeddingProperties) {
 		return new AggregationFacadeService(evaluationService, standardiserService, autowireBeanFactory, aggregatedDataRepository, apiProperties, gs1prefixService, dataSourceConfigService, configService, barcodeValidationService, brandservice, gts, blablaService, icecatFeatureService,
-				serialisationService, brandScoreService, embeddingService);
+				serialisationService, brandScoreService, embeddingService, embeddingProperties);
 	}
 
 	//////////////////////////////////////////////////////////

--- a/api/src/main/java/org/open4goods/api/services/AggregationFacadeService.java
+++ b/api/src/main/java/org/open4goods/api/services/AggregationFacadeService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
 import org.open4goods.embedding.service.DjlTextEmbeddingService;
 import org.open4goods.api.services.aggregation.AbstractAggregationService;
 import org.open4goods.api.services.aggregation.aggregator.ScoringBatchedAggregator;
@@ -87,6 +88,7 @@ public class AggregationFacadeService {
 	private IcecatService icecatFeatureService;
 	
 	private DjlTextEmbeddingService embeddingService;
+	private DjlEmbeddingProperties embeddingProperties;
 
 	private SerialisationService serialisationService;
 
@@ -102,7 +104,8 @@ public class AggregationFacadeService {
 			IcecatService icecatFeatureService,
 			SerialisationService serialisationService,
 			BrandScoreService brandScoreService,
-			DjlTextEmbeddingService embeddingService
+			DjlTextEmbeddingService embeddingService,
+			DjlEmbeddingProperties embeddingProperties
 			) {
 		super();
 		this.evaluationService = evaluationService;
@@ -119,6 +122,7 @@ public class AggregationFacadeService {
 		this.blablaService = blablaService;
 		this.icecatFeatureService = icecatFeatureService;
 		this.embeddingService = embeddingService;
+		this.embeddingProperties = embeddingProperties;
 		this.realtimeAggregator = getStandardAggregator("realtime");
 		this.serialisationService = serialisationService;
 		this.brandScoreService = brandScoreService;
@@ -353,7 +357,8 @@ public class AggregationFacadeService {
 		services.add(new IdentityAggregationService( logger, gs1prefixService,barcodeValidationService));
 		services.add(new TaxonomyRealTimeAggregationService(  logger, verticalConfigService, taxonomyService));
 		services.add(new AttributeRealtimeAggregationService(verticalConfigService, brandService, logger,icecatFeatureService));
-		services.add(new NamesAggregationService( logger, verticalConfigService, evaluationService, blablaService, embeddingService));
+		services.add(new NamesAggregationService( logger, verticalConfigService, evaluationService, blablaService, embeddingService,
+				embeddingProperties));
 		//		services.add(new CategoryService( taxonomyService));
 		//		services.add(new UrlsAggregationService(evaluationService,
 		//				config.getNamings().getProductUrlTemplates()));

--- a/api/src/test/java/org/open4goods/api/services/AggregationFacadeServiceParticipatingScoresIT.java
+++ b/api/src/test/java/org/open4goods/api/services/AggregationFacadeServiceParticipatingScoresIT.java
@@ -17,6 +17,7 @@ import org.open4goods.commons.services.BarcodeValidationService;
 import org.open4goods.commons.services.DataSourceConfigService;
 import org.open4goods.commons.services.Gs1PrefixService;
 import org.open4goods.commons.services.textgen.BlablaService;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
 import org.open4goods.embedding.service.DjlTextEmbeddingService;
 import org.open4goods.icecat.services.IcecatService;
 import org.open4goods.model.attribute.AttributeType;
@@ -82,7 +83,8 @@ class AggregationFacadeServiceParticipatingScoresIT {
                 mock(IcecatService.class),
                 mock(SerialisationService.class),
                 mock(BrandScoreService.class),
-                mock(DjlTextEmbeddingService.class));
+                mock(DjlTextEmbeddingService.class),
+                new DjlEmbeddingProperties());
     }
 
     private VerticalConfig verticalConfig() {

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.open4goods.embedding.service.DjlTextEmbeddingService;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
 import org.open4goods.commons.exceptions.AggregationSkipException;
 import org.open4goods.commons.services.textgen.BlablaService;
 import org.open4goods.model.exceptions.InvalidParameterException;
@@ -44,16 +45,20 @@ class NamesAggregationServiceTest {
 	@Mock
 	private DjlTextEmbeddingService embeddingService;
 
+	private DjlEmbeddingProperties embeddingProperties;
+
 	private NamesAggregationService service;
 
 	@BeforeEach
 	void setUp() {
+		embeddingProperties = new DjlEmbeddingProperties();
 		service = new NamesAggregationService(
 				LoggerFactory.getLogger(NamesAggregationService.class),
 				verticalsConfigService,
 				evaluationService,
 				blablaService,
-				embeddingService);
+				embeddingService,
+				embeddingProperties);
 	}
 
 	@Test

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -34,6 +34,7 @@ import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.verticals.VerticalsConfigService;
 import org.open4goods.embedding.service.DjlTextEmbeddingService;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
@@ -74,13 +75,17 @@ class SearchServiceTest {
     @Mock
     private DjlTextEmbeddingService textEmbeddingService;
 
+    private DjlEmbeddingProperties embeddingProperties;
+
     private SearchService searchService;
 
     @BeforeEach
     void setUp() {
         lenient().when(apiProperties.getResourceRootPath()).thenReturn("https://assets.nudger.test");
         lenient().when(repository.expirationClause()).thenReturn(0L);
-        searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties, textEmbeddingService);
+        embeddingProperties = new DjlEmbeddingProperties();
+        searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties, textEmbeddingService,
+                embeddingProperties);
     }
 
     @Test

--- a/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlEmbeddingProperties.java
+++ b/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlEmbeddingProperties.java
@@ -51,6 +51,18 @@ public class DjlEmbeddingProperties
     private String poolingMode = "mean";
 
     /**
+     * Prefix added to query text when generating embeddings.
+     */
+    @NotBlank
+    private String queryPrefix = "query:";
+
+    /**
+     * Prefix added to passage text when generating embeddings.
+     */
+    @NotBlank
+    private String passagePrefix = "passage:";
+
+    /**
      * Engine name supplied to DJL criteria.
      */
     @NotBlank
@@ -121,6 +133,26 @@ public class DjlEmbeddingProperties
     public void setPoolingMode(String poolingMode)
     {
         this.poolingMode = poolingMode;
+    }
+
+    public String getQueryPrefix()
+    {
+        return queryPrefix;
+    }
+
+    public void setQueryPrefix(String queryPrefix)
+    {
+        this.queryPrefix = queryPrefix;
+    }
+
+    public String getPassagePrefix()
+    {
+        return passagePrefix;
+    }
+
+    public void setPassagePrefix(String passagePrefix)
+    {
+        this.passagePrefix = passagePrefix;
     }
 
     public String getEngine()

--- a/services/embedding-djl/src/main/java/org/open4goods/embedding/util/EmbeddingVectorUtils.java
+++ b/services/embedding-djl/src/main/java/org/open4goods/embedding/util/EmbeddingVectorUtils.java
@@ -1,0 +1,45 @@
+package org.open4goods.embedding.util;
+
+/**
+ * Utility methods for handling embedding vectors before indexing or querying.
+ */
+public final class EmbeddingVectorUtils
+{
+    private EmbeddingVectorUtils()
+    {
+        // Utility class.
+    }
+
+    /**
+     * Applies L2 normalization to the provided vector in-place.
+     *
+     * @param vector embedding vector to normalize
+     * @return the normalized vector, or {@code null} if the input is null
+     */
+    public static float[] normalizeL2(float[] vector)
+    {
+        if (vector == null || vector.length == 0)
+        {
+            return vector;
+        }
+
+        double sumSquares = 0.0;
+        for (float value : vector)
+        {
+            sumSquares += (double) value * value;
+        }
+
+        if (sumSquares <= 0.0)
+        {
+            return vector;
+        }
+
+        double norm = Math.sqrt(sumSquares);
+        for (int i = 0; i < vector.length; i++)
+        {
+            vector[i] = (float) (vector[i] / norm);
+        }
+
+        return vector;
+    }
+}

--- a/services/embedding-djl/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/embedding-djl/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -43,6 +43,18 @@
       "defaultValue": "mean"
     },
     {
+      "name": "embedding.query-prefix",
+      "type": "java.lang.String",
+      "description": "Prefix added to query text when generating embeddings.",
+      "defaultValue": "query:"
+    },
+    {
+      "name": "embedding.passage-prefix",
+      "type": "java.lang.String",
+      "description": "Prefix added to passage text when generating embeddings.",
+      "defaultValue": "passage:"
+    },
+    {
       "name": "embedding.engine",
       "type": "java.lang.String",
       "description": "Engine name supplied to DJL when loading models.",


### PR DESCRIPTION
### Motivation
- Make embedding inputs explicit and configurable by adding query/passage prefixes to the DJL embedding configuration to allow model-specific prompting.
- Ensure consistent vector magnitudes for KNN searches by applying L2 normalization to embedding vectors before indexing/querying.
- Wire the new embedding configuration through the API/aggregation stack so both realtime name embeddings and semantic search use the same, configurable behavior.

### Description
- Added `queryPrefix` and `passagePrefix` properties to `DjlEmbeddingProperties` and exposed them in `additional-spring-configuration-metadata.json`.
- Introduced `EmbeddingVectorUtils.normalizeL2(float[])` to apply in-place L2 normalization of embedding vectors.
- Updated `SearchService` to build a prefixed query input via `buildQueryEmbeddingInput(...)`, call the embedding service with the prefixed text, and L2-normalize the `IdHelper.to512(...)` result before KNN search.
- Updated `NamesAggregationService` to prefix passage text with the configured passage prefix, embed the prefixed text, pad to 512 dims via `IdHelper.to512(...)`, and L2-normalize the vector; and wired `DjlEmbeddingProperties` through `AggregationFacadeService` and `ApiConfig` and adjusted affected tests to instantiate `DjlEmbeddingProperties`.

### Testing
- No automated tests were executed as part of this change.
- Unit tests referencing constructors were updated to pass a `new DjlEmbeddingProperties()` instance, but test runs were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958ea71a030832b9fc5ba47d9b99a43)