### PR TITLE
Add corner stacked `/20` impact badge and surface it on product cards

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -45,21 +45,37 @@
           <CategoryProductCompareToggle :product="product" size="compact" />
         </div>
 
-        <v-img
-          :src="resolveImage(product)"
-          :alt="
-            product.identity?.bestName ??
-            product.identity?.model ??
-            $t('category.products.untitledProduct')
-          "
-          :aspect-ratio="4 / 3"
-          contain
-          class="category-product-card-grid__image"
-        >
-          <template #placeholder>
-            <v-skeleton-loader type="image" class="h-100" />
-          </template>
-        </v-img>
+        <div class="category-product-card-grid__media">
+          <v-img
+            :src="resolveImage(product)"
+            :alt="
+              product.identity?.bestName ??
+              product.identity?.model ??
+              $t('category.products.untitledProduct')
+            "
+            :aspect-ratio="4 / 3"
+            contain
+            class="category-product-card-grid__image"
+          >
+            <template #placeholder>
+              <v-skeleton-loader type="image" class="h-100" />
+            </template>
+          </v-img>
+          <div class="category-product-card-grid__corner" role="presentation">
+            <ImpactScore
+              v-if="impactScoreValue(product) != null"
+              :score="impactScoreValue(product) ?? 0"
+              :max="5"
+              size="small"
+              mode="badge"
+              badge-layout="stacked"
+              badge-variant="corner"
+            />
+            <span v-else class="category-product-card-grid__corner-fallback">
+              {{ $t('category.products.notRated') }}
+            </span>
+          </div>
+        </div>
 
         <v-card-item class="category-product-card-grid__body">
           <div class="category-product-card-grid__header">
@@ -97,18 +113,6 @@
                 {{ attribute.value }}
               </span>
             </v-chip>
-          </div>
-
-          <div class="category-product-card-grid__score" role="presentation">
-            <ImpactScore
-              v-if="impactScoreValue(product) != null"
-              :score="impactScoreValue(product) ?? 0"
-              :max="5"
-              size="medium"
-            />
-            <span v-else class="category-product-card-grid__score-fallback">
-              {{ $t('category.products.notRated') }}
-            </span>
           </div>
 
           <template
@@ -439,6 +443,40 @@ const offerBadges = (product: ProductDto): OfferBadge[] => {
       mix-blend-mode: multiply
       background: #fff
 
+  &__media
+    position: relative
+    overflow: hidden
+    border-top-left-radius: inherit
+    border-top-right-radius: inherit
+
+  &__corner
+    position: absolute
+    top: 0
+    left: 0
+    width: 64px
+    height: 64px
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    border-radius: 0 0 54% 0
+    background: rgba(var(--v-theme-surface-glass-strong), 0.92)
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45)
+    color: rgb(var(--v-theme-text-neutral-strong))
+    box-shadow: 0 14px 26px rgba(15, 23, 42, 0.14)
+    backdrop-filter: blur(6px)
+    z-index: 2
+    pointer-events: none
+
+  &__corner-fallback
+    font-size: 0.72rem
+    font-weight: 700
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+    text-align: center
+    line-height: 1.1
+    transform: rotate(-12deg)
+
   &__compare
     position: absolute
     right: 1.25rem
@@ -496,16 +534,6 @@ const offerBadges = (product: ProductDto): OfferBadge[] => {
     gap: 0.25rem
 
   &__offers
-    font-size: 0.875rem
-    color: rgb(var(--v-theme-text-neutral-secondary))
-
-  &__score
-    display: flex
-    align-items: center
-    justify-content: center
-    min-height: 1.75rem
-
-  &__score-fallback
     font-size: 0.875rem
     color: rgb(var(--v-theme-text-neutral-secondary))
 

--- a/frontend/app/components/category/products/ProductTileCard.vue
+++ b/frontend/app/components/category/products/ProductTileCard.vue
@@ -9,7 +9,7 @@
     :rel="linkRel"
   >
     <div class="product-tile-card__layout">
-      <div>
+      <div class="product-tile-card__media">
         <v-img
           :src="imageSrc"
           :alt="headerTitle"
@@ -22,13 +22,19 @@
           </template>
         </v-img>
 
-        <div class="product-tile-card__score">
+        <div class="product-tile-card__corner" role="presentation">
           <ImpactScore
             v-if="impactScore != null"
             :score="impactScore"
             :max="5"
             size="small"
+            mode="badge"
+            badge-layout="stacked"
+            badge-variant="corner"
           />
+          <span v-else class="product-tile-card__corner-fallback">
+            {{ notRatedLabel }}
+          </span>
         </div>
       </div>
 
@@ -259,23 +265,34 @@ const toggleCompare = () => {
     }
   }
 
-  &__score {
+  &__corner {
     position: absolute;
-    top: 0.5rem;
-    left: 0.5rem;
+    top: 0;
+    left: 0;
+    width: 64px;
+    height: 64px;
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
-    padding: 0.35rem 0.6rem;
-    border-radius: 999px;
-    background: rgba(var(--v-theme-surface-default), 0.95);
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+    justify-content: center;
+    border-radius: 0 0 54% 0;
+    background: rgba(var(--v-theme-surface-glass-strong), 0.92);
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.45);
+    color: rgb(var(--v-theme-text-neutral-strong));
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14);
+    backdrop-filter: blur(6px);
+    z-index: 2;
+    pointer-events: none;
   }
 
-  &__score-fallback {
-    font-size: 0.75rem;
-    color: rgb(var(--v-theme-text-neutral-secondary));
-    font-weight: 600;
+  &__corner-fallback {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+    text-align: center;
+    line-height: 1.1;
+    transform: rotate(-12deg);
   }
 
   &__content {

--- a/frontend/app/components/shared/ui/ImpactScore.spec.ts
+++ b/frontend/app/components/shared/ui/ImpactScore.spec.ts
@@ -11,6 +11,7 @@ const i18n = createI18n({
     en: {
       'components.impactScore.tooltip': 'Score: {value} / {max}',
       'components.impactScore.tooltipBadge': 'Score: {value} / 20',
+      'components.impactScore.outOf20': '/20',
     },
   },
 })
@@ -169,5 +170,23 @@ describe('ImpactScore', () => {
 
     const badge = wrapper.find('.impact-score-badge')
     expect(badge.classes()).toContain('impact-score-badge--flat')
+  })
+
+  it('renders stacked badge layout for corner variant', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 4,
+        mode: 'badge',
+        badgeLayout: 'stacked',
+        badgeVariant: 'corner',
+      },
+      global: globalOptions,
+    })
+
+    const badge = wrapper.find('.impact-score-badge')
+    expect(badge.classes()).toContain('impact-score-badge--stacked')
+    expect(badge.classes()).toContain('impact-score-badge--corner')
+    expect(wrapper.text()).toContain('16')
+    expect(wrapper.text()).toContain('/20')
   })
 })

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -81,6 +81,8 @@
         class="impact-score-badge"
         :class="[
           `impact-score-badge--${size}`,
+          `impact-score-badge--${badgeLayout}`,
+          `impact-score-badge--${badgeVariant}`,
           { 'impact-score-badge--flat': flat },
         ]"
         v-bind="activatorProps"
@@ -88,7 +90,18 @@
         role="img"
         tabindex="0"
       >
-        <span class="impact-score-badge__value">
+        <div
+          v-if="badgeLayout === 'stacked'"
+          class="impact-score-badge__stack"
+        >
+          <span class="impact-score-badge__value-main">
+            {{ formattedBadgeValue }}
+          </span>
+          <span class="impact-score-badge__value-secondary">
+            {{ outOf20Label }}
+          </span>
+        </div>
+        <span v-else class="impact-score-badge__value">
           {{ formattedBadgeScore }}
         </span>
       </div>
@@ -148,6 +161,14 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  badgeLayout: {
+    type: String as PropType<'inline' | 'stacked'>,
+    default: 'inline',
+  },
+  badgeVariant: {
+    type: String as PropType<'default' | 'corner'>,
+    default: 'default',
+  },
 })
 
 const { t, n } = useI18n()
@@ -176,6 +197,12 @@ const formattedBadgeScore = computed(
   () =>
     `${n(scoreOutOf20.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 })} / 20`
 )
+
+const formattedBadgeValue = computed(() =>
+  n(scoreOutOf20.value, { maximumFractionDigits: 1, minimumFractionDigits: 0 })
+)
+
+const outOf20Label = computed(() => t('components.impactScore.outOf20'))
 
 const ratingSize = computed(() => {
   switch (props.size) {
@@ -247,6 +274,8 @@ const size = computed(() => props.size)
 const showValue = computed(() => props.showValue)
 const mode = computed(() => props.mode)
 const flat = computed(() => props.flat)
+const badgeLayout = computed(() => props.badgeLayout)
+const badgeVariant = computed(() => props.badgeVariant)
 </script>
 
 <style scoped>
@@ -335,6 +364,32 @@ const flat = computed(() => props.flat)
   z-index: 0;
 }
 
+.impact-score-badge--corner {
+  background: rgba(var(--v-theme-surface-glass-strong), 0.92);
+  border-color: rgba(var(--v-theme-border-primary-strong), 0.5);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+
+.impact-score-badge--corner::before {
+  content: none;
+}
+
+.impact-score-badge--stacked {
+  padding: 0.5rem 0.6rem;
+}
+
+.impact-score-badge__stack {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+  line-height: 1;
+}
+
+.impact-score-badge--corner.impact-score-badge--stacked .impact-score-badge__stack {
+  transform: rotate(-12deg);
+}
+
 .impact-score-badge--flat {
   border-color: transparent;
   box-shadow: none;
@@ -348,6 +403,26 @@ const flat = computed(() => props.flat)
 
 .impact-score-badge--small .impact-score-badge__value {
   font-size: 0.95rem;
+}
+
+.impact-score-badge__value-main {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.impact-score-badge__value-secondary {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+}
+
+.impact-score-badge--small .impact-score-badge__value-main {
+  font-size: 0.95rem;
+}
+
+.impact-score-badge--small .impact-score-badge__value-secondary {
+  font-size: 0.65rem;
 }
 
 .impact-score-badge--large .impact-score-badge__value {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -912,7 +912,9 @@
   },
   "components": {
     "impactScore": {
-      "tooltip": "Impact quality rated at {value} out of {max}"
+      "tooltip": "Impact quality rated at {value} out of {max}",
+      "tooltipBadge": "Impact quality rated at {value} out of 20",
+      "outOf20": "/20"
     },
     "pageLoadingOverlay": {
       "label": "Loading page content"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -937,7 +937,9 @@
   },
   "components": {
     "impactScore": {
-      "tooltip": "Qualité de l'impact évalué à {value} sur {max}"
+      "tooltip": "Qualité de l'impact évalué à {value} sur {max}",
+      "tooltipBadge": "Qualité de l'impact évalué à {value} sur 20",
+      "outOf20": "/20"
     },
     "pageLoadingOverlay": {
       "label": "Chargement du contenu"


### PR DESCRIPTION
### Motivation
- Surface the primary impact score in a compact corner badge on product cards to free space and improve visual consistency. 
- Provide a neutral glass corner treatment with no color accents to avoid conflicting with product imagery. 
- Support a compact stacked layout that splits the badge into two lines (value above `/20`) for the diagonal/corner container. 
- Keep an explicit `not rated` fallback rendered inside the same corner shape when a score is missing.

### Description
- Added `badgeLayout` and `badgeVariant` props to `ImpactScore.vue` and implemented a `stacked` layout and `corner` variant that render the score value and an `/20` label on two lines. 
- Introduced `formattedBadgeValue` and `outOf20Label` plus localized keys `components.impactScore.tooltipBadge` and `components.impactScore.outOf20` in `en-US.json` and `fr-FR.json`. 
- Updated `ProductTileCard.vue` and `CategoryProductCardGrid.vue` to render `ImpactScore` as a corner overlay (`mode=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a2c7338dc832b91d36186189dd00d)