### PR TITLE
Add rotating model variations for product page section copy

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-ai-review">
     <header class="product-ai-review__header">
       <h2 class="product-ai-review__title">
-        {{ $t('product.aiReview.title') }}
+        {{ sectionTitle }}
       </h2>
       <p class="product-ai-review__subtitle">
         {{ $t('product.aiReview.subtitle') }}
@@ -392,6 +392,14 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  productBrand: {
+    type: String,
+    default: '',
+  },
+  modelVariation: {
+    type: String,
+    default: '',
+  },
 })
 
 const { locale, t } = useI18n()
@@ -410,6 +418,20 @@ const showCaptcha = ref(false)
 const captchaToken = ref<string | null>(null)
 const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 const descriptionRef = ref<HTMLElement | null>(null)
+const sectionTitle = computed(() => {
+  const brand = props.productBrand.trim()
+  const modelVariation = props.modelVariation.trim()
+
+  if (modelVariation.length) {
+    return t('product.aiReview.titleWithModel', { modelVariation })
+  }
+
+  if (brand.length) {
+    return t('product.aiReview.titleWithBrand', { brand })
+  }
+
+  return t('product.aiReview.title')
+})
 
 watch(
   () => props.initialReview,

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-attributes">
     <header class="product-attributes__header">
       <h2 class="product-attributes__title">
-        {{ $t('product.attributes.title') }}
+        {{ sectionTitle }}
       </h2>
       <p class="product-attributes__subtitle">
         {{ $t('product.attributes.subtitle') }}
@@ -306,11 +306,34 @@ const props = defineProps({
     type: Object as PropType<ProductDto | null>,
     default: null,
   },
+  productBrand: {
+    type: String,
+    default: '',
+  },
+  modelVariation: {
+    type: String,
+    default: '',
+  },
 })
 
 const { t, n, locale } = useI18n()
 const runtimeConfig = useRuntimeConfig()
 const { isLoggedIn } = useAuth()
+
+const sectionTitle = computed(() => {
+  const brand = props.productBrand.trim()
+  const modelVariation = props.modelVariation.trim()
+
+  if (modelVariation.length) {
+    return t('product.attributes.titleWithModel', { modelVariation })
+  }
+
+  if (brand.length) {
+    return t('product.attributes.titleWithBrand', { brand })
+  }
+
+  return t('product.attributes.title')
+})
 
 const searchTerm = ref('')
 const hasSearchTerm = computed(() => searchTerm.value.trim().length > 0)

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -5,7 +5,7 @@
         {{ $t('product.impact.title') }}
       </h2>
       <p class="product-impact__subtitle">
-        {{ $t('product.impact.subtitle') }}
+        {{ subtitle }}
       </p>
     </header>
 
@@ -88,6 +88,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  modelVariation: {
+    type: String,
+    default: '',
+  },
   productImage: {
     type: String,
     default: '',
@@ -124,6 +128,23 @@ const radarAxes = computed<RadarAxisEntry[]>(() => radarData.value.axes ?? [])
 const availableSeries = computed<RadarSeriesEntry[]>(
   () => radarData.value.series ?? []
 )
+const subtitle = computed(() => {
+  const brand = props.productBrand.trim()
+  const modelVariation = props.modelVariation.trim()
+
+  if (modelVariation.length) {
+    return t('product.impact.subtitleWithModel', {
+      brand,
+      modelVariation,
+    })
+  }
+
+  if (brand.length) {
+    return t('product.impact.subtitleWithBrand', { brand })
+  }
+
+  return t('product.impact.subtitle')
+})
 
 const radarSeriesStyles: Record<
   RadarSeriesKey,

--- a/frontend/app/components/product/ProductPriceSection.vue
+++ b/frontend/app/components/product/ProductPriceSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-price">
     <header class="product-price__header">
       <h2 id="price-history" class="product-price__title">
-        {{ $t('product.price.title') }}
+        {{ sectionTitle }}
       </h2>
       <p class="product-price__subtitle">
         {{ $t('product.price.subtitle') }}
@@ -522,11 +522,37 @@ const props = defineProps({
     type: Array as PropType<CommercialEvent[]>,
     default: () => [],
   },
+  productBrand: {
+    type: String,
+    default: '',
+  },
+  modelVariation: {
+    type: String,
+    default: '',
+  },
 })
 
 const { locale, n, t } = useI18n()
 const { trackProductRedirect, extractTokenFromLink, isClientContribLink } =
   useAnalytics()
+
+const sectionTitle = computed(() => {
+  const brand = props.productBrand.trim()
+  const modelVariation = props.modelVariation.trim()
+
+  if (modelVariation.length) {
+    return t('product.price.titleWithModel', {
+      brand,
+      modelVariation,
+    })
+  }
+
+  if (brand.length) {
+    return t('product.price.titleWithBrand', { brand })
+  }
+
+  return t('product.price.title')
+})
 
 type HistoryEntry = { timestamp: number; price: number }
 

--- a/frontend/app/components/product/impact/ProductAlternatives.vue
+++ b/frontend/app/components/product/impact/ProductAlternatives.vue
@@ -5,7 +5,7 @@
         {{ t('product.impact.alternatives.title') }}
       </h3>
       <p class="product-alternatives__subtitle">
-        {{ t('product.impact.alternatives.subtitle') }}
+        {{ subtitle }}
       </p>
     </header>
 
@@ -125,9 +125,34 @@ const props = defineProps({
     type: Number,
     default: 5,
   },
+  productBrand: {
+    type: String,
+    default: '',
+  },
+  modelVariation: {
+    type: String,
+    default: '',
+  },
 })
 
 const { t, n } = useI18n()
+const subtitle = computed(() => {
+  const brand = props.productBrand.trim()
+  const modelVariation = props.modelVariation.trim()
+
+  if (modelVariation.length) {
+    return t('product.impact.alternatives.subtitleWithModel', {
+      brand,
+      modelVariation,
+    })
+  }
+
+  if (brand.length) {
+    return t('product.impact.alternatives.subtitleWithBrand', { brand })
+  }
+
+  return t('product.impact.alternatives.subtitle')
+})
 
 const alternatives = ref<ProductDto[]>([])
 const loading = ref(false)

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2042,10 +2042,14 @@
         "success": "Summary available"
       },
       "subtitle": "An AI-written synthesis built from verified sources.",
-      "title": "Test & review summary"
+      "title": "Test & review summary",
+      "titleWithBrand": "Test & review summary for {brand}",
+      "titleWithModel": "Test & review summary for {modelVariation}"
     },
     "attributes": {
       "title": "Technical specifications",
+      "titleWithBrand": "Technical specifications for {brand}",
+      "titleWithModel": "Technical specifications for {modelVariation}",
       "subtitle": "Browse every specification and filter with keywords.",
       "searchPlaceholder": "Search a specification",
       "audit": {
@@ -2214,6 +2218,8 @@
       "alternatives": {
         "title": "Greener alternatives",
         "subtitle": "Discover similar products with a better impact score or price.",
+        "subtitleWithBrand": "Discover similar products to {brand} with a better impact score and a more accessible price.",
+        "subtitleWithModel": "Discover similar products to {brand} - {modelVariation} with a better impact score and a more accessible price.",
         "bestProduct": "Voted best product for your criteria!",
         "error": "We couldn't load alternative products. Please try again.",
         "retry": "Retry",
@@ -2293,6 +2299,8 @@
       "scoreValue": "Relative score",
       "valueOutOf": "{value} / {max}",
       "subtitle": "Explore how this product scores across ecological and social criteria.",
+      "subtitleWithBrand": "Compare environmental and social scores for {brand}.",
+      "subtitleWithModel": "Compare environmental and social scores for {brand} - {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicator",
         "attributeValue": "Attribute value",
@@ -2369,6 +2377,8 @@
       "noHistory": "Price history is not yet available for this product.",
       "subtitle": "Track price evolution and compare offers.",
       "title": "Prices and trends",
+      "titleWithBrand": "Prices and trends for {brand}",
+      "titleWithModel": "Prices and trends for {brand} - {modelVariation}",
       "trend": {
         "decrease": "Price drop of {amount}",
         "increase": "Price increase of {amount}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2067,10 +2067,14 @@
         "success": "Synthèse disponible"
       },
       "subtitle": "Une synthèse rédigée par notre IA à partir de sources vérifiées.",
-      "title": "Synthèse des tests et avis"
+      "title": "Synthèse des tests et avis",
+      "titleWithBrand": "Synthèse des tests et avis sur {brand}",
+      "titleWithModel": "Synthèse des tests et avis sur le {modelVariation}"
     },
     "attributes": {
       "title": "Caractéristiques techniques",
+      "titleWithBrand": "Caractéristiques techniques de {brand}",
+      "titleWithModel": "Caractéristiques techniques de {modelVariation}",
       "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
       "searchPlaceholder": "Rechercher une caractéristique",
       "audit": {
@@ -2239,6 +2243,8 @@
       "alternatives": {
         "title": "Alternatives plus vertes",
         "subtitle": "Découvrez des produits similaires avec un meilleur score d'impact ou un prix plus accessible.",
+        "subtitleWithBrand": "Découvrez des produits similaires à {brand} avec un meilleur score d'impact et un prix plus accessible.",
+        "subtitleWithModel": "Découvrez des produits similaires au {brand} - {modelVariation} avec un meilleur score d'impact et un prix plus accessible.",
         "bestProduct": "Élu meilleur produit par rapport à vos critères !",
         "error": "Impossible de charger les alternatives pour le moment. Réessayez.",
         "retry": "Réessayer",
@@ -2318,6 +2324,8 @@
       "scoreValue": "Score relatif",
       "valueOutOf": "{value} / {max}",
       "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
+      "subtitleWithBrand": "Comparez les scores environnementaux et sociétaux de {brand}.",
+      "subtitleWithModel": "Comparez les scores environnementaux et sociétaux du {brand} - {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicateur",
         "attributeValue": "Valeur brute",
@@ -2394,6 +2402,8 @@
       "noHistory": "Pas assez de données pour afficher l'historique des prix.",
       "subtitle": "Suivez l’évolution des prix et comparez les offres.",
       "title": "Prix et évolution",
+      "titleWithBrand": "Prix et évolution de {brand}",
+      "titleWithModel": "Prix et évolution du {brand} - {modelVariation}",
       "trend": {
         "decrease": "Baisse de {amount}",
         "increase": "Hausse de {amount}",


### PR DESCRIPTION
### Motivation

- Provide more contextual, brand- and model-aware section headers across product pages to avoid repetitive copy. 
- Surface short model variations in different sections so each section can mention a different model alias when available. 
- Keep runtime work server-side so section copy can be rendered consistently during SSR. 
- Add localized strings so brand/model-aware headings have proper translations and fallbacks.

### Description

- Build a rotating list of model variations in `ProductPage.vue` (`modelVariations`, `resolveModelVariation`, `modelVariationBySection`) and thread per-section values into child components. 
- Pass `:product-brand` and `:model-variation` props into `ProductImpactSection`, `ProductAiReviewSection`, `ProductPriceSection`, `ProductAlternatives` and `ProductAttributesSection` and accept them in those components. 
- Compute section-specific titles/subtitles in components (brand -> model -> default) and use `vue-i18n` translation keys when available. 
- Add new i18n keys in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` (`*WithBrand`, `*WithModel`, `subtitleWithBrand`, `subtitleWithModel`) for the updated headings and subtitles.

### Testing

- Ran `pnpm lint` which completed with warnings but no errors. 
- Ran `pnpm test` (Vitest) and the test suite completed successfully (all tests passed). 
- `pnpm lint --offline` failed because the ESLint CLI does not accept the `--offline` flag. 
- Ran `pnpm generate --offline` which completed the static build but emitted non-blocking warnings about baseline mapping and a PWA glob pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a31fe696c832b818e6a42246b68b0)