### PR TITLE
feat(frontend): rotate model variations into product section titles/subtitles

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-ai-review">
     <header class="product-ai-review__header">
       <h2 class="product-ai-review__title">
-        {{ $t('product.aiReview.title') }}
+        {{ $t('product.aiReview.title', titleParams) }}
       </h2>
       <p class="product-ai-review__subtitle">
         {{ $t('product.aiReview.subtitle') }}
@@ -391,6 +391,10 @@ const props = defineProps({
   siteKey: {
     type: String,
     default: '',
+  },
+  titleParams: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
   },
 })
 

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-attributes">
     <header class="product-attributes__header">
       <h2 class="product-attributes__title">
-        {{ $t('product.attributes.title') }}
+        {{ $t('product.attributes.title', titleParams) }}
       </h2>
       <p class="product-attributes__subtitle">
         {{ $t('product.attributes.subtitle') }}
@@ -305,6 +305,10 @@ const props = defineProps({
   product: {
     type: Object as PropType<ProductDto | null>,
     default: null,
+  },
+  titleParams: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
   },
 })
 

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -5,7 +5,7 @@
         {{ $t('product.impact.title') }}
       </h2>
       <p class="product-impact__subtitle">
-        {{ $t('product.impact.subtitle') }}
+        {{ $t('product.impact.subtitle', subtitleParams) }}
       </p>
     </header>
 
@@ -104,6 +104,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  subtitleParams: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
+  },
 })
 
 const radarData = toRef(props, 'radarData')
@@ -113,6 +117,7 @@ const productModel = toRef(props, 'productModel')
 const productImage = toRef(props, 'productImage')
 const verticalHomeUrl = toRef(props, 'verticalHomeUrl')
 const verticalTitle = toRef(props, 'verticalTitle')
+const subtitleParams = toRef(props, 'subtitleParams')
 const { t } = useI18n()
 
 const primaryScore = computed(() => props.scores[0] ?? null)

--- a/frontend/app/components/product/ProductPriceSection.vue
+++ b/frontend/app/components/product/ProductPriceSection.vue
@@ -2,7 +2,7 @@
   <section :id="sectionId" class="product-price">
     <header class="product-price__header">
       <h2 id="price-history" class="product-price__title">
-        {{ $t('product.price.title') }}
+        {{ $t('product.price.title', titleParams) }}
       </h2>
       <p class="product-price__subtitle">
         {{ $t('product.price.subtitle') }}
@@ -521,6 +521,10 @@ const props = defineProps({
   commercialEvents: {
     type: Array as PropType<CommercialEvent[]>,
     default: () => [],
+  },
+  titleParams: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
   },
 })
 

--- a/frontend/app/components/product/impact/ProductAlternatives.vue
+++ b/frontend/app/components/product/impact/ProductAlternatives.vue
@@ -5,7 +5,7 @@
         {{ t('product.impact.alternatives.title') }}
       </h3>
       <p class="product-alternatives__subtitle">
-        {{ t('product.impact.alternatives.subtitle') }}
+        {{ t('product.impact.alternatives.subtitle', subtitleParams) }}
       </p>
     </header>
 
@@ -124,6 +124,10 @@ const props = defineProps({
   maxResults: {
     type: Number,
     default: 5,
+  },
+  subtitleParams: {
+    type: Object as PropType<Record<string, string> | undefined>,
+    default: undefined,
   },
 })
 

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2049,10 +2049,10 @@
         "success": "Summary available"
       },
       "subtitle": "An AI-written synthesis built from verified sources.",
-      "title": "Test & review summary"
+      "title": "Test & review summary for the {modelVariation}"
     },
     "attributes": {
-      "title": "Technical specifications",
+      "title": "Technical specifications for the {modelVariation}",
       "subtitle": "Browse every specification and filter with keywords.",
       "searchPlaceholder": "Search a specification",
       "audit": {
@@ -2220,7 +2220,7 @@
     "impact": {
       "alternatives": {
         "title": "Greener alternatives",
-        "subtitle": "Discover similar products with a better impact score or price.",
+        "subtitle": "Discover products similar to the {brand} - {modelVariation} with a better impact score and a more accessible price.",
         "bestProduct": "Voted best product for your criteria!",
         "error": "We couldn't load alternative products. Please try again.",
         "retry": "Retry",
@@ -2299,7 +2299,7 @@
       "scoreRanking": "Factor ranking",
       "scoreValue": "Relative score",
       "valueOutOf": "{value} / {max}",
-      "subtitle": "Explore how this product scores across ecological and social criteria.",
+      "subtitle": "Compare the ecological and social scores of the {brand} - {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicator",
         "attributeValue": "Attribute value",
@@ -2375,7 +2375,7 @@
       },
       "noHistory": "Price history is not yet available for this product.",
       "subtitle": "Track price evolution and compare offers.",
-      "title": "Prices and trends",
+      "title": "Prices and trends for the {brand} - {modelVariation}",
       "trend": {
         "decrease": "Price drop of {amount}",
         "increase": "Price increase of {amount}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2077,10 +2077,10 @@
         "success": "Synthèse disponible"
       },
       "subtitle": "Une synthèse rédigée par notre IA à partir de sources vérifiées.",
-      "title": "Synthèse des tests et avis"
+      "title": "Synthèse des tests et avis sur le {modelVariation}"
     },
     "attributes": {
-      "title": "Caractéristiques techniques",
+      "title": "Caractéristiques techniques de {modelVariation}",
       "subtitle": "Explorez toutes les caractéristiques et filtrez par mots-clés.",
       "searchPlaceholder": "Rechercher une caractéristique",
       "audit": {
@@ -2248,7 +2248,7 @@
     "impact": {
       "alternatives": {
         "title": "Alternatives plus vertes",
-        "subtitle": "Découvrez des produits similaires avec un meilleur score d'impact ou un prix plus accessible.",
+        "subtitle": "Découvrez des produits similaires au {brand} - {modelVariation} avec un meilleur score d'impact et un prix plus accessible.",
         "bestProduct": "Élu meilleur produit par rapport à vos critères !",
         "error": "Impossible de charger les alternatives pour le moment. Réessayez.",
         "retry": "Réessayer",
@@ -2327,7 +2327,7 @@
       "scoreRanking": "Classement du facteur",
       "scoreValue": "Score relatif",
       "valueOutOf": "{value} / {max}",
-      "subtitle": "Comparez les scores environnementaux et sociétaux de ce produit.",
+      "subtitle": "Comparez les scores environnementaux et sociétaux du {brand} - {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicateur",
         "attributeValue": "Valeur brute",
@@ -2403,7 +2403,7 @@
       },
       "noHistory": "Pas assez de données pour afficher l'historique des prix.",
       "subtitle": "Suivez l’évolution des prix et comparez les offres.",
-      "title": "Prix et évolution",
+      "title": "Prix et évolution du {brand} - {modelVariation}",
       "trend": {
         "decrease": "Baisse de {amount}",
         "increase": "Hausse de {amount}",


### PR DESCRIPTION
### Motivation
- Improve section-level SEO and clarity by injecting a short model variation (and brand where appropriate) into section titles and subtitles on the product page.
- Ensure consistent, localized phrasing by passing i18n parameters through the component tree instead of hardcoding variants.
- Avoid duplicate or empty model strings by normalizing and deduplicating known model variations.

### Description
- Added `modelVariations`, `sectionModelVariationCycle` and `buildModelVariationParams` to `ProductPage.vue` to pick and rotate deduplicated model variations per section and expose computed params like `impactSubtitleParams`, `aiTitleParams`, `priceTitleParams`, `alternativesSubtitleParams`, and `attributesTitleParams`.
- Wired the product page to pass these params into section components and updated `ProductImpactSection`, `ProductAiReviewSection`, `ProductPriceSection`, `ProductAlternatives`, and `ProductAttributesSection` to accept optional `titleParams` / `subtitleParams` props and use them in `$t(...)` calls.
- Updated English and French locale files to add `{brand}` / `{modelVariation}` placeholders in the affected titles and subtitles.
- Normalized input sources (including `akaModels` as arrays or sets), deduplicated case-insensitively using the current locale, and sorted variations by length before cycling.

### Testing
- Ran lint with `pnpm lint` and the linter completed successfully.
- Executed unit tests with `pnpm test` and the test suite completed successfully (`vitest` run reported all tests passed).
- Built a production generation with `pnpm generate` which completed successfully but emitted non-blocking warnings about baseline data and a PWA glob pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3bc83574832ba1d2edf67e965127)