### PR TITLE
Align category list impact score badge styling

### DIFF
--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -84,7 +84,9 @@
             :score="impactScoreValue(product) ?? 0"
             :max="5"
             size="large"
-            :show-value="true"
+            mode="badge"
+            badge-variant="corner"
+            badge-layout="stacked"
           />
           <span v-else class="category-product-list__score-fallback">
             {{ $t('category.products.notRated') }}


### PR DESCRIPTION
### Motivation
- The category list view showed a partial gradient behind the impact score that did not match the corner badge treatment used elsewhere. 
- The goal is to make the list-view impact score visually identical to the `ProductTileCard` corner badge for consistent UI. 
- This avoids duplicate styling hacks and keeps the badge behaviour consistent across components. 

### Description
- Updated `frontend/app/components/category/products/CategoryProductListView.vue` to render `ImpactScore` with `mode="badge"`, `badge-variant="corner"`, and `badge-layout="stacked"` instead of `:show-value="true"`.
- The change reuses the existing `ImpactScore.vue` badge styles so the `impact-score-badge--corner` class and stacked layout are applied.
- No changes were made to `ImpactScore.vue` itself; the list view now opts into the badge variant.

### Testing
- Ran `pnpm lint` and the linting step completed successfully.
- Ran `pnpm test` and the test suite started; most tests passed but the run ended with failures in `components/domains/blog/TheArticles.spec.ts` (test suite failure), so the full suite did not complete cleanly.
- Performed a production build via `pnpm generate` which completed successfully to verify the change does not break the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af820a0ac832baa9f245d5e152602)