### PR TITLE
Update product page model variation titles and i18n placeholders

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -652,9 +652,6 @@ const modelVariations = computed(() => {
 
 const sectionModelVariationCycle = computed(() => {
   const variations = modelVariations.value
-  if (!variations.length) {
-    return {}
-  }
 
   const sectionOrder = [
     'impactSubtitle',
@@ -672,6 +669,10 @@ const sectionModelVariationCycle = computed(() => {
     attributesTitle: '',
   }
 
+  if (!variations.length) {
+    return resolved
+  }
+
   let index = 0
   for (const key of sectionOrder) {
     resolved[key] = variations[index] ?? ''
@@ -681,6 +682,17 @@ const sectionModelVariationCycle = computed(() => {
   return resolved
 })
 
+const formatModelVariationLabel = (variation: string) => {
+  const trimmedVariation = variation.trim()
+  const brand = productBrand.value
+
+  if (brand && trimmedVariation) {
+    return `${brand} - ${trimmedVariation}`
+  }
+
+  return trimmedVariation || brand
+}
+
 const buildModelVariationParams = (options: {
   key:
     | 'impactSubtitle'
@@ -688,36 +700,32 @@ const buildModelVariationParams = (options: {
     | 'priceTitle'
     | 'alternativesSubtitle'
     | 'attributesTitle'
-  requireBrand?: boolean
 }) => {
-  const modelVariation = sectionModelVariationCycle.value[options.key]
-  const brand = productBrand.value
+  const variation = sectionModelVariationCycle.value[options.key]
+  const fallbackBrand = productBrand.value
+  const resolvedVariation = variation ? formatModelVariationLabel(variation) : ''
+  const modelVariation = resolvedVariation || fallbackBrand
 
   if (!modelVariation) {
     return undefined
   }
 
-  if (options.requireBrand && !brand) {
-    return undefined
-  }
-
   return {
-    brand,
     modelVariation,
   }
 }
 
 const impactSubtitleParams = computed(() =>
-  buildModelVariationParams({ key: 'impactSubtitle', requireBrand: true })
+  buildModelVariationParams({ key: 'impactSubtitle' })
 )
 const aiTitleParams = computed(() =>
   buildModelVariationParams({ key: 'aiTitle' })
 )
 const priceTitleParams = computed(() =>
-  buildModelVariationParams({ key: 'priceTitle', requireBrand: true })
+  buildModelVariationParams({ key: 'priceTitle' })
 )
 const alternativesSubtitleParams = computed(() =>
-  buildModelVariationParams({ key: 'alternativesSubtitle', requireBrand: true })
+  buildModelVariationParams({ key: 'alternativesSubtitle' })
 )
 const attributesTitleParams = computed(() =>
   buildModelVariationParams({ key: 'attributesTitle' })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2218,7 +2218,7 @@
     "impact": {
       "alternatives": {
         "title": "Greener alternatives",
-        "subtitle": "Discover products similar to the {brand} - {modelVariation} with a better impact score and a more accessible price.",
+        "subtitle": "Discover products similar to the {modelVariation} with a better impact score and a more accessible price.",
         "bestProduct": "Voted best product for your criteria!",
         "error": "We couldn't load alternative products. Please try again.",
         "retry": "Retry",
@@ -2297,7 +2297,7 @@
       "scoreRanking": "Factor ranking",
       "scoreValue": "Relative score",
       "valueOutOf": "{value} / {max}",
-      "subtitle": "Compare the ecological and social scores of the {brand} - {modelVariation}.",
+      "subtitle": "Compare the ecological and social scores of the {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicator",
         "attributeValue": "Attribute value",
@@ -2373,7 +2373,7 @@
       },
       "noHistory": "Price history is not yet available for this product.",
       "subtitle": "Track price evolution and compare offers.",
-      "title": "Prices and trends for the {brand} - {modelVariation}",
+      "title": "Prices and trends for the {modelVariation}",
       "trend": {
         "decrease": "Price drop of {amount}",
         "increase": "Price increase of {amount}",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2236,7 +2236,7 @@
     "impact": {
       "alternatives": {
         "title": "Alternatives plus vertes",
-        "subtitle": "Découvrez des produits similaires au {brand} - {modelVariation} avec un meilleur score d'impact et un prix plus accessible.",
+        "subtitle": "Découvrez des produits similaires au {modelVariation} avec un meilleur score d'impact et un prix plus accessible.",
         "bestProduct": "Élu meilleur produit par rapport à vos critères !",
         "error": "Impossible de charger les alternatives pour le moment. Réessayez.",
         "retry": "Réessayer",
@@ -2315,7 +2315,7 @@
       "scoreRanking": "Classement du facteur",
       "scoreValue": "Score relatif",
       "valueOutOf": "{value} / {max}",
-      "subtitle": "Comparez les scores environnementaux et sociétaux du {brand} - {modelVariation}.",
+      "subtitle": "Comparez les scores environnementaux et sociétaux du {modelVariation}.",
       "tableHeaders": {
         "scoreName": "Indicateur",
         "attributeValue": "Valeur brute",
@@ -2391,7 +2391,7 @@
       },
       "noHistory": "Pas assez de données pour afficher l'historique des prix.",
       "subtitle": "Suivez l’évolution des prix et comparez les offres.",
-      "title": "Prix et évolution du {brand} - {modelVariation}",
+      "title": "Prix et évolution du {modelVariation}",
       "trend": {
         "decrease": "Baisse de {amount}",
         "increase": "Hausse de {amount}",


### PR DESCRIPTION
### Motivation
- Implement Option A: use a single `{modelVariation}` placeholder in translations and pass a formatted "Brand - Model" when both brand and model variation exist.
- Cycle per-section model variation labels on the product page so different sections can show varied labels.
- Simplify the model variation parameter surface by removing the prior `requireBrand` gate and consolidating to a single `modelVariation` value.
- Align English and French SEO-facing strings to rely on the single `{modelVariation}` placeholder.

### Description
- In `ProductPage.vue` add `formatModelVariationLabel` and update `sectionModelVariationCycle` and `buildModelVariationParams` to compute a single `modelVariation` value that falls back to brand when needed.
- Remove the `requireBrand` option and stop returning `brand` separately from the model params; the params now only contain `modelVariation`.
- Update i18n files (`frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`) to replace occurrences of `"{brand} - {modelVariation}"` with `"{modelVariation}"` in titles and subtitles.
- Ensure the section cycle returns a resolved mapping even when no variations exist to avoid undefined values.

### Testing
- Ran `pnpm --offline lint`, which completed successfully.
- Ran `pnpm --offline test`, which executed the unit test suite but failed due to errors in `components/domains/blog/TheArticles.spec.ts` and the run was interrupted after failures.
- Ran `pnpm --offline generate`, which completed successfully (the build finished with a PWA glob warning about a missing `_payload.json` pattern).
- Local dev server and build-related transforms were exercised during generation and completed without build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b3d24ddcc832bb9ef84937810c1c2)