### PR TITLE
Adjust nudge tool card rendering and product page nav alignment

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -43,8 +43,71 @@
             :text="category.tooltip"
           >
             <template #activator="{ props: tooltipProps }">
+              <ClientOnly v-if="isStaticCategory(category)">
+                <component
+                  :is="category.externalLink ? 'a' : 'div'"
+                  class="nudge-step-category__card-link"
+                  :href="category.externalLink"
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                  v-bind="tooltipProps"
+                >
+                  <v-card
+                    class="nudge-step-category__card nudge-option-card"
+                    :class="{
+                      'nudge-option-card--selected':
+                        !isExternalCategory(category) && isSelected,
+                      'nudge-option-card--disabled':
+                        isCategoryDisabled(category),
+                      'nudge-step-category__card--static':
+                        isStaticCategory(category),
+                    }"
+                    variant="flat"
+                    rounded="xl"
+                    :role="category.externalLink ? 'link' : 'button'"
+                    :aria-pressed="
+                      (!isExternalCategory(category) && isSelected).toString()
+                    "
+                    :ripple="!isCategoryDisabled(category)"
+                    :tabindex="isCategoryDisabled(category) ? -1 : 0"
+                    @click="() => handleSelect(category, toggle)"
+                  >
+                    <div class="nudge-step-category__image">
+                      <v-img
+                        :src="category.imageMedium || category.imageSmall"
+                        :alt="category.verticalHomeTitle ?? category.id ?? ''"
+                        aspect-ratio="1"
+                        class="nudge-step-category__img"
+                        cover
+                      >
+                        <template #placeholder>
+                          <div class="nudge-step-category__fallback">
+                            <v-icon
+                              :icon="category.mdiIcon ?? 'mdi-tag'"
+                              size="28"
+                            />
+                          </div>
+                        </template>
+
+                        <template #error>
+                          <div class="nudge-step-category__fallback">
+                            <v-icon
+                              :icon="category.mdiIcon ?? 'mdi-tag'"
+                              size="28"
+                            />
+                          </div>
+                        </template>
+                      </v-img>
+                    </div>
+                    <p class="nudge-step-category__name">
+                      {{ category.verticalHomeTitle ?? category.id }}
+                    </p>
+                  </v-card>
+                </component>
+              </ClientOnly>
               <component
                 :is="category.externalLink ? 'a' : 'div'"
+                v-else
                 class="nudge-step-category__card-link"
                 :href="category.externalLink"
                 target="_blank"
@@ -56,7 +119,8 @@
                   :class="{
                     'nudge-option-card--selected':
                       !isExternalCategory(category) && isSelected,
-                    'nudge-option-card--disabled': isCategoryDisabled(category),
+                    'nudge-option-card--disabled':
+                      isCategoryDisabled(category),
                     'nudge-step-category__card--static':
                       isStaticCategory(category),
                   }"
@@ -104,6 +168,60 @@
               </component>
             </template>
           </v-tooltip>
+          <ClientOnly v-else-if="isStaticCategory(category)">
+            <component
+              :is="category.externalLink ? 'a' : 'div'"
+              class="nudge-step-category__card-link"
+              :href="category.externalLink"
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+            >
+              <v-card
+                class="nudge-step-category__card nudge-option-card"
+                :class="{
+                  'nudge-option-card--selected':
+                    !isExternalCategory(category) && isSelected,
+                  'nudge-option-card--disabled': isCategoryDisabled(category),
+                  'nudge-step-category__card--static':
+                    isStaticCategory(category),
+                }"
+                variant="flat"
+                rounded="xl"
+                :role="category.externalLink ? 'link' : 'button'"
+                :aria-pressed="
+                  (!isExternalCategory(category) && isSelected).toString()
+                "
+                :ripple="!isCategoryDisabled(category)"
+                :tabindex="isCategoryDisabled(category) ? -1 : 0"
+                @click="() => handleSelect(category, toggle)"
+              >
+                <div class="nudge-step-category__image">
+                  <v-img
+                    :src="category.imageMedium || category.imageSmall"
+                    :alt="category.verticalHomeTitle ?? category.id ?? ''"
+                    aspect-ratio="1"
+                    class="nudge-step-category__img"
+                    cover
+                  >
+                    <template #placeholder>
+                      <div class="nudge-step-category__fallback">
+                        <v-icon :icon="category.mdiIcon ?? 'mdi-tag'" size="28" />
+                      </div>
+                    </template>
+
+                    <template #error>
+                      <div class="nudge-step-category__fallback">
+                        <v-icon :icon="category.mdiIcon ?? 'mdi-tag'" size="28" />
+                      </div>
+                    </template>
+                  </v-img>
+                </div>
+                <p class="nudge-step-category__name">
+                  {{ category.verticalHomeTitle ?? category.id }}
+                </p>
+              </v-card>
+            </component>
+          </ClientOnly>
           <component
             :is="category.externalLink ? 'a' : 'div'"
             v-else

--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -1952,13 +1952,17 @@ useHead(() => {
 
 .product-page__nav {
   position: sticky;
-  top: 96px;
-  align-self: start;
+  top: 50%;
+  transform: translateY(-50%);
+  align-self: center;
   height: fit-content;
 }
 
 .product-page__nav--mobile {
   position: static;
+  top: auto;
+  transform: none;
+  align-self: stretch;
 }
 
 .product-page__content {
@@ -1992,6 +1996,8 @@ useHead(() => {
     position: sticky;
     top: 0;
     z-index: 20;
+    transform: none;
+    align-self: stretch;
   }
 
   .product-page__section {

--- a/frontend/app/components/search/SearchSuggestField.vue
+++ b/frontend/app/components/search/SearchSuggestField.vue
@@ -34,7 +34,6 @@
       @focus="handleFocus"
     >
       <template #append-inner>
-        <slot v-if="$slots['append-inner']" name="append-inner" />
         <v-btn
           v-if="shouldShowVoiceButton && isHydrated"
           class="search-suggest-field__voice-button"
@@ -77,6 +76,7 @@
         >
           <v-icon icon="mdi-barcode-scan" size="20" aria-hidden="true" />
         </v-btn>
+        <slot v-if="$slots['append-inner']" name="append-inner" />
       </template>
       <template #item="{ item, props: itemProps, index }">
         <div class="search-suggest-field__entry" :data-section="item.raw.type">


### PR DESCRIPTION
### Motivation
- Avoid rendering static nudge category cards during SSR to prevent hydration issues by ensuring they are mounted client-side only.
- Ensure the search field append area shows voice and scanner controls in the intended order relative to custom `append-inner` content.
- Improve desktop layout by vertically centering the sticky product page navigation for better visual alignment.

### Description
- Wrap static category card rendering in `NudgeToolStepCategory.vue` with `ClientOnly` in both tooltip activator and non-tooltip branches so static cards only render on the client.
- Move the `append-inner` slot in `SearchSuggestField.vue` after the voice and scanner buttons so custom appended content appears to the right of those controls.
- Update `ProductPage.vue` scoped styles to vertically center the `.product-page__nav` on desktop (`top: 50%` + `transform: translateY(-50%)`) and adjust mobile fallbacks (`transform: none`, `align-self: stretch`).

### Testing
- Ran `pnpm lint` in `frontend`, which completed successfully.
- Ran `pnpm test` in `frontend`; the test run executed many suites but the run failed due to failing tests in `components/domains/blog/TheArticles.spec.ts` (some tests passed, some failed).
- Ran `pnpm generate` in `frontend`, which completed successfully and produced the static `.output/public` build artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b4151005c832bb5dcfaf4e2e3ba9b)