### PR TITLE
Hide AI review section when product has no category

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -76,7 +76,11 @@
           {{ $t('product.uncategorized.noScore') }}
         </v-alert>
 
-        <section :id="sectionIds.ai" class="product-page__section">
+        <section
+          v-if="showAiReviewSection"
+          :id="sectionIds.ai"
+          class="product-page__section"
+        >
           <ProductAiReviewSection
             :gtin="product.gtin ?? gtin"
             :initial-review="product.aiReview?.review ?? null"
@@ -1495,6 +1499,7 @@ const showAttributesSection = computed(() => {
 const showAlternativesSection = computed(() =>
   Boolean(product.value && (categoryDetail.value?.id?.length ?? 0) > 0)
 )
+const showAiReviewSection = computed(() => Boolean(categoryDetail.value))
 
 const sectionIds = {
   hero: 'hero',
@@ -1528,7 +1533,7 @@ const primarySectionDefinitions = computed<ConditionalSection[]>(() => [
     id: sectionIds.ai,
     label: t('product.navigation.ai'),
     icon: 'mdi-robot-outline',
-    condition: true,
+    condition: showAiReviewSection.value,
   },
   {
     id: sectionIds.price,


### PR DESCRIPTION
### Motivation

- Prevent displaying the AI review UI for products that are not categorised to avoid confusing or empty content. 
- Keep the product navigation coherent by hiding the AI link when the section is not available. 
- Gate client-side features behind domain state (category availability) rather than show empty placeholders.

### Description

- Add a new computed `showAiReviewSection` which returns `Boolean(categoryDetail.value)` in `ProductPage.vue`.
- Wrap the `ProductAiReviewSection` `section` with `v-if="showAiReviewSection"` so the block is not rendered for uncategorised products. 
- Make the primary navigation entry for the AI section conditional by changing its `condition` to `showAiReviewSection.value`.
- Modified file: `frontend/app/components/pages/ProductPage.vue`.

### Testing

- Ran `pnpm lint` and the lint step completed successfully. 
- Ran the unit test suite with `pnpm test` and all tests passed. 
- Built and prerendered the frontend with `pnpm generate` and the production build and prerender steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af6da5ab0832bbe5f4aa7a4975f28)