### PR TITLE
Adjust product page sticky nav offset

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -1965,9 +1965,8 @@ useHead(() => {
 
 .product-page__nav {
   position: sticky;
-  top: 50%;
+  top: 50vh;
   transform: translateY(-50%);
-  align-self: center;
   height: fit-content;
 }
 


### PR DESCRIPTION
### Motivation
- Fix unwanted centering of the sticky navigation inside the grid column so it no longer appears vertically centered relative to the content column.
- Make the sticky offset viewport-based so vertical centering is consistent with the visible viewport instead of the content column.
- Preserve the visual vertical centering behavior using `transform: translateY(-50%)`.
- Keep mobile/horizontal layout behaviour unchanged by leaving the `@media (max-width: 1280px)` override in place.

### Description
- Updated `frontend/app/components/pages/ProductPage.vue` CSS for the sticky nav (`.product-page__nav`).
- Replaced `top: 50%` with `top: 50vh` and removed `align-self: center` in the `.product-page__nav` rule while keeping `transform: translateY(-50%)`.
- Confirmed the existing mobile override (`@media (max-width: 1280px)`) still sets `top: 0`, `transform: none`, and `align-self: stretch` for the horizontal layout.
- Committed the change to the repository.

### Testing
- Attempted a Playwright screenshot of the running frontend, but the script failed with `net::ERR_EMPTY_RESPONSE` because the dev server at `http://127.0.0.1:3000` was not running.
- No unit, lint, or integration tests were executed as part of this change.
- Manual visual verification is recommended by running the frontend dev server and confirming behavior at desktop and mobile breakpoints.
- No automated tests failed or passed because none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b8437949c832b8052a8ba94b2ffef)