### PR TITLE
Render agent prompt template variables and post rendered prompts as GitHub comments

### DIFF
--- a/services/github-feedback/src/main/java/org/open4goods/services/feedback/service/GitHubIssueService.java
+++ b/services/github-feedback/src/main/java/org/open4goods/services/feedback/service/GitHubIssueService.java
@@ -135,6 +135,12 @@ public class GitHubIssueService implements IssueService {
                 issue.getCommentsCount()
         );
     }
+
+    @Override
+    public GHIssueComment createIssueComment(int issueNumber, String commentBody) throws IOException {
+        return repository.getIssue(issueNumber).comment(commentBody);
+    }
+
     @Override
     public List<GHIssueComment> listIssueComments(int issueNumber) throws IOException {
         return repository.getIssue(issueNumber).getComments();

--- a/services/github-feedback/src/main/java/org/open4goods/services/feedback/service/IssueService.java
+++ b/services/github-feedback/src/main/java/org/open4goods/services/feedback/service/IssueService.java
@@ -49,6 +49,15 @@ public interface IssueService {
     IssueDto createIssue(String title, String description, String author, Set<String> labels) throws IOException;
 
     /**
+     * Add a comment to an existing GitHub issue.
+     * @param issueNumber GitHub issue number
+     * @param commentBody Body of the comment
+     * @return the created comment
+     * @throws IOException if GitHub communication fails
+     */
+    GHIssueComment createIssueComment(int issueNumber, String commentBody) throws IOException;
+
+    /**
      * Retrieve all comments for a given issue number ordered by GitHub.
      * @param issueNumber GitHub issue number
      * @return list of comments


### PR DESCRIPTION
### Motivation
- Support prompt templates containing `{{...}}` placeholders so users can fill variables (including the `{{prompt}}` field) before submission.
- Allow template variables to provide default values and require empty variables when no default is present.
- Ensure only the final rendered prompt (with variables substituted) is posted and stored publicly where configured.
- Post the rendered prompt as a GitHub comment on the created agent issue instead of embedding large user prompts directly in the issue body.

### Description
- Frontend: Updated `AgentPromptShell.vue` to parse `{{...}}` variables from a selected template, render a `v-text-field` per variable, populate defaults, compute `renderedPrompt`, validate on the rendered value, and submit `renderedPrompt` instead of the raw textarea content.
- Frontend tests: Added/updated `AgentPromptShell.spec.ts` to cover variable rendering and default-value substitution, and added a `VTextField` stub used by the new inputs.
- Backend: Extended `IssueService` with `createIssueComment(...)` and implemented it in `GitHubIssueService`, and updated `AgentService` to create the issue and then call `createIssueComment(...)` to post the rendered prompt; the issue description was simplified to reference the prompt posted in comments.
- Minor: Added JavaDoc comments and small refactors to `AgentService` mapping and title/description builders to reflect the new behavior.

### Testing
- Ran `pnpm lint` in the frontend and it completed successfully.
- Ran frontend unit tests (`pnpm test` / Vitest); the test suite ran and the majority passed, but automated runs reported failing tests (two failing tests surfaced during the run).
- Attempted targeted Vitest run for `AgentPromptShell` and full `pnpm test` iterations, which revealed a blocking i18n JSON parse error during some runs and caused some test runs to fail.
- `pnpm generate` (Nuxt build) failed due to an invalid JSON file (`frontend/i18n/locales/en-US.json`) containing conflict markers, preventing a successful generate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb5cae60c832baa29c00471f1faad)