### PR TITLE
Add CSRF and same-origin protections for frontend API routes

### DIFF
--- a/frontend/app/plugins/csrf-fetch.client.ts
+++ b/frontend/app/plugins/csrf-fetch.client.ts
@@ -1,0 +1,52 @@
+import { $fetch } from 'ofetch'
+
+import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME, isSafeMethod } from '~~/shared/utils/csrf'
+
+const API_PREFIX = '/api'
+
+const isApiRequest = (request: RequestInfo | URL) => {
+  if (typeof request === 'string') {
+    return request.startsWith(API_PREFIX)
+  }
+
+  if (request instanceof URL) {
+    return request.pathname.startsWith(API_PREFIX)
+  }
+
+  if (request instanceof Request) {
+    try {
+      return new URL(request.url).pathname.startsWith(API_PREFIX)
+    } catch {
+      return false
+    }
+  }
+
+  return false
+}
+
+export default defineNuxtPlugin(nuxtApp => {
+  const csrfCookie = useCookie(CSRF_COOKIE_NAME)
+
+  const csrfFetch = $fetch.create({
+    onRequest({ request, options }) {
+      const method = (options.method ?? 'GET').toString().toUpperCase()
+
+      if (isSafeMethod(method) || !isApiRequest(request)) {
+        return
+      }
+
+      if (!csrfCookie.value) {
+        return
+      }
+
+      const headers = new Headers(options.headers || {})
+      if (!headers.has(CSRF_HEADER_NAME)) {
+        headers.set(CSRF_HEADER_NAME, csrfCookie.value)
+        options.headers = headers
+      }
+    },
+  })
+
+  globalThis.$fetch = csrfFetch
+  nuxtApp.$fetch = csrfFetch
+})

--- a/frontend/server/middleware/csrf.ts
+++ b/frontend/server/middleware/csrf.ts
@@ -1,0 +1,26 @@
+import { defineEventHandler, getRequestURL } from 'h3'
+
+import {
+  assertCsrfToken,
+  assertSameOrigin,
+  ensureCsrfCookie,
+  shouldValidateCsrf,
+} from '~~/server/utils/csrf'
+
+const API_PREFIX = '/api'
+
+export default defineEventHandler(event => {
+  ensureCsrfCookie(event)
+
+  const { pathname } = getRequestURL(event)
+  if (!pathname.startsWith(API_PREFIX)) {
+    return
+  }
+
+  if (!shouldValidateCsrf(event)) {
+    return
+  }
+
+  assertSameOrigin(event)
+  assertCsrfToken(event)
+})

--- a/frontend/server/utils/csrf.spec.ts
+++ b/frontend/server/utils/csrf.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  assertCsrfToken,
+  assertSameOrigin,
+  ensureCsrfCookie,
+} from './csrf'
+import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from '~~/shared/utils/csrf'
+
+const getCookieMock = vi.hoisted(() => vi.fn())
+const setCookieMock = vi.hoisted(() => vi.fn())
+const getRequestHeaderMock = vi.hoisted(() => vi.fn())
+const createErrorMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:crypto', () => ({
+  randomUUID: () => 'csrf-token-123',
+}))
+
+vi.mock('h3', async importOriginal => ({
+  ...(await importOriginal<typeof import('h3')>()),
+  createError: createErrorMock,
+  getCookie: getCookieMock,
+  getRequestHeader: getRequestHeaderMock,
+  setCookie: setCookieMock,
+}))
+
+describe('csrf utilities', () => {
+  const event = {} as Parameters<typeof ensureCsrfCookie>[0]
+  const originalEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    getCookieMock.mockReset()
+    setCookieMock.mockReset()
+    getRequestHeaderMock.mockReset()
+    createErrorMock.mockReset()
+    process.env.NODE_ENV = 'test'
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('reuses an existing CSRF cookie', () => {
+    getCookieMock.mockReturnValue('existing-token')
+
+    const token = ensureCsrfCookie(event)
+
+    expect(token).toBe('existing-token')
+    expect(setCookieMock).not.toHaveBeenCalled()
+  })
+
+  it('sets a CSRF cookie when missing', () => {
+    getCookieMock.mockReturnValue(undefined)
+
+    const token = ensureCsrfCookie(event)
+
+    expect(token).toBe('csrf-token-123')
+    expect(setCookieMock).toHaveBeenCalledWith(event, CSRF_COOKIE_NAME, token, {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: false,
+      path: '/',
+      maxAge: 60 * 60 * 24,
+    })
+  })
+
+  it('allows same-origin requests', () => {
+    getRequestHeaderMock.mockImplementation((_, name: string) => {
+      if (name === 'origin') {
+        return 'https://nudger.fr'
+      }
+      if (name === 'host') {
+        return 'nudger.fr'
+      }
+      return undefined
+    })
+
+    expect(() => assertSameOrigin(event)).not.toThrow()
+  })
+
+  it('rejects cross-site requests', () => {
+    const error = new Error('Cross-site request blocked')
+    createErrorMock.mockReturnValue(error)
+    getRequestHeaderMock.mockImplementation((_, name: string) => {
+      if (name === 'origin') {
+        return 'https://evil.example'
+      }
+      if (name === 'host') {
+        return 'nudger.fr'
+      }
+      return undefined
+    })
+
+    expect(() => assertSameOrigin(event)).toThrow(error)
+  })
+
+  it('accepts matching CSRF header and cookie', () => {
+    getCookieMock.mockReturnValue('token-123')
+    getRequestHeaderMock.mockImplementation((_, name: string) => {
+      if (name === CSRF_HEADER_NAME) {
+        return 'token-123'
+      }
+      return undefined
+    })
+
+    expect(() => assertCsrfToken(event)).not.toThrow()
+  })
+
+  it('rejects missing CSRF header', () => {
+    const error = new Error('Invalid CSRF token')
+    createErrorMock.mockReturnValue(error)
+    getCookieMock.mockReturnValue('token-123')
+    getRequestHeaderMock.mockReturnValue(undefined)
+
+    expect(() => assertCsrfToken(event)).toThrow(error)
+  })
+})

--- a/frontend/server/utils/csrf.ts
+++ b/frontend/server/utils/csrf.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto'
+
+import type { H3Event } from 'h3'
+import {
+  createError,
+  getCookie,
+  getRequestHeader,
+  getRequestMethod,
+  setCookie,
+} from 'h3'
+
+import {
+  CSRF_COOKIE_NAME,
+  CSRF_HEADER_NAME,
+  isSafeMethod,
+} from '~~/shared/utils/csrf'
+
+const CSRF_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24
+
+const isProduction = () => process.env.NODE_ENV === 'production'
+
+const getRequestHost = (event: H3Event) =>
+  getRequestHeader(event, 'x-forwarded-host') ||
+  getRequestHeader(event, 'host')
+
+const normaliseHost = (host?: string | null) => host?.toLowerCase()
+
+const resolveOriginHost = (origin?: string | null) => {
+  if (!origin) {
+    return undefined
+  }
+
+  if (origin === 'null') {
+    return 'null'
+  }
+
+  try {
+    return new URL(origin).host.toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+const resolveRefererHost = (referer?: string | null) => {
+  if (!referer) {
+    return undefined
+  }
+
+  try {
+    return new URL(referer).host.toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+export const ensureCsrfCookie = (event: H3Event) => {
+  const existingToken = getCookie(event, CSRF_COOKIE_NAME)
+
+  if (existingToken) {
+    return existingToken
+  }
+
+  const token = randomUUID()
+  setCookie(event, CSRF_COOKIE_NAME, token, {
+    httpOnly: false,
+    sameSite: 'lax',
+    secure: isProduction(),
+    path: '/',
+    maxAge: CSRF_COOKIE_MAX_AGE_SECONDS,
+  })
+
+  return token
+}
+
+export const assertSameOrigin = (event: H3Event) => {
+  const host = normaliseHost(getRequestHost(event))
+  const originHost = resolveOriginHost(getRequestHeader(event, 'origin'))
+  const refererHost = resolveRefererHost(getRequestHeader(event, 'referer'))
+
+  if (!host) {
+    return
+  }
+
+  const matchesHost = (value?: string) => value === host
+
+  if (originHost && !matchesHost(originHost)) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Cross-site request blocked',
+    })
+  }
+
+  if (!originHost && refererHost && !matchesHost(refererHost)) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Cross-site request blocked',
+    })
+  }
+
+  if (originHost === 'null') {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Cross-site request blocked',
+    })
+  }
+}
+
+export const assertCsrfToken = (event: H3Event) => {
+  const csrfToken = getCookie(event, CSRF_COOKIE_NAME)
+  const headerToken = getRequestHeader(event, CSRF_HEADER_NAME)
+
+  if (!csrfToken || !headerToken || csrfToken !== headerToken) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: 'Invalid CSRF token',
+    })
+  }
+}
+
+export const shouldValidateCsrf = (event: H3Event) => {
+  return !isSafeMethod(getRequestMethod(event))
+}

--- a/frontend/shared/utils/csrf.ts
+++ b/frontend/shared/utils/csrf.ts
@@ -1,0 +1,7 @@
+export const CSRF_COOKIE_NAME = 'csrf_token'
+export const CSRF_HEADER_NAME = 'x-csrf-token'
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+export const isSafeMethod = (method: string) =>
+  SAFE_METHODS.has(method.toUpperCase())


### PR DESCRIPTION
### Motivation
- Prevent cross-site requests to the frontend API by issuing a SameSite CSRF cookie and requiring a matching CSRF header on unsafe requests.
- Block requests coming from a different origin by validating `Origin` and `Referer` against the request host.

### Description
- Added `frontend/shared/utils/csrf.ts` with `CSRF_COOKIE_NAME`, `CSRF_HEADER_NAME`, and `isSafeMethod` constants/helpers.
- Implemented server-side utilities in `frontend/server/utils/csrf.ts` (`ensureCsrfCookie`, `assertSameOrigin`, `assertCsrfToken`, `shouldValidateCsrf`) and updated `shouldValidateCsrf` to use `getRequestMethod`.
- Added Nitro middleware `frontend/server/middleware/csrf.ts` to set the CSRF cookie and enforce same-origin and token checks for requests under `/api`.
- Added a client plugin `frontend/app/plugins/csrf-fetch.client.ts` to automatically attach the CSRF header for unsafe `/api` calls and included unit tests in `frontend/server/utils/csrf.spec.ts`.

### Testing
- Ran `pnpm lint`, which completed successfully.
- Ran `pnpm test`, which stalled with all tests queued and was aborted, so the full test suite did not finish.
- Ran `pnpm generate`, which failed during build due to an existing invalid JSON (merge conflict markers) in `i18n/locales/en-US.json`, unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bb72f86c8832bac9112ebab84543e)