### PR TITLE
Add singular and singularDesignation generation and mapping for vertical i18n

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
@@ -186,6 +186,32 @@ public class NamesAggregationService extends AbstractAggregationService {
 						}
 					}
 
+					// ---- Singular ----
+					final boolean singularMissing =
+							data.getNames() == null
+							|| data.getNames().getSingular() == null
+							|| data.getNames().getSingular().get(lang) == null;
+
+					if ((vConf != null && vConf.isForceNameGeneration()) || singularMissing) {
+						if (data.getNames() != null && data.getNames().getSingular() != null) {
+							data.getNames().getSingular().put(lang,
+									computePrettyName(data, tConf.getSingular(), vConf, lang, " "));
+						}
+					}
+
+					// ---- Singular Designation ----
+					final boolean singularDesignationMissing =
+							data.getNames() == null
+							|| data.getNames().getSingularDesignation() == null
+							|| data.getNames().getSingularDesignation().get(lang) == null;
+
+					if ((vConf != null && vConf.isForceNameGeneration()) || singularDesignationMissing) {
+						if (data.getNames() != null && data.getNames().getSingularDesignation() != null) {
+							data.getNames().getSingularDesignation().put(lang,
+									computePrettyName(data, tConf.getSingularDesignation(), vConf, lang, " "));
+						}
+					}
+
 					// SEO meta generation intentionally left commented-out (as in original),
 					// because of previous disk-space / stack-trace issues and template evaluation failures.
 					// Keeping behavior unchanged.

--- a/api/src/main/resources/templates/vertical-definition.yml
+++ b/api/src/main/resources/templates/vertical-definition.yml
@@ -47,6 +47,18 @@ i18n:
           - BRAND
           - MODEL
           - YEAR
+      # Singular product name (same structure as prettyName)
+      singular:
+        prefix: "[(${singularPrefix})]"
+        attrs:
+          - BRAND
+          - MODEL
+      # Singular designation (grammatical designation of the product)
+      singularDesignation:
+        prefix: "[(${singularDesignationPrefix})]"
+        attrs:
+          - BRAND
+          - MODEL
         
       ##################################
       # Vertical page elements 
@@ -131,7 +143,6 @@ attributesConfig:
   ##################################################################################################################      
   configs: [] 
   
-
 
 
 

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationServiceTest.java
@@ -117,6 +117,22 @@ class NamesAggregationServiceTest {
 				.isEqualTo("TV 55 \"");
 	}
 
+	@Test
+	void onProduct_shouldComputeSingularAndDesignation() throws AggregationSkipException, InvalidParameterException {
+		VerticalConfig config = buildVerticalConfig();
+		when(verticalsConfigService.getConfigByIdOrDefault(any())).thenReturn(config);
+		when(blablaService.generateBlabla(anyString(), any()))
+				.thenAnswer(invocation -> invocation.getArgument(0, String.class));
+
+		Product product = new Product(11L);
+		product.setVertical("tv");
+
+		service.onProduct(product, config);
+
+		assertThat(product.getNames().getSingular().get("fr")).isEqualTo("Singular");
+		assertThat(product.getNames().getSingularDesignation().get("fr")).isEqualTo("Designation");
+	}
+
 	private VerticalConfig buildVerticalConfig() {
 		VerticalConfig config = new VerticalConfig();
 		ProductI18nElements productI18nElements = new ProductI18nElements();
@@ -127,6 +143,12 @@ class NamesAggregationServiceTest {
 		pretty.setPrefix("Cuisine");
 		pretty.setAttrs(java.util.List.of("DIAGONALE_POUCES"));
 		productI18nElements.setPrettyName(pretty);
+		PrefixedAttrText singular = new PrefixedAttrText();
+		singular.setPrefix("Singular");
+		productI18nElements.setSingular(singular);
+		PrefixedAttrText singularDesignation = new PrefixedAttrText();
+		singularDesignation.setPrefix("Designation");
+		productI18nElements.setSingularDesignation(singularDesignation);
 
 		HashMap<String, ProductI18nElements> i18n = new HashMap<>();
 		i18n.put("fr", productI18nElements);

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -12,6 +12,10 @@ public record ProductNamesDto(
         String h1Title,
         @Schema(description = "Pretty name for the requested language", example = "Télévision Samsung 55 \"")
         String prettyName,
+        @Schema(description = "Singular product name for the requested language", example = "Téléviseur")
+        String singular,
+        @Schema(description = "Singular designation for the requested language", example = "du téléviseur")
+        String singularDesignation,
         @Schema(description = "Meta description aligned with the requested language")
         String metaDescription,
         @Schema(description = "OpenGraph title for social sharing")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -540,6 +540,8 @@ public class ProductMappingService {
         return new ProductNamesDto(
                 resolveLocalisedString(product.getNames().getH1Title(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getPrettyName(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getSingular(), domainLanguage, locale),
+                resolveLocalisedString(product.getNames().getSingularDesignation(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getMetaDescription(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphTitle(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphDescription(), domainLanguage, locale),

--- a/frontend/shared/api-client/models/ProductNamesDto.ts
+++ b/frontend/shared/api-client/models/ProductNamesDto.ts
@@ -32,6 +32,18 @@ export interface ProductNamesDto {
      */
     prettyName?: string;
     /**
+     * Singular product name for the requested language
+     * @type {string}
+     * @memberof ProductNamesDto
+     */
+    singular?: string;
+    /**
+     * Singular designation for the requested language
+     * @type {string}
+     * @memberof ProductNamesDto
+     */
+    singularDesignation?: string;
+    /**
      * Meta description aligned with the requested language
      * @type {string}
      * @memberof ProductNamesDto
@@ -88,6 +100,8 @@ export function ProductNamesDtoFromJSONTyped(json: any, ignoreDiscriminator: boo
         
         'h1Title': json['h1Title'] == null ? undefined : json['h1Title'],
         'prettyName': json['prettyName'] == null ? undefined : json['prettyName'],
+        'singular': json['singular'] == null ? undefined : json['singular'],
+        'singularDesignation': json['singularDesignation'] == null ? undefined : json['singularDesignation'],
         'metaDescription': json['metaDescription'] == null ? undefined : json['metaDescription'],
         'ogTitle': json['ogTitle'] == null ? undefined : json['ogTitle'],
         'ogDescription': json['ogDescription'] == null ? undefined : json['ogDescription'],
@@ -110,6 +124,8 @@ export function ProductNamesDtoToJSONTyped(value?: ProductNamesDto | null, ignor
         
         'h1Title': value['h1Title'],
         'prettyName': value['prettyName'],
+        'singular': value['singular'],
+        'singularDesignation': value['singularDesignation'],
         'metaDescription': value['metaDescription'],
         'ogTitle': value['ogTitle'],
         'ogDescription': value['ogDescription'],
@@ -118,4 +134,3 @@ export function ProductNamesDtoToJSONTyped(value?: ProductNamesDto | null, ignor
         'shortestOfferName': value['shortestOfferName'],
     };
 }
-

--- a/model/src/main/java/org/open4goods/model/product/ProductTexts.java
+++ b/model/src/main/java/org/open4goods/model/product/ProductTexts.java
@@ -9,6 +9,10 @@ public class ProductTexts {
 	private Localisable<String,String> h1Title = new Localisable<>();
 
 	private Localisable<String,String> prettyName = new Localisable<>();
+
+	private Localisable<String,String> singular = new Localisable<>();
+
+	private Localisable<String,String> singularDesignation = new Localisable<>();
 	
 	private Localisable<String,String> metaDescription = new Localisable<>();
 	
@@ -43,6 +47,22 @@ public class ProductTexts {
 
 	public void setPrettyName(Localisable<String, String> prettyName) {
 		this.prettyName = prettyName;
+	}
+
+	public Localisable<String, String> getSingular() {
+		return singular;
+	}
+
+	public void setSingular(Localisable<String, String> singular) {
+		this.singular = singular;
+	}
+
+	public Localisable<String, String> getSingularDesignation() {
+		return singularDesignation;
+	}
+
+	public void setSingularDesignation(Localisable<String, String> singularDesignation) {
+		this.singularDesignation = singularDesignation;
 	}
 
 	public Localisable<String, String> getMetaDescription() {

--- a/model/src/main/java/org/open4goods/model/vertical/ProductI18nElements.java
+++ b/model/src/main/java/org/open4goods/model/vertical/ProductI18nElements.java
@@ -12,6 +12,10 @@ public class ProductI18nElements {
 	private PrefixedAttrText h1Title = new PrefixedAttrText();
 	@JsonMerge
 	private PrefixedAttrText prettyName = new PrefixedAttrText();
+	@JsonMerge
+	private PrefixedAttrText singular = new PrefixedAttrText();
+	@JsonMerge
+	private PrefixedAttrText singularDesignation = new PrefixedAttrText();
 
 
 
@@ -92,6 +96,27 @@ public class ProductI18nElements {
 		this.prettyName = prettyName;
 	}
 
+	/**
+	 * Return the singular form configured for product naming.
+	 */
+	public PrefixedAttrText getSingular() {
+		return singular;
+	}
+
+	public void setSingular(PrefixedAttrText singular) {
+		this.singular = singular;
+	}
+
+	/**
+	 * Return the singular designation configured for product naming.
+	 */
+	public PrefixedAttrText getSingularDesignation() {
+		return singularDesignation;
+	}
+
+	public void setSingularDesignation(PrefixedAttrText singularDesignation) {
+		this.singularDesignation = singularDesignation;
+	}
 
 	public String getVerticalHomeUrl() {
 		return verticalHomeUrl;

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -134,6 +134,14 @@ i18n:
         - BRAND
         - MODEL
 
+    singular:
+      prefix: ""
+      attrs: []
+
+    singularDesignation:
+      prefix: ""
+      attrs: []
+
     productMetaTitle: "[(${p.brand()})] [(${p.model()})] : Eco-score, compensation écologique et meilleurs prix"
     productMetaDescription: "[(${p.brand()})] [(${p.model()})] : Eco-score, compensation || écologique | environnementale || et meilleurs prix."
     productMetaOpenGraphTitle: "[(${p.brand()})] - [(${p.model()})] : Ecoscore de [(${p.ecoscore()})]. Venez nudger ce téléviseur au meilleur prix, et reversez gratuitement [(${p.compensation()})]"

--- a/verticals/src/main/resources/verticals/tv.yml
+++ b/verticals/src/main/resources/verticals/tv.yml
@@ -152,6 +152,12 @@ i18n:
         - BRAND
         - DIAGONALE_POUCES
         - DISPLAY_TECHNOLOGY
+    singular:
+      prefix: "|| tv | télévision | téléviseur ||"
+      attrs: []
+    singularDesignation:
+      prefix: "|| du téléviseur | de cette télévision | de la télévision ||"
+      attrs: []
     # TODO : Generate short title (for cards restitution, with popular attributes)
 
     ##################################
@@ -203,6 +209,12 @@ i18n:
         - BRAND
         - DIAGONALE_POUCES
         - DISPLAY_TECHNOLOGY
+    singular:
+      prefix: "|| tv | television ||"
+      attrs: []
+    singularDesignation:
+      prefix: "|| of the television | of this television ||"
+      attrs: []
 
     ##################################
     # Vertical page elements


### PR DESCRIPTION
### Motivation
- Introduce explicit support for a product "singular" name and its grammatical "singularDesignation" so vertical configurations can provide short/grammatical forms for product naming.
- Ensure generated singular forms are produced during realtime name aggregation and exposed through API and frontend DTOs for consistent UI rendering.

### Description
- Extend model objects by adding `singular` and `singularDesignation` to `ProductI18nElements` and `ProductTexts` to store configured and generated values.
- Update `NamesAggregationService` to generate `singular` and `singularDesignation` values using the existing name templating logic (`computePrettyName`), guarded by missing checks and `forceNameGeneration` behavior.
- Expose new fields by adding them to the API DTO `ProductNamesDto`, mapping in `ProductMappingService`, and updating the frontend client model `ProductNamesDto.ts`.
- Add template/default config entries in `api/src/main/resources/templates/vertical-definition.yml` and verticals `_default.yml`/`tv.yml`, and add a unit test in `NamesAggregationServiceTest` to cover generation.

### Testing
- Ran full test suite with `mvn test` which completed successfully (`BUILD SUCCESS`).
- Verified the new unit `NamesAggregationServiceTest#onProduct_shouldComputeSingularAndDesignation` passes as part of the test run.
- Existing aggregation and mapping tests (including `NamesAggregationServiceTest`) were executed and passed.
- No automated tests failed during the CI local run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf50c8658832b916acb3afa7dd58d)