### PR TITLE
Refactor ProductTileCard: use pretty display name, move attributes, replace compare button, and constrain images

### DIFF
--- a/frontend/app/components/category/products/ProductTileCard.spec.ts
+++ b/frontend/app/components/category/products/ProductTileCard.spec.ts
@@ -16,8 +16,12 @@ const i18n = createI18n({
       category: {
         products: {
           compare: {
-            added: 'Added',
-            buttonLabel: 'Compare',
+            addToList: 'Add to compare',
+            removeFromList: 'Remove from compare',
+            removeSingle: 'Remove {name}',
+            limitReached: 'Limit reached',
+            differentCategory: 'Different category',
+            missingIdentifier: 'Missing identifier',
           },
         },
       },
@@ -71,7 +75,9 @@ const createWrapper = (overrides: Partial<ProductDto> = {}) => {
         VSkeletonLoader: true,
         VChip: true,
         VIcon: true,
-        VBtn: true,
+        VTooltip: {
+          template: '<div><slot name="activator" :props="{}" /></div>',
+        },
         ImpactScore: true,
       },
     },
@@ -85,10 +91,10 @@ describe('ProductTileCard', () => {
   })
 
   it('builds the header title from the best available name', () => {
-    const wrapper = createWrapper()
+    const wrapper = createWrapper({ names: { prettyName: 'Pretty Z' } })
 
     expect(wrapper.find('.product-tile-card__title').text()).toBe(
-      'Acme Model Z'
+      'Pretty Z'
     )
     expect(wrapper.find('.product-tile-card__subtitle').text()).toBe('Model Z')
   })
@@ -106,7 +112,7 @@ describe('ProductTileCard', () => {
 
     expect(store.hasProduct(wrapper.props('product'))).toBe(false)
 
-    await wrapper.find('[data-test="product-tile-compare"]').trigger('click')
+    await wrapper.find('[data-test="category-product-compare"]').trigger('click')
 
     expect(store.hasProduct(wrapper.props('product'))).toBe(true)
   })

--- a/frontend/app/components/category/products/ProductTileCard.vue
+++ b/frontend/app/components/category/products/ProductTileCard.vue
@@ -16,7 +16,7 @@
         <div class="product-tile-card__media">
           <v-img
             :src="imageSrc"
-            :alt="headerTitle"
+            :alt="displayTitle"
             aspect-ratio="4 / 3"
             class="product-tile-card__image"
             cover
@@ -46,33 +46,33 @@
           <div class="product-tile-card__header">
             <div class="product-tile-card__header-top">
               <h3 class="product-tile-card__title text-truncate">
-                {{ headerTitle }}
+                {{ displayTitle }}
               </h3>
-              <div
-                v-if="hasAttributes"
-                class="product-tile-card__attributes"
-                role="list"
+            </div>
+            <div
+              v-if="hasAttributes"
+              class="product-tile-card__attributes"
+              role="list"
+            >
+              <v-chip
+                v-for="attribute in attributes"
+                :key="attribute.key"
+                class="product-tile-card__attribute"
+                variant="tonal"
+                size="small"
+                color="surface-primary-080"
+                role="listitem"
               >
-                <v-chip
-                  v-for="attribute in attributes"
-                  :key="attribute.key"
-                  class="product-tile-card__attribute"
-                  variant="tonal"
-                  size="small"
-                  color="surface-primary-080"
-                  role="listitem"
-                >
-                  <v-icon
-                    v-if="attribute.icon"
-                    :icon="attribute.icon"
-                    size="16"
-                    class="me-1"
-                  />
-                  <span class="product-tile-card__attribute-value">{{
-                    attribute.value
-                  }}</span>
-                </v-chip>
-              </div>
+                <v-icon
+                  v-if="attribute.icon"
+                  :icon="attribute.icon"
+                  size="16"
+                  class="me-1"
+                />
+                <span class="product-tile-card__attribute-value">{{
+                  attribute.value
+                }}</span>
+              </v-chip>
             </div>
             <p class="product-tile-card__subtitle text-truncate">
               {{ subtitle }}
@@ -83,9 +83,9 @@
             <v-img
               v-if="imageSrc"
               :src="imageSrc"
-              :alt="headerTitle"
-              width="150"
-              height="150"
+              :alt="displayTitle"
+              width="120"
+              height="120"
               class="product-tile-card__thumbnail"
               contain
             >
@@ -122,27 +122,11 @@
               <v-icon icon="mdi-store" size="16" class="me-1" />
               <span>{{ offersCountLabel }}</span>
             </div>
-
-            <v-btn
-              data-test="product-tile-compare"
-              variant="tonal"
-              size="small"
-              class="text-none"
-              density="comfortable"
-              :color="isCompared ? 'primary' : 'surface-primary-100'"
-              @click.prevent.stop="toggleCompare"
-            >
-              <v-icon
-                :icon="isCompared ? 'mdi-check' : 'mdi-plus'"
-                start
-                size="16"
-              />
-              {{
-                isCompared
-                  ? t('category.products.compare.added')
-                  : t('category.products.compare.buttonLabel')
-              }}
-            </v-btn>
+            <CategoryProductCompareToggle
+              class="product-tile-card__compare"
+              :product="product"
+              size="compact"
+            />
           </v-row>
         </div>
       </template>
@@ -154,7 +138,7 @@
           <div class="product-tile-card__header">
             <div class="product-tile-card__header-top">
               <h3 class="product-tile-card__title text-truncate">
-                {{ verticalTitle }}
+                {{ displayTitle }}
               </h3>
             </div>
             <div
@@ -192,7 +176,7 @@
           >
             <v-img
               :src="imageSrc"
-              :alt="verticalTitle"
+              :alt="displayTitle"
               aspect-ratio="4 / 3"
               class="product-tile-card__image"
               contain
@@ -251,27 +235,11 @@
               <v-icon icon="mdi-store" size="16" class="me-1" />
               <span>{{ offersCountLabel }}</span>
             </div>
-
-            <v-btn
-              data-test="product-tile-compare"
-              variant="tonal"
-              size="small"
-              class="text-none"
-              density="comfortable"
-              :color="isCompared ? 'primary' : 'surface-primary-100'"
-              @click.prevent.stop="toggleCompare"
-            >
-              <v-icon
-                :icon="isCompared ? 'mdi-check' : 'mdi-plus'"
-                start
-                size="16"
-              />
-              {{
-                isCompared
-                  ? t('category.products.compare.added')
-                  : t('category.products.compare.buttonLabel')
-              }}
-            </v-btn>
+            <CategoryProductCompareToggle
+              class="product-tile-card__compare"
+              :product="product"
+              size="compact"
+            />
           </v-row>
         </div>
       </template>
@@ -283,9 +251,8 @@
 import { computed } from 'vue'
 import type { ProductDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
-import { useProductCompareStore } from '~/stores/useProductCompareStore'
+import CategoryProductCompareToggle from '~/components/category/products/CategoryProductCompareToggle.vue'
 import { resolveProductDisplayName } from '~/utils/_product-title'
-import { useI18n } from 'vue-i18n'
 
 export type ProductTileAttribute = {
   key: string
@@ -330,16 +297,6 @@ const props = withDefaults(
   }
 )
 
-const { t } = useI18n()
-const compareStore = useProductCompareStore()
-
-const productBrand = computed(
-  () =>
-    props.product.identity?.brand ??
-    props.product.identity?.bestName ??
-    (props.product.gtin ? `#${props.product.gtin}` : props.untitledLabel)
-)
-
 const subtitle = computed(
   () =>
     props.product.identity?.model ??
@@ -349,20 +306,12 @@ const subtitle = computed(
 
 const hasAttributes = computed(() => props.attributes.length > 0)
 
-const headerTitle = computed(() => productBrand.value)
-
-const verticalTitle = computed(() =>
+const displayTitle = computed(() =>
   resolveProductDisplayName(props.product, {
     fallbackLabel: props.untitledLabel,
     preferPrettyName: true,
   })
 )
-
-const isCompared = computed(() => compareStore.hasProduct(props.product))
-
-const toggleCompare = () => {
-  compareStore.toggleProduct(props.product)
-}
 </script>
 
 <style scoped lang="scss">
@@ -403,11 +352,13 @@ const toggleCompare = () => {
     overflow: hidden;
     background: rgb(var(--v-theme-surface-glass));
     border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.25);
-    min-height: 180px;
+    min-height: 0;
+    max-height: 200px;
   }
 
   &__image {
     height: 100%;
+    max-height: 100%;
 
     :deep(img) {
       object-fit: contain;
@@ -590,7 +541,7 @@ const toggleCompare = () => {
   }
 
   &__media--stacked {
-    min-height: 160px;
+    max-height: 180px;
   }
 
   &__offers {


### PR DESCRIPTION
### Motivation
- Improve product title consistency by preferring the product `prettyName` and use a centralized resolver for display names.  
- Align attribute chips visually under the title for a clearer header layout.  
- Reuse the shared compare toggle component to keep compare logic/UX consistent across list/grid views.  
- Prevent media overflow in constrained layouts by reducing thumbnail size and capping media heights.

### Description
- Replace local header logic with `resolveProductDisplayName(...)` and expose it as `displayTitle` used for titles and image `alt` attributes.  
- Move the attributes block beneath the title and render `v-chip` list there (keeps markup consistent between variants).  
- Swap the inline compare `v-btn` for the shared `CategoryProductCompareToggle` component and pass `:product` and `size="compact"`.  
- Reduce thumbnail dimensions and add `max-height` constraints to `&__media`/`&__image`/`&__media--stacked` CSS rules to avoid overflow in tight containers, and update imports accordingly.

### Testing
- Performed dependency install with `pnpm install` which completed and generated Nuxt types (succeeded).  
- Started the dev server with `pnpm dev` and performed a smoke test; Nuxt launched and a Playwright script captured a screenshot (succeeded), though the running dev server logged backend fetch errors due to an unavailable backend.  
- Component spec updated (`ProductTileCard.spec.ts`) to expect the `prettyName` and to trigger the shared compare toggle selector; unit tests (`pnpm test` / `vitest`) were not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d32ba06e8832bb0d883cc983564f8)