### PR TITLE
Add compact mode to NudgeToolWizard and compact styles for hero layout

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -534,7 +534,7 @@ useHead({
             <v-sheet class="home-hero__panel" color="transparent" elevation="0">
               <div class="home-hero__panel-grid">
                 <div class="home-hero__panel-block">
-                  <NudgeToolWizard :verticals="wizardVerticals" />
+                  <NudgeToolWizard :verticals="wizardVerticals" compact />
                 </div>
                 <div class="home-hero__panel-block">
                   <form

--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="nudge-step-category">
+  <div
+    class="nudge-step-category"
+    :class="{ 'nudge-step-category--compact': compact }"
+  >
     <!-- Header removed, moved to Wizard -->
 
     <v-slide-group
@@ -288,6 +291,7 @@ const props = defineProps<{
   categories: NudgeToolCategory[]
   selectedCategoryId?: string | null
   isAuthenticated?: boolean
+  compact?: boolean
 }>()
 
 const emit = defineEmits<{ (event: 'select', categoryId: string): void }>()
@@ -503,6 +507,38 @@ watch(
     &__name {
       font-size: 0.95rem;
     }
+  }
+}
+
+.nudge-step-category--compact {
+  gap: clamp(0.75rem, 2.5vw, 1.25rem);
+  padding-bottom: 0.5rem;
+
+  .nudge-step-category__slider {
+    gap: 6px;
+
+    :deep(.v-slide-group__content) {
+      gap: 8px;
+    }
+  }
+
+  .nudge-step-category__card {
+    padding: 10px 12px;
+    min-width: 180px;
+    max-width: 220px;
+    flex-direction: row;
+    text-align: left;
+    gap: 10px;
+  }
+
+  .nudge-step-category__image {
+    width: clamp(56px, 8vw, 72px);
+    border-radius: 10px;
+  }
+
+  .nudge-step-category__name {
+    font-size: 0.95rem;
+    -webkit-line-clamp: 1;
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="nudge-step-condition">
+  <div
+    class="nudge-step-condition"
+    :class="{ 'nudge-step-condition--compact': compact }"
+  >
     <v-row dense class="nudge-step-condition__row" justify="center">
       <v-col
         v-for="option in options"
@@ -65,6 +68,7 @@ const NudgeConditionUsedIcon = defineAsyncComponent(
 
 const props = defineProps<{
   modelValue: ProductConditionChoice[]
+  compact?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -182,6 +186,39 @@ const toggleOption = (choice: ProductConditionChoice) => {
     .nudge-toggle-card__title {
       color: rgb(var(--v-theme-accent-supporting));
     }
+  }
+}
+
+.nudge-step-condition--compact {
+  .nudge-step-condition__row {
+    row-gap: 12px;
+    column-gap: 12px;
+  }
+
+  .nudge-toggle-card {
+    padding: 16px;
+    min-height: 150px;
+
+    &__header {
+      margin-bottom: 12px;
+    }
+
+    &__title {
+      font-size: 1rem;
+      line-height: 1.2;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    &__illustration {
+      max-width: 140px;
+      max-height: 96px;
+    }
+  }
+
+  .nudge-toggle-card--selected {
+    padding: 15px;
   }
 }
 </style>

--- a/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolWizard.spec.ts
@@ -51,6 +51,7 @@ const zoomedState = ref(false)
 vi.mock('@vueuse/core', () => ({
   useDebounceFn: (fn: (...args: unknown[]) => unknown) => fn,
   useElementSize: () => ({ height: ref(100) }),
+  useWindowSize: () => ({ height: ref(900) }),
   useTransition: (source: unknown) => source,
   usePreferredReducedMotion: () => ({ value: false }),
   useStorage: (_key: string, defaultValue: boolean) => {


### PR DESCRIPTION
### Motivation
- Reduce vertical footprint of the nudge wizard when rendered in the homepage hero to avoid locking large heights and to better fit the panel.
- Provide a toggleable `compact` mode so the same wizard component can be reused in full and compact contexts.
- Keep existing feature behavior (content-mode locking and animations) for non-compact usage.

### Description
- Add a `compact?: boolean` prop to `NudgeToolWizard` and forward it to child steps, and update `NudgeToolStepCategory` and `NudgeToolStepCondition` to accept `compact` and apply compact layout classes.
- When `compact` is enabled the height-locking logic is bypassed and `windowWrapperStyle` computes a clamped `maxHeight` using `useWindowSize` instead of locking exact heights.
- Add scoped compact CSS for the wizard (`.nudge-wizard--compact`), category cards (`.nudge-step-category--compact`) and condition tiles (`.nudge-step-condition--compact`) to tighten paddings, gap and image/card sizing.
- Enable compact mode on the homepage by using `<NudgeToolWizard compact />` and update the unit spec to mock `useWindowSize` accordingly.

### Testing
- Ran `pnpm lint` which completed successfully.
- Ran `pnpm test` (Vitest); the test run exercised many suites but was interrupted / did not complete in the CI session (partial run observed). 
- Ran `pnpm generate` (Nuxt generate) which completed successfully and built client and server bundles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f670240c8832b907ac62360527b7f)