### PR TITLE
Fix search filter state initialization in search page

### DIFF
--- a/frontend/app/pages/search/index.vue
+++ b/frontend/app/pages/search/index.vue
@@ -343,6 +343,9 @@ const showMinimumNotice = computed(
     trimmedInput.value.length < MIN_QUERY_LENGTH
 )
 
+const activeFilters = computed(() => filterRequest.value.filters ?? [])
+const isFiltered = computed(() => activeFilters.value.length > 0)
+
 // Global Search Data
 const { data, pending, error, refresh } =
   await useAsyncData<GlobalSearchResponseDto | null>(
@@ -374,9 +377,6 @@ const { data, pending, error, refresh } =
   )
 
 // Filtered Product Search Data
-const activeFilters = computed(() => filterRequest.value.filters ?? [])
-const isFiltered = computed(() => activeFilters.value.length > 0)
-
 const manualFields: FieldMetadataDto[] = [
   {
     mapping: 'price.minPrice.price',


### PR DESCRIPTION
### Motivation
- Navigating to categories triggered `ReferenceError: Cannot access 'isFiltered' before initialization` because `useAsyncData` watchers referenced `isFiltered` before it was declared. 
- The goal is to ensure reactive filter state is initialized prior to any async-data watchers that close over it. 
- This prevents runtime errors in the dev browser and keeps the global/filtered search guard logic consistent. 

### Description
- Move `activeFilters` and `isFiltered` declarations above the `useAsyncData` call in `frontend/app/pages/search/index.vue` so they are defined before being referenced. 
- The `useAsyncData` call still watches `() => isFiltered.value` and uses `hasMinimumLength.value` as the immediate condition. 
- No changes to the fetch logic or watched dependencies beyond ordering; behavior remains the same except for the initialization fix. 
- Modified file: `frontend/app/pages/search/index.vue`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696108bd068c832ba8b434a90e9856c9)