### PR TITLE
Mutualize Category hero actions and reuse ImpactScore CTA

### DIFF
--- a/frontend/app/components/category/CategoryHero.vue
+++ b/frontend/app/components/category/CategoryHero.vue
@@ -39,21 +39,8 @@
 
           <v-row dense class="category-hero__actions-row">
             <v-col cols="12" md="auto" class="flex-grow-1">
-              <HeroActionCard
-                v-if="$slots.actions || $slots['after-description']"
-              >
-                <div class="category-hero__actions-content">
-                  <div
-                    v-if="$slots['after-description']"
-                    class="category-hero__after-description"
-                  >
-                    <slot name="after-description" />
-                  </div>
-
-                  <div v-if="$slots.actions" class="category-hero__actions">
-                    <slot name="actions" />
-                  </div>
-                </div>
+              <HeroActionCard v-if="$slots.actions">
+                <slot name="actions" />
               </HeroActionCard>
             </v-col>
           </v-row>
@@ -207,18 +194,6 @@ defineExpose({ headingId, t })
     font-size: 1.05rem
     line-height: 1.6
     color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
-
-  &__after-description
-    display: flex
-    flex-direction: column
-    align-items: flex-start
-    gap: 0.75rem
-
-  &__actions
-    display: flex
-    flex-wrap: wrap
-    gap: 0.75rem
-    align-items: center
 
   &__media
     position: relative

--- a/frontend/app/components/category/CategoryHeroActionsContent.vue
+++ b/frontend/app/components/category/CategoryHeroActionsContent.vue
@@ -1,0 +1,106 @@
+<template>
+  <v-row dense class="category-hero-actions" align="stretch">
+    <v-col
+      v-if="hasEcoscore"
+      cols="12"
+      :md="columnMd"
+      class="category-hero-actions__col"
+    >
+      <CategoryEcoscoreCard
+        class="category-hero-actions__ecoscore"
+        :vertical-home-url="verticalHomeUrl"
+        :category-name="categoryName"
+      />
+    </v-col>
+
+    <v-col
+      v-if="hasNudge"
+      cols="12"
+      :md="columnMd"
+      class="category-hero-actions__col"
+    >
+      <div class="category-hero-actions__nudge">
+        <p class="category-hero-actions__eyebrow">
+          {{ t('category.hero.nudge.eyebrow') }}
+        </p>
+        <v-tooltip :text="t('category.hero.nudge.subtitle')">
+          <template #activator="{ props: tooltipProps }">
+            <v-btn
+              v-bind="tooltipProps"
+              color="primary"
+              variant="flat"
+              prepend-icon="mdi-robot-love"
+              class="category-hero-actions__cta"
+              @click="emit('open-nudge')"
+            >
+              {{ t('category.hero.nudge.cta') }}
+            </v-btn>
+          </template>
+        </v-tooltip>
+      </div>
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import CategoryEcoscoreCard from '~/components/category/CategoryEcoscoreCard.vue'
+
+const props = withDefaults(
+  defineProps<{
+    verticalHomeUrl?: string | null
+    categoryName?: string | null
+    showNudge?: boolean
+    showEcoscore?: boolean
+  }>(),
+  {
+    verticalHomeUrl: null,
+    categoryName: null,
+    showNudge: true,
+    showEcoscore: true,
+  }
+)
+
+const emit = defineEmits<{
+  (event: 'open-nudge'): void
+}>()
+
+const { t } = useI18n()
+
+const hasEcoscore = computed(
+  () => props.showEcoscore && Boolean(props.verticalHomeUrl)
+)
+const hasNudge = computed(() => props.showNudge)
+const columnMd = computed(() =>
+  hasEcoscore.value && hasNudge.value ? 6 : 12
+)
+</script>
+
+<style scoped lang="sass">
+.category-hero-actions
+  margin: 0
+
+  &__col
+    display: flex
+
+  &__ecoscore
+    width: 100%
+
+  &__nudge
+    display: flex
+    flex-direction: column
+    align-items: flex-start
+    gap: 0.5rem
+    width: 100%
+
+  &__eyebrow
+    margin: 0
+    font-size: 0.85rem
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgba(var(--v-theme-accent-supporting), 0.9)
+
+  &__cta
+    box-shadow: 0 12px 24px rgba(var(--v-theme-shadow-primary-600), 0.18)
+</style>

--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -240,16 +240,14 @@ afterEach(() => {
 })
 
 describe('HomeHeroSection', () => {
-  it('shows the launcher icon', async () => {
+  it('shows the logo icon', async () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.1)
 
     const wrapper = await mountComponent()
 
     const icon = wrapper.find('.home-hero__icon')
 
-    expect(icon.attributes('src')).toBe(
-      '/pwa-assets/icons/android/android-launchericon-512-512.png'
-    )
+    expect(icon.attributes('src')).toContain('data:image/svg+xml')
     expect(icon.attributes('alt')).toBe(messages['packs.default.hero.iconAlt'])
 
     await wrapper.unmount()

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -12,6 +12,7 @@ import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
+  useLogoAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
 import {
@@ -372,7 +373,7 @@ const heroIconAlt = computed(
       fallbackKeys: ['home.hero.iconAlt'],
     }) ?? ''
 )
-const heroIconSrc = '/pwa-assets/icons/android/android-launchericon-512-512.png'
+const heroIconSrc = useLogoAsset()
 const heroIconAnimationOptions = [
   'home-hero__icon--fade',
   'home-hero__icon--scale',

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -9,34 +9,12 @@
       :eyebrow="category.verticalMetaTitle"
       :show-image="isDesktop"
     >
-      <template #after-description>
-        <CategoryEcoscoreCard
-          v-if="category?.verticalHomeUrl"
-          class="category-page__ecoscore-card"
-          :vertical-home-url="category.verticalHomeUrl"
-          :category-name="categoryDisplayName"
-        />
-      </template>
       <template #actions>
-        <div class="category-page__hero-actions">
-          <p class="category-page__hero-eyebrow">
-            {{ $t('category.hero.nudge.eyebrow') }}
-          </p>
-          <v-tooltip :text="$t('category.hero.nudge.subtitle')">
-            <template #activator="{ props: tooltipProps }">
-              <v-btn
-                v-bind="tooltipProps"
-                color="primary"
-                variant="flat"
-                prepend-icon="mdi-robot-love"
-                class="category-page__hero-cta"
-                @click="isNudgeWizardOpen = true"
-              >
-                {{ $t('category.hero.nudge.cta') }}
-              </v-btn>
-            </template>
-          </v-tooltip>
-        </div>
+        <CategoryHeroActionsContent
+          :vertical-home-url="category?.verticalHomeUrl"
+          :category-name="categoryDisplayName"
+          @open-nudge="isNudgeWizardOpen = true"
+        />
       </template>
     </CategoryHero>
 
@@ -453,8 +431,8 @@ import { AggTypeEnum } from '~~/shared/api-client'
 import CategoryActiveFilters from '~/components/category/CategoryActiveFilters.vue'
 import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
 import CategoryHero from '~/components/category/CategoryHero.vue'
+import CategoryHeroActionsContent from '~/components/category/CategoryHeroActionsContent.vue'
 import CategoryFiltersSidebar from '~/components/category/CategoryFiltersSidebar.vue'
-import CategoryEcoscoreCard from '~/components/category/CategoryEcoscoreCard.vue'
 import CategoryResultsCount from '~/components/category/CategoryResultsCount.vue'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
 import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
@@ -2133,25 +2111,6 @@ const clearAllFilters = () => {
 
   &__container
     max-width: 1560px
-
-  &__hero-actions
-    display: inline-flex
-    flex-direction: column
-    align-items: flex-start
-    gap: 0.5rem
-
-  &__hero-eyebrow
-    margin: 0
-    font-size: 0.85rem
-    letter-spacing: 0.08em
-    text-transform: uppercase
-    color: rgba(var(--v-theme-accent-supporting), 0.9)
-
-  &__hero-cta
-    box-shadow: 0 12px 24px rgba(var(--v-theme-shadow-primary-600), 0.18)
-
-  &__ecoscore-card
-    align-self: flex-start
 
   &__toolbar
     display: flex

--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -30,6 +30,7 @@
         <ProductImpactCta
           v-if="categoryDetail && categoryDetail.impactScoreConfig"
           :category-detail="categoryDetail"
+          @open-nudge="isNudgeWizardOpen = true"
         />
 
         <ProductSummaryNavigation

--- a/frontend/app/components/product/ProductImpactCta.vue
+++ b/frontend/app/components/product/ProductImpactCta.vue
@@ -1,40 +1,11 @@
 <template>
   <div class="product-impact-cta mb-6">
     <HeroActionCard variant="default">
-      <div class="product-impact-cta__content">
-        <div class="product-impact-cta__header">
-          <v-icon
-            icon="mdi-leaf-circle"
-            size="24"
-            class="product-impact-cta__icon"
-          />
-          <span class="product-impact-cta__title font-weight-bold">
-            {{ $t('product.impact.cta.title', 'Impact Score') }}
-          </span>
-        </div>
-
-        <p class="product-impact-cta__description text-body-2 mb-3">
-          {{
-            $t(
-              'product.impact.cta.description',
-              'See how this product compares to others in {category}',
-              { category: categoryName }
-            )
-          }}
-        </p>
-
-        <v-btn
-          :to="categoryLink"
-          class="product-impact-cta__button"
-          color="white"
-          variant="flat"
-          block
-          rounded="lg"
-          prepend-icon="mdi-arrow-right"
-        >
-          {{ $t('product.impact.cta.button', 'View Category') }}
-        </v-btn>
-      </div>
+      <CategoryHeroActionsContent
+        :vertical-home-url="categoryLink"
+        :category-name="categoryName"
+        @open-nudge="emit('open-nudge')"
+      />
     </HeroActionCard>
   </div>
 </template>
@@ -42,10 +13,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import HeroActionCard from '~/components/shared/HeroActionCard.vue'
+import CategoryHeroActionsContent from '~/components/category/CategoryHeroActionsContent.vue'
 import type { CategoryDto } from '~~/shared/api-client'
 
 const props = defineProps<{
   categoryDetail: CategoryDto
+}>()
+
+const emit = defineEmits<{
+  (event: 'open-nudge'): void
 }>()
 
 const categoryName = computed(() => {
@@ -56,38 +32,3 @@ const categoryLink = computed(() => {
   return props.categoryDetail.verticalHomeUrl ?? ''
 })
 </script>
-
-<style scoped>
-.product-impact-cta__content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.product-impact-cta__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.25rem;
-}
-
-/** 
- * Ensure text colors work well on the SVG background.
- * The SVG is likely dark/rich, so white text is safer.
- * Helper classes or scoped styles can enforce this.
- */
-.product-impact-cta__title,
-.product-impact-cta__description,
-.product-impact-cta__icon {
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-}
-
-.product-impact-cta__button {
-  color: rgb(
-    var(--v-theme-primary)
-  ) !important; /* Text color for the white button */
-  font-weight: 700;
-  text-transform: none;
-}
-</style>


### PR DESCRIPTION
### Motivation

- Replace duplicated hero action markup with a reusable component to keep CTA and ecoscore logic consistent across category and product pages.
- Reuse the same CTA used on category pages inside the product `ImpactScore` CTA to avoid UI/UX drift and duplicated markup.
- Make logo resolution dynamic via the themed asset composable so the home hero uses the configured logo asset instead of a hard-coded file path.
- Ensure event wiring for opening the nudge wizard is propagated through the mutualised component.

### Description

- Add `frontend/app/components/category/CategoryHeroActionsContent.vue` that renders the ecoscore card and nudge CTA and emits `open-nudge` events.
- Replace the inline hero action/after-description content in `CategoryHero.vue` and `CategoryPage.vue` with the new `CategoryHeroActionsContent` component and import it in `CategoryPage.vue`.
- Update `ProductImpactCta.vue` to reuse `CategoryHeroActionsContent` and forward `open-nudge` via `emit`, and wire the `ProductPage.vue` caller to open the nudge wizard on the emitted event.
- Use the theme asset helper `useLogoAsset` in `HomeHeroSection.vue` and update the related test to expect the logo data returned by the themed resolver.

### Testing

- Ran lint via `pnpm lint` in the `frontend` workspace and it completed without errors.
- Ran unit tests via `pnpm test` in the `frontend` workspace and all tests passed locally after the updates.
- Performed a production build and static generation with `pnpm generate` which completed successfully and produced the public output.
- Launched the dev server and captured a Playwright screenshot (`artifacts/home-hero.png`) to validate the rendered home hero visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105c1d6c0832b92531c590c958ffe)