### PR TITLE
Reorder nudge wizard steps and guard zero-results selections

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import NudgeToolStepCondition from './NudgeToolStepCondition.vue'
+
+const VRowStub = defineComponent({
+  name: 'VRow',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-row-stub' }, slots.default?.())
+  },
+})
+
+const VColStub = defineComponent({
+  name: 'VCol',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-col-stub' }, slots.default?.())
+  },
+})
+
+const VCardStub = defineComponent({
+  name: 'VCard',
+  emits: ['click', 'keydown'],
+  setup(_, { slots, attrs, emit }) {
+    return () =>
+      h(
+        'div',
+        {
+          ...attrs,
+          class: ['v-card-stub', attrs.class],
+          onClick: (event: Event) => emit('click', event),
+          onKeydown: (event: KeyboardEvent) => emit('keydown', event),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: ['icon'],
+  setup(props) {
+    return () => h('i', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+describe('NudgeToolStepCondition', () => {
+  it('blocks unchecked selections when zero results', async () => {
+    const wrapper = mount(NudgeToolStepCondition, {
+      props: {
+        modelValue: [],
+        isZeroResults: true,
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+        },
+        mocks: {
+          $t: (t: string) => t,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('allows unchecking when zero results', async () => {
+    const wrapper = mount(NudgeToolStepCondition, {
+      props: {
+        modelValue: ['new'],
+        isZeroResults: true,
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+        },
+        mocks: {
+          $t: (t: string) => t,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]])
+  })
+})

--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -17,12 +17,14 @@
           elevation="2"
           :class="{
             'nudge-toggle-card--selected': isSelected(option.value),
+            'nudge-toggle-card--disabled': isDisabled(option.value),
           }"
           rounded="xl"
           role="button"
           :aria-pressed="isSelected(option.value).toString()"
+          :aria-disabled="isDisabled(option.value).toString()"
           :aria-label="option.label"
-          tabindex="0"
+          :tabindex="isDisabled(option.value) ? -1 : 0"
           @click="() => toggleOption(option.value)"
           @keydown.enter.prevent="toggleOption(option.value)"
           @keydown.space.prevent="toggleOption(option.value)"
@@ -70,6 +72,7 @@ const NudgeConditionUsedIcon = defineAsyncComponent(
 const props = defineProps<{
   modelValue: ProductConditionChoice[]
   compact?: boolean
+  isZeroResults?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -99,7 +102,14 @@ const isSelected = (choice: ProductConditionChoice) => {
   return props.modelValue.includes(choice)
 }
 
+const isDisabled = (choice: ProductConditionChoice) =>
+  Boolean(props.isZeroResults) && !isSelected(choice)
+
 const toggleOption = (choice: ProductConditionChoice) => {
+  if (isDisabled(choice)) {
+    return
+  }
+
   const nextSelection = isSelected(choice)
     ? props.modelValue.filter(entry => entry !== choice)
     : [...props.modelValue, choice]
@@ -187,6 +197,20 @@ const toggleOption = (choice: ProductConditionChoice) => {
 
     .nudge-toggle-card__title {
       color: rgb(var(--v-theme-accent-supporting));
+    }
+  }
+
+  .nudge-toggle-card--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none !important;
+    pointer-events: none;
+
+    &:hover,
+    &:focus-visible {
+      transform: none;
+      border-color: rgba(var(--v-theme-border-primary-strong), 0.4);
+      box-shadow: none !important;
     }
   }
 }

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import NudgeToolStepScores from './NudgeToolStepScores.vue'
+
+const VRowStub = defineComponent({
+  name: 'VRow',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-row-stub' }, slots.default?.())
+  },
+})
+
+const VColStub = defineComponent({
+  name: 'VCol',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-col-stub' }, slots.default?.())
+  },
+})
+
+const VCardStub = defineComponent({
+  name: 'VCard',
+  emits: ['click', 'keydown'],
+  setup(_, { slots, attrs, emit }) {
+    return () =>
+      h(
+        'div',
+        {
+          ...attrs,
+          class: ['v-card-stub', attrs.class],
+          onClick: (event: Event) => emit('click', event),
+          onKeydown: (event: KeyboardEvent) => emit('keydown', event),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: ['icon'],
+  setup(props) {
+    return () => h('i', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  setup(_, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub' }, [
+        slots.activator?.({ props: {} }),
+        slots.default?.(),
+      ])
+  },
+})
+
+describe('NudgeToolStepScores', () => {
+  it('blocks unchecked selections when zero results', async () => {
+    const wrapper = mount(NudgeToolStepScores, {
+      props: {
+        modelValue: [],
+        isZeroResults: true,
+        scores: [
+          {
+            scoreName: 'eco',
+            title: 'Eco',
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('allows unchecking when zero results', async () => {
+    const wrapper = mount(NudgeToolStepScores, {
+      props: {
+        modelValue: ['eco'],
+        isZeroResults: true,
+        scores: [
+          {
+            scoreName: 'eco',
+            title: 'Eco',
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]])
+  })
+})

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -17,12 +17,14 @@
               border="thin"
               :class="{
                 'nudge-toggle-card--selected': isSelected(score.scoreName),
+                'nudge-toggle-card--disabled': isDisabled(score.scoreName),
               }"
               rounded="lg"
               role="button"
               :aria-pressed="isSelected(score.scoreName).toString()"
+              :aria-disabled="isDisabled(score.scoreName).toString()"
               :aria-label="score.title"
-              tabindex="0"
+              :tabindex="isDisabled(score.scoreName) ? -1 : 0"
               @click="toggle(score.scoreName ?? '')"
               @keydown.enter.prevent="toggle(score.scoreName ?? '')"
               @keydown.space.prevent="toggle(score.scoreName ?? '')"
@@ -55,6 +57,7 @@ import type { NudgeToolScoreDto } from '~~/shared/api-client'
 const props = defineProps<{
   scores: NudgeToolScoreDto[]
   modelValue: string[]
+  isZeroResults?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -69,7 +72,14 @@ const getScoreIcon = (score: NudgeToolScoreDto) => score.mdiIcon ?? 'mdi-leaf'
 const isSelected = (scoreName?: string | null) =>
   scoreName ? selectedNames.value.includes(scoreName) : false
 
+const isDisabled = (scoreName?: string | null) =>
+  Boolean(props.isZeroResults) && !isSelected(scoreName)
+
 const toggle = (scoreName: string) => {
+  if (isDisabled(scoreName)) {
+    return
+  }
+
   const next = new Set(selectedNames.value)
 
   if (next.has(scoreName)) {
@@ -213,6 +223,20 @@ const toggle = (scoreName: string) => {
 
     .nudge-toggle-card__title {
       color: rgb(var(--v-theme-text-neutral-strong));
+    }
+  }
+
+  .nudge-toggle-card--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none !important;
+    pointer-events: none;
+
+    &:hover,
+    &:focus-visible {
+      transform: none;
+      border-color: rgba(var(--v-theme-border-primary-strong), 0.4);
+      box-shadow: none !important;
     }
   }
 }

--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import NudgeToolStepSubsetGroup from './NudgeToolStepSubsetGroup.vue'
+
+const VRowStub = defineComponent({
+  name: 'VRow',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-row-stub' }, slots.default?.())
+  },
+})
+
+const VColStub = defineComponent({
+  name: 'VCol',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-col-stub' }, slots.default?.())
+  },
+})
+
+const VCardStub = defineComponent({
+  name: 'VCard',
+  emits: ['click', 'keydown'],
+  setup(_, { slots, attrs, emit }) {
+    return () =>
+      h(
+        'div',
+        {
+          ...attrs,
+          class: ['v-card-stub', attrs.class],
+          onClick: (event: Event) => emit('click', event),
+          onKeydown: (event: KeyboardEvent) => emit('keydown', event),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  props: ['icon'],
+  setup(props) {
+    return () => h('i', { class: 'v-icon-stub', 'data-icon': props.icon })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  setup(_, { slots }) {
+    return () =>
+      h('div', { class: 'v-tooltip-stub' }, [
+        slots.activator?.({ props: {} }),
+        slots.default?.(),
+      ])
+  },
+})
+
+describe('NudgeToolStepSubsetGroup', () => {
+  it('blocks unchecked selections when zero results', async () => {
+    const wrapper = mount(NudgeToolStepSubsetGroup, {
+      props: {
+        group: {
+          id: 'price',
+          title: 'Budget',
+        },
+        subsets: [
+          {
+            id: 'price-1',
+            title: 'Budget',
+          },
+        ],
+        modelValue: [],
+        stepNumber: 2,
+        isZeroResults: true,
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+
+  it('allows unchecking when zero results', async () => {
+    const wrapper = mount(NudgeToolStepSubsetGroup, {
+      props: {
+        group: {
+          id: 'price',
+          title: 'Budget',
+        },
+        subsets: [
+          {
+            id: 'price-1',
+            title: 'Budget',
+          },
+        ],
+        modelValue: ['price-1'],
+        stepNumber: 2,
+        isZeroResults: true,
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[[]]])
+  })
+})

--- a/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepSubsetGroup.vue
@@ -14,12 +14,14 @@
               elevation="2"
               :class="{
                 'nudge-toggle-card--selected': isSelected(subset.id),
+                'nudge-toggle-card--disabled': isDisabled(subset.id),
               }"
               rounded="lg"
               role="button"
               :aria-pressed="isSelected(subset.id).toString()"
+              :aria-disabled="isDisabled(subset.id).toString()"
               :aria-label="subset.title"
-              tabindex="0"
+              :tabindex="isDisabled(subset.id) ? -1 : 0"
               @click="toggle(subset.id ?? '')"
               @keydown.enter.prevent="toggle(subset.id ?? '')"
               @keydown.space.prevent="toggle(subset.id ?? '')"
@@ -59,6 +61,7 @@ const props = defineProps<{
   stepNumber: number
   categoryIcon?: string | null
   categoryLabel?: string | null
+  isZeroResults?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -69,10 +72,17 @@ const emit = defineEmits<{
 const isSelected = (subsetId?: string | null) =>
   subsetId ? props.modelValue.includes(subsetId) : false
 
+const isDisabled = (subsetId?: string | null) =>
+  Boolean(props.isZeroResults) && !isSelected(subsetId)
+
 const getSubsetIcon = (subset: VerticalSubsetDto) =>
   subset.mdiIcon ?? 'mdi-sprout'
 
 const toggle = (subsetId: string) => {
+  if (isDisabled(subsetId)) {
+    return
+  }
+
   const next = new Set(props.modelValue)
 
   if (next.has(subsetId)) {
@@ -232,6 +242,20 @@ const toggle = (subsetId: string) => {
       color: rgb(var(--v-theme-surface-default));
       box-shadow: inset 0 0 0 1px rgba(var(--v-theme-accent-supporting), 0.55);
       transform: translateY(-1px);
+    }
+  }
+
+  .nudge-toggle-card--disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none !important;
+    pointer-events: none;
+
+    &:hover,
+    &:focus-visible {
+      transform: none;
+      border-color: rgba(var(--v-theme-border-primary-strong), 0.4);
+      box-shadow: none !important;
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure subset-group (e.g. price/budget) selections appear before the condition step so users pick subsets earlier in the nudge wizard flow.
- Prevent users from enabling unchecked filters when the current filter set yields zero product matches while still allowing them to uncheck previously selected options.
- Surface zero-results state to step components and gate the wizard `Next` action when there are no matches to avoid dead-end navigation.
- Add unit tests to assert ordering and the new zero-results behavior.

### Description
- Reordered the wizard steps in `NudgeToolWizard.vue` to insert subset groups before the `condition` step and added a `hasFetchedResults` ref plus `hasZeroMatches` computed to track zero-result state and gate `isNextDisabled`.
- Propagated `isZeroResults` into child steps and set/cleared `hasFetchedResults` when search responses are fetched and when category selection is reset.
- Updated `NudgeToolStepScores.vue`, `NudgeToolStepCondition.vue`, and `NudgeToolStepSubsetGroup.vue` to accept `isZeroResults`, add an `isDisabled` check, emit `aria-disabled`, adjust `tabindex`, early-return in toggle handlers, and add a `.nudge-toggle-card--disabled` style.
- Added component tests `NudgeToolStepCondition.spec.ts`, `NudgeToolStepScores.spec.ts`, `NudgeToolStepSubsetGroup.spec.ts` and extended `NudgeToolWizard.spec.ts` to assert step ordering and zero-result guard behavior.

### Testing
- Attempted `pnpm --offline lint`, which failed due to missing `node_modules` and ESLint configuration/parsing errors in the environment.
- Attempted `pnpm --offline test`, which failed because `vitest` (and other test dependencies) were not available in the offline environment.
- Attempted `pnpm --offline generate`, which failed because `nuxt` was not available in the offline environment.
- New unit tests were added for the three step components and the wizard ordering, but they were not executed successfully in this environment due to the missing dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f8c0b6cc832ba65eb86eaaaf3606)