### PR TITLE
Home hero: remove icon, full-width helper copy; restore split visuals with rotated gain image; add i18n keys

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -49,7 +49,6 @@ const messages: Record<string, unknown> = {
       ],
     },
   ],
-  'packs.default.hero.iconAlt': 'Icône du lanceur PWA Nudger',
   'packs.default.hero.background': 'hero-background.webp',
   'packs.default.hero.context.ariaLabel':
     'Carte contexte du héros présentant la promesse Nudger',
@@ -209,12 +208,6 @@ const mountComponent = async (options?: {
     seedState.value = { ...(options.variantSeeds ?? {}) }
   }
 
-  // Clear animation state to force re-evaluation of Math.random spy
-  const nuxtApp = useNuxtApp()
-  if (nuxtApp?.payload?.state) {
-    Reflect.deleteProperty(nuxtApp.payload.state, 'home-hero-icon-animation')
-  }
-
   return mountSuspended(HomeHeroSection, {
     props: {
       searchQuery: '',
@@ -246,37 +239,6 @@ afterEach(() => {
 })
 
 describe('HomeHeroSection', () => {
-  it('shows the logo icon', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.1)
-
-    const wrapper = await mountComponent()
-
-    const icon = wrapper.find('.home-hero__icon')
-
-    expect(icon.attributes('src')).toContain('data:image/svg+xml')
-    expect(icon.attributes('alt')).toBe(messages['packs.default.hero.iconAlt'])
-
-    await wrapper.unmount()
-  })
-
-  it('applies a random animation class from the configured list', async () => {
-    // Note: With useState, the random value might be persisted from previous tests in the environment.
-    // We check that the applied class is one of the valid options.
-    const validClasses = [
-      'home-hero__icon--fade',
-      'home-hero__icon--scale',
-      'home-hero__icon--pulse',
-    ]
-
-    const wrapper = await mountComponent()
-    const icon = wrapper.find('.home-hero__icon')
-    const classes = icon.classes()
-
-    expect(validClasses.some(c => classes.includes(c))).toBe(true)
-
-    await wrapper.unmount()
-  })
-
   it('renders helper text with linked segments', async () => {
     const wrapper = await mountComponent()
     const helpers = wrapper.findAll('.home-hero__helper')

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -12,7 +12,6 @@ import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
-  useLogoAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
 import {
@@ -367,27 +366,6 @@ const applyOpenDataMillionsPlaceholder = (items: HeroHelperItem[]) => {
   })
 }
 
-const heroIconAlt = computed(
-  () =>
-    packI18n.resolveString('hero.iconAlt', {
-      fallbackKeys: ['home.hero.iconAlt'],
-    }) ?? ''
-)
-const heroIconSrc = useLogoAsset()
-const heroIconAnimationOptions = [
-  'home-hero__icon--fade',
-  'home-hero__icon--scale',
-  'home-hero__icon--pulse',
-] as const
-const heroIconAnimation = useState<string>(
-  'home-hero-icon-animation',
-  () =>
-    heroIconAnimationOptions[
-      Math.floor(Math.random() * heroIconAnimationOptions.length)
-    ] || heroIconAnimationOptions[0]
-)
-const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
-
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundI18nKey = computed(
   () => props.heroBackgroundI18nKey?.trim() || 'hero.background'
@@ -614,24 +592,8 @@ useHead({
 
                       <v-row class="home-hero__helper-row" justify="center">
                         <v-col
-                          cols="4"
-                          class="align-center home-hero__eyebrow-block"
-                        >
-                          <div
-                            v-if="showHeroIcon"
-                            class="home-hero__icon-wrapper"
-                          >
-                            <img
-                              :src="heroIconSrc"
-                              :alt="heroIconAlt"
-                              :class="['home-hero__icon', heroIconAnimation]"
-                              loading="lazy"
-                            />
-                          </div>
-                        </v-col>
-                        <v-col
                           v-if="heroHelperItems.length"
-                          cols="6"
+                          cols="12"
                           class="home-hero__helpers-wrapper"
                         >
                           <ul class="home-hero__helpers">
@@ -773,49 +735,6 @@ useHead({
   align-items: center
   text-align: center
 
-.home-hero__eyebrow-block
-  display: inline-flex
-  flex-direction: column
-  gap: clamp(0.5rem, 1.5vw, 0.75rem)
-  padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
-  align-items: flex-start
-
-.home-hero__eyebrow
-  font-weight: 600
-  letter-spacing: 0.08em
-  text-transform: uppercase
-  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
-  margin: 0
-
-.home-hero__icon-wrapper
-  width: clamp(4.5rem, 16vw, 7.5rem)
-  height: clamp(4.5rem, 16vw, 7.5rem)
-  box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
-  backdrop-filter: blur(8px)
-  border-radius: 50%
-  padding: clamp(0.6rem, 1.6vw, 0.9rem)
-  box-sizing: border-box
-  background: rgba(var(--v-theme-surface-default), 0.92)
-
-.home-hero__icon
-  border-radius: inherit
-  width: 92%
-  height: 92%
-  transition: transform 250ms ease, filter 250ms ease
-  filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
-  object-fit: contain
-  display: block
-  margin: auto
-
-.home-hero__icon--fade
-  animation: home-hero-fade-up 900ms ease-out both
-
-.home-hero__icon--scale
-  animation: home-hero-scale-in 800ms ease-out both
-
-.home-hero__icon--pulse
-  animation: home-hero-pulse 1200ms ease-in-out both
-
 .home-hero__title
   font-size: clamp(2.2rem, 5vw, 3.8rem)
   line-height: 1.05
@@ -882,6 +801,9 @@ useHead({
   flex-wrap: wrap
   align-items: center
 
+.home-hero__helpers-wrapper
+  width: 100%
+
 .home-hero__helpers
   margin: 0
   padding: 0
@@ -922,48 +844,8 @@ useHead({
   width: 100%
 
 
-.home-hero__helpers-title
-  font-size: 0.875rem
-  font-weight: 600
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  margin-bottom: 0.5rem
-  display: block
-  letter-spacing: 0.01em
-
 .home-hero__wizard
   width: 100%
-
-
-
-@keyframes home-hero-fade-up
-  from
-    opacity: 0
-    transform: translateY(12px) scale(0.98)
-  to
-    opacity: 1
-    transform: translateY(0) scale(1)
-
-@keyframes home-hero-scale-in
-  from
-    opacity: 0
-    transform: scale(0.9)
-  55%
-    opacity: 1
-    transform: scale(1.02)
-  to
-    transform: scale(1)
-
-@keyframes home-hero-pulse
-  0%
-    transform: scale(0.92)
-    opacity: 0
-  35%
-    transform: scale(1.04)
-    opacity: 1
-  70%
-    transform: scale(0.98)
-  100%
-    transform: scale(1)
 
 @media (max-width: 959px)
   .home-hero

--- a/frontend/app/components/home/sections/HomeProblemsSection.vue
+++ b/frontend/app/components/home/sections/HomeProblemsSection.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import HomeSplitSection from './HomeSplitSection.vue'
-import HomeParallaxVisual from '../HomeParallaxVisual.vue'
 
 type ProblemItem = {
   icon: string
@@ -26,12 +25,6 @@ const sectionDescription = computed(() => t('home.problems.description'))
     :description="sectionDescription"
     visual-position="left"
   >
-    <template #visual>
-      <HomeParallaxVisual
-        src="/images/parallax/problem.svg"
-        :alt="sectionTitle"
-      />
-    </template>
     <v-row class="home-problems__list" dense>
       <v-col
         v-for="item in props.items"

--- a/frontend/app/components/home/sections/HomeSplitSection.vue
+++ b/frontend/app/components/home/sections/HomeSplitSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRandomHomepageImages } from '~/composables/useRandomHomepageImages'
 
 defineOptions({ inheritAttrs: false })
 
@@ -25,7 +26,26 @@ const props = withDefaults(
   }
 )
 
+const { t } = useI18n()
+const { painImage, gainImage } = useRandomHomepageImages()
+
 const titleId = computed(() => `${props.id}-title`)
+const fallbackImage = computed(() => {
+  const isPainVisual = props.visualPosition === 'left'
+
+  return {
+    src: isPainVisual ? painImage.value : gainImage.value,
+    alt: isPainVisual ? t('home.split.painAlt') : t('home.split.gainAlt'),
+    sizes: '(min-width: 960px) 320px, 70vw',
+    loading: 'lazy' as const,
+  }
+})
+const resolvedImage = computed(() => props.image ?? fallbackImage.value)
+const resolvedImageClass = computed(() =>
+  props.image ? null : props.visualPosition === 'right'
+    ? 'home-split__image--gain'
+    : 'home-split__image--pain'
+)
 const sectionClasses = computed(() => [
   'home-section',
   'home-split',
@@ -73,14 +93,14 @@ const sectionClasses = computed(() => [
             <div class="home-split__visual" role="presentation">
               <slot name="visual">
                 <NuxtImg
-                  v-if="props.image?.src"
-                  :src="props.image.src"
-                  :alt="props.image.alt"
-                  class="home-split__image"
-                  :sizes="props.image.sizes ?? '(min-width: 960px) 320px, 70vw'"
-                  :loading="props.image.loading ?? 'lazy'"
-                  :width="props.image.width"
-                  :height="props.image.height"
+                  v-if="resolvedImage?.src"
+                  :src="resolvedImage.src"
+                  :alt="resolvedImage.alt"
+                  :class="['home-split__image', resolvedImageClass]"
+                  :sizes="resolvedImage.sizes ?? '(min-width: 960px) 320px, 70vw'"
+                  :loading="resolvedImage.loading ?? 'lazy'"
+                  :width="resolvedImage.width"
+                  :height="resolvedImage.height"
                   decoding="async"
                 />
               </slot>
@@ -152,6 +172,9 @@ const sectionClasses = computed(() => [
   height: auto
   display: block
   margin-inline: auto
+
+.home-split__image--gain
+  transform: rotate(8deg)
 
 .home-split--visual-left .home-split__col--visual
   order: -1

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -303,6 +303,10 @@
         "ariaLabel": "Decorative background for the FAQ and call to action"
       }
     },
+    "split": {
+      "painAlt": "Illustration of a shopper feeling overwhelmed by product choices.",
+      "gainAlt": "Illustration of a shopper relieved after finding a responsible choice."
+    },
     "problems": {
       "title": "Too many labels, not enough clarity?",
       "description": "Comparing impact, price and trust sources across dozens of tabs is exhausting. Nudger brings it back to one place.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -305,6 +305,10 @@
         "ariaLabel": "Fond décoratif pour la FAQ et l’appel à l’action"
       }
     },
+    "split": {
+      "painAlt": "Illustration d’un acheteur submergé par les choix de produits.",
+      "gainAlt": "Illustration d’un acheteur soulagé après un choix responsable."
+    },
     "problems": {
       "title": "Trop d'infos, mais pas celle qu'il faut ?",
       "description": "Comparer impact, prix, fiabilité... Pas toujours facile !",


### PR DESCRIPTION
### Motivation
- Make the hero context helpers span the full available width on all breakpoints and remove the separate logo icon block to simplify the layout.  
- Preserve the original split layout (visual left/right) while reinstating randomized pain/gain visuals for split sections.  
- Add a subtle rotation (7–10°) to the positive/gain visual to match design direction.  
- Ensure proper i18n coverage for split visuals by adding alt text keys and prefer deep-pack fallbacks when resolving strings.

### Description
- Removed the hero icon markup, its `useState` animation logic and related CSS, and made the helper column use `cols="12"` with a new `.home-hero__helpers-wrapper` to span the full width.  
- Restored split-section visuals by using `useRandomHomepageImages` in `HomeSplitSection.vue`, added a `fallbackImage`/`resolvedImage` flow and a `home-split__image--gain` class that applies `transform: rotate(8deg)`.  
- Reverted the problems section to rely on the split defaults (removed its explicit visual slot), and updated `HomeHeroSection.spec.ts` to remove icon/animation assertions while keeping helper text/link assertions.  
- Added locale entries `home.split.painAlt` and `home.split.gainAlt` to `frontend/i18n/locales/en-US.json` and `fr-FR.json` for accessible alt text.

### Testing
- Ran `pnpm --offline lint` and it completed successfully.  
- Ran `pnpm --offline test` (Vitest) and the test suite passed (all tests green).  
- Built the app with `pnpm --offline generate` and the static generate completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f25e5b50832bbd2c5e936c077e55)