### PR TITLE
Simplify home hero, add ecoscore CTA to category filters (drawer + sidebar), update i18n and tests

### DIFF
--- a/frontend/app/components/category/CategoryEcoscoreCard.vue
+++ b/frontend/app/components/category/CategoryEcoscoreCard.vue
@@ -17,14 +17,12 @@
       <p class="category-ecoscore-card__title">
         {{ t('category.filters.ecoscore.title') }}
       </p>
-      <p
-        v-if="showDescription !== false"
-        class="category-ecoscore-card__description"
-      >
-        {{ description }}
-      </p>
       <span class="category-ecoscore-card__cta">
-        {{ t('category.filters.ecoscore.cta') }}
+        {{
+          t('category.filters.ecoscore.cta', {
+            category: normalizedCategoryName,
+          })
+        }}
         <v-icon icon="mdi-arrow-top-right" size="18" />
       </span>
     </div>
@@ -46,12 +44,6 @@ const normalizedCategoryName = computed(() => {
 
   return props.categoryName.toLocaleLowerCase(locale.value)
 })
-
-const description = computed(() =>
-  t('category.filters.ecoscore.description', {
-    category: normalizedCategoryName.value,
-  })
-)
 
 const ecoscoreUrl = computed(() => {
   if (!props.verticalHomeUrl) {
@@ -108,12 +100,6 @@ const ecoscoreUrl = computed(() => {
     font-size: 1rem
     font-weight: 600
     margin: 0
-
-  &__description
-    margin: 0
-    color: rgb(var(--v-theme-text-neutral-secondary))
-    font-size: 0.875rem
-    line-height: 1.5
 
   &__cta
     display: inline-flex

--- a/frontend/app/components/category/CategoryFiltersSidebar.vue
+++ b/frontend/app/components/category/CategoryFiltersSidebar.vue
@@ -23,6 +23,10 @@
       @update:filters="value => emit('update:filters', value)"
     />
 
+    <div v-if="$slots.extra" class="category-page__filters-extra">
+      <slot name="extra" />
+    </div>
+
     <div v-if="showMobileActions" class="category-page__filters-actions">
       <v-btn block color="primary" class="mb-2" @click="emit('apply-mobile')">
         {{ t('category.filters.mobileApply') }}

--- a/frontend/app/components/category/CategoryHeroActionsContent.vue
+++ b/frontend/app/components/category/CategoryHeroActionsContent.vue
@@ -10,7 +10,6 @@
         class="category-hero-actions__ecoscore"
         :vertical-home-url="verticalHomeUrl"
         :category-name="categoryName"
-        :show-description="showDescription"
       />
     </v-col>
 
@@ -52,14 +51,12 @@ const props = withDefaults(
     categoryName?: string | null
     showNudge?: boolean
     showEcoscore?: boolean
-    showDescription?: boolean
   }>(),
   {
     verticalHomeUrl: null,
     categoryName: null,
     showNudge: true,
     showEcoscore: true,
-    showDescription: true,
   }
 )
 

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -503,7 +503,7 @@ const getConditionCountLabel = (
   }
 
   if (count <= 0) return undefined
-  return translatePlural('category.products.offersCount', count)
+  return translatePlural('category.products.offerCount', count, { count })
 }
 </script>
 

--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -6,62 +6,13 @@ import HomeHeroSection from './HomeHeroSection.vue'
 import type { EventPackName } from '~~/config/theme/event-packs'
 
 const messages: Record<string, unknown> = {
-  'packs.default.hero.eyebrow': 'notre comparateur',
   'packs.default.hero.title': "Réconcilier écologie et pouvoir d'achat",
-  'packs.default.hero.subtitles': [
-    'Gagne du temps. Choisis librement.',
-    'Choisis librement.',
-  ],
-  'packs.hold.hero.subtitles': ['Pack retenu', 'Sous-titre placeholder'],
   'packs.default.hero.titleSubtitle': ['Acheter mieux. Sans dépenser plus.'],
-  'packs.default.hero.search.label': 'Tu sais déjà ce que tu cherches ?',
-  'packs.default.hero.search.placeholder':
-    'Recherchez un produit ou une catégorie',
-  'packs.default.hero.search.ariaLabel': 'Rechercher un produit responsable',
-  'packs.default.hero.search.cta': 'NUDGER',
-  'packs.default.hero.search.partnerLinkLabel':
-    '{formattedCount} partenaire | {formattedCount} partenaires',
-  'packs.default.hero.search.partnerLinkFallback': 'nos partenaires',
-  'packs.default.hero.search.helper': 'Comparateur indépendant',
-  'packs.default.hero.search.helpersTitle':
-    'Offre avec intention. Compare avec impact.',
-  'packs.default.hero.search.helpers': [
-    {
-      icon: '🌿',
-      label:
-        "L'impact Score : une évaluation écologique et environnementale unique",
-      segments: [
-        { text: "L'impact Score : une" },
-        {
-          text: 'évaluation écologique et environnementale',
-          to: '/impact-score',
-        },
-        { text: ' unique' },
-      ],
-    },
-    {
-      icon: '🏷️',
-      label:
-        '100% indépendant, logiciel libre et {millions}+ produits en données ouvertes',
-      segments: [
-        { text: '100% indépendant, logiciel libre et' },
-        { text: '{millions}+ produits en données ouvertes' },
-      ],
-    },
-  ],
-  'packs.default.hero.iconAlt': 'Icône du lanceur PWA Nudger',
   'packs.default.hero.background': 'hero-background.webp',
-  'packs.default.hero.context.ariaLabel':
-    'Carte contexte du héros présentant la promesse Nudger',
 }
 
-const helperItems = messages['packs.default.hero.search.helpers'] as unknown[]
-
 const subtitleCollections = {
-  default: messages['packs.default.hero.subtitles'] as string[],
-  events: {
-    hold: messages['packs.hold.hero.subtitles'] as string[],
-  },
+  default: messages['packs.default.hero.titleSubtitle'] as string[],
 }
 
 const activeEventPack = ref<EventPackName>('default')
@@ -91,56 +42,16 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (
       key: string,
-      choiceOrParams?: number | Record<string, unknown>,
-      params?: Record<string, unknown>
-    ) => {
-      const resolvedParams =
-        typeof choiceOrParams === 'object' && choiceOrParams != null
-          ? choiceOrParams
-          : (params ?? {})
-
-      const count =
-        typeof choiceOrParams === 'number'
-          ? choiceOrParams
-          : (resolvedParams as { count?: number }).count
-
-      const value = messages[key] ?? key
-
-      if (typeof value !== 'string') {
-        return value
-      }
-
-      const template =
-        value.includes('|') && typeof count === 'number'
-          ? count <= 1
-            ? value.split('|')[0]?.trim()
-            : value.split('|')[1]?.trim()
-          : value
-
-      return template.replace(/\{(\w+)\}/g, (_match, token) => {
-        const replacement = (resolvedParams as Record<string, unknown>)[token]
-        return replacement != null ? String(replacement) : _match
-      })
-    },
+      _choiceOrParams?: number | Record<string, unknown>,
+      _params?: Record<string, unknown>
+    ) => messages[key] ?? key,
     tm: (key: string) => {
       if (messages[key]) {
         return messages[key]
       }
 
-      if (key === 'packs.default.hero.search.helpers') {
-        return helperItems
-      }
-
-      if (key === 'packs.default.hero.subtitles') {
-        return subtitleCollections.default
-      }
-
-      if (key === 'packs.hold.hero.subtitles') {
-        return subtitleCollections.events.hold
-      }
-
       if (key === 'packs.default.hero.titleSubtitle') {
-        return ['Acheter mieux. Sans dépenser plus.']
+        return subtitleCollections.default
       }
 
       return []
@@ -167,74 +78,18 @@ const createStub = (tag: string, className = '') =>
     },
   })
 
-const VImgStub = defineComponent({
-  name: 'VImgStub',
-  setup(_, { slots, attrs }) {
-    return () =>
-      h(
-        'img',
-        { class: ['v-img-stub', attrs.class], ...attrs },
-        slots.default ? slots.default() : []
-      )
-  },
-})
-
-const NuxtLinkStub = defineComponent({
-  name: 'NuxtLinkStub',
-  setup(_, { slots, attrs }) {
-    return () =>
-      h(
-        'a',
-        {
-          class: attrs.class,
-          href:
-            (attrs as { to?: string; href?: string }).to ??
-            (attrs as { href?: string }).href,
-        },
-        slots.default ? slots.default() : []
-      )
-  },
-})
-
-const mountComponent = async (options?: {
-  variantSeeds?: Record<string, number>
-}) => {
+const mountComponent = async () => {
   resetHeroSubtitleState()
 
-  if (options?.variantSeeds) {
-    const seedState = useState<Record<string, number>>(
-      'event-pack-variant-seeds',
-      () => ({})
-    )
-    seedState.value = { ...(options.variantSeeds ?? {}) }
-  }
-
-  // Clear animation state to force re-evaluation of Math.random spy
-  const nuxtApp = useNuxtApp()
-  if (nuxtApp?.payload?.state) {
-    Reflect.deleteProperty(nuxtApp.payload.state, 'home-hero-icon-animation')
-  }
-
   return mountSuspended(HomeHeroSection, {
-    props: {
-      searchQuery: '',
-      minSuggestionQueryLength: 2,
-      partnersCount: 12,
-      openDataMillions: 42,
-    },
     global: {
       stubs: {
         HeroSurface: createStub('section'),
-        NudgeToolWizard: createStub('div', 'nudge-tool-wizard-stub'),
-        SearchSuggestField: createStub('div', 'search-suggest-field-stub'),
+        VFadeTransition: createStub('div'),
+        VSkeletonLoader: createStub('div'),
         VContainer: createStub('div'),
         VRow: createStub('div'),
         VCol: createStub('div'),
-        VAvatar: createStub('div'),
-        VImg: VImgStub,
-        VBtn: createStub('button'),
-        RoundedCornerCard: createStub('div', 'rounded-corner-card-stub'),
-        NuxtLink: NuxtLinkStub,
       },
     },
   })
@@ -246,56 +101,25 @@ afterEach(() => {
 })
 
 describe('HomeHeroSection', () => {
-  it('shows the logo icon', async () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.1)
-
+  it('renders the title and subtitle from the event pack', async () => {
     const wrapper = await mountComponent()
 
-    const icon = wrapper.find('.home-hero__icon')
-
-    expect(icon.attributes('src')).toContain('data:image/svg+xml')
-    expect(icon.attributes('alt')).toBe(messages['packs.default.hero.iconAlt'])
-
-    await wrapper.unmount()
-  })
-
-  it('applies a random animation class from the configured list', async () => {
-    // Note: With useState, the random value might be persisted from previous tests in the environment.
-    // We check that the applied class is one of the valid options.
-    const validClasses = [
-      'home-hero__icon--fade',
-      'home-hero__icon--scale',
-      'home-hero__icon--pulse',
-    ]
-
-    const wrapper = await mountComponent()
-    const icon = wrapper.find('.home-hero__icon')
-    const classes = icon.classes()
-
-    expect(validClasses.some(c => classes.includes(c))).toBe(true)
-
-    await wrapper.unmount()
-  })
-
-  it('renders helper text with linked segments', async () => {
-    const wrapper = await mountComponent()
-    const helpers = wrapper.findAll('.home-hero__helper')
-
-    expect(helpers).toHaveLength(2)
-
-    const impactHelperLink = helpers[0].find('.home-hero__helper-link')
-
-    expect(impactHelperLink.exists()).toBe(true)
-    expect(impactHelperLink.attributes('href')).toBe('/impact-score')
-
-    const openDataHelper = helpers[1]
-    const openDataHelperText = openDataHelper.find('.home-hero__helper-text')
-
-    expect(openDataHelperText.text()).toContain(
-      '100% indépendant, logiciel libre et'
+    expect(wrapper.find('.home-hero__title').text()).toBe(
+      messages['packs.default.hero.title']
     )
-    expect(openDataHelperText.text()).toContain(
-      '42+ produits en données ouvertes'
+    expect(wrapper.find('.home-hero__title-subtitle').text()).toBe(
+      subtitleCollections.default[0]
+    )
+
+    await wrapper.unmount()
+  })
+
+  it('uses the background image from the pack override', async () => {
+    const wrapper = await mountComponent()
+    const background = wrapper.find('.home-hero__background-media')
+
+    expect(background.attributes('src')).toContain(
+      messages['packs.default.hero.background']
     )
 
     await wrapper.unmount()

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,60 +1,24 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, toRefs } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useTheme } from 'vuetify'
-import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
-import SearchSuggestField, {
-  type CategorySuggestionItem,
-  type ProductSuggestionItem,
-} from '~/components/search/SearchSuggestField.vue'
-import type { VerticalConfigDto } from '~~/shared/api-client'
-import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
-import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
-  useLogoAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
-import {
-  DEFAULT_EVENT_PACK,
-  EVENT_PACK_I18N_BASE_KEY,
-} from '~~/config/theme/event-packs'
 import { useEventPackI18n } from '~/composables/useEventPackI18n'
 import { THEME_ASSETS_FALLBACK } from '~~/config/theme/assets'
 import { resolveThemeName } from '~~/shared/constants/theme'
-
-type HeroHelperSegment = {
-  text: string
-  to?: string
-}
-
-type HeroHelperItem = {
-  icon: string
-  segments: HeroHelperSegment[]
-}
 
 const isHeroImageLoaded = ref(false)
 const heroReadyFallbackDelayMs = 900
 
 const props = defineProps<{
-  searchQuery: string
-  minSuggestionQueryLength: number
-  verticals?: VerticalConfigDto[]
   heroImageLight?: string
   heroImageDark?: string
-  partnersCount?: number
-  openDataMillions?: number
   heroBackgroundI18nKey?: string
 }>()
 
-const emit = defineEmits<{
-  'update:searchQuery': [value: string]
-  submit: []
-  'select-category': [payload: CategorySuggestionItem]
-  'select-product': [payload: ProductSuggestionItem]
-}>()
-
-const { t, te, tm, locale } = useI18n()
 const theme = useTheme()
 const heroBackgroundAsset = useHeroBackgroundAsset()
 const activeEventPack = useSeasonalEventPack()
@@ -63,117 +27,12 @@ const themeName = computed(() =>
   resolveThemeName(theme.global.name.value, THEME_ASSETS_FALLBACK)
 )
 
-const partnersLinkPlaceholder = '{partnersLink}'
-const openDataMillionsPlaceholder = '{millions}'
-
-const searchQueryValue = computed(() => props.searchQuery)
-
-const { minSuggestionQueryLength } = toRefs(props)
-const wizardVerticals = computed(() => props.verticals ?? [])
-
-const updateSearchQuery = (value: string) => {
-  emit('update:searchQuery', value)
-}
-
-const normalizeHelperSegments = (segments: unknown): HeroHelperSegment[] => {
-  if (!Array.isArray(segments)) {
-    return []
-  }
-
-  return segments
-    .map(segment => {
-      if (typeof segment !== 'object' || segment == null) {
-        return null
-      }
-
-      const { text, to } = segment as { text?: unknown; to?: unknown }
-      const normalizedText = typeof text === 'string' ? text.trim() : ''
-      const normalizedTo =
-        typeof to === 'string' && to.trim().length > 0 ? to.trim() : undefined
-
-      if (!normalizedText) {
-        return null
-      }
-
-      return {
-        text: normalizedText,
-        to: normalizedTo,
-      }
-    })
-    .filter((segment): segment is HeroHelperSegment => segment != null)
-}
-
-const normalizeHelperItems = (items: unknown): HeroHelperItem[] => {
-  if (!Array.isArray(items)) {
-    return []
-  }
-
-  return items
-    .map(rawItem => {
-      if (typeof rawItem !== 'object' || rawItem == null) {
-        return null
-      }
-
-      const { icon, label, segments, labelParts } = rawItem as {
-        icon?: unknown
-        label?: unknown
-        segments?: unknown
-        labelParts?: unknown
-      }
-
-      const normalizedIcon =
-        typeof icon === 'string' && icon.trim().length > 0 ? icon.trim() : '•'
-      const normalizedSegments = normalizeHelperSegments(segments ?? labelParts)
-
-      if (normalizedSegments.length === 0) {
-        const normalizedLabel = typeof label === 'string' ? label.trim() : ''
-
-        if (!normalizedLabel) {
-          return null
-        }
-
-        normalizedSegments.push({ text: normalizedLabel })
-      }
-
-      return {
-        icon: normalizedIcon,
-        segments: normalizedSegments,
-      }
-    })
-    .filter((item): item is HeroHelperItem => item != null)
-}
-
-const heroHelperItems = computed<HeroHelperItem[]>(() => {
-  const packItems = packI18n.resolveList('hero.search.helpers', {
-    fallbackKeys: ['home.hero.search.helpers'],
-  })
-
-  // Robust check for array/object
-  const itemsToNormalize = Array.isArray(packItems)
-    ? packItems
-    : Object.values(packItems ?? {})
-
-  const translatedItems = normalizeHelperItems(itemsToNormalize)
-
-  if (translatedItems.length > 0) {
-    return applyOpenDataMillionsPlaceholder(
-      applyPartnerLinkPlaceholder(translatedItems)
-    )
-  }
-
-  // Fallback to direct translation if pack resolution failed slightly
-  const tmItems = tm('home.hero.search.helpers')
-  if (Array.isArray(tmItems) && tmItems.length > 0) {
-    const directTranslated = normalizeHelperItems(tmItems)
-    if (directTranslated.length > 0) {
-      return applyOpenDataMillionsPlaceholder(
-        applyPartnerLinkPlaceholder(directTranslated)
-      )
-    }
-  }
-
-  return []
-})
+const heroTitle = computed(
+  () =>
+    packI18n.resolveString('hero.title', {
+      fallbackKeys: ['home.hero.title'],
+    }) ?? ''
+)
 
 const heroTitleSubtitle = computed(
   () =>
@@ -182,211 +41,6 @@ const heroTitleSubtitle = computed(
       stateKey: 'home-hero-title-subtitle',
     }) ?? ''
 )
-
-const heroContextTitle = computed(
-  () =>
-    packI18n.resolveString('hero.context.title', {
-      fallbackKeys: ['home.hero.context.title'],
-    }) ?? ''
-)
-
-const normalizedPartnersCount = computed(() => {
-  const rawCount = Number(props.partnersCount ?? 0)
-
-  if (!Number.isFinite(rawCount)) {
-    return 0
-  }
-
-  return Math.max(0, Math.round(rawCount))
-})
-
-const formattedPartnersCount = computed(() => {
-  const count = normalizedPartnersCount.value
-
-  if (!count) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(count)
-  } catch {
-    return String(count)
-  }
-})
-
-const heroPartnersLinkText = computed(() => {
-  const count = normalizedPartnersCount.value
-  const formattedCount = formattedPartnersCount.value
-  const fallbackLabel =
-    packI18n
-      .resolveString('hero.search.partnerLinkFallback', {
-        fallbackKeys: ['home.hero.search.partnerLinkFallback'],
-      })
-      ?.trim() ?? ''
-
-  if (!count || !formattedCount) {
-    return fallbackLabel || null
-  }
-
-  const translateKey = (key: string) => {
-    if (!te(key)) {
-      return ''
-    }
-
-    const translated = t(key, { count, formattedCount })
-    const normalized =
-      typeof translated === 'string'
-        ? translated.trim()
-        : String(translated ?? '').trim()
-
-    return normalized && normalized !== key ? normalized : ''
-  }
-
-  const packKey = `${EVENT_PACK_I18N_BASE_KEY}.${activeEventPack.value}.hero.search.partnerLinkLabel`
-  const defaultKey = `${EVENT_PACK_I18N_BASE_KEY}.${DEFAULT_EVENT_PACK}.hero.search.partnerLinkLabel`
-
-  const translated =
-    translateKey(packKey) ||
-    translateKey(defaultKey) ||
-    translateKey('home.hero.search.partnerLinkLabel')
-
-  const normalizedTranslation =
-    typeof translated === 'string'
-      ? translated.trim()
-      : String(translated ?? '').trim()
-
-  if (
-    normalizedTranslation &&
-    normalizedTranslation !== 'home.hero.search.partnerLinkLabel'
-  ) {
-    return normalizedTranslation
-  }
-
-  if (!fallbackLabel) {
-    return formattedCount
-  }
-
-  return `${formattedCount} ${fallbackLabel}`
-})
-
-const formattedOpenDataMillions = computed(() => {
-  const value = props.openDataMillions
-
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(value)
-  } catch {
-    return String(value)
-  }
-})
-
-const applyPartnerLinkPlaceholder = (items: HeroHelperItem[]) => {
-  const partnerLinkText = heroPartnersLinkText.value
-
-  if (!partnerLinkText) {
-    return items
-  }
-
-  return items.map(item => {
-    const segmentsWithPartnerLink = item.segments
-      .map(segment => {
-        if (!segment.text.includes(partnersLinkPlaceholder)) {
-          return segment
-        }
-
-        const replacedText = segment.text.replaceAll(
-          partnersLinkPlaceholder,
-          partnerLinkText
-        )
-
-        const normalizedText = replacedText.trim()
-
-        if (!normalizedText) {
-          return null
-        }
-
-        return {
-          ...segment,
-          text: normalizedText,
-        }
-      })
-      .filter((segment): segment is HeroHelperSegment => segment != null)
-
-    return {
-      ...item,
-      segments:
-        segmentsWithPartnerLink.length > 0
-          ? segmentsWithPartnerLink
-          : item.segments,
-    }
-  })
-}
-
-const applyOpenDataMillionsPlaceholder = (items: HeroHelperItem[]) => {
-  const millionsLabel = formattedOpenDataMillions.value
-
-  if (!millionsLabel) {
-    return items
-  }
-
-  return items.map(item => {
-    const segmentsWithOpenDataMillions = item.segments
-      .map(segment => {
-        if (!segment.text.includes(openDataMillionsPlaceholder)) {
-          return segment
-        }
-
-        const replacedText = segment.text.replaceAll(
-          openDataMillionsPlaceholder,
-          millionsLabel
-        )
-
-        const normalizedText = replacedText.trim()
-
-        if (!normalizedText) {
-          return null
-        }
-
-        return {
-          ...segment,
-          text: normalizedText,
-        }
-      })
-      .filter((segment): segment is HeroHelperSegment => segment != null)
-
-    return {
-      ...item,
-      segments:
-        segmentsWithOpenDataMillions.length > 0
-          ? segmentsWithOpenDataMillions
-          : item.segments,
-    }
-  })
-}
-
-const heroIconAlt = computed(
-  () =>
-    packI18n.resolveString('hero.iconAlt', {
-      fallbackKeys: ['home.hero.iconAlt'],
-    }) ?? ''
-)
-const heroIconSrc = useLogoAsset()
-const heroIconAnimationOptions = [
-  'home-hero__icon--fade',
-  'home-hero__icon--scale',
-  'home-hero__icon--pulse',
-] as const
-const heroIconAnimation = useState<string>(
-  'home-hero-icon-animation',
-  () =>
-    heroIconAnimationOptions[
-      Math.floor(Math.random() * heroIconAnimationOptions.length)
-    ] || heroIconAnimationOptions[0]
-)
-const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
 
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundI18nKey = computed(
@@ -419,6 +73,7 @@ const resolveHeroBackgroundSource = (value?: string): string | undefined => {
 const heroBackgroundOverride = computed(() =>
   resolveHeroBackgroundSource(heroBackgroundI18nValue.value)
 )
+
 const heroBackgroundSrc = computed(() => {
   const themedAsset = heroBackgroundOverride.value?.trim()
 
@@ -431,24 +86,12 @@ const heroBackgroundSrc = computed(() => {
     return fallbackAsset
   }
 
-  /* Hydration mismatch fix: Ensure server and client initial render match. */
-  /* We assume light theme as default for SSR unless reliable cookie sync is present. */
-  // If we can't guarantee theme sync, we should force a default, then switch on mount.
-  // Ideally, use a client-side only guard for the dynamic theme part or strictly match server.
-
   const isDarkMode = Boolean(theme.global.current.value.dark)
   const lightImage = props.heroImageLight?.trim()
   const darkImage = props.heroImageDark?.trim()
 
   return isDarkMode ? (darkImage ?? '') : (lightImage ?? '')
 })
-
-const heroTitle = computed(
-  () =>
-    packI18n.resolveString('hero.title', {
-      fallbackKeys: ['home.hero.title'],
-    }) ?? ''
-)
 
 const handleHeroImageLoad = () => {
   isHeroImageLoaded.value = true
@@ -461,18 +104,6 @@ onMounted(() => {
     }
   }, heroReadyFallbackDelayMs)
 })
-
-const handleSubmit = () => {
-  emit('submit')
-}
-
-const handleCategorySelect = (payload: CategorySuggestionItem) => {
-  emit('select-category', payload)
-}
-
-const handleProductSelect = (payload: ProductSuggestionItem) => {
-  emit('select-product', payload)
-}
 
 useHead({
   link: [
@@ -514,7 +145,7 @@ useHead({
     </div>
     <v-container fluid class="home-hero__container">
       <div class="home-hero__inner">
-        <v-row class="home-hero__layout" align="stretch" justify="center">
+        <v-row class="home-hero__layout" align="center" justify="center">
           <v-col cols="12" class="home-hero__content">
             <h1 id="home-hero-title" class="home-hero__title">
               {{ heroTitle }}
@@ -522,165 +153,6 @@ useHead({
             <p v-if="heroTitleSubtitle" class="home-hero__title-subtitle">
               {{ heroTitleSubtitle }}
             </p>
-            <AnimatedSubtitle
-              class="home-hero__title-animated-subtitle"
-              i18n-key="home.hero.subtitle"
-              animation="fade"
-              :delay="600"
-              :duration-ms="420"
-            />
-          </v-col>
-        </v-row>
-        <v-row justify="center">
-          <v-col cols="12" lg="10" xl="8">
-            <v-sheet class="home-hero__panel" color="transparent" elevation="0">
-              <div class="home-hero__panel-grid">
-                <div class="home-hero__panel-block">
-                  <NudgeToolWizard :verticals="wizardVerticals" />
-                </div>
-                <div class="home-hero__panel-block">
-                  <form
-                    class="home-hero__search"
-                    role="search"
-                    @submit.prevent="handleSubmit"
-                  >
-                    <SearchSuggestField
-                      :model-value="searchQueryValue"
-                      class="home-hero__search-input"
-                      :label="
-                        packI18n.resolveString('hero.search.label', {
-                          fallbackKeys: ['home.hero.search.label'],
-                        })
-                      "
-                      :placeholder="
-                        packI18n.resolveString('hero.search.placeholder', {
-                          fallbackKeys: ['home.hero.search.placeholder'],
-                        })
-                      "
-                      :aria-label="
-                        packI18n.resolveString('hero.search.ariaLabel', {
-                          fallbackKeys: ['home.hero.search.ariaLabel'],
-                        })
-                      "
-                      :min-chars="minSuggestionQueryLength"
-                      :enable-scan="true"
-                      :scan-mobile="true"
-                      :scan-desktop="false"
-                      :enable-voice="true"
-                      :voice-mobile="true"
-                      :voice-desktop="true"
-                      @update:model-value="updateSearchQuery"
-                      @submit="handleSubmit"
-                      @select-category="handleCategorySelect"
-                      @select-product="handleProductSelect"
-                    >
-                      <template #append-inner>
-                        <v-btn
-                          class="home-hero__search-submit nudger_degrade-defaut"
-                          icon="mdi-arrow-right"
-                          variant="flat"
-                          color="primary"
-                          size="small"
-                          type="submit"
-                          :aria-label="
-                            packI18n.resolveString('hero.search.cta', {
-                              fallbackKeys: ['home.hero.search.cta'],
-                            })
-                          "
-                        />
-                      </template>
-                    </SearchSuggestField>
-                  </form>
-                  <RoundedCornerCard
-                    class="home-hero__context-card"
-                    surface="strong"
-                    accent-corner="bottom-right"
-                    corner-variant="none"
-                    corner-size="lg"
-                    rounded="lg"
-                    :selectable="false"
-                    :elevation="10"
-                    :hover-elevation="14"
-                    :aria-label="
-                      packI18n.resolveString('hero.context.ariaLabel', {
-                        fallbackKeys: ['home.hero.context.ariaLabel'],
-                      })
-                    "
-                  >
-                    <div class="home-hero__context">
-                      <p class="home-hero__subtitle text-center">
-                        {{ heroContextTitle }}
-                      </p>
-
-                      <v-row class="home-hero__helper-row" justify="center">
-                        <v-col
-                          cols="4"
-                          class="align-center home-hero__eyebrow-block"
-                        >
-                          <div
-                            v-if="showHeroIcon"
-                            class="home-hero__icon-wrapper"
-                          >
-                            <img
-                              :src="heroIconSrc"
-                              :alt="heroIconAlt"
-                              :class="['home-hero__icon', heroIconAnimation]"
-                              loading="lazy"
-                            />
-                          </div>
-                        </v-col>
-                        <v-col
-                          v-if="heroHelperItems.length"
-                          cols="6"
-                          class="home-hero__helpers-wrapper"
-                        >
-                          <ul class="home-hero__helpers">
-                            <li
-                              v-for="(item, index) in heroHelperItems"
-                              :key="`hero-helper-${index}`"
-                              class="home-hero__helper"
-                            >
-                              <span
-                                class="home-hero__helper-icon"
-                                aria-hidden="true"
-                                >{{ item.icon }}</span
-                              >
-                              <span class="home-hero__helper-text">
-                                <template
-                                  v-for="(
-                                    segment, segmentIndex
-                                  ) in item.segments"
-                                  :key="`hero-helper-segment-${index}-${segmentIndex}`"
-                                >
-                                  <NuxtLink
-                                    v-if="segment.to"
-                                    class="home-hero__helper-link"
-                                    :to="segment.to"
-                                  >
-                                    {{
-                                      segmentIndex > 0
-                                        ? ` ${segment.text}`
-                                        : segment.text
-                                    }}
-                                  </NuxtLink>
-                                  <span v-else>
-                                    {{
-                                      segmentIndex > 0
-                                        ? ` ${segment.text}`
-                                        : segment.text
-                                    }}
-                                  </span>
-                                </template>
-                              </span>
-                            </li>
-                          </ul>
-                        </v-col>
-                      </v-row>
-                    </div>
-                  </RoundedCornerCard>
-                </div>
-              </div>
-            </v-sheet>
           </v-col>
         </v-row>
       </div>
@@ -773,49 +245,6 @@ useHead({
   align-items: center
   text-align: center
 
-.home-hero__eyebrow-block
-  display: inline-flex
-  flex-direction: column
-  gap: clamp(0.5rem, 1.5vw, 0.75rem)
-  padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
-  align-items: flex-start
-
-.home-hero__eyebrow
-  font-weight: 600
-  letter-spacing: 0.08em
-  text-transform: uppercase
-  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
-  margin: 0
-
-.home-hero__icon-wrapper
-  width: clamp(4.5rem, 16vw, 7.5rem)
-  height: clamp(4.5rem, 16vw, 7.5rem)
-  box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
-  backdrop-filter: blur(8px)
-  border-radius: 50%
-  padding: clamp(0.6rem, 1.6vw, 0.9rem)
-  box-sizing: border-box
-  background: rgba(var(--v-theme-surface-default), 0.92)
-
-.home-hero__icon
-  border-radius: inherit
-  width: 92%
-  height: 92%
-  transition: transform 250ms ease, filter 250ms ease
-  filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
-  object-fit: contain
-  display: block
-  margin: auto
-
-.home-hero__icon--fade
-  animation: home-hero-fade-up 900ms ease-out both
-
-.home-hero__icon--scale
-  animation: home-hero-scale-in 800ms ease-out both
-
-.home-hero__icon--pulse
-  animation: home-hero-pulse 1200ms ease-in-out both
-
 .home-hero__title
   font-size: clamp(2.2rem, 5vw, 3.8rem)
   line-height: 1.05
@@ -830,170 +259,8 @@ useHead({
   font-size: clamp(1rem, 2.4vw, 1.4rem)
   line-height: 1.4
 
-.home-hero__title-animated-subtitle
-  font-size: clamp(0.95rem, 2.2vw, 1.2rem)
-  color: rgba(var(--v-theme-surface-default), 0.9)
-  font-size: clamp(1.2rem, 5vw, 1.8rem)
-  text-shadow: rgb(var(--v-theme-text-neutral-secondary)) 1px 0 10px
-
-.home-hero__search
-  display: flex
-  flex-direction: column
-  gap: 0.75rem
-
-.home-hero__search-input
-  border-radius: clamp(1.5rem, 4vw, 2rem)
-  background: rgba(var(--v-theme-surface-default), 0.85)
-  box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.1)
-
-.home-hero__search-submit
-  box-shadow: none
-
-.home-hero__panel
-  background: rgb(var(--v-theme-surface-default))
-  border-radius: clamp(1.5rem, 4vw, 2rem)
-  box-shadow: 0 4px 12px rgba(var(--v-theme-shadow-primary-600), 0.05)
-  padding: clamp(2rem, 5vw, 3rem)
-  margin-block-start: 1rem
-  width: 100%
-  max-width: clamp(56rem, 82vw, 72rem)
-  margin-inline: auto
-
-.home-hero__panel-grid
-  display: grid
-  gap: clamp(1.5rem, 4vw, 2.5rem)
-  grid-template-columns: 1fr
-
-.home-hero__panel-block
-  display: flex
-  flex-direction: column
-  gap: clamp(1.25rem, 2vw, 1.75rem)
-  min-width: 0
-
-.home-hero__context
-  flex-direction: column
-  gap: 0.75rem
-
-.home-hero__context-card
-  height: 100%
-
-.home-hero__helper-row
-  display: flex
-  flex-wrap: wrap
-  align-items: center
-
-.home-hero__helpers
-  margin: 0
-  padding: 0
-  display: grid
-  gap: clamp(0.4rem, 1.5vw, 0.65rem)
-  list-style: none
-
-.home-hero__helper
-  display: inline-flex
-  align-items: center
-  gap: 0.45rem
-  margin: 0
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  font-weight: 500
-
-.home-hero__helper-icon
-  font-size: 1.1rem
-
-.home-hero__helper-text
-  line-height: 1.35
-
-.home-hero__helper-link
-  color: rgb(var(--v-theme-text-neutral-strong))
-  font-weight: 600
-  text-decoration: underline
-  text-decoration-thickness: 0.08em
-  text-underline-offset: 0.1em
-
-.home-hero__context
-  display: flex
-  flex-direction: column
-  gap: 0.75rem
-
-.home-hero__subtitle
-  margin: 0
-  color: rgb(var(--v-theme-text-neutral-strong))
-  text-align: center
-  width: 100%
-
-
-.home-hero__helpers-title
-  font-size: 0.875rem
-  font-weight: 600
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  margin-bottom: 0.5rem
-  display: block
-  letter-spacing: 0.01em
-
-.home-hero__wizard
-  width: 100%
-
-
-
-@keyframes home-hero-fade-up
-  from
-    opacity: 0
-    transform: translateY(12px) scale(0.98)
-  to
-    opacity: 1
-    transform: translateY(0) scale(1)
-
-@keyframes home-hero-scale-in
-  from
-    opacity: 0
-    transform: scale(0.9)
-  55%
-    opacity: 1
-    transform: scale(1.02)
-  to
-    transform: scale(1)
-
-@keyframes home-hero-pulse
-  0%
-    transform: scale(0.92)
-    opacity: 0
-  35%
-    transform: scale(1.04)
-    opacity: 1
-  70%
-    transform: scale(0.98)
-  100%
-    transform: scale(1)
-
 @media (max-width: 959px)
   .home-hero
     min-height: clamp(520px, 68dvh, 760px)
     padding-block: clamp(2rem, 10vw, 4rem)
-
-  .home-hero__panel
-    padding: clamp(1.25rem, 5vw, 2rem)
-
-  .home-hero__panel-grid
-    gap: clamp(1rem, 3vw, 1.5rem)
-
-  .home-hero__media
-    order: 1
-
-  .home-hero__content
-    order: 2
-
-@media (min-width: 960px)
-  .home-hero__panel-grid
-    grid-template-columns: 1fr
-
-  .home-hero__helper-row
-    grid-template-columns: auto 1fr
-
-@media (min-width: 1280px)
-  .home-hero__panel-grid
-    grid-template-columns: 1fr
-
-@media (min-width: 90rem)
-  .home-hero__panel
-    max-width: clamp(60rem, 78vw, 74rem)
 </style>

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -1,24 +1,60 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, toRefs } from 'vue'
 import { useTheme } from 'vuetify'
+import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
+import SearchSuggestField, {
+  type CategorySuggestionItem,
+  type ProductSuggestionItem,
+} from '~/components/search/SearchSuggestField.vue'
+import type { VerticalConfigDto } from '~~/shared/api-client'
+import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
+import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
+  useLogoAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
+import {
+  DEFAULT_EVENT_PACK,
+  EVENT_PACK_I18N_BASE_KEY,
+} from '~~/config/theme/event-packs'
 import { useEventPackI18n } from '~/composables/useEventPackI18n'
 import { THEME_ASSETS_FALLBACK } from '~~/config/theme/assets'
 import { resolveThemeName } from '~~/shared/constants/theme'
+
+type HeroHelperSegment = {
+  text: string
+  to?: string
+}
+
+type HeroHelperItem = {
+  icon: string
+  segments: HeroHelperSegment[]
+}
 
 const isHeroImageLoaded = ref(false)
 const heroReadyFallbackDelayMs = 900
 
 const props = defineProps<{
+  searchQuery: string
+  minSuggestionQueryLength: number
+  verticals?: VerticalConfigDto[]
   heroImageLight?: string
   heroImageDark?: string
+  partnersCount?: number
+  openDataMillions?: number
   heroBackgroundI18nKey?: string
 }>()
 
+const emit = defineEmits<{
+  'update:searchQuery': [value: string]
+  submit: []
+  'select-category': [payload: CategorySuggestionItem]
+  'select-product': [payload: ProductSuggestionItem]
+}>()
+
+const { t, te, tm, locale } = useI18n()
 const theme = useTheme()
 const heroBackgroundAsset = useHeroBackgroundAsset()
 const activeEventPack = useSeasonalEventPack()
@@ -27,12 +63,117 @@ const themeName = computed(() =>
   resolveThemeName(theme.global.name.value, THEME_ASSETS_FALLBACK)
 )
 
-const heroTitle = computed(
-  () =>
-    packI18n.resolveString('hero.title', {
-      fallbackKeys: ['home.hero.title'],
-    }) ?? ''
-)
+const partnersLinkPlaceholder = '{partnersLink}'
+const openDataMillionsPlaceholder = '{millions}'
+
+const searchQueryValue = computed(() => props.searchQuery)
+
+const { minSuggestionQueryLength } = toRefs(props)
+const wizardVerticals = computed(() => props.verticals ?? [])
+
+const updateSearchQuery = (value: string) => {
+  emit('update:searchQuery', value)
+}
+
+const normalizeHelperSegments = (segments: unknown): HeroHelperSegment[] => {
+  if (!Array.isArray(segments)) {
+    return []
+  }
+
+  return segments
+    .map(segment => {
+      if (typeof segment !== 'object' || segment == null) {
+        return null
+      }
+
+      const { text, to } = segment as { text?: unknown; to?: unknown }
+      const normalizedText = typeof text === 'string' ? text.trim() : ''
+      const normalizedTo =
+        typeof to === 'string' && to.trim().length > 0 ? to.trim() : undefined
+
+      if (!normalizedText) {
+        return null
+      }
+
+      return {
+        text: normalizedText,
+        to: normalizedTo,
+      }
+    })
+    .filter((segment): segment is HeroHelperSegment => segment != null)
+}
+
+const normalizeHelperItems = (items: unknown): HeroHelperItem[] => {
+  if (!Array.isArray(items)) {
+    return []
+  }
+
+  return items
+    .map(rawItem => {
+      if (typeof rawItem !== 'object' || rawItem == null) {
+        return null
+      }
+
+      const { icon, label, segments, labelParts } = rawItem as {
+        icon?: unknown
+        label?: unknown
+        segments?: unknown
+        labelParts?: unknown
+      }
+
+      const normalizedIcon =
+        typeof icon === 'string' && icon.trim().length > 0 ? icon.trim() : '•'
+      const normalizedSegments = normalizeHelperSegments(segments ?? labelParts)
+
+      if (normalizedSegments.length === 0) {
+        const normalizedLabel = typeof label === 'string' ? label.trim() : ''
+
+        if (!normalizedLabel) {
+          return null
+        }
+
+        normalizedSegments.push({ text: normalizedLabel })
+      }
+
+      return {
+        icon: normalizedIcon,
+        segments: normalizedSegments,
+      }
+    })
+    .filter((item): item is HeroHelperItem => item != null)
+}
+
+const heroHelperItems = computed<HeroHelperItem[]>(() => {
+  const packItems = packI18n.resolveList('hero.search.helpers', {
+    fallbackKeys: ['home.hero.search.helpers'],
+  })
+
+  // Robust check for array/object
+  const itemsToNormalize = Array.isArray(packItems)
+    ? packItems
+    : Object.values(packItems ?? {})
+
+  const translatedItems = normalizeHelperItems(itemsToNormalize)
+
+  if (translatedItems.length > 0) {
+    return applyOpenDataMillionsPlaceholder(
+      applyPartnerLinkPlaceholder(translatedItems)
+    )
+  }
+
+  // Fallback to direct translation if pack resolution failed slightly
+  const tmItems = tm('home.hero.search.helpers')
+  if (Array.isArray(tmItems) && tmItems.length > 0) {
+    const directTranslated = normalizeHelperItems(tmItems)
+    if (directTranslated.length > 0) {
+      return applyOpenDataMillionsPlaceholder(
+        applyPartnerLinkPlaceholder(directTranslated)
+      )
+    }
+  }
+
+  return []
+})
 
 const heroTitleSubtitle = computed(
   () =>
@@ -41,6 +182,211 @@ const heroTitleSubtitle = computed(
       stateKey: 'home-hero-title-subtitle',
     }) ?? ''
 )
+
+const heroContextTitle = computed(
+  () =>
+    packI18n.resolveString('hero.context.title', {
+      fallbackKeys: ['home.hero.context.title'],
+    }) ?? ''
+)
+
+const normalizedPartnersCount = computed(() => {
+  const rawCount = Number(props.partnersCount ?? 0)
+
+  if (!Number.isFinite(rawCount)) {
+    return 0
+  }
+
+  return Math.max(0, Math.round(rawCount))
+})
+
+const formattedPartnersCount = computed(() => {
+  const count = normalizedPartnersCount.value
+
+  if (!count) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(count)
+  } catch {
+    return String(count)
+  }
+})
+
+const heroPartnersLinkText = computed(() => {
+  const count = normalizedPartnersCount.value
+  const formattedCount = formattedPartnersCount.value
+  const fallbackLabel =
+    packI18n
+      .resolveString('hero.search.partnerLinkFallback', {
+        fallbackKeys: ['home.hero.search.partnerLinkFallback'],
+      })
+      ?.trim() ?? ''
+
+  if (!count || !formattedCount) {
+    return fallbackLabel || null
+  }
+
+  const translateKey = (key: string) => {
+    if (!te(key)) {
+      return ''
+    }
+
+    const translated = t(key, { count, formattedCount })
+    const normalized =
+      typeof translated === 'string'
+        ? translated.trim()
+        : String(translated ?? '').trim()
+
+    return normalized && normalized !== key ? normalized : ''
+  }
+
+  const packKey = `${EVENT_PACK_I18N_BASE_KEY}.${activeEventPack.value}.hero.search.partnerLinkLabel`
+  const defaultKey = `${EVENT_PACK_I18N_BASE_KEY}.${DEFAULT_EVENT_PACK}.hero.search.partnerLinkLabel`
+
+  const translated =
+    translateKey(packKey) ||
+    translateKey(defaultKey) ||
+    translateKey('home.hero.search.partnerLinkLabel')
+
+  const normalizedTranslation =
+    typeof translated === 'string'
+      ? translated.trim()
+      : String(translated ?? '').trim()
+
+  if (
+    normalizedTranslation &&
+    normalizedTranslation !== 'home.hero.search.partnerLinkLabel'
+  ) {
+    return normalizedTranslation
+  }
+
+  if (!fallbackLabel) {
+    return formattedCount
+  }
+
+  return `${formattedCount} ${fallbackLabel}`
+})
+
+const formattedOpenDataMillions = computed(() => {
+  const value = props.openDataMillions
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(value)
+  } catch {
+    return String(value)
+  }
+})
+
+const applyPartnerLinkPlaceholder = (items: HeroHelperItem[]) => {
+  const partnerLinkText = heroPartnersLinkText.value
+
+  if (!partnerLinkText) {
+    return items
+  }
+
+  return items.map(item => {
+    const segmentsWithPartnerLink = item.segments
+      .map(segment => {
+        if (!segment.text.includes(partnersLinkPlaceholder)) {
+          return segment
+        }
+
+        const replacedText = segment.text.replaceAll(
+          partnersLinkPlaceholder,
+          partnerLinkText
+        )
+
+        const normalizedText = replacedText.trim()
+
+        if (!normalizedText) {
+          return null
+        }
+
+        return {
+          ...segment,
+          text: normalizedText,
+        }
+      })
+      .filter((segment): segment is HeroHelperSegment => segment != null)
+
+    return {
+      ...item,
+      segments:
+        segmentsWithPartnerLink.length > 0
+          ? segmentsWithPartnerLink
+          : item.segments,
+    }
+  })
+}
+
+const applyOpenDataMillionsPlaceholder = (items: HeroHelperItem[]) => {
+  const millionsLabel = formattedOpenDataMillions.value
+
+  if (!millionsLabel) {
+    return items
+  }
+
+  return items.map(item => {
+    const segmentsWithOpenDataMillions = item.segments
+      .map(segment => {
+        if (!segment.text.includes(openDataMillionsPlaceholder)) {
+          return segment
+        }
+
+        const replacedText = segment.text.replaceAll(
+          openDataMillionsPlaceholder,
+          millionsLabel
+        )
+
+        const normalizedText = replacedText.trim()
+
+        if (!normalizedText) {
+          return null
+        }
+
+        return {
+          ...segment,
+          text: normalizedText,
+        }
+      })
+      .filter((segment): segment is HeroHelperSegment => segment != null)
+
+    return {
+      ...item,
+      segments:
+        segmentsWithOpenDataMillions.length > 0
+          ? segmentsWithOpenDataMillions
+          : item.segments,
+    }
+  })
+}
+
+const heroIconAlt = computed(
+  () =>
+    packI18n.resolveString('hero.iconAlt', {
+      fallbackKeys: ['home.hero.iconAlt'],
+    }) ?? ''
+)
+const heroIconSrc = useLogoAsset()
+const heroIconAnimationOptions = [
+  'home-hero__icon--fade',
+  'home-hero__icon--scale',
+  'home-hero__icon--pulse',
+] as const
+const heroIconAnimation = useState<string>(
+  'home-hero-icon-animation',
+  () =>
+    heroIconAnimationOptions[
+      Math.floor(Math.random() * heroIconAnimationOptions.length)
+    ] || heroIconAnimationOptions[0]
+)
+const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
 
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundI18nKey = computed(
@@ -73,7 +419,6 @@ const resolveHeroBackgroundSource = (value?: string): string | undefined => {
 const heroBackgroundOverride = computed(() =>
   resolveHeroBackgroundSource(heroBackgroundI18nValue.value)
 )
-
 const heroBackgroundSrc = computed(() => {
   const themedAsset = heroBackgroundOverride.value?.trim()
 
@@ -86,12 +431,24 @@ const heroBackgroundSrc = computed(() => {
     return fallbackAsset
   }
 
+  /* Hydration mismatch fix: Ensure server and client initial render match. */
+  /* We assume light theme as default for SSR unless reliable cookie sync is present. */
+  // If we can't guarantee theme sync, we should force a default, then switch on mount.
+  // Ideally, use a client-side only guard for the dynamic theme part or strictly match server.
+
   const isDarkMode = Boolean(theme.global.current.value.dark)
   const lightImage = props.heroImageLight?.trim()
   const darkImage = props.heroImageDark?.trim()
 
   return isDarkMode ? (darkImage ?? '') : (lightImage ?? '')
 })
+
+const heroTitle = computed(
+  () =>
+    packI18n.resolveString('hero.title', {
+      fallbackKeys: ['home.hero.title'],
+    }) ?? ''
+)
 
 const handleHeroImageLoad = () => {
   isHeroImageLoaded.value = true
@@ -104,6 +461,18 @@ onMounted(() => {
     }
   }, heroReadyFallbackDelayMs)
 })
+
+const handleSubmit = () => {
+  emit('submit')
+}
+
+const handleCategorySelect = (payload: CategorySuggestionItem) => {
+  emit('select-category', payload)
+}
+
+const handleProductSelect = (payload: ProductSuggestionItem) => {
+  emit('select-product', payload)
+}
 
 useHead({
   link: [
@@ -145,7 +514,7 @@ useHead({
     </div>
     <v-container fluid class="home-hero__container">
       <div class="home-hero__inner">
-        <v-row class="home-hero__layout" align="center" justify="center">
+        <v-row class="home-hero__layout" align="stretch" justify="center">
           <v-col cols="12" class="home-hero__content">
             <h1 id="home-hero-title" class="home-hero__title">
               {{ heroTitle }}
@@ -153,6 +522,165 @@ useHead({
             <p v-if="heroTitleSubtitle" class="home-hero__title-subtitle">
               {{ heroTitleSubtitle }}
             </p>
+            <AnimatedSubtitle
+              class="home-hero__title-animated-subtitle"
+              i18n-key="home.hero.subtitle"
+              animation="fade"
+              :delay="600"
+              :duration-ms="420"
+            />
+          </v-col>
+        </v-row>
+        <v-row justify="center">
+          <v-col cols="12" lg="10" xl="8">
+            <v-sheet class="home-hero__panel" color="transparent" elevation="0">
+              <div class="home-hero__panel-grid">
+                <div class="home-hero__panel-block">
+                  <NudgeToolWizard :verticals="wizardVerticals" />
+                </div>
+                <div class="home-hero__panel-block">
+                  <form
+                    class="home-hero__search"
+                    role="search"
+                    @submit.prevent="handleSubmit"
+                  >
+                    <SearchSuggestField
+                      :model-value="searchQueryValue"
+                      class="home-hero__search-input"
+                      :label="
+                        packI18n.resolveString('hero.search.label', {
+                          fallbackKeys: ['home.hero.search.label'],
+                        })
+                      "
+                      :placeholder="
+                        packI18n.resolveString('hero.search.placeholder', {
+                          fallbackKeys: ['home.hero.search.placeholder'],
+                        })
+                      "
+                      :aria-label="
+                        packI18n.resolveString('hero.search.ariaLabel', {
+                          fallbackKeys: ['home.hero.search.ariaLabel'],
+                        })
+                      "
+                      :min-chars="minSuggestionQueryLength"
+                      :enable-scan="true"
+                      :scan-mobile="true"
+                      :scan-desktop="false"
+                      :enable-voice="true"
+                      :voice-mobile="true"
+                      :voice-desktop="true"
+                      @update:model-value="updateSearchQuery"
+                      @submit="handleSubmit"
+                      @select-category="handleCategorySelect"
+                      @select-product="handleProductSelect"
+                    >
+                      <template #append-inner>
+                        <v-btn
+                          class="home-hero__search-submit nudger_degrade-defaut"
+                          icon="mdi-arrow-right"
+                          variant="flat"
+                          color="primary"
+                          size="small"
+                          type="submit"
+                          :aria-label="
+                            packI18n.resolveString('hero.search.cta', {
+                              fallbackKeys: ['home.hero.search.cta'],
+                            })
+                          "
+                        />
+                      </template>
+                    </SearchSuggestField>
+                  </form>
+                  <RoundedCornerCard
+                    class="home-hero__context-card"
+                    surface="strong"
+                    accent-corner="bottom-right"
+                    corner-variant="none"
+                    corner-size="lg"
+                    rounded="lg"
+                    :selectable="false"
+                    :elevation="10"
+                    :hover-elevation="14"
+                    :aria-label="
+                      packI18n.resolveString('hero.context.ariaLabel', {
+                        fallbackKeys: ['home.hero.context.ariaLabel'],
+                      })
+                    "
+                  >
+                    <div class="home-hero__context">
+                      <p class="home-hero__subtitle text-center">
+                        {{ heroContextTitle }}
+                      </p>
+
+                      <v-row class="home-hero__helper-row" justify="center">
+                        <v-col
+                          cols="4"
+                          class="align-center home-hero__eyebrow-block"
+                        >
+                          <div
+                            v-if="showHeroIcon"
+                            class="home-hero__icon-wrapper"
+                          >
+                            <img
+                              :src="heroIconSrc"
+                              :alt="heroIconAlt"
+                              :class="['home-hero__icon', heroIconAnimation]"
+                              loading="lazy"
+                            />
+                          </div>
+                        </v-col>
+                        <v-col
+                          v-if="heroHelperItems.length"
+                          cols="6"
+                          class="home-hero__helpers-wrapper"
+                        >
+                          <ul class="home-hero__helpers">
+                            <li
+                              v-for="(item, index) in heroHelperItems"
+                              :key="`hero-helper-${index}`"
+                              class="home-hero__helper"
+                            >
+                              <span
+                                class="home-hero__helper-icon"
+                                aria-hidden="true"
+                                >{{ item.icon }}</span
+                              >
+                              <span class="home-hero__helper-text">
+                                <template
+                                  v-for="(
+                                    segment, segmentIndex
+                                  ) in item.segments"
+                                  :key="`hero-helper-segment-${index}-${segmentIndex}`"
+                                >
+                                  <NuxtLink
+                                    v-if="segment.to"
+                                    class="home-hero__helper-link"
+                                    :to="segment.to"
+                                  >
+                                    {{
+                                      segmentIndex > 0
+                                        ? ` ${segment.text}`
+                                        : segment.text
+                                    }}
+                                  </NuxtLink>
+                                  <span v-else>
+                                    {{
+                                      segmentIndex > 0
+                                        ? ` ${segment.text}`
+                                        : segment.text
+                                    }}
+                                  </span>
+                                </template>
+                              </span>
+                            </li>
+                          </ul>
+                        </v-col>
+                      </v-row>
+                    </div>
+                  </RoundedCornerCard>
+                </div>
+              </div>
+            </v-sheet>
           </v-col>
         </v-row>
       </div>
@@ -245,6 +773,49 @@ useHead({
   align-items: center
   text-align: center
 
+.home-hero__eyebrow-block
+  display: inline-flex
+  flex-direction: column
+  gap: clamp(0.5rem, 1.5vw, 0.75rem)
+  padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
+  align-items: flex-start
+
+.home-hero__eyebrow
+  font-weight: 600
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgba(var(--v-theme-hero-gradient-end), 0.9)
+  margin: 0
+
+.home-hero__icon-wrapper
+  width: clamp(4.5rem, 16vw, 7.5rem)
+  height: clamp(4.5rem, 16vw, 7.5rem)
+  box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
+  backdrop-filter: blur(8px)
+  border-radius: 50%
+  padding: clamp(0.6rem, 1.6vw, 0.9rem)
+  box-sizing: border-box
+  background: rgba(var(--v-theme-surface-default), 0.92)
+
+.home-hero__icon
+  border-radius: inherit
+  width: 92%
+  height: 92%
+  transition: transform 250ms ease, filter 250ms ease
+  filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
+  object-fit: contain
+  display: block
+  margin: auto
+
+.home-hero__icon--fade
+  animation: home-hero-fade-up 900ms ease-out both
+
+.home-hero__icon--scale
+  animation: home-hero-scale-in 800ms ease-out both
+
+.home-hero__icon--pulse
+  animation: home-hero-pulse 1200ms ease-in-out both
+
 .home-hero__title
   font-size: clamp(2.2rem, 5vw, 3.8rem)
   line-height: 1.05
@@ -259,8 +830,170 @@ useHead({
   font-size: clamp(1rem, 2.4vw, 1.4rem)
   line-height: 1.4
 
+.home-hero__title-animated-subtitle
+  font-size: clamp(0.95rem, 2.2vw, 1.2rem)
+  color: rgba(var(--v-theme-surface-default), 0.9)
+  font-size: clamp(1.2rem, 5vw, 1.8rem)
+  text-shadow: rgb(var(--v-theme-text-neutral-secondary)) 1px 0 10px
+
+.home-hero__search
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-hero__search-input
+  border-radius: clamp(1.5rem, 4vw, 2rem)
+  background: rgba(var(--v-theme-surface-default), 0.85)
+  box-shadow: 0 18px 30px rgba(var(--v-theme-shadow-primary-600), 0.1)
+
+.home-hero__search-submit
+  box-shadow: none
+
+.home-hero__panel
+  background: rgb(var(--v-theme-surface-default))
+  border-radius: clamp(1.5rem, 4vw, 2rem)
+  box-shadow: 0 4px 12px rgba(var(--v-theme-shadow-primary-600), 0.05)
+  padding: clamp(2rem, 5vw, 3rem)
+  margin-block-start: 1rem
+  width: 100%
+  max-width: clamp(56rem, 82vw, 72rem)
+  margin-inline: auto
+
+.home-hero__panel-grid
+  display: grid
+  gap: clamp(1.5rem, 4vw, 2.5rem)
+  grid-template-columns: 1fr
+
+.home-hero__panel-block
+  display: flex
+  flex-direction: column
+  gap: clamp(1.25rem, 2vw, 1.75rem)
+  min-width: 0
+
+.home-hero__context
+  flex-direction: column
+  gap: 0.75rem
+
+.home-hero__context-card
+  height: 100%
+
+.home-hero__helper-row
+  display: flex
+  flex-wrap: wrap
+  align-items: center
+
+.home-hero__helpers
+  margin: 0
+  padding: 0
+  display: grid
+  gap: clamp(0.4rem, 1.5vw, 0.65rem)
+  list-style: none
+
+.home-hero__helper
+  display: inline-flex
+  align-items: center
+  gap: 0.45rem
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  font-weight: 500
+
+.home-hero__helper-icon
+  font-size: 1.1rem
+
+.home-hero__helper-text
+  line-height: 1.35
+
+.home-hero__helper-link
+  color: rgb(var(--v-theme-text-neutral-strong))
+  font-weight: 600
+  text-decoration: underline
+  text-decoration-thickness: 0.08em
+  text-underline-offset: 0.1em
+
+.home-hero__context
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.home-hero__subtitle
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-strong))
+  text-align: center
+  width: 100%
+
+
+.home-hero__helpers-title
+  font-size: 0.875rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  margin-bottom: 0.5rem
+  display: block
+  letter-spacing: 0.01em
+
+.home-hero__wizard
+  width: 100%
+
+
+
+@keyframes home-hero-fade-up
+  from
+    opacity: 0
+    transform: translateY(12px) scale(0.98)
+  to
+    opacity: 1
+    transform: translateY(0) scale(1)
+
+@keyframes home-hero-scale-in
+  from
+    opacity: 0
+    transform: scale(0.9)
+  55%
+    opacity: 1
+    transform: scale(1.02)
+  to
+    transform: scale(1)
+
+@keyframes home-hero-pulse
+  0%
+    transform: scale(0.92)
+    opacity: 0
+  35%
+    transform: scale(1.04)
+    opacity: 1
+  70%
+    transform: scale(0.98)
+  100%
+    transform: scale(1)
+
 @media (max-width: 959px)
   .home-hero
     min-height: clamp(520px, 68dvh, 760px)
     padding-block: clamp(2rem, 10vw, 4rem)
+
+  .home-hero__panel
+    padding: clamp(1.25rem, 5vw, 2rem)
+
+  .home-hero__panel-grid
+    gap: clamp(1rem, 3vw, 1.5rem)
+
+  .home-hero__media
+    order: 1
+
+  .home-hero__content
+    order: 2
+
+@media (min-width: 960px)
+  .home-hero__panel-grid
+    grid-template-columns: 1fr
+
+  .home-hero__helper-row
+    grid-template-columns: auto 1fr
+
+@media (min-width: 1280px)
+  .home-hero__panel-grid
+    grid-template-columns: 1fr
+
+@media (min-width: 90rem)
+  .home-hero__panel
+    max-width: clamp(60rem, 78vw, 74rem)
 </style>

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -8,15 +8,7 @@
       :breadcrumbs="category.breadCrumb ?? []"
       :eyebrow="category.verticalMetaTitle"
       :show-image="isDesktop"
-    >
-      <template #actions>
-        <CategoryHeroActionsContent
-          :vertical-home-url="category?.verticalHomeUrl"
-          :category-name="categoryDisplayName"
-          @open-nudge="isNudgeWizardOpen = true"
-        />
-      </template>
-    </CategoryHero>
+    />
 
     <v-dialog
       v-model="isNudgeWizardOpen"
@@ -103,29 +95,48 @@
               class="category-page__filters-drawer"
               temporary
             >
-              <CategoryFiltersSidebar
-                :filter-options="filterOptions"
-                :aggregations="currentAggregations"
-                :baseline-aggregations="baselineAggregations"
-                :filters="manualFilters"
-                :impact-expanded="impactExpanded"
-                :technical-expanded="technicalExpanded"
-                :show-mobile-actions="true"
-                :has-documentation="hasDocumentation"
-                :wiki-pages="category?.wikiPages ?? []"
-                :related-posts="category?.relatedPosts ?? []"
-                :show-admin-panel="showAdminFilters"
-                :admin-filter-fields="adminFilterFields"
-                @update:filters="onFiltersChange"
-                @update:impact-expanded="
-                  (value: boolean) => (impactExpanded = value)
-                "
-                @update:technical-expanded="
-                  (value: boolean) => (technicalExpanded = value)
-                "
-                @apply-mobile="applyMobileFilters"
-                @clear-mobile="clearAllFilters"
-              />
+            <CategoryFiltersSidebar
+              :filter-options="filterOptions"
+              :aggregations="currentAggregations"
+              :baseline-aggregations="baselineAggregations"
+              :filters="manualFilters"
+              :impact-expanded="impactExpanded"
+              :technical-expanded="technicalExpanded"
+              :show-mobile-actions="true"
+              :has-documentation="hasDocumentation"
+              :wiki-pages="category?.wikiPages ?? []"
+              :related-posts="category?.relatedPosts ?? []"
+              :show-admin-panel="showAdminFilters"
+              :admin-filter-fields="adminFilterFields"
+              @update:filters="onFiltersChange"
+              @update:impact-expanded="
+                (value: boolean) => (impactExpanded = value)
+              "
+              @update:technical-expanded="
+                (value: boolean) => (technicalExpanded = value)
+              "
+              @apply-mobile="applyMobileFilters"
+              @clear-mobile="clearAllFilters"
+            >
+              <template #extra>
+                <div class="category-page__filters-cta">
+                  <CategoryEcoscoreCard
+                    :vertical-home-url="category?.verticalHomeUrl"
+                    :category-name="categoryDisplayName"
+                  />
+                  <v-btn
+                    block
+                    color="primary"
+                    variant="flat"
+                    prepend-icon="mdi-robot-love"
+                    class="category-page__nudge-cta"
+                    @click="isNudgeWizardOpen = true"
+                  >
+                    {{ $t('category.hero.nudge.cta') }}
+                  </v-btn>
+                </div>
+              </template>
+            </CategoryFiltersSidebar>
             </v-navigation-drawer>
           </ClientOnly>
         </template>
@@ -163,7 +174,26 @@
               @update:technical-expanded="
                 (value: boolean) => (technicalExpanded = value)
               "
-            />
+            >
+              <template #extra>
+                <div class="category-page__filters-cta">
+                  <CategoryEcoscoreCard
+                    :vertical-home-url="category?.verticalHomeUrl"
+                    :category-name="categoryDisplayName"
+                  />
+                  <v-btn
+                    block
+                    color="primary"
+                    variant="flat"
+                    prepend-icon="mdi-robot-love"
+                    class="category-page__nudge-cta"
+                    @click="isNudgeWizardOpen = true"
+                  >
+                    {{ $t('category.hero.nudge.cta') }}
+                  </v-btn>
+                </div>
+              </template>
+            </CategoryFiltersSidebar>
           </aside>
 
           <div
@@ -431,7 +461,7 @@ import { AggTypeEnum } from '~~/shared/api-client'
 import CategoryActiveFilters from '~/components/category/CategoryActiveFilters.vue'
 import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
 import CategoryHero from '~/components/category/CategoryHero.vue'
-import CategoryHeroActionsContent from '~/components/category/CategoryHeroActionsContent.vue'
+import CategoryEcoscoreCard from '~/components/category/CategoryEcoscoreCard.vue'
 import CategoryFiltersSidebar from '~/components/category/CategoryFiltersSidebar.vue'
 import CategoryResultsCount from '~/components/category/CategoryResultsCount.vue'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
@@ -2322,6 +2352,19 @@ const clearAllFilters = () => {
 
   &__filters-actions
     padding: 0.5rem 0.75rem 0
+
+  &__filters-extra
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__filters-cta
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+  &__nudge-cta
+    box-shadow: 0 14px 28px -22px rgba(var(--v-theme-shadow-primary-600), 0.45)
 
   &__results
     min-height: 420px

--- a/frontend/app/components/product/ProductImpactCta.vue
+++ b/frontend/app/components/product/ProductImpactCta.vue
@@ -5,7 +5,6 @@
         :vertical-home-url="categoryLink"
         :category-name="categoryName"
         :show-nudge="false"
-        :show-description="false"
         @open-nudge="emit('open-nudge')"
       />
     </HeroActionCard>

--- a/frontend/app/components/product/impact/ProductImpactRadarChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactRadarChart.vue
@@ -87,20 +87,19 @@ const option = computed<EChartsOption | null>(() => {
     return null
   }
 
-  const finiteValues = props.series
-    .flatMap(entry => entry.values)
-    .filter(
-      (value): value is number =>
-        typeof value === 'number' && Number.isFinite(value)
-    )
+  const indicator = props.axes.map((entry, index) => {
+    const valuesForAxis = props.series
+      .map(s => s.values[index])
+      .filter((v): v is number => typeof v === 'number' && Number.isFinite(v))
 
-  const maxObservedValue = finiteValues.length ? Math.max(...finiteValues) : 5
-  const paddedMax = maxObservedValue > 0 ? maxObservedValue * 1.1 : 5
+    const maxObserved = valuesForAxis.length ? Math.max(...valuesForAxis) : 5
+    const paddedMax = maxObserved > 0 ? maxObserved * 1.1 : 5
 
-  const indicator = props.axes.map(entry => ({
-    name: entry.name,
-    max: paddedMax,
-  }))
+    return {
+      name: entry.name,
+      max: paddedMax,
+    }
+  })
   const seriesData = props.series.map(entry => ({
     value: entry.values.map(value =>
       typeof value === 'number' && Number.isFinite(value) ? value : null

--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
@@ -268,6 +268,7 @@ const worstValue = computed(() => formatNumber(worstRawValue.value))
 
 const bestValue = computed(() => formatNumber(bestRawValue.value))
 const averageValue = computed(() => formatNumber(absoluteStats.value?.avg))
+
 const averageOn20Value = computed(() => {
   // Sigma scoring definition: Average is always the pivot at 10/20 (2.5/5)
   return formatNumber(10, { maximumFractionDigits: 0 })

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -639,20 +639,18 @@ describe('Home page', () => {
     vi.unstubAllGlobals()
   })
 
-  it('submits the search query using the localized search route', async () => {
+  it('renders the hero title and subtitle', async () => {
     const wrapper = await mountHomePage()
 
-    const searchForm = wrapper.find('section.home-hero form[role="search"]')
-    const searchInput = searchForm.find('input')
+    const heroTitle = wrapper.find('section.home-hero .home-hero__title')
+    const heroSubtitle = wrapper.find(
+      'section.home-hero .home-hero__title-subtitle'
+    )
 
-    await searchInput.setValue('smart tv')
-    await searchForm.trigger('submit.prevent')
-
-    expect(localePathMock).toHaveBeenCalledWith({
-      name: 'search',
-      query: { q: 'smart tv' },
-    })
-    expect(routerPush).toHaveBeenCalledWith('/localized/search?q=smart tv')
+    expect(heroTitle.text()).toBe(messages['packs.default.hero.title'])
+    expect(heroSubtitle.text()).toBe(
+      (messages['packs.default.hero.titleSubtitle'] as string[])[0]
+    )
   })
 
   it('registers FAQ structured data in head tags', async () => {

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -4,7 +4,11 @@ import { usePreferredReducedMotion } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { useTheme } from 'vuetify'
 import { resolveLocalizedRoutePath } from '~~/shared/utils/localized-routes'
-import type { BlogPostDto } from '~~/shared/api-client'
+import type {
+  AffiliationPartnerDto,
+  BlogPostDto,
+  CategoriesStatsDto,
+} from '~~/shared/api-client'
 import HomeHeroSection from '~/components/home/sections/HomeHeroSection.vue'
 import HomeProblemsSection from '~/components/home/sections/HomeProblemsSection.vue'
 import HomeSolutionSection from '~/components/home/sections/HomeSolutionSection.vue'
@@ -46,6 +50,7 @@ const { t, locale, availableLocales } = useI18n()
 const router = useRouter()
 const localePath = useLocalePath()
 const requestURL = useRequestURL()
+const requestHeaders = useRequestHeaders(['host', 'x-forwarded-host'])
 
 const searchQuery = ref('')
 
@@ -58,6 +63,62 @@ const { categories: rawCategories, fetchCategories } = useCategories()
 const { paginatedArticles, fetchArticles, loading: blogLoading } = useBlog()
 
 const BLOG_ARTICLES_LIMIT = 4
+
+const { data: categoriesStats } = await useAsyncData<CategoriesStatsDto | null>(
+  'home-categories-stats',
+  () =>
+    $fetch<CategoriesStatsDto>('/api/stats/categories', {
+      headers: requestHeaders,
+    }).catch(() => null),
+  {
+    default: () => null,
+    server: true,
+    lazy: true,
+  }
+)
+
+const { data: affiliationPartners } = await useAsyncData<
+  AffiliationPartnerDto[]
+>(
+  'home-affiliation-partners',
+  () =>
+    $fetch<AffiliationPartnerDto[]>('/api/partners/affiliation', {
+      headers: requestHeaders,
+    }).catch(() => []),
+  {
+    default: () => [],
+    server: true,
+    lazy: true,
+  }
+)
+
+const heroPartnersCount = computed(() => {
+  const statsCount = categoriesStats.value?.affiliationPartnersCount
+
+  if (typeof statsCount === 'number' && Number.isFinite(statsCount)) {
+    return statsCount
+  }
+
+  return affiliationPartners.value?.length ?? 0
+})
+
+const openDataMillions = computed(() => {
+  const gtinCount = categoriesStats.value?.gtinOpenDataItemsCount
+  const isbnCount = categoriesStats.value?.isbnOpenDataItemsCount
+  const resolvedGtinCount =
+    typeof gtinCount === 'number' && Number.isFinite(gtinCount) ? gtinCount : 0
+  const resolvedIsbnCount =
+    typeof isbnCount === 'number' && Number.isFinite(isbnCount) ? isbnCount : 0
+  const totalCount = resolvedGtinCount + resolvedIsbnCount
+
+  if (totalCount <= 0) {
+    return null
+  }
+
+  const roundedMillions = Math.round(totalCount / 1_000_000)
+
+  return roundedMillions > 0 ? roundedMillions : null
+})
 
 const seasonalEventPack = useSeasonalEventPack()
 const theme = useTheme()
@@ -735,8 +796,16 @@ useHead(() => ({
     />
     <div class="home-page">
       <HomeHeroSection
+        v-model:search-query="searchQuery"
         class="d-none d-md-block"
+        :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
+        :verticals="rawCategories"
+        :partners-count="heroPartnersCount"
+        :open-data-millions="openDataMillions"
         hero-background-i18n-key="hero.background"
+        @submit="handleSearchSubmit"
+        @select-category="handleCategorySuggestion"
+        @select-product="handleProductSuggestion"
       />
       <div class="home-page__sections">
         <ParallaxWidget

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -808,7 +808,7 @@
       "ecoscore": {
         "title": "Discover the Impact Score",
         "description": "Understand how the eco-score is calculated for {category}",
-        "cta": "Explore the methodology",
+        "cta": "Methodology {category}",
         "ariaLabel": "Open the Eco-score guide"
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2494,15 +2494,15 @@
           "readIndicator": {
             "title": "Comment lire cet indicateur",
             "higher": {
-              "worst": "Le plus faible {scoreLabelLower} observé est de {worst}, soit une note de 0/20.",
-              "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
-              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
+              "worst": "Le plus faible {scoreLabelLower} observé est de {worst}.",
+              "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, note pivot de 10/20.",
               "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
             },
             "lower": {
-              "worst": "Le {scoreLabelLower} le plus élevé observé est de {worst}, ce qui vaut la note de 0/20.",
-              "best": "Le {scoreLabelLower} le plus faible constaté parmi les {count} {verticalTitle} atteint {best}, pour une note de 20/20.",
-              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, ce qui correspond à {averageOn20}/20.",
+              "worst": "Le {scoreLabelLower} le plus élevé observé est de {worst}.",
+              "best": "Le {scoreLabelLower} le plus faible constaté parmi les {count} {verticalTitle} atteint {best}.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}, note pivot de 10/20.",
               "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}, obtient la note de {productOn20}/20."
             }
           }
@@ -2512,15 +2512,15 @@
           "readIndicator": {
             "title": "Comment lire cet indicateur de réparabilité",
             "higher": {
-              "worst": "Le pire indice de réparabilité est {worst}, ce qui vaut la note de 0/20.",
-              "best": "Le meilleur indice de réparabilité rencontré pour les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
-              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
+              "worst": "Le pire indice de réparabilité est {worst}.",
+              "best": "Le meilleur indice de réparabilité rencontré pour les {count} {verticalTitle} est {best}.",
+              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, note pivot de 10/20.",
               "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
             },
             "lower": {
-              "worst": "L'indice de réparabilité le plus élevé observé est {worst}, ce qui vaut la note de 0/20.",
-              "best": "L'indice de réparabilité le plus bas constaté parmi les {count} {verticalTitle} est {best}, ce qui donne la note de 20/20.",
-              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, ce qui équivaut à {averageOn20}/20.",
+              "worst": "L'indice de réparabilité le plus élevé observé est {worst}.",
+              "best": "L'indice de réparabilité le plus bas constaté parmi les {count} {verticalTitle} est {best}.",
+              "average": "La moyenne de ce critère pour les {count} {verticalTitle} disposant d'informations est de {average}, note pivot de 10/20.",
               "product": "Le {productName}, avec un indice de réparabilité de {productAbsolute}, obtient la note de {productOn20}/20."
             }
           }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -815,7 +815,7 @@
       "ecoscore": {
         "title": "Découvrir l'Impact Score",
         "description": "Comprendre comment est calculé l'écoscore des {category}",
-        "cta": "Explorer la méthodologie",
+        "cta": "Méthodologie {category}",
         "ariaLabel": "Ouvrir le guide Eco-score"
       }
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -838,7 +838,7 @@
       "breadcrumbDivider": "/",
       "missingBreadcrumbTitle": "Catégorie",
       "nudge": {
-        "cta": "Trouver les bons produits",
+        "cta": "Assistant",
         "subtitle": "Passe directement aux meilleures pistes de cette catégorie avec un accompagnement guidé.",
         "eyebrow": "Assistant intelligent"
       }

--- a/verticals/src/main/resources/verticals/oven-attribute-coverage.txt
+++ b/verticals/src/main/resources/verticals/oven-attribute-coverage.txt
@@ -1,0 +1,3536 @@
+{
+  "totalItems": 3030,
+  "stats": {
+    "CUSTOM_4": {
+      "hits": 2277,
+      "datasourceNames": [
+        "natureetdecouvertes.com",
+        "backmarket.fr",
+        "joom.com",
+        "darty.com",
+        "fnac.com",
+        "JoomFR",
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "ELECTROMENAGER": 741,
+        "Materiel CHR Pro": 445,
+        "$linkur": 133,
+        "0.0": 73,
+        "Super10Count": 71,
+        "Icoza": 62,
+        "M24": 47,
+        "Villatech": 46,
+        "Doctor Brandt": 42,
+        "Digital Bay": 37,
+        "BLAN SRL": 34,
+        "ElectroStore": 29,
+        "ASD": 26,
+        "2KINGS": 25,
+        "ZOOMICI STORE": 25,
+        "To B To C Srl": 20,
+        "AsDiscount": 17,
+        "decides85": 16,
+        "Darty Occasion": 16,
+        "G": 15,
+        "ART DE LA TABLE - ARTICLES CULINAIRES": 14,
+        "White Outlet Factory": 12,
+        "0.00": 11,
+        "ELECTRO DIRECT": 11,
+        "SATENCO": 11,
+        "Digital Bay Srl": 11,
+        "NouveauMarchand": 10,
+        "Euro Hub Store": 9,
+        "JARDIN - PISCINE": 9,
+        "Average": 9,
+        "Cecotec Official Store": 8,
+        "HOTPOINT": 8,
+        "OCstore": 7,
+        "DROGUERIE": 7,
+        "Underdog": 7,
+        "HOME BOULEVARD": 6,
+        "BLANSRL": 6,
+        "Minfo PT": 6,
+        "CHRONOPRIX": 6,
+        "ALPEXE": 5,
+        "Zenkaa": 5,
+        "Livea Sanitaire": 5,
+        "La Boutique du Net": 5,
+        "YOUKAPIcom": 5,
+        "SCML Store": 4,
+        "Darty": 4,
+        "egenta": 4,
+        "TopSellers": 4,
+        "ProComponentes": 4,
+        "Domtek": 4,
+        "SIRGE": 3,
+        "SMEG FRANCE": 3,
+        "Arboremedia": 3,
+        "MINFO PT": 3,
+        "Belongfr": 3,
+        "Sotel France": 3,
+        "ePolis": 3,
+        "Le Petit Patron": 3,
+        "JEquipe Ma Maison": 3,
+        "Siemtech": 3,
+        "LaBoutiqueDuNet": 3,
+        "INFORMATIQUE": 3,
+        "You Get - Innovation and Technology": 2,
+        "ClubTek": 2,
+        "H Koenig": 2,
+        "Club": 2,
+        "MATERIELCHRPRO": 2,
+        "Stockly Technologies": 2,
+        "Electro-Direct": 2,
+        "eQuokka": 2,
+        "Alpexe France": 2,
+        "Zoomici Store": 2,
+        "Erkson online": 2,
+        "AUTO - MOTO": 2,
+        "MaxiMondo": 2,
+        "Commaxx Group": 2,
+        "Get Goods": 2,
+        "GreaTecno": 2,
+        "Darty Occasion DGO": 2,
+        "DANS MON PANIER": 2,
+        "NEI Electronics": 2,
+        "Erresse shop": 2
+      }
+    },
+    "CUSTOM_5": {
+      "hits": 2209,
+      "datasourceNames": [
+        "backmarket.fr",
+        "joom.com",
+        "darty.com",
+        "fnac.com",
+        "JoomFR",
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "0": 1273,
+        "25 euros offerts des 249 euros d'achat jusqu'au 09/01/2026": 151,
+        "15 euros offerts des 129 euros d'achat jusqu'au 09/01/2026": 90,
+        "10 euros offerts des 79 euros d'achat jusqu'au 01/12/2025": 71,
+        "true": 26,
+        "15 euros offerts des 129 euros d'achat jusqu'au 21/11/2025": 5,
+        "15 euros offerts des 129 euros d'achat jusqu'au 08/10/2025": 5,
+        "25 euros de remise des 249 euros d'achat": 4,
+        "11 euros offerts des 111 euros d'achat jusqu'au 11/11/2025": 4,
+        "0.00": 3,
+        "15 euros offerts des 129 euros d'achat jusqu'au 27/11/2025": 2,
+        "1108.89": 2,
+        "15 euros offerts des 129 euros d'achat jusqu'au 07/10/2025": 2,
+        "Verified Refurbished": 2,
+        "15euros offerts des 129euros d'achat jusqu'au 30/09/2025": 2,
+        "15euros offerts des 129euros d'achat jusqu'au 09/07/2025": 2,
+        "25euros offerts des 249euros d'achat jusqu'au 31/12/2025": 2,
+        "25euros offerts des 249euros d'achat jusqu'au 20/08/2025": 2
+      }
+    },
+    "CUSTOM_1": {
+      "hits": 2192,
+      "datasourceNames": [
+        "rueducommerce.fr",
+        "natureetdecouvertes.com",
+        "backmarket.fr",
+        "joom.com",
+        "darty.com",
+        "fnac.com",
+        "JoomFR",
+        "underdog.shop",
+        "UNDERDOGFR",
+        "manomano.fr",
+        "e.leclerc"
+      ],
+      "values": {
+        "1": 18,
+        "34": 62,
+        "58": 8,
+        "530": 6,
+        "574": 17,
+        "629": 3,
+        "649": 25,
+        "652": 8,
+        "766": 9,
+        "767": 42,
+        "786": 6,
+        "795": 13,
+        "858": 5,
+        "963": 2,
+        "1004": 40,
+        "1005": 8,
+        "1099": 39,
+        "1100": 2,
+        "1102": 55,
+        "1103": 12,
+        "1104": 3,
+        "1106": 20,
+        "1109": 22,
+        "1110": 9,
+        "1117": 42,
+        "1123": 2,
+        "1124": 20,
+        "1129": 4,
+        "1144": 7,
+        "1176": 2,
+        "1192": 7,
+        "1206": 6,
+        "1221": 9,
+        "1290": 6,
+        "1310": 4,
+        "1318": 3,
+        "1564": 3,
+        "1805": 5,
+        "1971": 18,
+        "2372": 4,
+        "2662": 2,
+        "2739": 5,
+        "2756": 6,
+        "2794": 7,
+        "2931": 4,
+        "3038": 2,
+        "3609": 3,
+        "3612": 5,
+        "3703": 6,
+        "3707": 5,
+        "4636": 5,
+        "4659": 3,
+        "5160": 3,
+        "5258": 6,
+        "5276": 2,
+        "5724": 12,
+        "5929": 13,
+        "6449": 5,
+        "6501": 2,
+        "7534": 2,
+        "9469": 14,
+        "22872": 5,
+        "36718": 10,
+        "66074": 5,
+        "79083": 8,
+        "82399": 13,
+        "82938": 9,
+        "109071": 2,
+        "111518": 2,
+        "122868": 2,
+        "133607": 6,
+        "149810": 43,
+        "187146": 14,
+        "200299": 4,
+        "237622": 2,
+        "237688": 3,
+        "238746": 10,
+        "239680": 2,
+        "239970": 13,
+        "240000": 2,
+        "244078": 2,
+        "244348": 2,
+        "244910": 7,
+        "248602": 2,
+        "251584": 5,
+        "255946": 2,
+        "261113": 5,
+        "263449": 2,
+        "264858": 4,
+        "268110": 3,
+        "268427": 12,
+        "269099": 12,
+        "275477": 3,
+        "281808": 4,
+        "3599998": 14,
+        "34382196": 3,
+        "54747897": 3,
+        "59010914": 2,
+        "69895176": 3,
+        "69900174": 2,
+        "69900865": 2,
+        "69901460": 3,
+        "69903322": 2,
+        "100000337": 4,
+        "100016602": 2,
+        "100021150": 2,
+        "100023192": 2,
+        "100024607": 2,
+        "Produit MarketPlace": 500,
+        "G": 370,
+        "bons plans": 35,
+        "unisex": 27,
+        "A": 17,
+        "BLACK": 16,
+        "Etat correct": 15,
+        "A+": 12,
+        "Comme neuf": 9,
+        "H": 6,
+        "Trés bon état": 6,
+        "Zombies": 6,
+        "High-Tech": 4,
+        "A++": 4,
+        "-1&-1": 3,
+        "34.90": 3,
+        "Bon état": 3,
+        "946.03": 2
+      }
+    },
+    "COLOUR": {
+      "hits": 2039,
+      "datasourceNames": [
+        "rueducommerce.fr",
+        "backmarket.fr",
+        "CastoramaFR",
+        "Enjify",
+        "joom.com",
+        "fnac.com",
+        "2echoix.fr",
+        "underdog.shop",
+        "cdiscount.com",
+        "SamsungFR",
+        "castorama.fr",
+        "2echoix",
+        "JoomFR",
+        "UNDERDOGFR",
+        "manomano.fr",
+        "e.leclerc"
+      ],
+      "values": {
+        "1": 92,
+        "Noir": 949,
+        "Gris": 362,
+        "Blanc": 253,
+        "Argent": 42,
+        "Acier inoxydable": 36,
+        "Rouge": 30,
+        "Inox": 23,
+        "NC": 21,
+        "Beige": 21,
+        "Bleu": 20,
+        "Multicouleur": 19,
+        "Argenté": 18,
+        "Jaune": 14,
+        "Anthracite": 11,
+        "Marron": 10,
+        "Inox sous verre": 7,
+        "Vert": 7,
+        "inox": 6,
+        "Acier": 6,
+        "Inox noir brossé": 5,
+        "Transparent": 4,
+        "Orange": 4,
+        "Rose": 4,
+        "Black": 3,
+        "Crème": 3,
+        "Multicolore": 2,
+        "Noire": 2,
+        "Voir Description / Demander Vendeur": 2,
+        "Couleur argent": 2,
+        "Noir propre": 2,
+        "Dark Inox": 2,
+        "NOIR": 2
+      }
+    },
+    "CUSTOM_3": {
+      "hits": 2037,
+      "datasourceNames": [
+        "natureetdecouvertes.com",
+        "fnac.com",
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "0": 1016,
+        "1": 4,
+        "3": 2,
+        "11": 2,
+        "13": 2,
+        "14": 2,
+        "19": 2,
+        "23": 3,
+        "24": 2,
+        "32": 2,
+        "33": 2,
+        "35": 2,
+        "44": 3,
+        "46": 2,
+        "49": 2,
+        "68": 2,
+        "74": 2,
+        "80": 2,
+        "87": 2,
+        "89": 2,
+        "91": 3,
+        "92": 2,
+        "97": 2,
+        "101": 2,
+        "108": 2,
+        "115": 2,
+        "124": 2,
+        "129": 2,
+        "131": 2,
+        "132": 2,
+        "159": 2,
+        "170": 2,
+        "0.00": 488,
+        "59.00": 19,
+        "19.90": 7,
+        "6.95": 5,
+        "14.90": 4,
+        "14.41": 3,
+        "9.99": 3,
+        "10.00": 2,
+        "7.99": 2,
+        "52.00": 2,
+        "30.00": 2,
+        "39.99": 2
+      }
+    },
+    "CUSTOM_2": {
+      "hits": 1769,
+      "datasourceNames": [
+        "natureetdecouvertes.com",
+        "backmarket.fr",
+        "joom.com",
+        "JoomFR",
+        "fnac.com",
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "Marketplace": 761,
+        "adult": 52,
+        "Offre Propre": 30,
+        "Boys and Girls": 13,
+        "T3323P299299": 2
+      }
+    },
+    "THEME": {
+      "hits": 1744,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Four Electrique": 626,
+        "Ménage, repassage": 218,
+        "Four": 157,
+        "Appareil de cuisson": 140,
+        "Robots, mixeurs": 91,
+        "Four Vapeur": 81,
+        "Cuisson": 62,
+        "Mini four": 58,
+        "Micro-ondes": 50,
+        "Four Micro-ondes": 24,
+        "Mini four Electrique": 19,
+        "Presse-agrumes électrique": 16,
+        "Machine à café": 15,
+        "Friteuse": 15,
+        "Bouilloire": 13,
+        "Poêle": 11,
+        "Grille-pain": 9,
+        "Wok électrique": 9,
+        "Autre": 8,
+        "Four Gaz": 8,
+        "Mini four Vapeur": 7,
+        "Barbecue électrique": 6,
+        "Centres de cuisson": 5,
+        "Crêpière": 5,
+        "Appareil chauffant": 5,
+        "Appareil à pizza": 4,
+        "Rotisserie": 4,
+        "Brasero": 4,
+        "Fournitures Papeterie": 3,
+        "Four Vitro": 3,
+        "Robots, Mixeurs...": 3,
+        "Cuiseur à oeuf": 3,
+        "Froid": 3,
+        "Yaourtière": 3,
+        "Petits appareils divers": 3,
+        "Cuisinière": 3,
+        "Four à micro-ondes": 3,
+        "Mixeur plongeant": 2,
+        "Balance de cuisine Little Balance": 2,
+        "Four Bois": 2,
+        "Grill": 2,
+        "Hotte": 2,
+        "Cric": 2,
+        "Blender": 2,
+        "Mini four Micro-ondes": 2,
+        "Centrifugeuse": 2,
+        "Accessoire entretien piscine": 2,
+        "Gaufrier": 2,
+        "Tiroir chauffant": 2,
+        "Nettoyeur haute pression": 2
+      }
+    },
+    "FABRICANT": {
+      "hits": 1743,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Electrolux": 110,
+        "Bosch": 96,
+        "Whirlpool": 62,
+        "Beko": 57,
+        "Brandt": 52,
+        "Smeg": 50,
+        "Moulinex": 49,
+        "Severin": 47,
+        "Cecotec": 44,
+        "Teka": 40,
+        "Candy": 39,
+        "Samsung": 38,
+        "Siemens": 36,
+        "AEG": 34,
+        "Balay": 31,
+        "De Dietrich": 23,
+        "ASKO": 23,
+        "Hisense": 21,
+        "Sauter": 21,
+        "De'Longhi": 20,
+        "Rowenta": 20,
+        "Clatronic": 18,
+        "Indesit": 18,
+        "Neff": 17,
+        "Black & Decker": 17,
+        "vidaXL": 17,
+        "Princess": 16,
+        "Tefal": 15,
+        "H.Koenig": 15,
+        "Haier": 15,
+        "Little Balance": 15,
+        "Livoo": 15,
+        "Kärcher": 14,
+        "Ariete": 13,
+        "Proline": 13,
+        "Bestron": 13,
+        "Miele": 13,
+        "Hoover": 12,
+        "Philips": 12,
+        "Rosières": 12,
+        "Cata": 12,
+        "Essentiel B": 11,
+        "G3 Ferrari": 11,
+        "Taurus": 11,
+        "Continental Edison": 10,
+        "LG": 10,
+        "DOMO": 10,
+        "Jata": 9,
+        "Hotpoint-Ariston": 9,
+        "Sencor": 9,
+        "Fagor": 8,
+        "Thomson": 8,
+        "Lagrange": 8,
+        "Tristar": 8,
+        "Thomas": 8,
+        "Rommelsbacher": 8,
+        "Orbegozo": 8,
+        "Adler": 8,
+        "Girmi": 8,
+        "Braun": 7,
+        "Schneider": 7,
+        "Russell Hobbs": 7,
+        "Medion": 6,
+        "Polti": 6,
+        "Beper": 6,
+        "Airlux": 6,
+        "Riviera & Bar": 6,
+        "ProfiCook": 6,
+        "FALMEC": 6,
+        "Telefunken": 6,
+        "Vacmaster": 5,
+        "Ecovacs": 5,
+        "Bomann": 5,
+        "Smartwares Group": 5,
+        "Steba": 5,
+        "KitchenCook": 5,
+        "Ufesa": 5,
+        "Sharp": 5,
+        "EUREKA": 5,
+        "Ardes": 5,
+        "roborock": 5,
+        "Glem": 5,
+        "HerzBerg": 4,
+        "Oceanic": 4,
+        "Techwood": 4,
+        "Einhell": 4,
+        "JIMMY": 4,
+        "Elica": 4,
+        "Carrefour Home": 4,
+        "Gastroback": 4,
+        "HAUSHOF": 4,
+        "Sitram": 4,
+        "Simogas": 4,
+        "ALPINA": 4,
+        "Ooni": 4,
+        "BEPER": 4,
+        "ZEEGMA": 3,
+        "Amica": 3,
+        "Caso Design": 3,
+        "Seb": 3,
+        "Kenwood": 3,
+        "JOCCA": 3,
+        "Zanussi": 3,
+        "Nedis": 3,
+        "Rayen": 3,
+        "Xiaomi": 3,
+        "Naturamix": 3,
+        "Krups": 3,
+        "Relaxdays": 3,
+        "Big Green Egg": 3,
+        "Duronic": 3,
+        "Carrefour home": 3,
+        "Aspes": 2,
+        "Draper Tools": 2,
+        "Sage by Heston Blumenthal": 2,
+        "le creuset": 2,
+        "Arthur Martin": 2,
+        "Lacor": 2,
+        "BlueSky": 2,
+        "beper": 2,
+        "JATA": 2,
+        "EZICLEAN": 2,
+        "Daewoo": 2,
+        "Ninja": 2,
+        "Klaiser": 2,
+        "Valberg": 2,
+        "HOTPOINT": 2,
+        "UWANT": 2,
+        "Kitchen Chef": 2,
+        "Bodum": 2,
+        "KitchenAid": 2,
+        "Numatic": 2,
+        "Grundig International": 2,
+        "LMAC": 2,
+        "Baumalu": 2,
+        "Ohmex": 2,
+        "Faber": 2,
+        "Leifheit": 2,
+        "SIMPL": 2,
+        "Kalorik": 2,
+        "Beldray": 2,
+        "Trebs": 2,
+        "Concept": 2,
+        "Ibili": 2,
+        "Campingaz": 2,
+        "Listo": 2,
+        "Emerio": 2,
+        "Hagerty": 2
+      }
+    },
+    "CUSTOM_9": {
+      "hits": 1465,
+      "datasourceNames": [
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "Acier inoxydable (inox)": 10,
+        "Average": 5,
+        "Verre": 3
+      }
+    },
+    "TYPE DE PRODUIT": {
+      "hits": 1357,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Four": 903,
+        "Appareil de cuisson": 140,
+        "Mini four": 87,
+        "Micro-ondes": 50,
+        "Presse-agrumes électrique": 16,
+        "Friteuse": 15,
+        "Machine à café": 14,
+        "Bouilloire": 14,
+        "Grille-pain": 9,
+        "Wok électrique": 9,
+        "Autre": 7,
+        "Poêle": 7,
+        "Barbecue électrique": 6,
+        "Centres de cuisson": 5,
+        "Crêpière": 5,
+        "Appareil chauffant": 5,
+        "Appareil à pizza": 4,
+        "Rotisserie": 4,
+        "Brasero": 4,
+        "Centrifugeuse": 4,
+        "Balance de cuisine": 3,
+        "Robots, Mixeurs...": 3,
+        "Cuiseur à oeuf": 3,
+        "Yaourtière": 3,
+        "Cuisinière": 3,
+        "Mixeur plongeant": 2,
+        "Enveloppe": 2,
+        "Grill": 2,
+        "Hotte": 2,
+        "Cric": 2,
+        "Blender": 2,
+        "Gaufrier": 2,
+        "Tiroir chauffant": 2,
+        "Nettoyeur haute pression": 2
+      }
+    },
+    "DESCRIPTIF": {
+      "hits": 1245,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "1": 7,
+        "Â <br/> - â <br/>": 16,
+        "<br><br><div class=\"rakuten_rich_content\" ><div> <h5>Grille AIRFRY</h5> <div> <p>Pour ceux qui souhaitent pre?parer des plats plus sains, sans renoncer a? l'irre?sistible croquant des aliments frits, la grille AIRFRY est la solution parfaite pour cuisiner rapidement et facilement des plats tels que des frites, des le?gumes et du poisson, avec la moitie? des calories et des graisses de friture.</p> </div> Livre de recettes de la grille AIRFRY </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <h5>Grille viande BBQ</h5> <div> <p>Parfait pour les amateurs de barbecue, l'accessoire BBQ permet de recréer des plats succulents et croustillants au four avec le goût typique de la cuisson au gril.</p> </div> Livre de recettes du grille viande BBQ </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <h5>Pierre réfractaire STONE</h5> <div> <p>Idéale pour obtenir des produits avec la saveur et le croquant typiques de la cuisson dans un four à bois. La pierre réfractaire peut être utilisée pour cuire de la pizza, du pain, de la fougasse et d'autres recettes telles que le poisson en papillote ou les biscuits.</p> </div> Livre de recettes de la pierre réfractaire STONE </div></div>": 3,
+        "TRAITEMENT DES COMMANDES ET EXPÉDITION :Tous le produits sont expédiés par courrier avec suivi. Nous engageons à envoyer le produits au maximum 5 jours après la réception de paiement. Le droit de retourner des produits peut être exercé dans la limite de 14 jours après le jour de réception de colis. Nous vous rappelons que tous les produits doivent être renvoyés dans leur emballage d'origine avec tous les accessoires": 2,
+        "<br />": 2,
+        "Capacité 1,5 L. Puissance 600 W, 22 000 tours/min. 2 vitesses et fonction turbo. Doubles lames croisées en acier inoxydable. Couvercle avec ouverture de remplissage et bouchon gradué 40 ml. Indicateur de niveau. 4 pieds anti-dérapants. Compatible lave-vaisselle. Verrouillage de sécurité": 2,
+        "<div class=\"rakuten_rich_content\" > <div> <ul> <li>Design compact : profitez de sa capacité de 10 litres.</li> <li>Vous marquez l'heure : il dispose d'une minuterie jusqu'à 60 minutes.</li> <li>Avertissement sonore : le four vous avertira par un son en fin de cuisson.</li> <li>Porte double vitrage : sa porte double vitrage haute résistance permet de maintenir la température.</li> <li>Résistances à quartz : le four dispose de résistances à quartz protégées, idéales pour ce type d'appareil.</li> <li>Accessoires inclus : le four de table est livré avec une plaque à pâtisserie, un grill et une poignée avec pince pour retirer tout ce que vous y mettez.</li> <li>Régule la température : température réglable jusqu'à 230 °C pour que vous puissiez choisir celle qui convient le mieux à vos recettes et aliments.</li> <li>Haute performance : ses 1000 W de puissance assurent des performances élevées à chaque utilisation.</li> </ul> </div> </div> </br> <div> <span>Composition</span> <ul> <li>four de table</li> </ul> </div>": 2,
+        "<div class=\"rakuten_rich_content\" ><div> <div> <h3>NETTOYAGE FACILE</h3> <div> <p>Le four combiné vapeur Steam One est conçu pour faciliter les procédures de nettoyage interne. En plus de la <strong>vitre amovible</strong> permettant un nettoyage complet de la porte, la<strong> fonction Pyrolyse </strong>élimine tous les résidus de la cavité, en détruisant toutes les substances grâce aux hautes températures.</p> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <div> <div> <h3>NETTOYAGE FACILE</h3> <div> <p>Le four combiné vapeur Steam One est conçu pour faciliter les procédures de nettoyage interne. En plus de la <strong>vitre amovible</strong> permettant un nettoyage complet de la porte, la<strong> fonction Pyrolyse </strong>élimine tous les résidus de la cavité, en détruisant toutes les substances grâce aux hautes températures.</p> </div> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <h5>Grille AIRFRY</h5> <div> <p>Pour ceux qui souhaitent pre?parer des plats plus sains, sans renoncer a? l'irre?sistible croquant des aliments frits, la grille AIRFRY est la solution parfaite pour cuisiner rapidement et facilement des plats tels que des frites, des le?gumes et du poisson, avec la moitie? des calories et des graisses de friture.</p> </div> Livre de recettes de la grille AIRFRY </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <h5>Grille viande BBQ</h5> <div> <p>Parfait pour les amateurs de barbecue, l'accessoire BBQ permet de recréer des plats succulents et croustillants au four avec le goût typique de la cuisson au gril.</p> </div> Livre de recettes du grille viande BBQ </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <h5>Pierre réfractaire STONE</h5> <div> <p>Idéale pour obtenir des produits avec la saveur et le croquant typiques de la cuisson dans un four à bois. La pierre réfractaire peut être utilisée pour cuire de la pizza, du pain, de la fougasse et d'autres recettes telles que le poisson en papillote ou les biscuits.</p> </div> Livre de recettes de la pierre réfractaire STONE </div></div>": 2,
+        "<ul><li>Ecran LED, affichage rouge: facile à utiliser</li><li>Hotair 3D: une répartition homogène de la chaleur pour des cuissons absolument parfaites, sur trois niveaux</li><li>EcoClean Direct: un revêtement unique qui élimine la graisse en chauffant pour faciliter le nettoyage</li><li>Classe d'efficacité énergétique A+: l'amélioration de la construction du four permet d'économiser de l'énergie</li></ul><br><br>Ecran LED<br>Lisez facilement l'écran de votre four.<br><br>Une cuisson au four parfaitement homogène, sur trois niveaux.<br>Une fournée de cookies à cuire ? Ne vous posez plus de questions ! Faites-les cuire tous ensemble, sur trois niveaux, sans aucune différence de température. Le ventilateur 3D Hotair répartit la chaleur rapidement et de façon homogène dans l'ensemble du four. Trois plats différents à cuire en même temps ? Pas de problème non plus ! Les cuissons sont aussi parfaites en haut et en bas qu'au milieu, les saveurs ne se mélangent pas et en plus vous gagnez du temps !<br><br>Nettoyer son four n'a jamais été aussi facile.<br>D'ordinaire, nettoyer son four est une véritable corvée... Avec EcoClean Direct, c'est un jeu d'enfant ! Les parois en céramique ultra poreuse éliminent les graisses au cours de la cuisson. Il vous suffit d'essuyer la paroi du bas et l'intérieur de la vitre une fois le four refroidi pour un nettoyage rapide. Pour un nettoyage plus en profondeur, activez de temps en temps le cycle de régénération.<br><br>Économiser de l'énergie pendant la cuisson.<br>Les fours et cuisinières Bosch atteignent la classe d'efficacité énergétique A+ et consomment moins d'énergie lors de la cuisson pendant toute la durée de vie de l'appareil. Un flux d'air optimisé, des matériaux du four améliorés et de meilleures capacités d'isolation garantissent des réductions considérables de la consommation d'énergie.<br><br>": 2,
+        "Entrez dans une nouvelle dimension ou la cuisine est accessible à tous ! Mijoter, griller, fumer, préparez tous ce qu'il vous plaira dans ce four en céramique qui préserve le gout et la saveur des aliments, et vous permet de cuisiner plusieurs plats en simultanés pour des repas à vie quelque soit le temps !": 2,
+        "<div class=\"rakuten_rich_content\" ><div> <div> <h3>3 Manettes de commande</h3> <div> <p>Programmez votre four en quelques secondes avec les trois manettes du four \"Victoria\". Une pour le réglage de la minuterie, une pour la température et une dernière pour programmer les différentes fonctions. Rien de plus simple pour programmer son four et gagner un temps précieux !</p> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <div> <h3>Nettoyage Vapor Clean</h3> <div> <p>Le Vapor Clean est un procédé qui simplifie le nettoyage des fours. Une petite quantité d'eau est entreposée sur le fond de la cavité, la chaleur et la vapeur d'eau qui se produisent permettent d'assouplir les résidus graisseux et de les retirer facilement.</p> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <div> <div> <h3>3 Manettes de commande</h3> <div> <p>Programmez votre four en quelques secondes avec les trois manettes du four \"Victoria\". Une pour le réglage de la minuterie, une pour la température et une dernière pour programmer les différentes fonctions. Rien de plus simple pour programmer son four et gagner un temps précieux !</p> </div> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\" ><div> <div> <div> <h3>Nettoyage Vapor Clean</h3> <div> <p>Le Vapor Clean est un procédé qui simplifie le nettoyage des fours. Une petite quantité d'eau est entreposée sur le fond de la cavité, la chaleur et la vapeur d'eau qui se produisent permettent d'assouplir les résidus graisseux et de les retirer facilement.</p> </div> </div> </div> </div></div>": 2,
+        "<div class=\"rakuten_rich_content\" ><div class=\"rakuten_rich_content\"> <div> <div> <strong> Nettoyer son four n'a jamais été aussi facile.</strong> </div> <div> <div> <p>D'ordinaire, nettoyer son four est une véritable corvée... Avec EcoClean Direct, c'est un jeu d'enfant ! Les parois en céramique ultra poreuse éliminent les graisses au cours de la cuisson. Il vous suffit d'essuyer la paroi du bas et l'intérieur de la vitre une fois le four refroidi pour un nettoyage rapide. Pour un nettoyage plus en profondeur, activez de temps en temps le cycle de régénération.</p> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\"> <div> <div> <strong> Boutons push-pull</strong> </div> <div> <div> <p>Pour nettoyer votre four, appuyez sur les boutons, ils rentrent et se maintiennent ainsi. Cela vous permet d'avoir une surface plane pour nettoyer plus facilement. Une fois propre, vous pouvez appuyer de nouveau sur les boutons... ou les laisser rentrés, pour un design épuré !</p> </div> </div> </div></div><br><br><div class=\"rakuten_rich_content\"> <div> <div> <strong> Ecran LED</strong> </div> <div> <div> <p>Lisez facilement l'écran de votre four.</p> </div> </div> </div></div></div>": 2
+      }
+    },
+    "STORE_PRICE": {
+      "hits": 967,
+      "datasourceNames": [
+        "Enjify",
+        "underdog.shop",
+        "UNDERDOGFR",
+        "cdiscount.com",
+        "SamsungFR",
+        "manomano.fr"
+      ],
+      "values": {
+        "114": 2,
+        "124": 3,
+        "140": 2,
+        "154": 3,
+        "174": 2,
+        "204": 2,
+        "214": 2,
+        "224": 3,
+        "287": 2,
+        "304": 2,
+        "324": 2,
+        "344": 3,
+        "354": 2,
+        "355": 2,
+        "364": 2,
+        "371": 2,
+        "374": 8,
+        "384": 2,
+        "404": 2,
+        "414": 3,
+        "423": 2,
+        "424": 3,
+        "454": 2,
+        "474": 5,
+        "524": 5,
+        "573": 2,
+        "574": 5,
+        "674": 4,
+        "684": 2,
+        "774": 5,
+        "884": 2,
+        "974": 3,
+        "1074": 2,
+        "89.99": 7,
+        "224.99": 6,
+        "374.99": 6,
+        "274.99": 5,
+        "124.99": 5,
+        "134.99": 4,
+        "174.99": 4,
+        "254.99": 4,
+        "29.99": 4,
+        "144.99": 4,
+        "59.99": 3,
+        "264.99": 3,
+        "14.9": 3,
+        "69.99": 3,
+        "509.00": 3,
+        "114.99": 3,
+        "334.99": 3,
+        "244.99": 3,
+        "214.9": 2,
+        "319.0": 2,
+        "574.99": 2,
+        "119.99": 2,
+        "439.99": 2,
+        "599.0": 2,
+        "163.52": 2,
+        "439.0": 2,
+        "549.00": 2,
+        "234.99": 2,
+        "204.99": 2,
+        "534.99": 2,
+        "89.9": 2,
+        "379.00": 2,
+        "107.99": 2,
+        "408.09": 2,
+        "84.99": 2,
+        "79.99": 2,
+        "39.99": 2,
+        "357.99": 2,
+        "120.99": 2,
+        "264.9": 2,
+        "174.9": 2,
+        "444.99": 2,
+        "559.00": 2,
+        "299.00": 2,
+        "939.0": 2,
+        "184.99": 2,
+        "109.99": 2,
+        "114.9": 2,
+        "219.0": 2,
+        "149.95": 2,
+        "44.99": 2,
+        "289.0": 2,
+        "122.7": 2,
+        "119.95": 2,
+        "546.99": 2,
+        "359.99": 2,
+        "539.99": 2,
+        "869.0": 2,
+        "309.0": 2,
+        "324.99": 2,
+        "474.99": 2
+      }
+    },
+    "ENERGIE": {
+      "hits": 924,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Electrique": 665,
+        "Vapeur": 109,
+        "Micro-ondes": 76,
+        "Gaz": 28,
+        "Induction": 27,
+        "Vitro": 8,
+        "Bois": 8,
+        "Mixte": 3
+      }
+    },
+    "DIMENSIONS": {
+      "hits": 873,
+      "datasourceNames": [
+        "fnac.com"
+      ],
+      "values": {
+        "59.5000 cmx59.5000 cm": 25,
+        "548.0000 mmx594.0000 mmx595.0000 mm": 11,
+        "56.40 cmx59.50 cmx59.70 cm": 10,
+        "57.00 cmx60.00 cmx59.00 cm": 10,
+        "59.50 cmx57.00 cmx59.60 cm": 9,
+        "56.70 cmx59.40 cmx59.50 cm": 9,
+        "54.4000 cmx59.2000 cmx59.6000 cm": 9,
+        "56.4000 cmx59.5000 cmx59.5000 cm": 9,
+        "54.00 cmx59.00 cmx45.50 cm": 8,
+        "60.90 cmx59.20 cmx59.20 cm": 8,
+        "56.9000 cmx59.6000 cmx59.4000 cm": 8,
+        "54.80 cmx59.70 cmx59.20 cm": 8,
+        "54.40 cmx59.20 cmx59.60 cm": 7,
+        "54.60 cmx59.50 cmx45.50 cm": 7,
+        "66.0000 cmx59.2000 cmx59.6000 cm": 7,
+        "55.10 cmx59.50 cmx59.50 cm": 6,
+        "56.7000 cmx59.4000 cmx59.5000 cm": 6,
+        "56.40 cmx59.50 cmx59.50 cm": 5,
+        "57.5000 cmx59.5000 cmx59.5000 cm": 5,
+        "51.00 cmx50.00 cmx40.00 cm": 5,
+        "56.8000 cmx59.5000 cmx59.5000 cm": 5,
+        "55.1000 cmx59.5000 cmx59.5000 cm": 5,
+        "56.90 cmx59.60 cmx59.40 cm": 5,
+        "55.9000 cmx59.5000 cmx59.5000 cm": 5,
+        "54.8000 cmx59.4000 cmx59.5000 cm": 5,
+        "54.70 cmx59.00 cmx59.50 cm": 5,
+        "54.60 cmx59.50 cmx59.70 cm": 5,
+        "56.70 cmx59.50 cmx59.40 cm": 4,
+        "54.80 cmx59.60 cmx59.50 cm": 4,
+        "59.50 cmx59.50 cm": 4,
+        "56.90 cmx59.50 cmx59.60 cm": 4,
+        "56.0000 cmx59.4000 cmx59.0000 cm": 4,
+        "57.0000 cmx59.5000 cmx59.6000 cm": 4,
+        "59.5000 cmx59.5000 cmx59.5000 cm": 4,
+        "60.0000 cm": 4,
+        "59.5000 cmx57.5000 cmx59.5000 cm": 4,
+        "56.80 cmx59.50 cmx59.50 cm": 3,
+        "56.7000 cmx59.5000 cmx59.4000 cm": 3,
+        "57.50 cmx59.50 cmx59.50 cm": 3,
+        "0.0700 cmx0.0600 cmx0.0700 cm": 3,
+        "57.00 cmx59.00 cmx59.00 cm": 3,
+        "120.0000 cmx96.0000 cmx120.0000 cm": 3,
+        "59.50 cmx55.00 cmx59.50 cm": 3,
+        "59.5000 cmx59.4000 cmx56.5000 cm": 3,
+        "54.80 cmx59.40 cmx59.50 cm": 3,
+        "57.0000 cmx59.5000 cmx59.5000 cm": 3,
+        "59.70 cmx59.20 cm": 3,
+        "59.20 cmx59.20 cm": 3,
+        "54.80 cmx59.60 cmx45.50 cm": 2,
+        "60.00 cmx100.00 cmx90.00 cm": 2,
+        "51.5000 cmx36.0000 cm": 2,
+        "62.70 cmx44.50 cm": 2,
+        "54.8000 cmx59.5000 cmx59.5000 cm": 2,
+        "54.6800 cmx59.5000 cmx59.6000 cm": 2,
+        "59.50 cmx56.80 cmx59.50 cm": 2,
+        "68.0000 cmx66.0000 cmx67.0000 cm": 2,
+        "32.7000 cmx45.1000 cmx25.6000 cm": 2,
+        "57.0000 cmx46.0000 cmx161.0000 cm": 2,
+        "47.00 cmx28.00 cm": 2,
+        "62.0000 cmx64.6000 cmx66.5000 cm": 2,
+        "59.50 cmx45.50 cm": 2,
+        "60.00 cmx58.00 cmx60.00 cm": 2,
+        "59.0000 cm": 2,
+        "59.6000 cmx59.4000 cm": 2,
+        "57.00 cmx59.50 cmx59.60 cm": 2,
+        "55.5000 cmx56.5000 cmx58.0000 cm": 2,
+        "51.7000 cmx32.7000 cmx44.0000 cm": 2,
+        "548.0000 mmx594.0000 mmx455.0000 mm": 2,
+        "548.0000 mmx597.0000 mmx592.0000 mm": 2,
+        "57.1000 cmx59.7000 cmx59.2000 cm": 2,
+        "37.20 cmx29.00 cm": 2,
+        "59.4000 cmx59.0000 cm": 2,
+        "60.00 cmx90.00 cmx90.00 cm": 2,
+        "55.70 cmx37.00 cm": 2,
+        "56.8000 cmx59.4000 cmx59.4000 cm": 2,
+        "548.0000 mmx596.0000 mmx595.0000 mm": 2,
+        "59.5000 cmx59.4000 cmx59.5000 cm": 2,
+        "57.00 cmx60.00 cmx46.00 cm": 2,
+        "56.0000 cmx59.5000 cmx59.5000 cm": 2,
+        "59.5000 cm": 2,
+        "59.50 cmx59.70 cm": 2,
+        "64.0000 cmx59.5000 cmx59.5000 cm": 2,
+        "59.5000 cmx56.8000 cmx59.5000 cm": 2,
+        "66.0000 cmx64.0000 cmx66.0000 cm": 2,
+        "40.00 cmx58.10 cmx37.60 cm": 2
+      }
+    },
+    "TYPE DE POSE": {
+      "hits": 830,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Encastrable": 407,
+        "Pose libre": 262,
+        "Intégré": 156,
+        "Portable": 4
+      }
+    },
+    "TRANCHE DE POIDS": {
+      "hits": 796,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "17": 2,
+        "40": 3,
+        "45": 2,
+        "30 à 50 kg": 219,
+        "500 g à 3 kg": 197,
+        "3 à 10 kg": 189,
+        "250 à 500 g": 52,
+        "10 à 15 kg": 38,
+        "15 à 30 kg": 33,
+        "0 à 100 g": 27,
+        "+ de 100 kg": 11,
+        "100 à 250 g": 8,
+        "50 à 70 kg": 5,
+        "70 à 100 kg": 2
+      }
+    },
+    "CUSTOM_6": {
+      "hits": 666,
+      "datasourceNames": [
+        "darty.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "Acier inoxydable (inox)": 192,
+        "Verre": 185,
+        "Acier": 50,
+        "Métal": 49,
+        "Plastique": 32,
+        "Aluminium": 27,
+        "Céramique": 23,
+        "Verre trempé": 19,
+        "Choix durable": 17,
+        "Cuir": 7,
+        "Bois": 6,
+        "Polystyrène (PS)": 6,
+        "Pierre": 5,
+        "Silicone": 4,
+        "Argent": 4,
+        "Noyer": 4,
+        "Polypropylène": 4,
+        "ABS": 2,
+        "Bois d'ingénierie": 2,
+        "Polyester": 2,
+        "Papier": 2,
+        "Fonte": 2,
+        "Cuivre": 2,
+        "Caoutchouc": 2,
+        "Microfibre": 2
+      }
+    },
+    "EXPORTDATETS": {
+      "hits": 616,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "1761568467578": 18,
+        "1761554112455": 16,
+        "1761570252984": 13,
+        "1761437658107": 12,
+        "1761568467577": 11,
+        "1761440046173": 10,
+        "1761568467573": 10,
+        "1761554112462": 10,
+        "1761566688726": 9,
+        "1761570252985": 9,
+        "1761561902265": 9,
+        "1761564318632": 8,
+        "1761557110071": 8,
+        "1761561902270": 8,
+        "1761561902266": 8,
+        "1761554112454": 7,
+        "1761572097949": 7,
+        "1761559512271": 7,
+        "1761573851628": 7,
+        "1761561902267": 7,
+        "1761570252986": 6,
+        "1761557110068": 6,
+        "1761575685629": 6,
+        "1761557110077": 6,
+        "1761573851629": 6,
+        "1761554112464": 6,
+        "1761443525866": 5,
+        "1761440046170": 5,
+        "1761559512272": 5,
+        "1761573851624": 5,
+        "1761432741396": 5,
+        "1761403295603": 5,
+        "1761437658111": 4,
+        "1761403295602": 4,
+        "1761551190690": 4,
+        "1761554112463": 4,
+        "1761557110069": 4,
+        "1761570252983": 4,
+        "1761573851625": 4,
+        "1761568467574": 4,
+        "1761554112459": 4,
+        "1761400342019": 4,
+        "1761441222416": 4,
+        "1761564318630": 4,
+        "1761559512267": 4,
+        "1761572097945": 4,
+        "1761559512268": 4,
+        "1761557110076": 4,
+        "1761566688722": 4,
+        "1761437658106": 4,
+        "1761432741399": 4,
+        "1761561902269": 3,
+        "1761551190674": 3,
+        "1761572097951": 3,
+        "1761559512270": 3,
+        "1761559512275": 3,
+        "1761557110078": 3,
+        "1761407947943": 3,
+        "1761572097955": 3,
+        "1761570252995": 3,
+        "1761442437085": 3,
+        "1761400342007": 3,
+        "1761570252989": 3,
+        "1761405674685": 3,
+        "1761434005361": 3,
+        "1761554112456": 3,
+        "1761557110072": 3,
+        "1761572097944": 3,
+        "1761573851626": 3,
+        "1761441222419": 3,
+        "1761551190691": 3,
+        "1761557110066": 3,
+        "1761557110070": 3,
+        "1761551190685": 3,
+        "1761554112461": 3,
+        "1761573851632": 3,
+        "1761568467572": 3,
+        "1761566688721": 3,
+        "1761407947941": 3,
+        "1761436382702": 3,
+        "1761575685631": 2,
+        "1761432741395": 2,
+        "1761551190683": 2,
+        "1761570252994": 2,
+        "1761436382710": 2,
+        "1761440046176": 2,
+        "1761575685630": 2,
+        "1761561902268": 2,
+        "1761442437086": 2,
+        "1761400342013": 2,
+        "1761570252996": 2,
+        "1761572097957": 2,
+        "1761572097952": 2,
+        "1761566688724": 2,
+        "1761559512273": 2,
+        "1761564318623": 2,
+        "1761572097946": 2,
+        "1761573851622": 2,
+        "1761441222420": 2,
+        "1761570252990": 2,
+        "1761575685624": 2,
+        "1761434005365": 2,
+        "1761551190680": 2,
+        "1761434005362": 2,
+        "1761432741392": 2,
+        "1761554112465": 2,
+        "1761442437089": 2,
+        "1761423479310": 2,
+        "1761434005368": 2,
+        "1761564318631": 2,
+        "1761400342010": 2,
+        "1761438809789": 2,
+        "1761551190688": 2,
+        "1761400342006": 2,
+        "1761572097948": 2,
+        "1761570252992": 2,
+        "1761407947940": 2,
+        "1761566688727": 2,
+        "1761575685633": 2,
+        "1761443525870": 2,
+        "1761570252993": 2,
+        "1761400342015": 2,
+        "1761405674688": 2,
+        "1761561902263": 2,
+        "1761440046171": 2,
+        "1761415133684": 2,
+        "1761566688723": 2
+      }
+    },
+    "CONTENANCE DU FOUR": {
+      "hits": 605,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "0": 3,
+        "71 litres": 118,
+        "72 litres": 73,
+        "70 litres": 66,
+        "73 litres": 61,
+        "65 litres": 38,
+        "76 litres": 37,
+        "66 litres": 20,
+        "77 litres": 15,
+        "30 litres": 13,
+        "68 litres": 12,
+        "60 litres": 11,
+        "40 litres": 10,
+        "20 litres": 9,
+        "45 litres": 8,
+        "78 litres": 7,
+        "38 litres": 6,
+        "42 litres": 6,
+        "50 litres": 6,
+        "67 litres": 6,
+        "46 litres": 6,
+        "28 litres": 5,
+        "44 litres": 5,
+        "47 litres": 5,
+        "39 litres": 4,
+        "21 litres": 3,
+        "26 litres": 3,
+        "80 litres": 3,
+        "29 litres": 3,
+        "32 litres": 3,
+        "24 litres": 3,
+        "55 litres": 3,
+        "10 litres": 2,
+        "34 litres": 2,
+        "31 litres": 2,
+        "53 litres": 2,
+        "74 litres": 2,
+        "85 litres": 2,
+        "61 litres": 2,
+        "33 litres": 2,
+        "41 litres": 2,
+        "25 litres": 2,
+        "18 litres": 2
+      }
+    },
+    "ENERGYCLASS": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP": 332,
+        "A": 226,
+        "APP": 27,
+        "B": 5
+      }
+    },
+    "CAVITIES[0]-VOLUME": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "31": 2,
+        "40": 4,
+        "47": 11,
+        "50": 20,
+        "53": 2,
+        "56": 2,
+        "57": 2,
+        "58": 3,
+        "60": 4,
+        "61": 3,
+        "62": 2,
+        "64": 2,
+        "65": 37,
+        "66": 9,
+        "67": 11,
+        "68": 15,
+        "69": 3,
+        "70": 70,
+        "71": 172,
+        "72": 61,
+        "73": 49,
+        "74": 4,
+        "76": 46,
+        "77": 22,
+        "78": 6,
+        "79": 2,
+        "80": 10,
+        "85": 3
+      }
+    },
+    "CAVITIES[0]-ENERGYCLASS": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP": 332,
+        "A": 229,
+        "APP": 27,
+        "B": 2
+      }
+    },
+    "ENERGYCLASSIMAGE": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP-Left-LightGreen.png": 332,
+        "A-Left-Yellow.png": 226,
+        "APP-Left-MediumGreen.png": 27,
+        "B-Left-LightOrange.png": 5
+      }
+    },
+    "CAVITIES[0]-ORDERNUMBER": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "1": 591
+      }
+    },
+    "CAVITIES[0]-HEATSOURCETYPE": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "ELECTRIC": 586,
+        "GAS": 5
+      }
+    },
+    "CAVITIES[0]-ENERGYEFFICIENCYINDEX": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "61": 2,
+        "73": 3,
+        "81": 34,
+        "94": 18,
+        "95": 2,
+        "100": 2,
+        "81.2": 161,
+        "95.3": 52,
+        "81.6": 45,
+        "95.2": 37,
+        "81.4": 30,
+        "94.7": 23,
+        "95.1": 22,
+        "81.3": 13,
+        "81.7": 12,
+        "81.9": 11,
+        "75.6": 9,
+        "95.4": 8,
+        "94.3": 7,
+        "61.9": 6,
+        "61.2": 6,
+        "58.7": 5,
+        "61.4": 5,
+        "75.3": 5,
+        "94.1": 4,
+        "94.4": 4,
+        "95.5": 4,
+        "93.9": 3,
+        "94.9": 3,
+        "80.2": 3,
+        "92.9": 3,
+        "92.3": 2,
+        "97.2": 2,
+        "86.6": 2,
+        "95.8": 2,
+        "93.7": 2,
+        "84.4": 2,
+        "83.9": 2,
+        "94.6": 2
+      }
+    },
+    "ENERGYCLASSRANGE": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "APPP_D": 591
+      }
+    },
+    "NUMBERCAVITIES": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "1": 582,
+        "2": 9
+      }
+    },
+    "CAVITIES[0]-ENERGYCLASSIMAGE": {
+      "hits": 591,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP-Left-LightGreen.png": 332,
+        "A-Left-Yellow.png": 229,
+        "APP-Left-MediumGreen.png": 27,
+        "B-Left-LightOrange.png": 2
+      }
+    },
+    "CAVITIES[0]-ENERGYCLASSIMAGEWITHSCALE": {
+      "hits": 590,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP-Left-LightGreen-WithAPPPDScale.svg": 331,
+        "A-Left-Yellow-WithAPPPDScale.svg": 229,
+        "APP-Left-MediumGreen-WithAPPPDScale.svg": 27,
+        "B-Left-LightOrange-WithAPPPDScale.svg": 2
+      }
+    },
+    "ENERGYCLASSIMAGEWITHSCALE": {
+      "hits": 590,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "AP-Left-LightGreen-WithAPPPDScale.svg": 331,
+        "A-Left-Yellow-WithAPPPDScale.svg": 226,
+        "APP-Left-MediumGreen-WithAPPPDScale.svg": 27,
+        "B-Left-LightOrange-WithAPPPDScale.svg": 5
+      }
+    },
+    "BRAND_NAME": {
+      "hits": 577,
+      "datasourceNames": [
+        "2echoix",
+        "alternateFR",
+        "rueducommerce.fr",
+        "backmarket.fr",
+        "CastoramaFR",
+        "darty.com",
+        "fnac.com",
+        "JoomFR",
+        "UNDERDOGFR",
+        "cdiscount.com",
+        "manomano.fr",
+        "e.leclerc"
+      ],
+      "values": {
+        "Smeg": 35,
+        "Electrolux": 29,
+        "Beko": 27,
+        "Teka": 27,
+        "Bosch": 23,
+        "AEG": 18,
+        "Candy": 18,
+        "VENIX": 17,
+        "Whirlpool": 17,
+        "Samsung": 17,
+        "Non communiqué": 16,
+        "Miele": 13,
+        "Moulinex": 12,
+        "GAGGENAU": 11,
+        "Delonghi": 11,
+        "Siemens": 9,
+        "GENERIQUE": 9,
+        "Cata": 9,
+        "Bartscher": 9,
+        "Proline": 8,
+        "De Dietrich": 7,
+        "Tristar": 7,
+        "Hotpoint": 7,
+        "Princess": 7,
+        "Kaiser": 7,
+        "Sauter": 6,
+        "Indesit": 6,
+        "Schneider": 6,
+        "TZS FIRST AUSTRIA": 5,
+        "Bestron": 5,
+        "Balay": 5,
+        "Hisense": 5,
+        "Brandt": 5,
+        "ORBEGOZO": 4,
+        "Beper": 4,
+        "Thomson": 4,
+        "Cecotec": 4,
+        "Ardes": 4,
+        "Asko": 4,
+        "Syntrox Germany": 3,
+        "Ariete": 3,
+        "G3 FERRARI": 3,
+        "SYNTROX": 3,
+        "Rommelsbacher": 3,
+        "Taurus": 3,
+        "Rosieres": 3,
+        "Haier": 3,
+        "Tefal": 3,
+        "KITCHENCOOK": 3,
+        "MEIRELES": 3,
+        "Gastroback": 3,
+        "Adler": 3,
+        "Combisteel": 3,
+        "Sogo": 2,
+        "Sirge": 2,
+        "Lacor": 2,
+        "HOMCOM": 2,
+        "Falmec": 2,
+        "Techwood": 2,
+        "ADEXI": 2,
+        "Gastro M": 2,
+        "Clatronic": 2,
+        "Zanussi": 2,
+        "Hoover": 2,
+        "Meireles": 2,
+        "Bimar": 2,
+        "Glem": 2,
+        "Sharp": 2,
+        "Livoo": 2,
+        "Camry": 2,
+        "OONI": 2,
+        "Mx Onda": 2
+      }
+    },
+    "CAVITIES[0]-ENERGYCONSUMPTIONCYCLEFANFORCED": {
+      "hits": 574,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "0.69": 171,
+        "0.71": 54,
+        "0.81": 47,
+        "0.8": 40,
+        "0.68": 34,
+        "0.79": 21,
+        "1.1": 21,
+        "0.72": 19,
+        "0.78": 18,
+        "0.87": 15,
+        "0.82": 14,
+        "0.52": 12,
+        "0.67": 11,
+        "0.83": 11,
+        "0.77": 10,
+        "0.7": 10,
+        "0.51": 6,
+        "0.61": 6,
+        "0.54": 5,
+        "0.84": 5,
+        "0.75": 4,
+        "0.85": 4,
+        "0.76": 4,
+        "0.65": 4,
+        "0.74": 3,
+        "0.73": 3,
+        "0.9": 2,
+        "1.77": 2,
+        "0.92": 2
+      }
+    },
+    "LARGEUR": {
+      "hits": 573,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "14": 2,
+        "23": 2,
+        "24": 3,
+        "40": 2,
+        "41": 2,
+        "43": 2,
+        "44": 4,
+        "45": 3,
+        "46": 3,
+        "47": 2,
+        "48": 2,
+        "49": 3,
+        "50": 4,
+        "52": 3,
+        "53": 2,
+        "54": 2,
+        "55": 3,
+        "58": 3,
+        "59": 6,
+        "60": 6,
+        "320": 2,
+        "590": 3,
+        "592": 5,
+        "594": 64,
+        "595": 39,
+        "596": 5,
+        "597": 2,
+        "600": 2,
+        "59.5": 126,
+        "59.4": 61,
+        "59.2": 33,
+        "59.7": 26,
+        "59.6": 15,
+        "59,5": 6,
+        "57.8": 4,
+        "45.5": 3,
+        "50.5": 3,
+        "89.6": 3,
+        "23.6": 2,
+        "32.5": 2,
+        "51.5": 2,
+        "62.7": 2,
+        "44.5": 2,
+        "48.9": 2,
+        "45.2": 2,
+        "597 mm": 2,
+        "595 mm": 2,
+        "52.5": 2,
+        "4,5": 2,
+        "58.8": 2,
+        "55.7": 2,
+        "62.2": 2,
+        "48.5": 2,
+        "59.8": 2,
+        "42.5": 2,
+        "44.6": 2
+      }
+    },
+    "CAVITIES[0]-ENERGYCONSUMPTIONCYCLE": {
+      "hits": 568,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "1": 4,
+        "0.94": 78,
+        "0.99": 49,
+        "0.87": 46,
+        "1.09": 40,
+        "0.93": 40,
+        "1.05": 32,
+        "0.7": 25,
+        "0.89": 24,
+        "0.98": 18,
+        "0.97": 16,
+        "1.03": 15,
+        "0.68": 13,
+        "1.1": 12,
+        "1.15": 12,
+        "0.65": 10,
+        "0.81": 10,
+        "0.96": 9,
+        "0.88": 8,
+        "0.86": 8,
+        "0.83": 7,
+        "0.79": 7,
+        "0.84": 7,
+        "0.64": 7,
+        "1.25": 7,
+        "0.73": 6,
+        "0.8": 6,
+        "0.85": 5,
+        "0.95": 5,
+        "1.06": 3,
+        "0.66": 3,
+        "1.13": 3,
+        "1.59": 3,
+        "0.92": 3,
+        "0.9": 3,
+        "0.72": 3,
+        "0.76": 2,
+        "0.82": 2,
+        "0.78": 2,
+        "0.74": 2,
+        "0.52": 2,
+        "1.4": 2
+      }
+    },
+    "PROFONDEUR": {
+      "hits": 565,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "27": 2,
+        "29": 2,
+        "31": 5,
+        "32": 4,
+        "34": 2,
+        "35": 2,
+        "36": 2,
+        "37": 2,
+        "38": 5,
+        "39": 2,
+        "40": 10,
+        "41": 3,
+        "43": 3,
+        "44": 6,
+        "45": 2,
+        "49": 2,
+        "50": 2,
+        "51": 2,
+        "55": 4,
+        "56": 9,
+        "57": 21,
+        "320": 2,
+        "374": 2,
+        "543": 4,
+        "545": 2,
+        "548": 59,
+        "550": 3,
+        "564": 2,
+        "565": 4,
+        "566": 2,
+        "567": 2,
+        "568": 12,
+        "569": 7,
+        "570": 6,
+        "575": 4,
+        "594": 2,
+        "595": 3,
+        "600": 2,
+        "609": 3,
+        "56.7": 43,
+        "54.8": 35,
+        "56.4": 23,
+        "54.4": 19,
+        "56.8": 16,
+        "56.9": 14,
+        "55.1": 13,
+        "54.6": 11,
+        "57.5": 11,
+        "55.9": 10,
+        "54.7": 10,
+        "60.9": 8,
+        "46.5": 3,
+        "37.8": 3,
+        "42.9": 2,
+        "44.7": 2,
+        "37.5": 2,
+        "56.5": 2,
+        "56.2": 2,
+        "35.5": 2,
+        "57.1": 2,
+        "43.5": 2,
+        "37.4": 2,
+        "39.5": 2,
+        "548 mm": 2,
+        "57.2": 2,
+        "42.5": 2,
+        "59.3": 2,
+        "43.3": 2,
+        "33.5": 2,
+        "54.5": 2,
+        "16.5": 2,
+        "34.6": 2,
+        "59.5": 2
+      }
+    },
+    "HAUTEUR": {
+      "hits": 563,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "13": 2,
+        "21": 4,
+        "24": 2,
+        "28": 5,
+        "29": 2,
+        "30": 3,
+        "31": 3,
+        "33": 3,
+        "34": 4,
+        "35": 4,
+        "36": 2,
+        "37": 6,
+        "38": 2,
+        "40": 2,
+        "41": 2,
+        "59": 6,
+        "60": 8,
+        "382": 2,
+        "455": 10,
+        "548": 2,
+        "568": 2,
+        "590": 2,
+        "592": 4,
+        "593": 4,
+        "594": 16,
+        "595": 68,
+        "596": 5,
+        "59.5": 137,
+        "59.6": 34,
+        "59.2": 22,
+        "59.4": 21,
+        "45.5": 19,
+        "59.7": 9,
+        "45.6": 6,
+        "37.6": 4,
+        "32.5": 4,
+        "34.8": 3,
+        "27.5": 3,
+        "38.2": 3,
+        "58.8": 3,
+        "27.3": 2,
+        "44.5": 2,
+        "33.5": 2,
+        "36.5": 2,
+        "20.5": 2,
+        "37.5": 2,
+        "34.5": 2,
+        "25.5": 2,
+        "32.7": 2,
+        "45.4": 2,
+        "36.6": 2,
+        "26.2": 2,
+        "47.5": 2,
+        "30.5": 2,
+        "41.6": 2,
+        "28.6": 2,
+        "594 mm": 2,
+        "27.1": 2,
+        "58.9": 2,
+        "32.1": 2
+      }
+    },
+    "CATEGORIE DE COULEUR": {
+      "hits": 552,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Noir": 300,
+        "Argent": 110,
+        "Blanc": 45,
+        "Acier inoxydable": 40,
+        "Gris": 40,
+        "Anthracite": 3,
+        "Beige": 3,
+        "Marron": 2,
+        "Crème": 2,
+        "Rouge": 2,
+        "Transparent": 2
+      }
+    },
+    "CLASSE D'EFFICACITE ENERGETIQUE": {
+      "hits": 551,
+      "datasourceNames": [
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Classe A+": 326,
+        "Classe A": 175,
+        "Classe A++": 32,
+        "Classe B": 8,
+        "Classe C": 4,
+        "Classe D": 2,
+        "Classe E": 2
+      }
+    },
+    "POIDS": {
+      "hits": 532,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "1": 3,
+        "7": 2,
+        "9": 3,
+        "10": 3,
+        "12": 4,
+        "14": 3,
+        "25": 4,
+        "27": 3,
+        "28": 2,
+        "29": 4,
+        "30": 2,
+        "31": 4,
+        "32": 4,
+        "33": 5,
+        "34": 13,
+        "35": 5,
+        "36": 11,
+        "37": 15,
+        "38": 2,
+        "40": 6,
+        "41": 3,
+        "42": 7,
+        "43": 2,
+        "45": 2,
+        "47": 5,
+        "35000": 2,
+        "36300": 2,
+        "36,9": 5,
+        "37.5": 5,
+        "40.20": 4,
+        "38,00": 4,
+        "27.1": 4,
+        "36.8": 4,
+        "37,2": 4,
+        "9.5": 3,
+        "32,60": 3,
+        "33.4": 3,
+        "10.5": 3,
+        "36.5": 3,
+        "37.3": 3,
+        "34,5": 3,
+        "33.50": 3,
+        "36.6": 2,
+        "11.5": 2,
+        "10.2": 2,
+        "12.14": 2,
+        "43.7": 2,
+        "38.40": 2,
+        "37,6": 2,
+        "33.9": 2,
+        "14.6": 2,
+        "43.70": 2,
+        "33,3": 2,
+        "40.6": 2,
+        "33.20": 2,
+        "8.7": 2,
+        "27.2": 2,
+        "33.6": 2,
+        "37.4": 2,
+        "31,3": 2,
+        "2.4": 2,
+        "8,4": 2,
+        "36.1": 2,
+        "34,2": 2,
+        "37.2": 2,
+        "29,3": 2,
+        "34.5": 2,
+        "32.6": 2,
+        "34.6": 2,
+        "34,9": 2,
+        "33,2": 2,
+        "9.4": 2,
+        "27.6": 2,
+        "27,00": 2,
+        "33.3": 2,
+        "40.5": 2,
+        "10.8": 2,
+        "28,1": 2,
+        "46.1": 2,
+        "32,5": 2,
+        "4.5": 2,
+        "32,6": 2,
+        "33,6": 2,
+        "38,1": 2
+      }
+    },
+    "WARRANTY": {
+      "hits": 521,
+      "datasourceNames": [
+        "electrodepot.fr",
+        "jpg.fr",
+        "rueducommerce.fr",
+        "backmarket.fr",
+        "fnac.com",
+        "underdog.shop",
+        "UNDERDOGFR",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "2": 22,
+        "2 ans": 393,
+        "30 jours": 81,
+        "12 Months": 9,
+        "GARTIE 2": 8,
+        "12 MONTHS": 6
+      }
+    },
+    "CATEGORIE": {
+      "hits": 444,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Electromenager": 431,
+        "Informatique": 5,
+        "Livres": 4
+      }
+    },
+    "NOMFOURNISSEUR": {
+      "hits": 440,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Electrolux": 30,
+        "Teka": 30,
+        "Beko": 24,
+        "Whirlpool": 18,
+        "AEG": 15,
+        "Bosch": 14,
+        "Smeg": 14,
+        "Candy": 13,
+        "Samsung": 13,
+        "Essentiel B": 11,
+        "Moulinex": 11,
+        "Brandt": 9,
+        "Princess": 9,
+        "Proline": 9,
+        "Miele": 9,
+        "Siemens": 8,
+        "De Dietrich": 7,
+        "Cata": 7,
+        "Hotpoint-Ariston": 7,
+        "Indesit": 6,
+        "Haier": 6,
+        "Hisense": 6,
+        "De'Longhi": 6,
+        "LG": 5,
+        "Tefal": 5,
+        "Tristar": 5,
+        "KitchenCook": 5,
+        "Cecotec": 5,
+        "Adler": 5,
+        "Beper": 4,
+        "Thomson": 4,
+        "Schneider": 4,
+        "G3 Ferrari": 4,
+        "Rommelsbacher": 4,
+        "Bestron": 4,
+        "Sauter": 4,
+        "Balay": 4,
+        "Livoo": 4,
+        "H.Koenig": 3,
+        "Ariete": 3,
+        "Techwood": 3,
+        "Seb": 3,
+        "Rosières": 3,
+        "Ardes": 3,
+        "Simogas": 3,
+        "Duronic": 3,
+        "Arthur Martin": 2,
+        "Lacor": 2,
+        "Klaiser": 2,
+        "Taurus": 2,
+        "Zanussi": 2,
+        "Hoover": 2,
+        "Baumalu": 2,
+        "Severin": 2,
+        "Nedis": 2,
+        "Arthur Martin Electrolux": 2,
+        "Orbegozo": 2,
+        "Ooni": 2,
+        "Gastroback": 2
+      }
+    },
+    "AVAILABILITY": {
+      "hits": 396,
+      "datasourceNames": [
+        "jpg.fr",
+        "WelcomeOfficecom",
+        "LesCavesGnriqueSTANDBYpartirdu15022023",
+        "darty.com",
+        "MaxxessStandard",
+        "DartyProCashback",
+        "DIM",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "ElectrodepotGuidesetComparateurs",
+        "welcomeoffice.com",
+        "comptoirsrichard.fr",
+        "electrodepot.fr",
+        "JPGCashbackReward",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "0": 2,
+        "Livré par Darty": 173,
+        "En stock": 55,
+        "in stock": 52,
+        "Expédié sous 5 j": 26,
+        "Livré sous 3 sem.": 23,
+        "en stock": 19,
+        "En stock sous 3 à 6 semaines": 17,
+        "Livré sous 15 j": 13,
+        "Livré sous 5 j": 6,
+        "Livré sous 10 j": 3,
+        "Retrait en magasin sous 2/3j": 3,
+        "Expédié sous 10 j": 2
+      }
+    },
+    "STOCK": {
+      "hits": 395,
+      "datasourceNames": [
+        "jpg.fr",
+        "LesCavesGnriqueSTANDBYpartirdu15022023",
+        "darty.com",
+        "MaxxessStandard",
+        "DartyProCashback",
+        "DIM",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "ElectrodepotGuidesetComparateurs",
+        "electrodepot.fr",
+        "JPGCashbackReward",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "1": 91,
+        "2": 9,
+        "3": 7,
+        "4": 3,
+        "5": 2,
+        "6": 3,
+        "7": 3,
+        "9": 4,
+        "10": 61,
+        "21": 2,
+        "22": 2,
+        "31": 2,
+        "44": 2,
+        "47": 2,
+        "50": 96,
+        "100": 88
+      }
+    },
+    "EPREL CERTIFICATION CODE": {
+      "hits": 370,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "0": 12,
+        "121878": 2,
+        "552756": 3,
+        "1143399": 2,
+        "1842239": 2
+      }
+    },
+    "EPREL CATEGORY": {
+      "hits": 357,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "ovens": 353,
+        "rangehoods": 4
+      }
+    },
+    "ECHELLE D'EFFICACITE ENERGETIQUE": {
+      "hits": 356,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "A+++-D": 351,
+        "APPP_D": 5
+      }
+    },
+    "DISPOSITIF DE SECURITE": {
+      "hits": 352,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Porte froide": 143,
+        "Sécurité enfants": 47,
+        "Verrouillage": 28,
+        "Arrêt automatique": 24,
+        "Double porte vitrée": 20,
+        "Système de refroidissement par ventilateur": 20,
+        "Porte à quadruple vitrage": 10,
+        "Indicateur de chaleur résiduelle": 10,
+        "Porte refroidissante": 10,
+        "Thermostat de sécurité": 5,
+        "Auto Stop System": 5,
+        "Verrou de porte": 4,
+        "Cool touch": 3,
+        "Paroi froide": 3,
+        "Porte à triple vitrage": 3,
+        "Verrou de porte électronique": 2,
+        "Fermeture automatique de sécurité sur ouverture de porte": 2,
+        "Charnière CoolDoor": 2
+      }
+    },
+    "ECOLABEL": {
+      "hits": 330,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "false": 328,
+        "true": 2
+      }
+    },
+    "COLOR": {
+      "hits": 323,
+      "datasourceNames": [
+        "electrodepot.fr",
+        "rakuten.com",
+        "MaisonsdumondeFrance",
+        "cdiscount.com",
+        "123comparer.fr",
+        "mda-electromenager.com",
+        "maisonsdumonde.com",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "NOIR": 132,
+        "GRIS": 74,
+        "BLANC": 54,
+        "ACIER INOXYDABLE": 10,
+        "INOX": 8,
+        "Noir": 7,
+        "ARGENT": 7,
+        "ROUGE": 4,
+        "BEIGE": 4,
+        "Blanc": 3,
+        "Rouge": 3,
+        "Inox": 2,
+        "BLEU": 2
+      }
+    },
+    "GAMME DE PRODUITS": {
+      "hits": 316,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Brandt": 26,
+        "SEVERIN": 22,
+        "Sauter": 10,
+        "Whirlpool": 8,
+        "Moulinex Optimo": 7,
+        "Samsung Series 4": 7,
+        "Clatronic": 7,
+        "Indesit": 7,
+        "Tristar": 6,
+        "Princess": 5,
+        "Riviera & Bar": 5,
+        "Hotpoint Ariston": 5,
+        "Bosch Serie 4": 5,
+        "Continental Edison": 4,
+        "De'Longhi": 4,
+        "ASKO Craft": 4,
+        "Camry Premium": 4,
+        "Smeg Victoria": 4,
+        "De Dietrich": 3,
+        "ASKO": 3,
+        "CASO Design": 3,
+        "Schneider": 3,
+        "Electrolux SteamBoost 800": 3,
+        "Teka MAESTRO": 3,
+        "Samsung": 3,
+        "Candy": 3,
+        "Hisense": 3,
+        "Ariete Bon Cuisine": 3,
+        "Airlux Serie 100": 3,
+        "Electrolux": 3,
+        "Bosch Serie 8": 3,
+        "Rommelsbacher": 3,
+        "Candy IDEA": 3,
+        "Siemens iQ700": 3,
+        "ASKO Elements": 3,
+        "Whirlpool Absolute": 3,
+        "Sage": 2,
+        "CATA": 2,
+        "Oceanic": 2,
+        "DOMO": 2,
+        "Taurus White and Brown": 2,
+        "De Dietrich Collection Blanc Pur": 2,
+        "Smeg Cucina": 2,
+        "Bestron": 2,
+        "Philips Series 5000": 2,
+        "Kitchen Chef Professional": 2,
+        "Beko": 2,
+        "Moulinex": 2,
+        "Siemens iQ500": 2,
+        "Siemens iQ300": 2,
+        "Electrolux Serie 600": 2,
+        "Miele": 2,
+        "Electrolux 300": 2,
+        "Whirlpool Absolute Core": 2,
+        "Candy Smart": 2,
+        "Glem Metropol": 2,
+        "De'Longhi SfornaTutto Midi": 2
+      }
+    },
+    "COULEUR GENERIQUE": {
+      "hits": 302,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Noir": 186,
+        "Argent": 73,
+        "Blanc": 27,
+        "Gris": 6,
+        "Rouge": 3,
+        "Beige": 2,
+        "Jaune": 2
+      }
+    },
+    "COULEUR EXTERIEURE": {
+      "hits": 282,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Noir": 80,
+        "Acier inoxydable": 74,
+        "Blanc": 25,
+        "Noir/inox": 9,
+        "Argent": 9,
+        "Inox": 9,
+        "Aluminium": 5,
+        "Noir propre": 4,
+        "Noir / argent": 4,
+        "Noir/inox brossé": 4,
+        "Inox noir": 3,
+        "Noir mat": 3,
+        "Inox/noir": 3,
+        "Anthracite": 3,
+        "Noir mat/inox": 3,
+        "Verre noir": 3,
+        "Inox brossé": 2,
+        "Verre en céramique noir": 2,
+        "Inox et verre noir": 2,
+        "Transparent": 2,
+        "Acier inoxydable/cristal": 2,
+        "Soie blanc mate": 2,
+        "Noir intense": 2,
+        "Argent/noir": 2,
+        "Blanc/noir": 2,
+        "Crème": 2,
+        "Graphite noir": 2
+      }
+    },
+    "ORIGINE_IMPORT": {
+      "hits": 278,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "All-in-one": 259,
+        "Converter": 16,
+        "hightech_minimaliste": 3
+      }
+    },
+    "HAUTEUR EMBALLEE": {
+      "hits": 277,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "37": 2,
+        "40": 2,
+        "47": 2,
+        "55": 8,
+        "64": 2,
+        "65": 3,
+        "66": 18,
+        "67": 26,
+        "69": 3,
+        "70": 8,
+        "640": 3,
+        "654": 3,
+        "660": 4,
+        "665": 10,
+        "670": 14,
+        "675": 22,
+        "690": 3,
+        "65.5": 30,
+        "66.5": 9,
+        "67.5": 8,
+        "43.5": 4,
+        "65.4": 3,
+        "42.5": 3,
+        "64.8": 2,
+        "32.6": 2,
+        "33.7": 2,
+        "44.2": 2,
+        "32.3": 2,
+        "49.7": 2,
+        "36.6": 2,
+        "42.4": 2
+      }
+    },
+    "LARGEUR EMBALLEE": {
+      "hits": 277,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "36": 2,
+        "50": 2,
+        "52": 2,
+        "54": 2,
+        "62": 15,
+        "63": 5,
+        "64": 19,
+        "65": 4,
+        "66": 48,
+        "68": 6,
+        "69": 8,
+        "70": 2,
+        "395": 2,
+        "620": 11,
+        "635": 5,
+        "640": 3,
+        "650": 2,
+        "660": 23,
+        "670": 6,
+        "675": 3,
+        "680": 5,
+        "688": 2,
+        "694": 2,
+        "69.4": 11,
+        "63.5": 9,
+        "57.5": 3,
+        "68.8": 2,
+        "55.2": 2,
+        "65.4": 2,
+        "52.5": 2,
+        "62.8": 2
+      }
+    },
+    "COULEUR": {
+      "hits": 275,
+      "datasourceNames": [
+        "rakuten.com",
+        "cdiscount.com"
+      ],
+      "values": {
+        "Noir": 84,
+        "Acier inoxydable": 59,
+        "Argent": 22,
+        "Blanc": 22,
+        "Inox": 15,
+        "Noir/inox": 9,
+        "Noir propre": 4,
+        "Noir / argent": 4,
+        "Inox noir": 3,
+        "Noir mat/inox": 3,
+        "Verre noir": 3,
+        "Inox brossé": 2,
+        "Verre en céramique noir": 2,
+        "Inox et verre noir": 2,
+        "Noir mat": 2,
+        "Inox/noir": 2,
+        "Acier inoxydable/cristal": 2,
+        "Anthracite": 2,
+        "Acier": 2,
+        "Beige": 2,
+        "Blanc/noir": 2,
+        "Crème": 2,
+        "Graphite noir": 2
+      }
+    },
+    "PROFONDEUR EMBALLEE": {
+      "hits": 275,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "15": 2,
+        "27": 2,
+        "42": 4,
+        "47": 2,
+        "57": 2,
+        "64": 10,
+        "65": 7,
+        "66": 64,
+        "67": 14,
+        "68": 2,
+        "69": 2,
+        "70": 13,
+        "150": 2,
+        "640": 4,
+        "646": 8,
+        "648": 2,
+        "660": 7,
+        "670": 6,
+        "675": 4,
+        "680": 5,
+        "685": 3,
+        "690": 21,
+        "720": 2,
+        "67.5": 4,
+        "48.8": 3,
+        "64.6": 3,
+        "42.3": 2,
+        "50.5": 2,
+        "35.6": 2,
+        "45.6": 2,
+        "65.2": 2,
+        "65.5": 2,
+        "44.5": 2
+      }
+    },
+    "STYLE": {
+      "hits": 272,
+      "datasourceNames": [
+        "LesCavesGnriqueSTANDBYpartirdu15022023",
+        "darty.com",
+        "DartyProCashback",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "null": 272
+      }
+    },
+    "MODE DE NETTOYAGE": {
+      "hits": 270,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Pyrolyse": 155,
+        "Hydrolyse": 40,
+        "Catalyse": 28,
+        "Multifonction": 15,
+        "Pyrolytique/hydrolytique": 15,
+        "Vapor Clean": 9,
+        "Ecoclean": 5
+      }
+    },
+    "POIDS EMBALLE": {
+      "hits": 255,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "11": 2,
+        "14": 4,
+        "21": 2,
+        "29": 2,
+        "30": 5,
+        "31": 2,
+        "32": 2,
+        "34": 4,
+        "35": 3,
+        "36": 4,
+        "37": 4,
+        "38": 3,
+        "39": 4,
+        "38.6": 4,
+        "38.1": 4,
+        "13.5": 4,
+        "38.5": 3,
+        "37,5": 3,
+        "37,6": 3,
+        "38.8": 3,
+        "38.2": 3,
+        "49.7": 2,
+        "33.4": 2,
+        "35.4": 2,
+        "45.3": 2,
+        "41.3": 2,
+        "7.18": 2,
+        "14.5": 2,
+        "30,3": 2,
+        "37.8": 2,
+        "40.5": 2,
+        "36.5": 2,
+        "34,5": 2,
+        "10.9": 2,
+        "31.3": 2,
+        "35.7": 2,
+        "34,7": 2,
+        "44.4": 2,
+        "13.6": 2,
+        "1.3": 2,
+        "33,6": 2
+      }
+    },
+    "MARQUE": {
+      "hits": 252,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Brandt": 22,
+        "Severin": 21,
+        "Bosch": 15,
+        "Samsung": 11,
+        "Electrolux": 11,
+        "De'Longhi": 10,
+        "Whirlpool": 10,
+        "Moulinex": 9,
+        "Sauter": 9,
+        "Smeg": 7,
+        "Clatronic": 6,
+        "Candy": 6,
+        "Philips": 6,
+        "De Dietrich": 5,
+        "Princess": 5,
+        "Tristar": 5,
+        "Riviera & Bar": 5,
+        "Ariete": 5,
+        "ASKO": 5,
+        "Siemens": 5,
+        "Continental Edison": 4,
+        "Bestron": 4,
+        "Beko": 4,
+        "Camry Premium": 4,
+        "Schneider": 3,
+        "Hotpoint-Ariston": 3,
+        "Indesit": 3,
+        "Hisense": 3,
+        "Sage": 2,
+        "CASO Design": 2,
+        "Oceanic": 2,
+        "DOMO": 2,
+        "Taurus": 2,
+        "Kitchen Chef": 2,
+        "Hoover": 2,
+        "Tefal": 2,
+        "Rommelsbacher": 2
+      }
+    },
+    "PUISSANCE (W)": {
+      "hits": 242,
+      "datasourceNames": [
+        "rakuten.com",
+        "mda-electromenager.com"
+      ],
+      "values": {
+        "2000 W": 27,
+        "3600 W": 25,
+        "3500 W": 17,
+        "1200 W": 15,
+        "1800 W": 15,
+        "3400 W": 15,
+        "3300 W": 14,
+        "3000 W": 13,
+        "2200 W": 11,
+        "3385 W": 7,
+        "3450 W": 5,
+        "3950 W": 4,
+        "900 W": 4,
+        "2320 W": 4,
+        "800 W": 3,
+        "3390 W": 3,
+        "2400 W": 3,
+        "1500 W": 3,
+        "3490 W": 3,
+        "1380 W": 3,
+        "3552 W": 3,
+        "2500 W": 3,
+        "1600 W": 3,
+        "1400 W": 3,
+        "2900 W": 3,
+        "2250 W": 2,
+        "3480 W": 2,
+        "1450 W": 2,
+        "3 kW": 2
+      }
+    },
+    "PUISSANCE ELECTRIQUE": {
+      "hits": 228,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "1": 4,
+        "2": 11,
+        "3": 9,
+        "400": 3,
+        "800": 5,
+        "1300": 2,
+        "1600": 2,
+        "1800": 3,
+        "2000": 3,
+        "2500": 2,
+        "2615": 2,
+        "3000": 4,
+        "3385": 4,
+        "3400": 6,
+        "3500": 5,
+        "3552": 2,
+        "3650": 2,
+        "3850": 2,
+        "3950": 5,
+        "3.385": 18,
+        "1.5": 18,
+        "1.4": 14,
+        "1.8": 13,
+        "3.6": 10,
+        "2.2": 6,
+        "1.6": 5,
+        "3.4": 4,
+        "1.3": 4,
+        "2.9": 4,
+        "3.1": 4,
+        "3.65": 4,
+        "2.3": 3,
+        "2.4": 2,
+        "3.5": 2,
+        "1.2": 2,
+        "3.3": 2,
+        "1.1": 2
+      }
+    },
+    "NBRE DE FOURS": {
+      "hits": 146,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "1": 2,
+        "3": 3,
+        "Four simple": 140
+      }
+    },
+    "MODES DE CUISSON DU FOUR": {
+      "hits": 144,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Chaleur tournante": 12,
+        "Gril": 11,
+        "Décongélation": 9,
+        "Chaleur de fond": 8,
+        "Convection": 6,
+        "Grill de surface": 6,
+        "Gril ventilé": 6,
+        "Éco": 5,
+        "Traditionnel": 5,
+        "Gril turbo": 4,
+        "Chauffage inférieur + ventilateur": 3,
+        "Conventionnel": 3,
+        "Pizza": 3,
+        "10 fonctions de cuisson automatique Dual Cook": 2,
+        "Étuve": 2,
+        "Cuisson chaleur tournante": 2,
+        "Fonctions de cuisson automatique": 2,
+        "Circulaire + ventilateur": 2,
+        "Chaleur par le bas + convection": 2,
+        "Micro-ondes combiné": 2,
+        "Cuisson basse température": 2,
+        "Préchauffage rapide": 2
+      }
+    },
+    "SHIPPING_TIME": {
+      "hits": 131,
+      "datasourceNames": [
+        "jpg.fr",
+        "WelcomeOfficecom",
+        "MaxxessStandard",
+        "DIM",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "ElectrodepotGuidesetComparateurs",
+        "welcomeoffice.com",
+        "electrodepot.fr",
+        "JPGCashbackReward",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "3": 5,
+        "24/48H": 55,
+        "Livré en 24-48H": 51,
+        "2 Jours": 20
+      }
+    },
+    "SHIPPING_COST": {
+      "hits": 131,
+      "datasourceNames": [
+        "jpg.fr",
+        "WelcomeOfficecom",
+        "MaxxessStandard",
+        "DIM",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "ElectrodepotGuidesetComparateurs",
+        "welcomeoffice.com",
+        "electrodepot.fr",
+        "JPGCashbackReward",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "0": 33,
+        "30": 13,
+        "10.68": 38,
+        "17.88": 26,
+        "8,90": 12,
+        "0.00": 5
+      }
+    },
+    "BRAND": {
+      "hits": 131,
+      "datasourceNames": [
+        "WelcomeOfficecom",
+        "LesCavesGnriqueSTANDBYpartirdu15022023",
+        "MaxxessStandard",
+        "DartyProCashback",
+        "DIM",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "ElectrodepotGuidesetComparateurs",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "but.fr",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "123comparer.fr",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "Miele": 13,
+        "Aeg": 7,
+        "ELECTROLUX": 7,
+        "SAMSUNG": 7,
+        "Samsung": 5,
+        "BRANDT": 5,
+        "BEKO": 5,
+        "Electrolux": 4,
+        "De Dietrich": 4,
+        "Teka": 4,
+        "Gaggenau": 3,
+        "KITCHEN COOK": 3,
+        "SMEG": 3,
+        "HISENSE": 3,
+        "BOSCH": 3,
+        "Thomson": 3,
+        "WHIRLPOOL": 3,
+        "Asko": 3,
+        "Bosch": 2,
+        "Falmec": 2,
+        "VALBERG": 2,
+        "Schneider": 2,
+        "Rosieres": 2,
+        "SAUTER": 2,
+        "Siemens": 2,
+        "Moulinex": 2
+      }
+    },
+    "RESSUM": {
+      "hits": 130,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "1": 90,
+        "2": 40
+      }
+    },
+    "SHIPPING_WEIGHT": {
+      "hits": 125,
+      "datasourceNames": [
+        "electrodepot.fr",
+        "jpg.fr",
+        "JPGCashbackReward",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "0": 92,
+        "35.000000": 2,
+        "34.000000": 2,
+        "44.000000": 2
+      }
+    },
+    "CUSTOM_LABEL_3": {
+      "hits": 113,
+      "datasourceNames": [
+        "jpg.fr",
+        "JPGCashbackReward",
+        "piecesetpneusGuidesdachat",
+        "ObjetramaPortailsguidescomparateurs",
+        "RuckfieldStandard",
+        "MaxxessStandard",
+        "DIM",
+        "123ConsommablesStandardSTANDBYpartirdu01012024",
+        "MaisonsdumondeFrance",
+        "Jemabonne",
+        "PiscinecoSTANDBYpartirdu17112023",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "17": 3,
+        "320": 2,
+        "52.22": 6,
+        "69.44": 5,
+        "MDM - Price Range 0-50": 4,
+        "78.33": 3,
+        "93.33": 2,
+        "87.44": 2,
+        "23.25": 2,
+        "70.22": 2,
+        "26.33": 2,
+        "44.11": 2,
+        "165.5": 2,
+        "21.88": 2,
+        "53.56": 2,
+        "58.75": 2
+      }
+    },
+    "CUSTOM_LABEL_2": {
+      "hits": 109,
+      "datasourceNames": [
+        "jpg.fr",
+        "JPGCashbackReward",
+        "MaisonsdumondeFrance"
+      ],
+      "values": {
+        "17": 3,
+        "209": 2,
+        "320": 2,
+        "52.22": 6,
+        "69.44": 5,
+        "78.33": 3,
+        "93.33": 2,
+        "87.44": 2,
+        "23.25": 2,
+        "70.22": 2,
+        "26.33": 2,
+        "44.11": 2,
+        "165.5": 2,
+        "21.88": 2,
+        "53.56": 2,
+        "58.75": 2
+      }
+    },
+    "CLASSE_ENERGY": {
+      "hits": 108,
+      "datasourceNames": [
+        "rakuten.com",
+        "123comparer.fr",
+        "mda-electromenager.com"
+      ],
+      "values": {
+        "A+": 58,
+        "A": 38,
+        "A++": 8,
+        "C": 3
+      }
+    },
+    "CONSOMMATION D'ENERGIE": {
+      "hits": 96,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "3385 Watt": 16,
+        "3950 Watt": 7,
+        "3000 Watt": 7,
+        "3600 Watt": 7,
+        "3500 Watt": 6,
+        "1500 Watt": 5,
+        "2000 Watt": 4,
+        "1800 Watt": 4,
+        "3400 Watt": 4,
+        "1400 Watt": 4,
+        "2900 Watt": 3,
+        "3650 Watt": 3,
+        "3850 Watt": 3,
+        "2300 Watt": 2,
+        "1300 Watt": 2,
+        "2200 Watt": 2,
+        "800 Watt": 2,
+        "3300 Watt": 2,
+        "2090 Watt": 2
+      }
+    },
+    "COMMISSION_GROUP": {
+      "hits": 89,
+      "datasourceNames": [
+        "joom.com",
+        "JoomFR"
+      ],
+      "values": {
+        "category_15": 62,
+        "default": 26
+      }
+    },
+    "CUSTOM_LABEL_1": {
+      "hits": 81,
+      "datasourceNames": [
+        "jpg.fr",
+        "MaisonsdumondeFrance",
+        "maisonsdumonde.com"
+      ],
+      "values": {
+        "1": 73,
+        "6": 2,
+        "MIDDLE": 5
+      }
+    },
+    "CATEGORY": {
+      "hits": 78,
+      "datasourceNames": [
+        "WelcomeOfficecom",
+        "DartyProCashback",
+        "MaisonsdumondeFrance",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "Gros électroménager": 60,
+        "ELECTRO DEPOT": 9,
+        "Petit électroménager": 5
+      }
+    },
+    "CUSTOM_LABEL_4": {
+      "hits": 72,
+      "datasourceNames": [
+        "jpg.fr",
+        "JPGCashbackReward"
+      ],
+      "values": {
+        "3. LOW": 55,
+        "2. MIDDLE": 15
+      }
+    },
+    "CATEGORY_LEVEL2": {
+      "hits": 71,
+      "datasourceNames": [
+        "DartyProCashback",
+        "MaisonsdumondeFrance",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "Four": 47,
+        "FOUR, MICRO-ONDES": 8,
+        "Hotte": 6,
+        "Micro ondes": 4,
+        "Cuisinières": 2
+      }
+    },
+    "TYPE DE COMMANDE": {
+      "hits": 49,
+      "datasourceNames": [
+        "icecat.biz",
+        "rakuten.com",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Mécanique": 29,
+        "Électronique": 5,
+        "Rotatif": 4,
+        "Rotatif, Tactile": 3,
+        "Tactile": 3
+      }
+    },
+    "CAVITIES[0]-ENERGYCONSUMPTIONCYCLEGAS": {
+      "hits": 46,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "3.92": 22,
+        "4.14": 12,
+        "4.07": 3,
+        "5.71": 3
+      }
+    },
+    "CAVITIES[0]-ENERGYCONSUMPTIONCYCLEFANFORCEDGAS": {
+      "hits": 44,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "2.45": 17,
+        "2.88": 14,
+        "2.77": 3,
+        "6.36": 2
+      }
+    },
+    "CUSTOM_LABEL_0": {
+      "hits": 41,
+      "datasourceNames": [
+        "electrodepot.fr",
+        "jpg.fr",
+        "MaisonsdumondeFrance",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "2": 3,
+        "3": 4,
+        "5": 7,
+        "6": 3,
+        "7": 2,
+        "FR": 8,
+        "CN": 4,
+        "3. LOW": 4,
+        "RO": 3
+      }
+    },
+    "OBJET CONNECTE": {
+      "hits": 39,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Objets connectés": 35,
+        "Oui": 4
+      }
+    },
+    "ORIGINE_MS": {
+      "hits": 38,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "MSMarket": 27,
+        "Ajoutimages": 8,
+        "AjoutEAN": 3
+      }
+    },
+    "CONTENANCE DU FOUR A MICRO-ONDES": {
+      "hits": 33,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "20 litres": 10,
+        "23 litres": 3,
+        "25 litres": 3,
+        "45 litres": 3,
+        "44 litres": 2,
+        "26 litres": 2,
+        "40 l": 2,
+        "17 litres": 2
+      }
+    },
+    "MATIERE DOMINANTE": {
+      "hits": 24,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Aluminium": 5,
+        "Plastique": 4,
+        "Acier inoxydable": 3,
+        "Bois": 2,
+        "Stainless steel": 2,
+        "Acier peint": 2,
+        "Verre": 2,
+        "Céramique": 2
+      }
+    },
+    "CATEGORY_NAME": {
+      "hits": 24,
+      "datasourceNames": [
+        "alternateFR",
+        "2echoix",
+        "UNDERDOGFR",
+        "cdiscount.com",
+        "manomano.fr"
+      ],
+      "values": {
+        "Cookers & Ovens": 15,
+        "Kitchen": 3
+      }
+    },
+    "PUISSANCE MAXIMALE DU MICRO-ONDES": {
+      "hits": 23,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "900 Watt": 9,
+        "700 Watt": 5,
+        "800 Watt": 4,
+        "800 W": 2,
+        "850 Watt": 2
+      }
+    },
+    "KEYWORDS": {
+      "hits": 22,
+      "datasourceNames": [
+        "rueducommerce.fr"
+      ],
+      "values": {
+        "Four": 11,
+        "Mini-four": 9
+      }
+    },
+    "SPECIFICATIONS": {
+      "hits": 21,
+      "datasourceNames": [
+        "alternateFR",
+        "backmarket.fr"
+      ],
+      "values": {
+        "good": 5,
+        "excellent": 4,
+        "fair": 4,
+        "refurbished": 3,
+        "A+": 3,
+        "A": 2
+      }
+    },
+    "TYPE DE FOUR A MICRO-ONDES": {
+      "hits": 21,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Four micro-ondes monofonction": 9,
+        "Four micro-ondes grill": 5,
+        "Four micro-ondes combiné - grill": 4,
+        "Four micro-ondes combiné": 3
+      }
+    },
+    "CAPACITE EN TASSES": {
+      "hits": 19,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "1": 8,
+        "2": 3,
+        "10": 2,
+        "15": 4
+      }
+    },
+    "HOTTE/TYPE": {
+      "hits": 18,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Decorative": 8,
+        "Groupe filtrant": 4,
+        "Cheminée coudée": 3,
+        "Standard": 2
+      }
+    },
+    "VALID_TO": {
+      "hits": 18,
+      "datasourceNames": [
+        "fnac.com"
+      ],
+      "values": {
+        "02/03/2026 23:59:00": 10,
+        "09/30/2025 23:59:00": 3
+      }
+    },
+    "VALID_FROM": {
+      "hits": 18,
+      "datasourceNames": [
+        "fnac.com"
+      ],
+      "values": {
+        "01/07/2026 08:00:00": 9,
+        "08/22/2025 10:00:00": 3,
+        "12/02/2025 10:00:00": 2
+      }
+    },
+    "TYPE DE FRITEUSE": {
+      "hits": 14,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Friteuse à air chaud": 13
+      }
+    },
+    "TECHNOLOGIE DES COMMUNICATIONS": {
+      "hits": 14,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Wi-Fi": 13
+      }
+    },
+    "METHODE D'INFUSION": {
+      "hits": 13,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Espresso": 8,
+        "Filtre": 5
+      }
+    },
+    "COMPATIBLE AVEC L'INTERNET DES OBJETS (IDO)": {
+      "hits": 13,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Oui": 13
+      }
+    },
+    "MODE DE FONCTIONNEMENT": {
+      "hits": 13,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Recyclage": 9,
+        "Extraction et recirculation (avec kit de recirculation supplémentaire)": 2
+      }
+    },
+    "ITEM_GROUP_ID": {
+      "hits": 12,
+      "datasourceNames": [
+        "jpg.fr",
+        "JPGCashbackReward"
+      ],
+      "values": {
+        "14": 3,
+        "WW": 9
+      }
+    },
+    "NOMBRE DE FOURS": {
+      "hits": 12,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "1": 12
+      }
+    },
+    "TYPE DE NETTOYAGE": {
+      "hits": 12,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "A pyrolyse": 8,
+        "Dry": 2
+      }
+    },
+    "COMPATIBLE": {
+      "hits": 11,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Café moulu": 5,
+        "Senseo": 3,
+        "Grains de café": 2
+      }
+    },
+    "TYPE DE FOUR": {
+      "hits": 11,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Four électrique": 10
+      }
+    },
+    "LARGEUR DE COMPARTIMENT D'INSTALLATION": {
+      "hits": 11,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "56 cm": 7
+      }
+    },
+    "TAILLE DU FOUR": {
+      "hits": 11,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Moyenne": 7,
+        "Grand": 3
+      }
+    },
+    "PROFONDEUR DE COMPARTIMENT D'INSTALLATION": {
+      "hits": 11,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "55 cm": 7,
+        "56 cm": 3
+      }
+    },
+    "CATEGORY_LEVEL3": {
+      "hits": 10,
+      "datasourceNames": [
+        "MaisonsdumondeFrance",
+        "ElectrodepotGuidesetComparateurs"
+      ],
+      "values": {
+        "Four encastrable": 8
+      }
+    },
+    "POSITION DE CONTROLE": {
+      "hits": 10,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Devant": 9
+      }
+    },
+    "DELIVERY_RESTRICTIONS": {
+      "hits": 10,
+      "datasourceNames": [
+        "rueducommerce.fr"
+      ],
+      "values": {
+        "Livraison à domicile": 6,
+        "Fedex Express au rez-de-chaussée": 2
+      }
+    },
+    "CAVITIES[1]-ENERGYCLASSIMAGEWITHSCALE": {
+      "hits": 9,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "A-Left-Yellow-WithAPPPDScale.svg": 6,
+        "B-Left-LightOrange-WithAPPPDScale.svg": 3
+      }
+    },
+    "CAVITIES[1]-HEATSOURCETYPE": {
+      "hits": 9,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "ELECTRIC": 9
+      }
+    },
+    "CAVITIES[1]-ENERGYCLASSIMAGE": {
+      "hits": 9,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "A-Left-Yellow.png": 6,
+        "B-Left-LightOrange.png": 3
+      }
+    },
+    "CAVITIES[1]-ORDERNUMBER": {
+      "hits": 9,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "2": 9
+      }
+    },
+    "CAVITIES[1]-ENERGYCLASS": {
+      "hits": 9,
+      "datasourceNames": [
+        "eprel"
+      ],
+      "values": {
+        "A": 6,
+        "B": 3
+      }
+    },
+    "DIAGONALE": {
+      "hits": 9,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "7": 9
+      }
+    },
+    "NORME": {
+      "hits": 9,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "SD": 9
+      }
+    },
+    "TYPE DE LAMPE": {
+      "hits": 9,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Halogène": 8
+      }
+    },
+    "BARBECUE/ENERGIE": {
+      "hits": 9,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "Electrique": 7,
+        "Charbon": 2
+      }
+    },
+    "ECRAN INTEGRE": {
+      "hits": 8,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Oui": 6
+      }
+    },
+    "EMPLACEMENT CHARNIERE DE PORTE": {
+      "hits": 8,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Bas": 7
+      }
+    },
+    "PLATEFORME": {
+      "hits": 7,
+      "datasourceNames": [
+        "rakuten.com"
+      ],
+      "values": {
+        "SmartThings": 7
+      }
+    },
+    "FASHION:SUITABLE_FOR": {
+      "hits": 7,
+      "datasourceNames": [
+        "cdiscount.com"
+      ],
+      "values": {
+        "Mixte": 7
+      }
+    },
+    "GRILL": {
+      "hits": 7,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Oui": 5
+      }
+    },
+    "CUISSON PAR CONVECTION": {
+      "hits": 7,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "Oui": 5
+      }
+    },
+    "NOMBRE DE PANNEAUX DE PORTE EN VERRE": {
+      "hits": 7,
+      "datasourceNames": [
+        "123comparer.fr"
+      ],
+      "values": {
+        "4": 5
+      }
+    },
+    "PLAGE D’EFFICACITE ENERGETIQUE": {
+      "hits": 6,
+      "datasourceNames": [
+        "icecat.biz",
+        "123comparer.fr"
+      ],
+      "values": {
+        "A+++ à D": 5
+      }
+    },
+    "CUISSON AU MICRO-ONDES": {
+      "hits": 5,
+      "datasourceNames": [
+        "123comparer.fr"
+      ],
+      "values": {
+        "Non": 5
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce the home hero to only the core title and subtitle content to simplify the UI and avoid duplicated helper/search elements.
- Show the category-specific ecoscore CTA inside the category filters column and the mobile filters drawer to increase discoverability of the ecosystem guidance.  
- Ensure the ecoscore CTA shows the category name lowercased to match existing descriptions and localization style.  
- Fix a pluralization/translation call used for offers counts to use the correct i18n key and parameter.

### Description
- Simplified `HomeHeroSection.vue` to render only the `heroTitle` and `heroTitleSubtitle` and removed search, helper items, icons and related props; updated `HomeHeroSection.spec.ts` accordingly.  
- Updated `CategoryEcoscoreCard.vue` to remove the inline description and make the CTA accept a `category` parameter (normalized to the current locale via `normalizedCategoryName`) and updated `fr-FR.json` and `en-US.json` CTA strings.  
- Added an `extra` slot to `CategoryFiltersSidebar.vue` and wired it from `CategoryPage.vue` so a `CategoryEcoscoreCard` and a nudge CTA button now appear both in the mobile drawer and the desktop sidebar, and removed the unused `showDescription` prop from `CategoryHeroActionsContent.vue` and `ProductImpactCta.vue`.  
- Fixed plural translation usage in `CategoryProductCardGrid.vue` to call `translatePlural('category.products.offerCount', count, { count })` and adjusted related tests and specs (`index.spec.ts`, etc.).

### Testing
- Ran `pnpm --offline lint` and addressed reported issues to satisfy the linter.  
- Ran `pnpm --offline test` (Vitest) — the full test suite completed and all unit tests passed.  
- Ran `pnpm --offline generate` to build and prerender the frontend, and the static generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f2786140832bab698e9204027dac)