### PR TITLE
Make ImpactScore flat semi‑transparent and refine ProductAttributes identity/GTIN display

### DIFF
--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -48,8 +48,14 @@
                     v-for="detail in row.details"
                     :key="detail.key"
                     class="product-attributes__identity-detail"
+                    :class="{
+                      'product-attributes__identity-detail--muted': detail.muted,
+                    }"
                   >
-                    <span class="product-attributes__identity-detail-label">
+                    <span
+                      v-if="detail.label"
+                      class="product-attributes__identity-detail-label"
+                    >
                       {{ detail.label }}
                     </span>
                     <ul class="product-attributes__identity-detail-list">
@@ -78,7 +84,7 @@
                 })
               "
               class="product-attributes__gtin-image"
-              cover
+              contain
             />
             <figcaption class="product-attributes__gtin-caption">
               {{ $t('product.attributes.main.identity.gtinLabel') }}
@@ -536,8 +542,9 @@ const buildSynonymTokenSet = (
 
 interface IdentityDetail {
   key: string
-  label: string
+  label?: string
   values: string[]
+  muted?: boolean
 }
 
 interface IdentityRow {
@@ -584,8 +591,8 @@ const identityRows = computed<IdentityRow[]>(() => {
     if (alternativeModels.length) {
       details.push({
         key: 'akaModels',
-        label: t('product.attributes.main.identity.akaModels'),
         values: alternativeModels,
+        muted: true,
       })
     }
 
@@ -594,14 +601,6 @@ const identityRows = computed<IdentityRow[]>(() => {
       label: t('product.attributes.main.identity.model'),
       value: model ?? '—',
       details: details.length ? details : undefined,
-    })
-  }
-
-  if (gtinDisplay.value) {
-    rows.push({
-      key: 'gtin',
-      label: t('product.attributes.main.identity.gtin'),
-      value: gtinDisplay.value,
     })
   }
 
@@ -622,6 +621,14 @@ const identityRows = computed<IdentityRow[]>(() => {
       key: 'lastUpdated',
       label: t('product.attributes.main.identity.lastUpdated'),
       value: lastUpdated,
+    })
+  }
+
+  if (gtinDisplay.value) {
+    rows.push({
+      key: 'gtin',
+      label: t('product.attributes.main.identity.gtin'),
+      value: gtinDisplay.value,
     })
   }
 
@@ -1229,6 +1236,16 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
   color: rgb(var(--v-theme-text-neutral-strong));
 }
 
+.product-attributes__identity-detail--muted {
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+  font-size: 0.9rem;
+}
+
+.product-attributes__identity-detail--muted
+  .product-attributes__identity-detail-list {
+  color: inherit;
+}
+
 .product-attributes__gtin {
   display: flex;
   flex-direction: column;
@@ -1238,9 +1255,11 @@ const filteredGroups = computed<DetailGroupView[]>(() => {
 .product-attributes__gtin-image {
   border-radius: 16px;
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.6);
-  min-height: 160px;
   background: rgb(var(--v-theme-surface-primary-080));
-  width: min(180px, 33%);
+  width: min(200px, 100%);
+  max-width: 200px;
+  max-height: 80px;
+  height: auto;
   align-self: center;
 }
 

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -389,6 +389,7 @@ const badgeVariant = computed(() => props.badgeVariant)
 
 .impact-score-badge--flat {
   border-color: transparent;
+  background: rgba(var(--v-theme-surface-glass), 0.6);
   box-shadow: none;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a semi‑transparent flat style for impact score badges to match design glassiness and improve contrast. 
- Constrain GTIN image sizing to be responsive and preserve aspect ratio with a 200px cap for consistent product pages. 
- Show only the raw aka model values under the model row (no label) and render those lines in a muted style to reduce visual noise.

### Description
- Added a semi‑transparent background to the flat badge variant in `frontend/app/components/shared/ui/ImpactScore.vue` (`.impact-score-badge--flat` uses `rgba(var(--v-theme-surface-glass), 0.6)`).
- Updated `ProductAttributesSection.vue` to render `detail.label` only when present, introduced a `muted` flag on identity details, and bound a `product-attributes__identity-detail--muted` class to subdued aka model lines.
- Moved the GTIN identity row to the end of the identity rows and changed the GTIN image from `cover` to `contain`, with CSS limits (`width: min(200px, 100%); max-width: 200px; max-height: 80px; height: auto`) to preserve aspect ratio.
- Adjusted the identity detail TypeScript interface to make `label` optional and added `muted?: boolean` to the shape.

### Testing
- Ran `pnpm lint` successfully with no new lint errors.
- Ran `pnpm test` and all automated tests passed: final report shows 99 test files and 354 tests executed and passing.
- Ran `pnpm generate` which completed successfully and produced a static build; the build emitted warnings about an unresolved `/backgrounds/impact-score.svg` and a PWA glob pattern for `_payload.json` that doesn't match any files.
- Test output included non‑blocking warnings about duplicate i18n component registration and missing i18n keys observed during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696504e19038832b8360035e24d79252)