### PR TITLE
Add dynamic product navigation submenus, impact grouping and history anchors

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -109,6 +109,7 @@
             :vertical-id="categoryDetail?.id ?? ''"
             :popular-attributes="categoryDetail?.popularAttributes ?? []"
             :subtitle-params="alternativesSubtitleParams"
+            @alternatives-updated="handleAlternativesUpdated"
           />
         </section>
 
@@ -215,6 +216,10 @@ import { useI18n } from 'vue-i18n'
 import { buildCategoryHash } from '~/utils/_category-filter-state'
 import { resolveScoreNumericValue } from '~/utils/score-values'
 import { formatBrandModelTitle, humanizeSlug } from '~/utils/_product-title'
+import {
+  buildImpactAggregateAnchorId,
+  buildImpactScoreGroups,
+} from '~/components/product/impact/impact-score-groups'
 
 const ProductImpactSection = defineAsyncComponent(
   () => import('~/components/product/ProductImpactSection.vue')
@@ -603,6 +608,14 @@ const handleNudgeNavigate = (payload?: {
     path: normalizedSlug,
     hash: normalizedHash || undefined,
   })
+}
+
+const handleAlternativesUpdated = (payload: {
+  hasAlternatives: boolean
+  hydrated: boolean
+}) => {
+  alternativesHydrated.value = payload.hydrated
+  hasAlternatives.value = payload.hasAlternatives
 }
 
 const productBrand = computed(() => {
@@ -1507,6 +1520,8 @@ const showAttributesSection = computed(() => {
 const showAlternativesSection = computed(() =>
   Boolean(product.value && (categoryDetail.value?.id?.length ?? 0) > 0)
 )
+const alternativesHydrated = ref(false)
+const hasAlternatives = ref(true)
 const showAiReviewSection = computed(() => Boolean(categoryDetail.value))
 
 const sectionIds = {
@@ -1521,8 +1536,71 @@ const sectionIds = {
   adminJson: 'admin-json',
 } as const
 
-type NavigableSection = { id: string; label: string; icon: string }
+const subSectionIds = {
+  priceOffers: 'offers-list',
+  priceHistory: 'price-history',
+  attributesMain: 'attributes-main',
+  attributesTimeline: 'attributes-timeline',
+  attributesDetails: 'attributes-details',
+} as const
+
+type NavigableSection = {
+  id: string
+  label: string
+  icon: string
+  subsections?: Array<{ id: string; label: string; icon?: string }>
+}
 type ConditionalSection = NavigableSection & { condition: boolean }
+
+const impactSubsections = computed(() => {
+  if (!impactScores.value.length) {
+    return []
+  }
+
+  const { groups, divers } = buildImpactScoreGroups(impactScores.value, t)
+  const entries = groups.map(group => ({
+    id: buildImpactAggregateAnchorId(group.id),
+    label: group.label,
+  }))
+
+  if (divers) {
+    entries.push({
+      id: buildImpactAggregateAnchorId(divers.id),
+      label: divers.label,
+    })
+  }
+
+  return entries
+})
+
+const attributesSubsections = computed(() => {
+  const entries = [
+    {
+      id: subSectionIds.attributesMain,
+      label: t('product.navigation.submenus.attributes.summary'),
+    },
+  ]
+
+  if (product.value?.timeline) {
+    entries.push({
+      id: subSectionIds.attributesTimeline,
+      label: t('product.navigation.submenus.attributes.dates'),
+    })
+  }
+
+  entries.push({
+    id: subSectionIds.attributesDetails,
+    label: t('product.navigation.submenus.attributes.details'),
+  })
+
+  return entries
+})
+
+const shouldShowAlternativesNavigation = computed(
+  () =>
+    showAlternativesSection.value &&
+    (!alternativesHydrated.value || hasAlternatives.value)
+)
 
 const primarySectionDefinitions = computed<ConditionalSection[]>(() => [
   {
@@ -1536,6 +1614,7 @@ const primarySectionDefinitions = computed<ConditionalSection[]>(() => [
     label: t('product.navigation.impact'),
     icon: 'mdi-leaf',
     condition: impactScores.value.length > 0,
+    subsections: impactSubsections.value,
   },
   {
     id: sectionIds.ai,
@@ -1548,18 +1627,29 @@ const primarySectionDefinitions = computed<ConditionalSection[]>(() => [
     label: t('product.navigation.price'),
     icon: 'mdi-currency-eur',
     condition: !!product.value?.offers,
+    subsections: [
+      {
+        id: subSectionIds.priceOffers,
+        label: t('product.navigation.submenus.price.bestOffers'),
+      },
+      {
+        id: subSectionIds.priceHistory,
+        label: t('product.navigation.submenus.price.history'),
+      },
+    ],
   },
   {
     id: sectionIds.alternatives,
     label: t('product.navigation.alternatives'),
     icon: 'mdi-compare-horizontal',
-    condition: showAlternativesSection.value,
+    condition: shouldShowAlternativesNavigation.value,
   },
   {
     id: sectionIds.attributes,
     label: t('product.navigation.attributes'),
     icon: 'mdi-format-list-bulleted',
     condition: showAttributesSection.value,
+    subsections: attributesSubsections.value,
   },
   {
     id: sectionIds.docs,

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -11,7 +11,10 @@
 
     <div class="product-attributes__block">
       <div class="product-attributes__block-header">
-        <h3 class="product-attributes__block-title">
+        <h3
+          id="attributes-main"
+          class="product-attributes__block-title"
+        >
           {{ $t('product.attributes.main.title') }}
         </h3>
       </div>
@@ -113,7 +116,7 @@
 
       <v-row v-if="timeline" class="product-attributes__timeline-row" dense>
         <v-col cols="12">
-          <ProductLifeTimeline :timeline="timeline" />
+          <ProductLifeTimeline id="attributes-timeline" :timeline="timeline" />
         </v-col>
       </v-row>
     </div>
@@ -227,7 +230,10 @@
       <div
         class="product-attributes__block-header product-attributes__block-header--detailed"
       >
-        <h3 class="product-attributes__block-title">
+        <h3
+          id="attributes-details"
+          class="product-attributes__block-title"
+        >
           {{ $t('product.attributes.detailed.title') }}
         </h3>
         <v-text-field

--- a/frontend/app/components/product/ProductSummaryNavigation.spec.ts
+++ b/frontend/app/components/product/ProductSummaryNavigation.spec.ts
@@ -57,6 +57,37 @@ describe('ProductSummaryNavigation', () => {
     await wrapper.unmount()
   })
 
+  it('renders submenu entries and emits navigate', async () => {
+    const wrapper = await mountComponent({
+      sections: [
+        {
+          id: 'impact',
+          label: 'Impact',
+          icon: 'mdi-leaf',
+          subsections: [
+            { id: 'impact-energy', label: 'Energy' },
+            { id: 'impact-repair', label: 'Repairability' },
+          ],
+        },
+      ],
+    })
+
+    const toggle = wrapper.find('button.product-summary-navigation__toggle')
+    await toggle.trigger('click')
+
+    const submenuLinks = wrapper.findAll(
+      'button.product-summary-navigation__submenu-link'
+    )
+    expect(submenuLinks).toHaveLength(2)
+
+    await submenuLinks[1]?.trigger('click')
+
+    const emitted = wrapper.emitted('navigate') ?? []
+    expect(emitted[emitted.length - 1]).toEqual(['impact-repair'])
+
+    await wrapper.unmount()
+  })
+
   it('applies horizontal orientation modifier', async () => {
     const wrapper = await mountComponent({ orientation: 'horizontal' })
 

--- a/frontend/app/components/product/impact/impact-score-groups.ts
+++ b/frontend/app/components/product/impact/impact-score-groups.ts
@@ -1,0 +1,108 @@
+import type { ScoreView } from './impact-types'
+
+type Translator = (key: string) => string
+
+export const DIVERS_AGGREGATE_ID = 'DIVERS'
+
+export type ImpactScoreGroup<T extends ScoreView = ScoreView> = {
+  id: string
+  label: string
+  aggregate: T | null
+  subscores: T[]
+}
+
+const normalizeParticipations = (participations?: string[] | null): string[] =>
+  (participations ?? [])
+    .map(entry => entry?.toString().trim().toUpperCase())
+    .filter((entry): entry is string => Boolean(entry))
+
+const resolveAggregateLabel = <T extends ScoreView>(
+  t: Translator,
+  aggregateId: string,
+  aggregateScore: T | null
+) => {
+  const translationKey = `product.impact.aggregateScores.${aggregateId}`
+  if (t(translationKey) !== translationKey) {
+    return t(translationKey)
+  }
+
+  return aggregateScore?.label ?? aggregateId
+}
+
+const normalizeScoreId = (value: unknown) =>
+  typeof value === 'string' ? value.trim().toUpperCase() : ''
+
+export const buildImpactScoreGroups = <T extends ScoreView>(
+  scores: T[],
+  t: Translator
+): { groups: ImpactScoreGroup<T>[]; divers: ImpactScoreGroup<T> | null } => {
+  const filteredScores = scores.filter(
+    score => normalizeScoreId(score.id) !== 'ECOSCORE'
+  )
+
+  const scoreMap = filteredScores.reduce<Map<string, T>>((map, score) => {
+    const normalizedId = normalizeScoreId(score.id)
+    if (normalizedId) {
+      map.set(normalizedId, score)
+    }
+
+    return map
+  }, new Map())
+
+  const aggregateSet = new Set<string>()
+  const participationMap = new Map<string, T[]>()
+  const standalone: T[] = []
+
+  filteredScores.forEach(score => {
+    const participations = normalizeParticipations(score.participateInScores)
+
+    if (!participations.length) {
+      standalone.push(score)
+      return
+    }
+
+    participations.forEach(aggregateId => {
+      aggregateSet.add(aggregateId)
+
+      if (!participationMap.has(aggregateId)) {
+        participationMap.set(aggregateId, [])
+      }
+
+      participationMap.get(aggregateId)?.push(score)
+    })
+  })
+
+  const groups = Array.from(participationMap.entries()).map(
+    ([id, subscores]) => {
+      const aggregate = scoreMap.get(id) ?? null
+      return {
+        id,
+        label: resolveAggregateLabel(t, id, aggregate),
+        aggregate,
+        subscores,
+      }
+    }
+  )
+
+  const filteredStandalone = standalone.filter(score => {
+    const normalizedId = normalizeScoreId(score.id)
+    return normalizedId && !aggregateSet.has(normalizedId)
+  })
+
+  const divers = filteredStandalone.length
+    ? {
+        id: DIVERS_AGGREGATE_ID,
+        label: resolveAggregateLabel(t, DIVERS_AGGREGATE_ID, null),
+        aggregate: null,
+        subscores: filteredStandalone,
+      }
+    : null
+
+  return { groups, divers }
+}
+
+export const buildImpactAggregateAnchorId = (aggregateId: string) => {
+  const normalized = aggregateId.trim().toLowerCase()
+  const safeId = normalized.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  return `impact-criteria-${safeId || 'unknown'}`
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2571,7 +2571,18 @@
       "label": "Product detail navigation",
       "overview": "Overview",
       "alternatives": "Alternatives",
-      "price": "Pricing"
+      "price": "Pricing",
+      "submenus": {
+        "price": {
+          "bestOffers": "Best offers",
+          "history": "Trends & tracking"
+        },
+        "attributes": {
+          "summary": "Summary",
+          "dates": "Dates",
+          "details": "Details"
+        }
+      }
     },
     "nudge": {
       "fabAriaLabel": "Open the Nudger assistant for this category",
@@ -2604,6 +2615,7 @@
         "viewOffer": "Open offer from {source}",
         "unknownSource": "Unknown source"
       },
+      "historyTitle": "Price history",
       "noHistory": "Price history is not yet available for this product.",
       "subtitle": "Track price evolution and compare offers.",
       "title": "Prices and trends",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2579,7 +2579,18 @@
       "label": "Navigation de la fiche produit",
       "overview": "Aperçu",
       "alternatives": "Alternatives",
-      "price": "Prix"
+      "price": "Prix",
+      "submenus": {
+        "price": {
+          "bestOffers": "Meilleurs prix",
+          "history": "Évolution & suivi"
+        },
+        "attributes": {
+          "summary": "Synthèse",
+          "dates": "Dates",
+          "details": "Détails"
+        }
+      }
     },
     "nudge": {
       "fabAriaLabel": "Ouvrir l'assistant Nudger pour cette catégorie",
@@ -2612,6 +2623,7 @@
         "viewOffer": "Ouvrir l'offre chez {source}",
         "unknownSource": "Source inconnue"
       },
+      "historyTitle": "Historique des prix",
       "noHistory": "Pas assez de données pour afficher l'historique des prix.",
       "subtitle": "Suivez l’évolution des prix et comparez les offres.",
       "title": "Prix et évolution",


### PR DESCRIPTION
### Motivation

- Provide expandable, accessible submenus in the product summary navigation so users can jump to subsections (impact criteria, price history, attribute anchors) from the product page.
- Hide the alternatives navigation entry when alternatives are known to be absent after the client-side alternatives query hydrates to avoid dead navigation targets.
- Expose reusable logic to group impact subscores into aggregates to keep the impact UI consistent and to generate stable anchor ids for smooth scrolling.

### Description

- Extend `ProductSummaryNavigation.vue` to accept optional `subsections`, render expandable submenu items, and expose `navigate` events for subsection clicks with accessible toggle controls and state handling.
- Wire submenu definitions in `ProductPage.vue` (impact criteria, price submenus, attributes subsections) including logic to hide the alternatives menu entry when no alternatives are returned after hydration, and handle the `alternatives-updated` event from `ProductAlternatives.vue`.
- Add `impact-score-groups.ts` utility to compute grouped impact aggregates and use it in `ProductImpactDetailsTable.vue` to render grouped rows and to produce stable anchor ids with `buildImpactAggregateAnchorId` for submenu targets.
- Rework price and attributes sections to expose anchors (`id=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650413bc14832bb1b23ee2192044b2)