### PR TITLE
Improve product title resolution and attribute mapping

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -215,6 +215,7 @@ import { useI18n } from 'vue-i18n'
 import { buildCategoryHash } from '~/utils/_category-filter-state'
 import { resolveScoreNumericValue } from '~/utils/score-values'
 import { formatBrandModelTitle, humanizeSlug } from '~/utils/_product-title'
+import { resolveProductTitle } from '~/utils/_product-title-resolver'
 
 const ProductImpactSection = defineAsyncComponent(
   () => import('~/components/product/ProductImpactSection.vue')
@@ -509,12 +510,17 @@ const productTitle = computed(() => {
     ? t('product.meta.gtinFallback', { gtin: gtinValue })
     : ''
 
-  return (
-    product.value?.names?.h1Title ??
-    product.value?.identity?.bestName ??
-    slugFallback ??
-    gtinFallback
-  )
+  if (!product.value) {
+    return slugFallback || gtinFallback
+  }
+
+  const resolvedTitle = resolveProductTitle(product.value, locale.value, {
+    preferH1Title: true,
+    uppercaseBrand: true,
+    gtinFallback,
+  })
+
+  return resolvedTitle || slugFallback || gtinFallback
 })
 
 const heroPopularAttributes = computed(

--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -158,7 +158,7 @@ const stubs = {
 }
 
 const baseProduct: ProductDto = {
-  names: { h1Title: 'Orbital Product' },
+  names: { h1Title: 'Television orbit 43 pouces lcd' },
   identity: { brand: 'Orbit', model: 'X1', bestName: 'Orbit X1' },
   base: {
     bestName: 'Orbit X1',
@@ -188,7 +188,7 @@ describe('ProductHero', () => {
     const wrapper = await mountComponent()
 
     expect(wrapper.get('.product-hero__title').text()).toContain(
-      'Next-gen Orbit X1'
+      'Television ORBIT 43 pouces lcd'
     )
     expect(wrapper.find('.product-hero__panel--pricing').exists()).toBe(true)
     expect(wrapper.find('.product-hero__details-section').exists()).toBe(true)

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -228,7 +228,10 @@ const normalizeString = (value: string | null | undefined) =>
   typeof value === 'string' ? value.trim() : ''
 
 const heroTitle = computed(() => {
-  return resolveProductTitle(props.product, locale.value)
+  return resolveProductTitle(props.product, locale.value, {
+    preferH1Title: true,
+    uppercaseBrand: true,
+  })
 })
 
 const productBrandName = computed(() =>

--- a/frontend/app/utils/_product-attributes.spec.ts
+++ b/frontend/app/utils/_product-attributes.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { formatAttributeValue } from './_product-attributes'
+
+const t = (key: string) => key
+const n = (value: number) => value.toString()
+
+describe('formatAttributeValue', () => {
+  it('applies attribute mappings for string values', () => {
+    const value = formatAttributeValue(
+      {
+        key: 'DISPLAY_TECHNOLOGY',
+        label: 'Display technology',
+        rawValue: 'lcd',
+        mappings: { lcd: 'LCD' },
+      },
+      t,
+      n
+    )
+
+    expect(value).toBe('LCD')
+  })
+
+  it('applies attribute mappings for array values', () => {
+    const value = formatAttributeValue(
+      {
+        key: 'DISPLAY_TECHNOLOGY',
+        label: 'Display technology',
+        rawValue: ['lcd', 'oled'],
+        mappings: { lcd: 'LCD', oled: 'OLED' },
+      },
+      t,
+      n
+    )
+
+    expect(value).toBe('LCD, OLED')
+  })
+})

--- a/frontend/app/utils/_product-title-resolver.ts
+++ b/frontend/app/utils/_product-title-resolver.ts
@@ -1,46 +1,101 @@
 import type { ProductDto } from '~~/shared/api-client'
 import { humanizeSlug } from '~/utils/_product-title'
 
+export interface ProductTitleOptions {
+  preferH1Title?: boolean
+  preferPrettyName?: boolean
+  uppercaseBrand?: boolean
+  gtinFallback?: string
+}
+
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const applyBrandCasing = (
+  title: string,
+  brand: string,
+  locale?: string
+): string => {
+  if (!brand.length) {
+    return title
+  }
+
+  const normalizedBrand = brand.toLocaleUpperCase(locale)
+  const regex = new RegExp(escapeRegExp(brand), 'gi')
+
+  return title.replace(regex, normalizedBrand)
+}
+
 export const resolveProductTitle = (
   product: ProductDto,
-  locale?: string
+  locale?: string,
+  options: ProductTitleOptions = {}
 ): string => {
   const normalizeString = (value: string | null | undefined) =>
     typeof value === 'string' ? value.trim() : ''
 
-  // 1. Pretty Name / AI Medium Title
-  const prettyName = normalizeString(product.names?.prettyName)
-  if (prettyName) return prettyName
+  const {
+    preferH1Title = false,
+    preferPrettyName = true,
+    uppercaseBrand = false,
+    gtinFallback,
+  } = options
+
+  const brand = normalizeString(product.identity?.brand)
+  const resolvedBrand = uppercaseBrand
+    ? brand.toLocaleUpperCase(locale)
+    : brand
+
+  const finalizeTitle = (title: string): string =>
+    uppercaseBrand ? applyBrandCasing(title, brand, locale) : title
+
+  // 1. H1 Title (long form)
+  if (preferH1Title) {
+    const h1Title = normalizeString(product.names?.h1Title)
+    if (h1Title) return finalizeTitle(h1Title)
+  }
+
+  // 2. Pretty Name / AI Medium Title
+  if (preferPrettyName) {
+    const prettyName = normalizeString(product.names?.prettyName)
+    if (prettyName) return finalizeTitle(prettyName)
+  }
 
   const aiTitle = normalizeString(product.aiReview?.review?.mediumTitle)
-  if (aiTitle) return aiTitle
+  if (aiTitle) return finalizeTitle(aiTitle)
 
-  // 2. Best Name
+  // 3. Best Name
   const identityBestName = normalizeString(product.identity?.bestName)
-  if (identityBestName) return identityBestName
+  if (identityBestName) return finalizeTitle(identityBestName)
 
   const baseBestName = normalizeString(product.base?.bestName)
-  if (baseBestName) return baseBestName
+  if (baseBestName) return finalizeTitle(baseBestName)
 
-  // 3. Brand - Model
-  const brand = normalizeString(product.identity?.brand)
+  // 4. Brand - Model
   const model = normalizeString(product.identity?.model)
-  if (brand && model) return `${brand} - ${model}`
-  if (model) return model // If only model is present, it's better than nothing, although priority says "Brand - Model"
+  if (resolvedBrand && model) {
+    return finalizeTitle(`${resolvedBrand} - ${model}`)
+  }
+  if (model) return finalizeTitle(model) // If only model is present, it's better than nothing, although priority says "Brand - Model"
 
-  // 4. Best Offer Name
+  // 5. Best Offer Name
   const bestOfferName = normalizeString(product.offers?.bestPrice?.offerName)
-  if (bestOfferName) return bestOfferName
+  if (bestOfferName) return finalizeTitle(bestOfferName)
 
   // Fallbacks (from original ProductHero logic)
   const namesH1 = normalizeString(product.names?.h1Title)
-  if (namesH1) return namesH1
+  if (namesH1) return finalizeTitle(namesH1)
 
   const slug = normalizeString(product.slug)
-  if (slug && locale) return humanizeSlug(slug, locale)
+  if (slug && locale) return finalizeTitle(humanizeSlug(slug, locale))
 
   const gtin = normalizeString(product.gtin?.toString())
-  if (gtin) return `GTIN: ${gtin}` // Or localized "GTIN: ..." if we had access to i18n here, but this is a utility.
+  if (gtin) {
+    const fallbackValue =
+      gtinFallback?.trim().length ? gtinFallback : `GTIN: ${gtin}`
+
+    return finalizeTitle(fallbackValue)
+  }
 
   return ''
 }


### PR DESCRIPTION
### Motivation

- Ensure product pages and hero components prefer long-form H1 titles and present brand names in uppercased form for clearer, consistent display.
- Apply attribute configuration mappings when formatting attribute values so configured canonical labels are used instead of raw attribute tokens.
- Normalize and centralize title and attribute formatting logic in utilities to make behavior predictable across components.
- Provide test coverage for the new title formatting and attribute mapping behaviors.

### Description

- Add `resolveProductTitle` options via `frontend/app/utils/_product-title-resolver.ts` to prefer H1 titles and optionally uppercase the brand, and wire it into `ProductHero.vue` and `ProductPage.vue` to use `preferH1Title: true` and `uppercaseBrand: true` when rendering titles.
- Extend the resolved attribute model to include `mappings` and implement mapping normalization and resolution in `frontend/app/utils/_product-attributes.ts`, so `AttributeConfigDto.mappings` are applied (case-insensitive key matching) when formatting attribute values.
- Update the `ProductHero` unit test to match the new title formatting and add `frontend/app/utils/_product-attributes.spec.ts` to verify mapping behavior for both string and array attribute values.
- Minor helpers added: mapping normalization, brand-casing helper, and safe GTIN fallback handling in the title resolver.

### Testing

- Ran `pnpm lint` in the frontend and it completed successfully.
- Ran `pnpm test` and the full test suite passed (all specs executed and green) in the frontend.
- Ran `pnpm generate` to build the static site; generation succeeded but produced benign warnings about an unresolved `/backgrounds/impact-score.svg` and a workbox glob pattern for `_payload.json` not matching files.
- New unit tests added: `frontend/app/utils/_product-attributes.spec.ts`, and `ProductHero.spec.ts` was updated to reflect title changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650047250c832b9aed78877b956636)