### PR TITLE
Update home hero helpers and restore split visuals

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -12,7 +12,6 @@ import AnimatedSubtitle from '~/components/shared/ui/AnimatedSubtitle.vue'
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
-  useLogoAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
 import {
@@ -367,27 +366,6 @@ const applyOpenDataMillionsPlaceholder = (items: HeroHelperItem[]) => {
   })
 }
 
-const heroIconAlt = computed(
-  () =>
-    packI18n.resolveString('hero.iconAlt', {
-      fallbackKeys: ['home.hero.iconAlt'],
-    }) ?? ''
-)
-const heroIconSrc = useLogoAsset()
-const heroIconAnimationOptions = [
-  'home-hero__icon--fade',
-  'home-hero__icon--scale',
-  'home-hero__icon--pulse',
-] as const
-const heroIconAnimation = useState<string>(
-  'home-hero-icon-animation',
-  () =>
-    heroIconAnimationOptions[
-      Math.floor(Math.random() * heroIconAnimationOptions.length)
-    ] || heroIconAnimationOptions[0]
-)
-const showHeroIcon = computed(() => Boolean(heroIconAlt.value))
-
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundI18nKey = computed(
   () => props.heroBackgroundI18nKey?.trim() || 'hero.background'
@@ -614,24 +592,8 @@ useHead({
 
                       <v-row class="home-hero__helper-row" justify="center">
                         <v-col
-                          cols="4"
-                          class="align-center home-hero__eyebrow-block"
-                        >
-                          <div
-                            v-if="showHeroIcon"
-                            class="home-hero__icon-wrapper"
-                          >
-                            <img
-                              :src="heroIconSrc"
-                              :alt="heroIconAlt"
-                              :class="['home-hero__icon', heroIconAnimation]"
-                              loading="lazy"
-                            />
-                          </div>
-                        </v-col>
-                        <v-col
                           v-if="heroHelperItems.length"
-                          cols="6"
+                          cols="12"
                           class="home-hero__helpers-wrapper"
                         >
                           <ul class="home-hero__helpers">
@@ -773,48 +735,12 @@ useHead({
   align-items: center
   text-align: center
 
-.home-hero__eyebrow-block
-  display: inline-flex
-  flex-direction: column
-  gap: clamp(0.5rem, 1.5vw, 0.75rem)
-  padding-inline-start: clamp(0.25rem, 1.25vw, 0.75rem)
-  align-items: flex-start
-
 .home-hero__eyebrow
   font-weight: 600
   letter-spacing: 0.08em
   text-transform: uppercase
   color: rgba(var(--v-theme-hero-gradient-end), 0.9)
   margin: 0
-
-.home-hero__icon-wrapper
-  width: clamp(4.5rem, 16vw, 7.5rem)
-  height: clamp(4.5rem, 16vw, 7.5rem)
-  box-shadow: 0 12px 30px rgba(var(--v-theme-shadow-primary-600), 0.12)
-  backdrop-filter: blur(8px)
-  border-radius: 50%
-  padding: clamp(0.6rem, 1.6vw, 0.9rem)
-  box-sizing: border-box
-  background: rgba(var(--v-theme-surface-default), 0.92)
-
-.home-hero__icon
-  border-radius: inherit
-  width: 92%
-  height: 92%
-  transition: transform 250ms ease, filter 250ms ease
-  filter: drop-shadow(0 6px 14px rgba(var(--v-theme-shadow-primary-600), 0.25))
-  object-fit: contain
-  display: block
-  margin: auto
-
-.home-hero__icon--fade
-  animation: home-hero-fade-up 900ms ease-out both
-
-.home-hero__icon--scale
-  animation: home-hero-scale-in 800ms ease-out both
-
-.home-hero__icon--pulse
-  animation: home-hero-pulse 1200ms ease-in-out both
 
 .home-hero__title
   font-size: clamp(2.2rem, 5vw, 3.8rem)
@@ -881,6 +807,10 @@ useHead({
   display: flex
   flex-wrap: wrap
   align-items: center
+  width: 100%
+
+.home-hero__helpers-wrapper
+  width: 100%
 
 .home-hero__helpers
   margin: 0
@@ -888,6 +818,7 @@ useHead({
   display: grid
   gap: clamp(0.4rem, 1.5vw, 0.65rem)
   list-style: none
+  width: 100%
 
 .home-hero__helper
   display: inline-flex
@@ -933,38 +864,6 @@ useHead({
 .home-hero__wizard
   width: 100%
 
-
-
-@keyframes home-hero-fade-up
-  from
-    opacity: 0
-    transform: translateY(12px) scale(0.98)
-  to
-    opacity: 1
-    transform: translateY(0) scale(1)
-
-@keyframes home-hero-scale-in
-  from
-    opacity: 0
-    transform: scale(0.9)
-  55%
-    opacity: 1
-    transform: scale(1.02)
-  to
-    transform: scale(1)
-
-@keyframes home-hero-pulse
-  0%
-    transform: scale(0.92)
-    opacity: 0
-  35%
-    transform: scale(1.04)
-    opacity: 1
-  70%
-    transform: scale(0.98)
-  100%
-    transform: scale(1)
-
 @media (max-width: 959px)
   .home-hero
     min-height: clamp(520px, 68dvh, 760px)
@@ -988,6 +887,9 @@ useHead({
 
   .home-hero__helper-row
     grid-template-columns: auto 1fr
+
+  .home-hero__helpers
+    margin-inline-start: 1.5rem
 
 @media (min-width: 1280px)
   .home-hero__panel-grid

--- a/frontend/app/components/home/sections/HomeSplitSection.vue
+++ b/frontend/app/components/home/sections/HomeSplitSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useRandomHomepageImages } from '~/composables/useRandomHomepageImages'
+import gainImageSrc from '~/assets/homepage/gain/nudger-screaming.webp'
+import painImageSrc from '~/assets/homepage/pain/nudger-problem.webp'
 
 defineOptions({ inheritAttrs: false })
 
@@ -27,14 +28,12 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
-const { painImage, gainImage } = useRandomHomepageImages()
-
 const titleId = computed(() => `${props.id}-title`)
 const fallbackImage = computed(() => {
   const isPainVisual = props.visualPosition === 'left'
 
   return {
-    src: isPainVisual ? painImage.value : gainImage.value,
+    src: isPainVisual ? painImageSrc : gainImageSrc,
     alt: isPainVisual ? t('home.split.painAlt') : t('home.split.gainAlt'),
     sizes: '(min-width: 960px) 320px, 70vw',
     loading: 'lazy' as const,


### PR DESCRIPTION
### Motivation

- Simplify the home hero UI by removing the decorative hero icon and letting helper text span the full width for improved readability.
- Reduce coupling to the random logo asset and remove the animation state to make the hero block more deterministic.
- Ensure the split visual section has explicit, deterministic fallback images for the pain/gain visuals.

### Description

- Removed the hero icon block and related state/computed logic from `HomeHeroSection.vue`, including the `useLogoAsset` import and icon animation options.
- Expanded the helper column to full width by changing the `v-col` layout, added `.home-hero__helpers-wrapper`, and removed icon-specific CSS and keyframes from the hero styles.
- Restored explicit image fallbacks in `HomeSplitSection.vue` by importing `gainImageSrc` and `painImageSrc` assets and replacing the `useRandomHomepageImages` fallback.
- Added layout/styling adjustments for the helpers including full-width rules and a desktop left margin (`margin-inline-start`) for the helper list.

### Testing

- Ran `pnpm lint`, which failed due to an unrelated unused variable (`sortedOffers`) in `ProductPriceSection.vue`.
- Ran `pnpm test` (Vitest); the test run executed but reported a failing test in `app/components/product/ProductPriceSection.spec.ts` and the suite did not fully pass.
- Ran `pnpm generate`, which completed successfully (build/generate succeeded, with a PWA precache warning about an unmatched glob pattern).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651ae48e34832b88f44541ec767302)