### PR TITLE
Refine dishwasher vertical: add attributes, filters and i18n copy fixes

### DIFF
--- a/verticals/src/main/resources/attributes/ENERGY_CONSUMPTION_100_CYCLES.yml
+++ b/verticals/src/main/resources/attributes/ENERGY_CONSUMPTION_100_CYCLES.yml
@@ -1,0 +1,33 @@
+key: "ENERGY_CONSUMPTION_100_CYCLES"
+betterIs: "LOWER"
+faIcon: "mdi-flash"
+name:
+  default: "Energy consumption per 100 cycles"
+  fr: "Consommation d'énergie pour 100 cycles"
+suffix:
+  default: "kWh/100 cycles"
+  fr: "kWh/100 cycles"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "ENERGYCONS100"
+    - "ENERGY CONSUMPTION 100 CYCLES"
+    - "ENERGYCONSUMPTION100CYCLES"
+    - "CONSOMMATION D'ENERGIE PAR 100 CYCLES"
+    - "CONSOMMATION D'ENERGIE POUR 100 CYCLES"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "KWH"
+    - "KWH/100"
+    - "KWH/100 CYCLE"
+    - "KWH/100 CYCLES"
+    - "KWH/100CYCLES"
+    - "KWH/100-CYCLES"
+    - "KWH / 100 CYCLES"
+    - "CYCLES"

--- a/verticals/src/main/resources/attributes/ENERGY_CONSUMPTION_PER_CYCLE.yml
+++ b/verticals/src/main/resources/attributes/ENERGY_CONSUMPTION_PER_CYCLE.yml
@@ -1,0 +1,31 @@
+key: "ENERGY_CONSUMPTION_PER_CYCLE"
+betterIs: "LOWER"
+faIcon: "mdi-flash"
+name:
+  default: "Energy consumption per cycle"
+  fr: "Consommation d'énergie par cycle"
+suffix:
+  default: "kWh/cycle"
+  fr: "kWh/cycle"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "ENERGYCONS"
+    - "ENERGY CONSUMPTION PER CYCLE"
+    - "ENERGYCONSUMPTIONPERCYCLE"
+    - "CONSOMMATION D'ENERGIE PAR CYCLE"
+    - "CONSOMMATION D'ENERGIE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "KWH"
+    - "KWH/CYCLE"
+    - "KWH PAR CYCLE"
+    - "KWH PER CYCLE"
+    - "KWH/PER CYCLE"
+    - "CYCLE"

--- a/verticals/src/main/resources/attributes/INSTALLATION_TYPE.yml
+++ b/verticals/src/main/resources/attributes/INSTALLATION_TYPE.yml
@@ -1,0 +1,19 @@
+key: "INSTALLATION_TYPE"
+faIcon: "mdi-wrench-outline"
+name:
+  default: "Installation type"
+  fr: "Type de pose"
+filteringType: "TEXT"
+asScore: false
+synonyms:
+  all:
+    - "TYPE DE POSE"
+    - "TYPE"
+    - "BUILTIN"
+    - "BUILT_IN"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false

--- a/verticals/src/main/resources/attributes/NOISE_CLASS.yml
+++ b/verticals/src/main/resources/attributes/NOISE_CLASS.yml
@@ -1,0 +1,27 @@
+key: "NOISE_CLASS"
+betterIs: "GREATER"
+faIcon: "mdi-volume-medium"
+name:
+  default: "Noise class"
+  fr: "Classe sonore"
+filteringType: "TEXT"
+asScore: false
+attributeValuesOrdering: "MAPPED"
+numericMapping:
+  A: 4.0
+  B: 3.0
+  C: 2.0
+  D: 1.0
+  E: 0.0
+synonyms:
+  all:
+    - "NOISECLASS"
+    - "CLASSE DE PERCEPTION SONORE"
+    - "CLASSE DE BRUIT"
+    - "CLASSE SONORE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false

--- a/verticals/src/main/resources/attributes/NOISE_LEVEL.yml
+++ b/verticals/src/main/resources/attributes/NOISE_LEVEL.yml
@@ -1,0 +1,29 @@
+key: "NOISE_LEVEL"
+betterIs: "LOWER"
+faIcon: "mdi-volume-high"
+name:
+  default: "Noise level"
+  fr: "Niveau sonore"
+suffix:
+  default: "dB"
+  fr: "dB"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "NOISE"
+    - "DECIBELS_MAX"
+    - "DECIBELS"
+    - "NIVEAU SONORE"
+    - "NIVEAU SONORE MAXIMUM"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "DB"
+    - "DB(A)"
+    - "DECIBEL"
+    - "DECIBELS"

--- a/verticals/src/main/resources/attributes/PLACE_SETTINGS.yml
+++ b/verticals/src/main/resources/attributes/PLACE_SETTINGS.yml
@@ -1,0 +1,25 @@
+key: "PLACE_SETTINGS"
+betterIs: "GREATER"
+faIcon: "mdi-silverware-fork-knife"
+name:
+  default: "Place settings"
+  fr: "Nombre de couverts"
+suffix:
+  default: "place settings"
+  fr: "couverts"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "NOMBRE DE COUVERTS"
+    - "RATEDCAPACITY"
+    - "CAPACITE"
+    - "CAPACITÉ"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "COUVERTS"

--- a/verticals/src/main/resources/attributes/PROGRAM_COUNT.yml
+++ b/verticals/src/main/resources/attributes/PROGRAM_COUNT.yml
@@ -1,0 +1,22 @@
+key: "PROGRAM_COUNT"
+betterIs: "GREATER"
+faIcon: "mdi-format-list-numbered"
+name:
+  default: "Program count"
+  fr: "Nombre de programmes"
+suffix:
+  default: "programs"
+  fr: "programmes"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "NBRE DE PROGRAMMES"
+    - "NOMBRE DE PROGRAMMES"
+    - "PROGRAM_COUNT"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false

--- a/verticals/src/main/resources/attributes/PROGRAM_DURATION_ECO.yml
+++ b/verticals/src/main/resources/attributes/PROGRAM_DURATION_ECO.yml
@@ -1,0 +1,28 @@
+key: "PROGRAM_DURATION_ECO"
+betterIs: "LOWER"
+faIcon: "mdi-timer-outline"
+name:
+  default: "Eco program duration"
+  fr: "Durée du programme éco"
+suffix:
+  default: "min"
+  fr: "min"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "PROGRAMMEDURATION"
+    - "DUREE DU PROGRAMME ECO EN HEURES"
+    - "DUREE DU PROGRAMME ECO"
+    - "DURÉE DU PROGRAMME ÉCO"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "MIN"
+    - "MINUTES"
+    - "HEURES"
+    - "H"

--- a/verticals/src/main/resources/attributes/WATER_CONSUMPTION.yml
+++ b/verticals/src/main/resources/attributes/WATER_CONSUMPTION.yml
@@ -1,0 +1,31 @@
+key: "WATER_CONSUMPTION"
+betterIs: "LOWER"
+faIcon: "mdi-water"
+name:
+  default: "Water consumption per cycle"
+  fr: "Consommation d'eau par cycle"
+suffix:
+  default: "L/cycle"
+  fr: "L/cycle"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "WATERCONS"
+    - "WATER CONSUMPTION"
+    - "WATER CONSUMPTION PER CYCLE"
+    - "CONSOMMATION D'EAU"
+    - "CONSOMMATION D'EAU PAR CYCLE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "L"
+    - "LITRE"
+    - "LITRES"
+    - "L/CYCLE"
+    - "L PAR CYCLE"
+    - "CYCLE"

--- a/verticals/src/main/resources/verticals/dishwasher.yml
+++ b/verticals/src/main/resources/verticals/dishwasher.yml
@@ -33,7 +33,10 @@ popular: true
 # The mainly presented attributes for this category
 popularAttributes:
   - CLASSE_ENERGY
-  - POWER_CONSUMPTION_TYPICAL
+  - ENERGY_CONSUMPTION_100_CYCLES
+  - WATER_CONSUMPTION
+  - NOISE_LEVEL
+  - PLACE_SETTINGS
 
 # GenAiConfig for this vertical
 genAiConfig:
@@ -83,7 +86,7 @@ i18n:
         - MODEL
         - YEAR
     h1Title:
-      prefix: "|| lave vaisselle | lave-vaisselles ||"
+      prefix: "|| Lave-vaisselle | Lave-vaisselles ||"
       attrs:
         - BRAND
         - MODEL
@@ -97,9 +100,9 @@ i18n:
     productMetaOpenGraphType: "product"
 
     # Vertical page elements
-    verticalHomeUrl: "laves-vaisselles"
-    verticalHomeTitle: "Laves-Vaisselles"
-    verticalHomeDescription: "Comparez les laves vaisselles (encastrables, chaleur tournante, pyrolyse…) selon l’éco-score et le prix."
+    verticalHomeUrl: "lave-vaisselles"
+    verticalHomeTitle: "Lave-vaisselles"
+    verticalHomeDescription: "Comparez les lave-vaisselles (pose libre, encastrables, 45/60 cm, nombre de couverts, niveau sonore…) selon l’éco-score et le prix."
 
     # A mapping beetween custom page names behind this vertical and wiki pages (sample)
   #    wikiPages:
@@ -110,13 +113,13 @@ i18n:
 
   en:
     url:
-      prefix: "|| lave-vaisselle | lave vaisselle ||"
+      prefix: "|| dishwasher | dishwashers ||"
       attrs:
         - BRAND
         - MODEL
         - YEAR
     h1Title:
-      prefix: "Lave Vaisselle"
+      prefix: "|| Dishwasher | Dishwashers ||"
       attrs:
         - BRAND
         - MODEL
@@ -130,7 +133,7 @@ i18n:
 
     verticalHomeUrl: "dishwashers"
     verticalHomeTitle: "Dishwashers"
-    verticalHomeDescription: "Compare dishwashers (built-in, convection, self-cleaning…) by eco-score and price."
+    verticalHomeDescription: "Compare dishwashers (built-in or freestanding, 45/60 cm, capacity, noise level) by eco-score and price."
 
 #####################################################################################################################################
 # NUDGE TOOL CONFIGURATION
@@ -145,7 +148,7 @@ nudgeToolConfig:
         fr: "Consommation énergétique"
       description:
         en: "dishwashers with a low energy consumption"
-        fr: "Laves vaisselles avec une faible consommation énergétique"
+        fr: "Lave-vaisselles avec une faible consommation énergétique"
 
     - scoreName: "DURABILITY"
       scoreMinValue: 3
@@ -165,7 +168,7 @@ nudgeToolConfig:
         fr: "Réparabilité"
       description:
         en: "dishwashers with a good reparability"
-        fr: "Laves vaisselles avec une bonne réparabilité"
+        fr: "Lave-vaisselles avec une bonne réparabilité"
 
     - scoreName: "BRAND_SUSTAINABILITY"
       scoreMinValue: 4
@@ -210,10 +213,10 @@ nudgeToolConfig:
         fr: "< 400 €"
       title:
         en: "Affordable dishwashers"
-        fr: "Laves vaisselles pas chers"
+        fr: "Lave-vaisselles pas chers"
       description:
         en: "dishwashers priced under €400."
-        fr: "Les laves vaisselles dont le prix est inférieur à 400€."
+        fr: "Les lave-vaisselles dont le prix est inférieur à 400€."
 
     - id: "price_400_800"
       group: "price"
@@ -233,10 +236,10 @@ nudgeToolConfig:
         fr: "400 - 800 €"
       title:
         en: "Mid-range dishwashers"
-        fr: "Laves vaisselles milieu de gamme"
+        fr: "Lave-vaisselles milieu de gamme"
       description:
         en: "dishwashers priced between €400 and €800."
-        fr: "Les laves-vaisselle dont le prix est compris entre 400€ et 800€."
+        fr: "Les lave-vaisselles dont le prix est compris entre 400€ et 800€."
 
     - id: "price_greater_800"
       group: "price"
@@ -253,10 +256,10 @@ nudgeToolConfig:
         fr: "> 800 €"
       title:
         en: "Premium dishwashers"
-        fr: "Laves vaisselles haut de gamme"
+        fr: "Lave-vaisselles haut de gamme"
       description:
         en: "dishwashers priced over €800."
-        fr: "Les Laves-vaisselles dont le prix est supérieur à 800€."
+        fr: "Les lave-vaisselles dont le prix est supérieur à 800€."
 
 ##############################################################################
 # Custom search filters : the following filters
@@ -281,8 +284,20 @@ aggregationConfiguration:
   "scores.DATA_QUALITY.value":
     interval: 1
     buckets: 5
-  "attributes.indexed.POWER_CONSUMPTION_TYPICAL":
-    interval: 250
+  "attributes.indexed.ENERGY_CONSUMPTION_100_CYCLES":
+    interval: 10
+    buckets: 12
+  "attributes.indexed.WATER_CONSUMPTION":
+    interval: 1
+    buckets: 12
+  "attributes.indexed.NOISE_LEVEL":
+    interval: 2
+    buckets: 12
+  "attributes.indexed.PLACE_SETTINGS":
+    interval: 1
+    buckets: 16
+  "attributes.indexed.PROGRAM_DURATION_ECO":
+    interval: 20
     buckets: 12
   "attributes.indexed.WEIGHT":
     interval: 2
@@ -293,9 +308,15 @@ aggregationConfiguration:
 
 ecoFilters:
   - "CLASSE_ENERGY"
+  - "ENERGY_CONSUMPTION_100_CYCLES"
+  - "WATER_CONSUMPTION"
 
 technicalFilters:
-  - "POWER_CONSUMPTION_TYPICAL"
+  - "NOISE_LEVEL"
+  - "PLACE_SETTINGS"
+  - "PROGRAM_DURATION_ECO"
+  - "PROGRAM_COUNT"
+  - "INSTALLATION_TYPE"
   - "WEIGHT"
 
 ####################################################################################
@@ -304,7 +325,15 @@ technicalFilters:
 attributesConfig:
   configs:
     - key: "CLASSE_ENERGY"
-    - key: "POWER_CONSUMPTION_TYPICAL"
+    - key: "ENERGY_CONSUMPTION_100_CYCLES"
+    - key: "ENERGY_CONSUMPTION_PER_CYCLE"
+    - key: "WATER_CONSUMPTION"
+    - key: "NOISE_LEVEL"
+    - key: "NOISE_CLASS"
+    - key: "PLACE_SETTINGS"
+    - key: "PROGRAM_DURATION_ECO"
+    - key: "PROGRAM_COUNT"
+    - key: "INSTALLATION_TYPE"
     - key: "WEIGHT"
     - key: "WARRANTY"
     - key: "YEAR"


### PR DESCRIPTION
### Motivation
- Align French/English copy and correct wording for the dishwasher vertical to use consistent terminology.
- Surface important dishwasher-specific attributes (energy per 100 cycles, per cycle, water, noise, capacity, programs, installation) for search, filters and scoring.
- Provide attribute definitions and parsing rules to normalize supplier data and improve aggregations.
- Update aggregations and eco/technical filters to expose the new attributes in the UI.

### Description
- Updated `verticals/src/main/resources/verticals/dishwasher.yml` to change `popularAttributes`, fix i18n copy, add new `aggregationConfiguration` entries, expand `ecoFilters`/`technicalFilters`, and extend `attributesConfig` to include the new keys.
- Added new attribute definitions under `verticals/src/main/resources/attributes/` for `ENERGY_CONSUMPTION_100_CYCLES`, `ENERGY_CONSUMPTION_PER_CYCLE`, `WATER_CONSUMPTION`, `NOISE_LEVEL`, `NOISE_CLASS`, `PLACE_SETTINGS`, `PROGRAM_DURATION_ECO`, `PROGRAM_COUNT`, and `INSTALLATION_TYPE` including parsing rules and synonyms.
- Adjusted aggregation intervals/buckets for the new numeric attributes (`ENERGY_CONSUMPTION_100_CYCLES`, `WATER_CONSUMPTION`, `NOISE_LEVEL`, `PLACE_SETTINGS`, `PROGRAM_DURATION_ECO`) to appropriate scales.
- Fixed several French strings (e.g. pluralization/typos) to improve displayed copy consistency.

### Testing
- No automated tests were run for this change because it is configuration-only and introduces new resource files; CI will validate on merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651f5a25c0832b9deffbbbad11452a)