### PR TITLE
Add English i18n and new washing-machine attributes (capacity, spin)

### DIFF
--- a/verticals/src/main/resources/attributes/SPIN_CLASS.yml
+++ b/verticals/src/main/resources/attributes/SPIN_CLASS.yml
@@ -1,0 +1,26 @@
+key: "SPIN_CLASS"
+betterIs: "GREATER"
+faIcon: "mdi-alphabetical"
+name:
+  default: "Spin class"
+  fr: "Classe d'essorage"
+filteringType: "TEXT"
+asScore: false
+attributeValuesOrdering: "MAPPED"
+numericMapping:
+  A: 4.0
+  B: 3.0
+  C: 2.0
+  D: 1.0
+  E: 0.0
+synonyms:
+  all:
+    - "SPINCLASS"
+    - "SPINDRYINGCLASS"
+    - "CLASSE D'ESSORAGE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false

--- a/verticals/src/main/resources/attributes/SPIN_SPEED.yml
+++ b/verticals/src/main/resources/attributes/SPIN_SPEED.yml
@@ -1,0 +1,31 @@
+key: "SPIN_SPEED"
+betterIs: "GREATER"
+faIcon: "mdi-fan"
+name:
+  default: "Spin speed"
+  fr: "Vitesse d'essorage"
+suffix:
+  default: "rpm"
+  fr: "tr/min"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "SPINSPEEDRATED"
+    - "MAXIMUMSPINSPEED"
+    - "SPINSPEEDHALF"
+    - "SPINSPEEDQUARTER"
+    - "VITESSE D'ESSORAGE"
+    - "ESSORAGE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "RPM"
+    - "TR/MIN"
+    - "TR MIN"
+    - "TOURS/MIN"
+    - "TOURS/MINUTE"

--- a/verticals/src/main/resources/attributes/WASHING_CAPACITY.yml
+++ b/verticals/src/main/resources/attributes/WASHING_CAPACITY.yml
@@ -1,0 +1,31 @@
+key: "WASHING_CAPACITY"
+betterIs: "GREATER"
+faIcon: "mdi-weight-kilogram"
+name:
+  default: "Washing capacity"
+  fr: "Capacité de lavage"
+suffix:
+  default: "kg"
+  fr: "kg"
+filteringType: "NUMERIC"
+asScore: false
+synonyms:
+  all:
+    - "RATEDCAPACITY"
+    - "CAPACITY"
+    - "CAPACITE"
+    - "CAPACITÉ"
+    - "CAPACITE DE LAVAGE"
+    - "CAPACITÉ DE LAVAGE"
+    - "CHARGE"
+parser:
+  normalize: true
+  trim: true
+  lowerCase: false
+  upperCase: true
+  removeParenthesis: false
+  deleteTokens:
+    - "KG"
+    - "KGS"
+    - "KILOGRAMME"
+    - "KILOGRAMMES"

--- a/verticals/src/main/resources/verticals/washing-machine.yml
+++ b/verticals/src/main/resources/verticals/washing-machine.yml
@@ -58,7 +58,7 @@ i18n:
     ##################################
     # The product h1 title. Constructed on the same basis than "url", but without the concatened hyphens
     h1Title:
-      prefix: "|| Lave-linge | Machine à laver | Lave linge ||"
+      prefix: "|| Lave-linge | Machine à laver ||"
       attrs:
         - BRAND
         - MODEL
@@ -69,7 +69,7 @@ i18n:
     ##################################
 
     # url for vertical (appened to baseUrl). No templating here
-    verticalHomeUrl: "laves-linges"
+    verticalHomeUrl: "lave-linges"
     # Text displaid as title for the vertical
     # TODO : Make verticalHomeTitle/ verticalHomeDescription templatable
     verticalHomeTitle: "Machines à laver"
@@ -83,6 +83,45 @@ i18n:
 #          verticalUrl: "oled-qled-lcd-que-choisir"
 #          title: "OLED, QLED,LCD, ... Quelle technologie choisir ?"
 #          faIcon: "fa-star"
+  en:
+    # The layout a product url will have. Ex : 81234555-washing-machine-samsung-QL659P-2023
+    url:
+      # We can add a custom prefix (with our conditional templating language if we want)
+      prefix: "|| washing machine | washer ||"
+      # Then we add some attributes values with hyphens if present (ex : samsung-QL659P-2023)
+      attrs:
+        - BRAND
+        - MODEL
+        - YEAR
+    ##################################
+    # Product page meta and h1 title
+    ##################################
+    # The product h1 title. Constructed on the same basis than "url", but without the concatened hyphens
+    h1Title:
+      prefix: "|| Washing machine | Washer ||"
+      attrs:
+        - BRAND
+        - MODEL
+        - YEAR
+
+    # Product metas (generic templates reused)
+    productMetaTitle: "[(${p.brand()})] [(${p.model()})] : Eco-score, ecological offset and best prices"
+    productMetaDescription: "[(${p.brand()})] [(${p.model()})] : Eco-score, || ecological | environmental || offset and best prices."
+    productMetaOpenGraphTitle: "[(${p.brand()})] - [(${p.model()})] : Ecoscore [(${p.ecoscore()})]."
+    productMetaOpenGraphDescription: "[(${p.brand()})] [(${p.model()})] : Eco-score, || ecological | environmental || offset and best prices."
+    productMetaOpenGraphType: "product"
+
+    ##################################
+    # Vertical page elements
+    ##################################
+
+    # url for vertical (appened to baseUrl). No templating here
+    verticalHomeUrl: "washing-machines"
+    # Text displaid as title for the vertical
+    # TODO : Make verticalHomeTitle/ verticalHomeDescription templatable
+    verticalHomeTitle: "Washing machines"
+    # Text displaid as jumbotron for the vertical
+    verticalHomeDescription: "Explore our selection of washing machines. Water and energy use, noise levels, and durability all matter for environmental impact. Nudger helps you choose the most responsible model that still matches your daily needs."
 
 ##############################################################################
 # Custom search filters : the following filters
@@ -164,3 +203,14 @@ attributesConfig:
   ##################################################################################################################
   configs:
     - key: CLASSE_ENERGY
+    - key: INSTALLATION_TYPE
+    - key: WASHING_CAPACITY
+    - key: SPIN_SPEED
+    - key: SPIN_CLASS
+    - key: ENERGY_CONSUMPTION_100_CYCLES
+    - key: ENERGY_CONSUMPTION_PER_CYCLE
+    - key: WATER_CONSUMPTION
+    - key: NOISE_LEVEL
+    - key: NOISE_CLASS
+    - key: PROGRAM_DURATION_ECO
+    - key: PROGRAM_COUNT


### PR DESCRIPTION
### Motivation
- Provide English localization for the washing-machine vertical and correct French title/url inconsistencies.
- Extend attribute coverage for washing machines so product data like capacity and spin characteristics can be parsed and surfaced.
- Ensure vertical URLs and H1 titles follow expected pluralization and templating conventions.
- Support value ordering/scoring for spin class via a numeric mapping.

### Description
- Update `verticals/src/main/resources/verticals/washing-machine.yml` to fix the French `h1Title` prefix, correct the French `verticalHomeUrl`, add an `en` i18n block (product metas, H1, and `verticalHomeUrl`), and add new attribute keys to `attributesConfig`.
- Add `verticals/src/main/resources/attributes/WASHING_CAPACITY.yml` defining `WASHING_CAPACITY` with name, `kg` suffix, synonyms and parser rules.
- Add `verticals/src/main/resources/attributes/SPIN_SPEED.yml` defining `SPIN_SPEED` with `rpm` suffix, synonyms and token deletion rules for common unit variants.
- Add `verticals/src/main/resources/attributes/SPIN_CLASS.yml` defining `SPIN_CLASS` as a text attribute with `numericMapping` for ordered values and synonyms.

### Testing
- No automated tests were executed for this configuration-only change.
- Changes were limited to YAML configuration and attribute definitions only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653ce69384832b8422495b090291b2)