### PR TITLE
Fix homepage asset rendering (use local WebP and avoid IPX 404s)

### DIFF
--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import HomeParallaxVisual from '../HomeParallaxVisual.vue'
+import solutionImageSrc from '~/assets/homepage/gain/nudger-screaming.webp'
 
 type SolutionBenefit = {
   emoji: string
@@ -60,9 +60,13 @@ const sectionDescription = computed(() => t('home.solution.description'))
         </v-col>
         <v-col cols="12" md="6" class="home-solution__visual">
           <div class="home-solution__image-wrapper">
-            <HomeParallaxVisual
-              src="/images/parallax/solution.svg"
+            <NuxtImg
+              :src="solutionImageSrc"
               :alt="sectionTitle"
+              class="home-solution__image"
+              sizes="(min-width: 960px) 320px, 70vw"
+              loading="lazy"
+              decoding="async"
             />
           </div>
         </v-col>

--- a/frontend/app/components/home/sections/HomeSplitSection.vue
+++ b/frontend/app/components/home/sections/HomeSplitSection.vue
@@ -45,6 +45,9 @@ const resolvedImageClass = computed(() =>
     ? 'home-split__image--gain'
     : 'home-split__image--pain'
 )
+const isLocalAsset = computed(() =>
+  Boolean(resolvedImage.value?.src?.startsWith('/'))
+)
 const sectionClasses = computed(() => [
   'home-section',
   'home-split',
@@ -91,8 +94,18 @@ const sectionClasses = computed(() => [
           >
             <div class="home-split__visual" role="presentation">
               <slot name="visual">
+                <img
+                  v-if="resolvedImage?.src && isLocalAsset"
+                  :src="resolvedImage.src"
+                  :alt="resolvedImage.alt"
+                  :class="['home-split__image', resolvedImageClass]"
+                  :loading="resolvedImage.loading ?? 'lazy'"
+                  :width="resolvedImage.width"
+                  :height="resolvedImage.height"
+                  decoding="async"
+                />
                 <NuxtImg
-                  v-if="resolvedImage?.src"
+                  v-else-if="resolvedImage?.src"
                   :src="resolvedImage.src"
                   :alt="resolvedImage.alt"
                   :class="['home-split__image', resolvedImageClass]"


### PR DESCRIPTION
### Motivation
- Replace a missing/parallax SVG visual with a static WebP asset to ensure the homepage visual renders reliably.
- Avoid IPX (Nuxt Image) 404s for locally bundled images by using a standard image element when the source is a local asset.
- Improve build/prerender stability by serving assets that do not rely on the parallax SVG pipeline.

### Description
- Import the gain WebP (`~/assets/homepage/gain/nudger-screaming.webp`) and use it via `NuxtImg` in `HomeSolutionSection.vue` instead of the missing `HomeParallaxVisual` component.
- Add `isLocalAsset` computed and conditional rendering in `HomeSplitSection.vue` to render a native `<img>` when `resolvedImage.src` is a local path and fall back to `NuxtImg` otherwise.
- Preserve image attributes like `sizes`, `loading`, `decoding`, `width` and `height` for `NuxtImg` and appropriate attributes for the native `<img>`.
- Remove the problematic `sizes` binding from the plain `<img>` branch and keep `NuxtImg` for remote/processed sources.

### Testing
- Ran `pnpm lint` which completed successfully (ESLint without the `--offline` flag).
- Ran `pnpm test` (Vitest): most tests passed but one test failed: `app/components/product/ProductPriceSection.spec.ts > ProductPriceSection > sorts offers by ascending price in the table`.
- Ran `pnpm generate` which completed successfully and produced the static output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654e34d6d4832b9dc5e7bcde4b1812)