### PR TITLE
Expose category product counts for homepage hero stats

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
@@ -2,6 +2,8 @@ package org.open4goods.nudgerfrontapi.dto.stats;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.Map;
+
 /**
  * DTO exposing aggregated statistics about vertical categories.
  */
@@ -16,5 +18,11 @@ public record CategoriesStatsDto(
         long gtinOpenDataItemsCount,
 
         @Schema(description = "Total number of ISBN items available in the OpenData exports.", example = "870000")
-        long isbnOpenDataItemsCount
+        long isbnOpenDataItemsCount,
+
+        @Schema(description = "Per-category product counts for recent products with offers, keyed by vertical id.", example = "{\"electronics\": 12000, \"appliances\": 8500}")
+        Map<String, Long> productsCountByCategory,
+
+        @Schema(description = "Sum of product counts across enabled categories.", example = "20500")
+        long productsCountSum
 ) { }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
@@ -81,6 +81,7 @@ public class StatsService {
                 .toList();
 
         Map<String, Long> productsCountByCategory = new LinkedHashMap<>();
+        long productsCountSum = 0L;
         for (VerticalConfig vertical : enabledVerticals) {
             String verticalId = vertical.getId();
             if (verticalId == null || verticalId.isBlank()) {
@@ -88,12 +89,10 @@ public class StatsService {
             }
 
             Long count = productRepository.countMainIndexHavingVertical(verticalId);
-            productsCountByCategory.put(verticalId, count == null ? 0L : count);
+            long safeCount = count == null ? 0L : count;
+            productsCountByCategory.put(verticalId, safeCount);
+            productsCountSum += safeCount;
         }
-
-        long productsCountSum = productsCountByCategory.values().stream()
-                .mapToLong(Long::longValue)
-                .sum();
 
         return new CategoriesStatsDto(
                 Math.toIntExact(enabledVerticals.size()),

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -120,6 +120,28 @@ const openDataMillions = computed(() => {
   return roundedMillions > 0 ? roundedMillions : null
 })
 
+const productsCount = computed(() => {
+  const count = categoriesStats.value?.productsCountSum
+
+  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) {
+    return null
+  }
+
+  return count
+})
+
+const categoriesCount = computed(() => {
+  const count = rawCategories.value?.length ?? 0
+
+  if (count > 0) {
+    return count
+  }
+
+  const fallbackCount = categoriesStats.value?.enabledVerticalConfigs ?? 0
+
+  return fallbackCount > 0 ? fallbackCount : null
+})
+
 const seasonalEventPack = useSeasonalEventPack()
 const theme = useTheme()
 const parallaxAplatFallback = useThemeAsset('parallaxAplat')
@@ -802,6 +824,8 @@ useHead(() => ({
         :verticals="rawCategories"
         :partners-count="heroPartnersCount"
         :open-data-millions="openDataMillions"
+        :products-count="productsCount"
+        :categories-count="categoriesCount"
         hero-background-i18n-key="hero.background"
         @submit="handleSearchSubmit"
         @select-category="handleCategorySuggestion"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -58,14 +58,14 @@
             "helpers": [
               {
                 "icon": "🌿",
-                "label": "A unique ecological and environmental assessment",
+                "label": "A unique ecological and environmental assessment for {products} across {categories} categories",
                 "segments": [
                   {
                     "text": "A unique ecological assessment",
                     "to": "/impact-score"
                   },
                   {
-                    "text": " and environmental review"
+                    "text": " and environmental review for {products} across {categories} categories"
                   }
                 ]
               },
@@ -84,21 +84,21 @@
               },
               {
                 "icon": "🛡️",
-                "label": "Independent comparator, open-source software and open data",
+                "label": "100% independent. Over {millions}M products in open data and free software",
                 "segments": [
                   {
-                    "text": "Independent comparator, "
+                    "text": "100% independent. Over {millions}M products in "
                   },
                   {
-                    "text": "open-source software",
-                    "to": "/opensource"
+                    "text": "open data",
+                    "to": "/opendata"
                   },
                   {
                     "text": " and "
                   },
                   {
-                    "text": "open data",
-                    "to": "/opendata"
+                    "text": "free software",
+                    "to": "/opensource"
                   }
                 ]
               }
@@ -230,14 +230,14 @@
         "helpers": [
           {
             "icon": "🌿",
-            "label": "A unique ecological and environmental assessment",
+            "label": "A unique ecological and environmental assessment for {products} across {categories} categories",
             "segments": [
               {
                 "text": "A unique ecological assessment",
                 "to": "/impact-score"
               },
               {
-                "text": " and environmental review"
+                "text": " and environmental review for {products} across {categories} categories"
               }
             ]
           },
@@ -256,21 +256,21 @@
           },
           {
             "icon": "🛡️",
-            "label": "Independent comparator, open-source software and open data",
+            "label": "100% independent. Over {millions}M products in open data and free software",
             "segments": [
               {
-                "text": "Independent comparator, "
+                "text": "100% independent. Over {millions}M products in "
               },
               {
-                "text": "open-source software",
-                "to": "/opensource"
+                "text": "open data",
+                "to": "/opendata"
               },
               {
                 "text": " and "
               },
               {
-                "text": "open data",
-                "to": "/opendata"
+                "text": "free software",
+                "to": "/opensource"
               }
             ]
           }
@@ -3182,14 +3182,14 @@
           "helpers": [
             {
               "icon": "🌿",
-              "label": "A unique ecological and environmental assessment",
+              "label": "A unique ecological and environmental assessment for {products} across {categories} categories",
               "segments": [
                 {
                   "text": "A unique ecological assessment",
                   "to": "/impact-score"
                 },
                 {
-                  "text": " and environmental review"
+                  "text": " and environmental review for {products} across {categories} categories"
                 }
               ]
             },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -58,34 +58,34 @@
             "helpers": [
               {
                 "icon": "🌿",
-                "label": "Une évaluation écologique et environnementale unique",
+                "label": "Une évaluation écologique et environnementale unique pour {products} dans {categories} catégories",
                 "segments": [
                   {
                     "text": "Une évaluation écologique",
                     "to": "/impact-score"
                   },
                   {
-                    "text": " et environnementale unique"
+                    "text": " et environnementale unique pour {products} dans {categories} catégories"
                   }
                 ]
               },
               {
                 "icon": "🛡️",
-                "label": "100% indépendant, logiciel libre et données ouvertes",
+                "label": "100% indépendant. Plus de {millions}M de produits en données ouvertes et logiciel libre",
                 "segments": [
                   {
-                    "text": "100% indépendant, "
+                    "text": "100% indépendant. Plus de {millions}M de produits en "
                   },
                   {
-                    "text": "logiciel libre",
-                    "to": "/opensource"
+                    "text": "données ouvertes",
+                    "to": "/opendata"
                   },
                   {
                     "text": " et "
                   },
                   {
-                    "text": "données ouvertes",
-                    "to": "/opendata"
+                    "text": "logiciel libre",
+                    "to": "/opensource"
                   }
                 ]
               },
@@ -232,34 +232,34 @@
         "helpers": [
           {
             "icon": "🌿",
-            "label": "Une évaluation écologique et environnementale unique",
+            "label": "Une évaluation écologique et environnementale unique pour {products} dans {categories} catégories",
             "segments": [
               {
                 "text": "Une évaluation écologique",
                 "to": "/impact-score"
               },
               {
-                "text": " et environnementale unique"
+                "text": " et environnementale unique pour {products} dans {categories} catégories"
               }
             ]
           },
           {
             "icon": "🛡️",
-            "label": "100% indépendant, logiciel libre et données ouvertes",
+            "label": "100% indépendant. Plus de {millions}M de produits en données ouvertes et logiciel libre",
             "segments": [
               {
-                "text": "100% indépendant, "
+                "text": "100% indépendant. Plus de {millions}M de produits en "
               },
               {
-                "text": "logiciel libre",
-                "to": "/opensource"
+                "text": "données ouvertes",
+                "to": "/opendata"
               },
               {
                 "text": " et "
               },
               {
-                "text": "données ouvertes",
-                "to": "/opendata"
+                "text": "logiciel libre",
+                "to": "/opensource"
               }
             ]
           },
@@ -3168,14 +3168,14 @@
           "helpers": [
             {
               "icon": "🎄",
-              "label": "Une évaluation écologique et environnementale unique",
+              "label": "Une évaluation écologique et environnementale unique pour {products} dans {categories} catégories",
               "segments": [
                 {
                   "text": "Une évaluation écologique",
                   "to": "/impact-score"
                 },
                 {
-                  "text": " et environnementale unique"
+                  "text": " et environnementale unique pour {products} dans {categories} catégories"
                 }
               ]
             },
@@ -3286,34 +3286,34 @@
           "helpers": [
             {
               "icon": "🌿",
-              "label": "Une évaluation écologique et environnementale unique",
+              "label": "Une évaluation écologique et environnementale unique pour {products} dans {categories} catégories",
               "segments": [
                 {
                   "text": "Une évaluation écologique",
                   "to": "/impact-score"
                 },
                 {
-                  "text": " et environnementale unique"
+                  "text": " et environnementale unique pour {products} dans {categories} catégories"
                 }
               ]
             },
             {
               "icon": "🛡️",
-              "label": "100% indépendant, logiciel libre et données ouvertes",
+              "label": "100% indépendant. Plus de {millions}M de produits en données ouvertes et logiciel libre",
               "segments": [
                 {
-                  "text": "100% indépendant, "
+                  "text": "100% indépendant. Plus de {millions}M de produits en "
                 },
                 {
-                  "text": "logiciel libre",
-                  "to": "/opensource"
+                  "text": "données ouvertes",
+                  "to": "/opendata"
                 },
                 {
                   "text": " et "
                 },
                 {
-                  "text": "données ouvertes",
-                  "to": "/opendata"
+                  "text": "logiciel libre",
+                  "to": "/opensource"
                 }
               ]
             },

--- a/frontend/shared/api-client/models/CategoriesStatsDto.ts
+++ b/frontend/shared/api-client/models/CategoriesStatsDto.ts
@@ -43,6 +43,18 @@ export interface CategoriesStatsDto {
      * @memberof CategoriesStatsDto
      */
     isbnOpenDataItemsCount?: number;
+    /**
+     * Per-category product counts for recent products with offers, keyed by vertical id.
+     * @type {{ [key: string]: number; }}
+     * @memberof CategoriesStatsDto
+     */
+    productsCountByCategory?: { [key: string]: number; };
+    /**
+     * Sum of product counts across enabled categories.
+     * @type {number}
+     * @memberof CategoriesStatsDto
+     */
+    productsCountSum?: number;
 }
 
 /**
@@ -66,6 +78,8 @@ export function CategoriesStatsDtoFromJSONTyped(json: any, ignoreDiscriminator: 
         'affiliationPartnersCount': json['affiliationPartnersCount'] == null ? undefined : json['affiliationPartnersCount'],
         'gtinOpenDataItemsCount': json['gtinOpenDataItemsCount'] == null ? undefined : json['gtinOpenDataItemsCount'],
         'isbnOpenDataItemsCount': json['isbnOpenDataItemsCount'] == null ? undefined : json['isbnOpenDataItemsCount'],
+        'productsCountByCategory': json['productsCountByCategory'] == null ? undefined : mapValues(json['productsCountByCategory'], (item) => item),
+        'productsCountSum': json['productsCountSum'] == null ? undefined : json['productsCountSum'],
     };
 }
 
@@ -84,6 +98,7 @@ export function CategoriesStatsDtoToJSONTyped(value?: CategoriesStatsDto | null,
         'affiliationPartnersCount': value['affiliationPartnersCount'],
         'gtinOpenDataItemsCount': value['gtinOpenDataItemsCount'],
         'isbnOpenDataItemsCount': value['isbnOpenDataItemsCount'],
+        'productsCountByCategory': value['productsCountByCategory'] == null ? undefined : mapValues(value['productsCountByCategory'], (item) => item),
+        'productsCountSum': value['productsCountSum'],
     };
 }
-

--- a/scripts/dev-doctor.sh
+++ b/scripts/dev-doctor.sh
@@ -58,17 +58,17 @@ else
     node_version_ok=false
 fi
 
-PNPM_TARGET="10.26.0"
+PNPM_MINIMUM="10.12.1"
 if command -v pnpm >/dev/null 2>&1; then
     PNPM_VERSION=$(pnpm -v)
-    if [[ "${PNPM_VERSION}" != "${PNPM_TARGET}" ]]; then
-        echo "[WARN] pnpm ${PNPM_VERSION} detected; expected ${PNPM_TARGET}." \
-             "Run: npm install -g pnpm@${PNPM_TARGET}"
+    if [[ "$(printf '%s\n' "${PNPM_MINIMUM}" "${PNPM_VERSION}" | sort -V | head -n1)" != "${PNPM_MINIMUM}" ]]; then
+        echo "[WARN] pnpm ${PNPM_VERSION} detected; expected >= ${PNPM_MINIMUM}." \
+             "Run: npm install -g pnpm@${PNPM_MINIMUM}"
     else
-        echo "[OK] pnpm ${PNPM_VERSION} matches ${PNPM_TARGET}"
+        echo "[OK] pnpm ${PNPM_VERSION} >= ${PNPM_MINIMUM}"
     fi
 else
-    echo "[WARN] pnpm missing; install pnpm@${PNPM_TARGET}"
+    echo "[WARN] pnpm missing; install pnpm@${PNPM_MINIMUM}"
 fi
 
 print_header "Environment variables"


### PR DESCRIPTION
### Motivation

- Provide per-category counts of recent products that have offers so the homepage hero can show product and category summaries.  
- Compute these counts server-side from the product repository and reuse local caching to avoid expensive repeated queries.  
- Surface the new counts in the generated OpenAPI model so the frontend can consume them without additional API calls.  
- Relax the dev tooling check to require a minimum `pnpm` version instead of an exact match.

### Description

- Add `productsCountByCategory: Map<String,Long>` and `productsCountSum: long` to `CategoriesStatsDto` and update the generated client model `frontend/shared/api-client/models/CategoriesStatsDto.ts`.  
- Implement per-vertical counting in `StatsService.categories(...)` by loading enabled `VerticalConfig`s and calling `ProductRepository.countMainIndexHavingVertical(verticalId)`, summing results and caching with `CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME`.  
- Wire counts into the frontend: pass `productsCount` and `categoriesCount` from `index.vue` into `HomeHeroSection.vue`, add formatting and placeholder replacement for `{products}` and `{categories}`, and update i18n strings in `en-US.json` and `fr-FR.json`.  
- Update tests and tooling: extend `StatsServiceTest` to mock `ProductRepository` and assert new DTO fields, and change `scripts/dev-doctor.sh` to enforce `pnpm >= 10.12.1`.

### Testing

- Ran `pnpm lint` in `frontend` and it completed successfully.  
- Ran `pnpm test` (Vitest) in `frontend`: the suite executed and most tests passed, but one frontend spec failed: `ProductPriceSection > sorts offers by ascending price in the table`.  
- Ran `pnpm generate` / `nuxt generate` to rebuild the frontend and server bundles and prerender static routes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654c61134c832b99ece7a65317c478)