### PR TITLE
Enable semantic fallback for suggest search

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/SearchProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/SearchProperties.java
@@ -1,0 +1,62 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for search-related front API settings.
+ */
+@ConfigurationProperties(prefix = "front.search")
+public class SearchProperties {
+
+    /**
+     * Suggest endpoint configuration.
+     */
+    private Suggest suggest = new Suggest();
+
+    /**
+     * Returns the suggest configuration.
+     *
+     * @return suggest configuration settings
+     */
+    public Suggest getSuggest() {
+        return suggest;
+    }
+
+    /**
+     * Updates the suggest configuration.
+     *
+     * @param suggest new suggest configuration settings
+     */
+    public void setSuggest(Suggest suggest) {
+        this.suggest = suggest;
+    }
+
+    /**
+     * Suggest-specific configuration properties.
+     */
+    public static class Suggest {
+
+        /**
+         * Enable semantic fallback for product suggestions when prefix search returns no products.
+         */
+        private boolean semanticFallbackEnabled = true;
+
+        /**
+         * Returns whether semantic fallback is enabled for product suggests.
+         *
+         * @return {@code true} when semantic fallback is enabled
+         */
+        public boolean isSemanticFallbackEnabled() {
+            return semanticFallbackEnabled;
+        }
+
+        /**
+         * Updates the semantic fallback toggle for product suggests.
+         *
+         * @param semanticFallbackEnabled enabled flag for semantic fallback
+         */
+        public void setSemanticFallbackEnabled(boolean semanticFallbackEnabled) {
+            this.semanticFallbackEnabled = semanticFallbackEnabled;
+        }
+    }
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -40,6 +40,12 @@
       "type": "java.time.Duration",
       "description": "Duration of the quota window used to count review generations per IP.",
       "defaultValue": "24h"
+    },
+    {
+      "name": "front.search.suggest.semantic-fallback-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable semantic fallback for product suggestions when prefix search yields no results.",
+      "defaultValue": true
     }
   ]
 }

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -67,6 +67,9 @@ front:
     quota:
       max-per-ip: ${FRONT_REVIEW_GENERATION_MAX_PER_IP:3}
       window: ${FRONT_REVIEW_GENERATION_WINDOW:24h}
+  search:
+    suggest:
+      semantic-fallback-enabled: true
 
   partners:
     ecosystem:

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -23,6 +23,7 @@ import org.open4goods.model.product.Product;
 import org.open4goods.model.vertical.ProductI18nElements;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
+import org.open4goods.nudgerfrontapi.config.properties.SearchProperties;
 import org.open4goods.nudgerfrontapi.dto.search.SearchMode;
 import org.open4goods.nudgerfrontapi.dto.search.SearchType;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
@@ -45,6 +46,7 @@ class SearchServiceTest {
     private ProductMappingService productMappingService;
     @Mock
     private ApiProperties apiProperties;
+    private SearchProperties searchProperties;
     @Mock
     private DjlTextEmbeddingService textEmbeddingService;
     @Mock
@@ -55,8 +57,9 @@ class SearchServiceTest {
 
     @BeforeEach
     void setUp() {
+        searchProperties = new SearchProperties();
         searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties,
-                textEmbeddingService, embeddingProperties);
+                searchProperties, textEmbeddingService, embeddingProperties);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Allow the suggest endpoint to fall back to semantic (embedding/KNN) product search when text prefix queries return no product matches. 
- Expose a new `front.search` configuration namespace to toggle the fallback behavior. 
- Keep category suggestions unchanged and run semantic fallback for products only when appropriate. 
- Reuse the same product DTO mapping for semantic hits so the API response shape remains identical.

### Description

- Add `SearchProperties` (`@ConfigurationProperties(prefix = "front.search")`) with `suggest.semanticFallbackEnabled` defaulting to `true` and register metadata in `additional-spring-configuration-metadata.json`.
- Wire `SearchProperties` into `SearchService`, add `isSemanticSuggestFallbackEnabled()` and perform a semantic fallback when `productMatches.isEmpty()` in `suggest(...)`.
- Implement `executeSemanticSuggestProductSearch(...)` which builds normalized embeddings and issues a KNN search with the shared suggest filters via `buildSuggestFilterQuery()` and maps results to the existing product suggest DTOs.
- Update `application.yml` to enable the new property by default and adjust unit tests to construct `SearchService` with the new `SearchProperties` dependency.

### Testing

- Ran `mvn --offline -pl front-api -am test` to execute the module test suite. 
- Front-api tests completed successfully (`Tests run: 57, Failures: 0, Errors: 0, Skipped: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696550774df0832b8dff77e5c319106e)