### PR TITLE
Add accessibility dropdown with theme & zoom controls to hero and mobile menus

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -408,8 +408,68 @@
           </div>
         </template>
       </v-list>
-      <ThemeToggle test-id="hero-theme-toggle" />
-      <ZoomToggle />
+      <v-menu
+        location="bottom"
+        transition="fade-transition"
+        :offset="[0, 12]"
+        :close-on-content-click="false"
+      >
+        <template #activator="{ props, isActive }">
+          <v-btn
+            v-bind="props"
+            variant="text"
+            class="accessibility-menu__activator"
+            :aria-label="accessibilityLabel"
+          >
+            <v-icon icon="mdi-sunglasses" start />
+            <span class="accessibility-menu__label">{{ accessibilityLabel }}</span>
+            <v-icon
+              :icon="isActive ? 'mdi-menu-up' : 'mdi-menu-down'"
+              size="18"
+              end
+            />
+          </v-btn>
+        </template>
+
+        <v-card class="accessibility-menu" color="surface-default" elevation="8">
+          <div class="accessibility-menu__section">
+            <p class="accessibility-menu__section-title">
+              {{ t('siteIdentity.menu.themeToggle') }}
+            </p>
+            <ThemeToggle
+              test-id="hero-theme-toggle"
+              density="compact"
+              size="small"
+              show-labels
+            />
+          </div>
+
+          <v-divider class="accessibility-menu__divider" />
+
+          <v-list density="comfortable" class="accessibility-menu__list">
+            <v-list-item class="accessibility-menu__item">
+              <template #prepend>
+                <v-icon :icon="zoomIcon" />
+              </template>
+              <v-list-item-title>
+                {{ t('siteIdentity.menu.zoom.label') }}
+              </v-list-item-title>
+              <template #append>
+                <v-switch
+                  :model-value="isZoomed"
+                  inset
+                  color="primary"
+                  density="compact"
+                  hide-details
+                  :aria-label="t('siteIdentity.menu.zoom.label')"
+                  @click.stop
+                  @update:model-value="setZoomed"
+                />
+              </template>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-menu>
       <v-menu
         v-if="isLoggedIn"
         v-model="isAccountMenuOpen"
@@ -511,8 +571,8 @@
 
 <script setup lang="ts">
 import { defineAsyncComponent } from 'vue'
+import { storeToRefs } from 'pinia'
 import ThemeToggle from './ThemeToggle.vue'
-import ZoomToggle from './ZoomToggle.vue'
 import { useI18n } from 'vue-i18n'
 import { useCommunityMenu } from './useCommunityMenu'
 import type { CommunitySection } from './useCommunityMenu'
@@ -529,6 +589,7 @@ import {
   MIN_SEARCH_QUERY_LENGTH,
   useMenuSearchControls,
 } from '~/composables/menus/useMenuSearchControls'
+import { useAccessibilityStore } from '~/stores/useAccessibilityStore'
 
 const SearchSuggestField = defineAsyncComponent({
   loader: () => import('~/components/search/SearchSuggestField.vue'),
@@ -546,6 +607,13 @@ const nuxtApp = useNuxtApp()
 const { isLoggedIn, logout, username, roles } = useAuth()
 const { t, locale } = useI18n()
 const currentLocale = computed(() => normalizeLocale(locale.value))
+const accessibilityStore = useAccessibilityStore()
+const { isZoomed } = storeToRefs(accessibilityStore)
+const { setZoomed } = accessibilityStore
+const accessibilityLabel = computed(() => t('siteIdentity.menu.zoom.label'))
+const zoomIcon = computed(() =>
+  isZoomed.value ? 'mdi-magnify-minus' : 'mdi-magnify-plus'
+)
 const {
   navigation: categoryNavigation,
   fetchNavigation,
@@ -1495,6 +1563,43 @@ const isMenuItemActive = (item: MenuItem): boolean => {
 
 .text-neutral-soft
   color: rgb(var(--v-theme-text-neutral-soft))
+
+.accessibility-menu__activator
+  text-transform: none
+  color: rgb(var(--v-theme-text-neutral-strong))
+  gap: 0.35rem
+
+  &:hover
+    color: rgb(var(--v-theme-accent-supporting))
+
+.accessibility-menu__label
+  font-weight: 700
+
+.accessibility-menu
+  min-width: 240px
+  padding: 1rem
+  border-radius: 1rem
+  box-shadow: 0 18px 40px rgba(var(--v-theme-shadow-primary-600), 0.16)
+
+.accessibility-menu__section
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.accessibility-menu__section-title
+  margin: 0
+  font-size: 0.85rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.accessibility-menu__divider
+  margin-block: 0.85rem
+
+.accessibility-menu__list
+  padding: 0
+
+.accessibility-menu__item
+  padding-inline: 0
 
 @media (max-width: 1263px)
   .community-menu

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -187,29 +187,61 @@
         </div>
       </v-list-group>
 
-      <v-list-item class="px-6 py-4">
-        <template #prepend>
-          <v-icon icon="mdi-theme-light-dark" class="me-4" />
+      <v-list-group class="mobile-menu__accessibility">
+        <template #activator="{ props, isOpen }">
+          <v-list-item
+            v-bind="props"
+            class="px-6 py-4 mobile-menu__accessibility-activator"
+            :append-icon="isOpen ? 'mdi-menu-up' : 'mdi-menu-down'"
+          >
+            <template #prepend>
+              <v-icon icon="mdi-sunglasses" class="me-4" />
+            </template>
+            <v-list-item-title class="text-body-1">
+              {{ accessibilityLabel }}
+            </v-list-item-title>
+          </v-list-item>
         </template>
-        <v-list-item-title class="text-body-1">
-          {{ themeToggleLabel }}
-        </v-list-item-title>
-        <template #append>
-          <ThemeToggle test-id="mobile-theme-toggle" density="compact" />
-        </template>
-      </v-list-item>
 
-      <v-list-item class="px-6 py-4">
-        <template #prepend>
-          <v-icon icon="mdi-face-woman-outline" class="me-4" />
-        </template>
-        <v-list-item-title class="text-body-1">
-          {{ t('siteIdentity.menu.zoom.label') }}
-        </v-list-item-title>
-        <template #append>
-          <ZoomToggle density="compact" />
-        </template>
-      </v-list-item>
+        <div class="mobile-menu__accessibility-content px-6 pb-4">
+          <div class="mobile-menu__accessibility-section">
+            <p class="mobile-menu__accessibility-title">
+              {{ t('siteIdentity.menu.themeToggle') }}
+            </p>
+            <ThemeToggle
+              test-id="mobile-theme-toggle"
+              density="compact"
+              size="small"
+              show-labels
+            />
+          </div>
+
+          <v-divider class="my-4" />
+
+          <v-list class="mobile-menu__accessibility-list" nav density="compact">
+            <v-list-item class="mobile-menu__accessibility-item">
+              <template #prepend>
+                <v-icon :icon="zoomIcon" class="me-4" />
+              </template>
+              <v-list-item-title class="text-body-1">
+                {{ t('siteIdentity.menu.zoom.label') }}
+              </v-list-item-title>
+              <template #append>
+                <v-switch
+                  :model-value="isZoomed"
+                  inset
+                  color="primary"
+                  density="compact"
+                  hide-details
+                  :aria-label="t('siteIdentity.menu.zoom.label')"
+                  @click.stop
+                  @update:model-value="setZoomed"
+                />
+              </template>
+            </v-list-item>
+          </v-list>
+        </div>
+      </v-list-group>
 
       <v-divider v-if="isLoggedIn" class="mx-6" />
 
@@ -271,8 +303,8 @@
 
 <script setup lang="ts">
 import { defineAsyncComponent } from 'vue'
+import { storeToRefs } from 'pinia'
 import ThemeToggle from './ThemeToggle.vue'
-import ZoomToggle from './ZoomToggle.vue'
 import { useI18n } from 'vue-i18n'
 
 import {
@@ -285,6 +317,7 @@ import {
   MIN_SEARCH_QUERY_LENGTH,
   useMenuSearchControls,
 } from '~/composables/menus/useMenuSearchControls'
+import { useAccessibilityStore } from '~/stores/useAccessibilityStore'
 
 const SearchSuggestField = defineAsyncComponent({
   loader: () => import('~/components/search/SearchSuggestField.vue'),
@@ -300,12 +333,13 @@ const {
 } = usePwaInstallPromptBridge()
 const currentLocale = computed(() => normalizeLocale(locale.value))
 
-const themeToggleLabel = computed(() => {
-  const translation = t('siteIdentity.menu.themeToggle')
-  return translation === 'siteIdentity.menu.themeToggle'
-    ? 'Toggle theme'
-    : translation
-})
+const accessibilityStore = useAccessibilityStore()
+const { isZoomed } = storeToRefs(accessibilityStore)
+const { setZoomed } = accessibilityStore
+const accessibilityLabel = computed(() => t('siteIdentity.menu.zoom.label'))
+const zoomIcon = computed(() =>
+  isZoomed.value ? 'mdi-magnify-minus' : 'mdi-magnify-plus'
+)
 
 const emit = defineEmits<{
   close: []
@@ -594,6 +628,33 @@ const menuItems = computed<MenuLink[]>(() =>
 .mobile-menu__community-link-description
   font-size: 0.8rem
   color: rgb(var(--v-theme-text-neutral-secondary))
+
+.mobile-menu__accessibility
+  --v-list-group-prepend-width: 36px
+
+.mobile-menu__accessibility-activator
+  transition: color 0.2s ease
+
+.mobile-menu__accessibility-content
+  background-color: rgba(var(--v-theme-surface-primary-080), 0.18)
+  border-block-start: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35)
+
+.mobile-menu__accessibility-section
+  display: flex
+  flex-direction: column
+  gap: 0.75rem
+
+.mobile-menu__accessibility-title
+  margin: 0
+  font-size: 0.85rem
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-secondary))
+
+.mobile-menu__accessibility-list
+  padding-inline: 0
+
+.mobile-menu__accessibility-item
+  padding-inline: 0
 
 .border-bottom
   border-bottom: 1px solid rgba(0, 0, 0, 0.12)

--- a/frontend/app/components/shared/menus/ThemeToggle.vue
+++ b/frontend/app/components/shared/menus/ThemeToggle.vue
@@ -2,6 +2,7 @@
   <v-btn-toggle
     v-model="selectedTheme"
     class="theme-toggle"
+    :class="{ 'theme-toggle--labeled': showLabels }"
     :density="density"
     color="accent"
     mandatory
@@ -19,7 +20,12 @@
           icon
           variant="plain"
         >
-          <v-icon icon="mdi-white-balance-sunny" />
+          <span class="theme-toggle__content">
+            <v-icon icon="mdi-white-balance-sunny" />
+            <span v-if="showLabels" class="theme-toggle__label">
+              {{ lightLabel }}
+            </span>
+          </span>
         </v-btn>
       </template>
     </v-tooltip>
@@ -35,7 +41,12 @@
           icon
           variant="plain"
         >
-          <v-icon icon="mdi-weather-night" />
+          <span class="theme-toggle__content">
+            <v-icon icon="mdi-weather-night" />
+            <span v-if="showLabels" class="theme-toggle__label">
+              {{ darkLabel }}
+            </span>
+          </span>
         </v-btn>
       </template>
     </v-tooltip>
@@ -59,11 +70,13 @@ const props = withDefaults(
     density?: 'default' | 'comfortable' | 'compact'
     size?: 'x-small' | 'small' | 'default'
     testId?: string
+    showLabels?: boolean
   }>(),
   {
     density: 'comfortable',
     size: 'small',
     testId: 'theme-toggle',
+    showLabels: false,
   }
 )
 
@@ -118,10 +131,13 @@ const lightAriaLabel = computed(() =>
   t('siteIdentity.menu.theme.lightAriaLabel')
 )
 const darkAriaLabel = computed(() => t('siteIdentity.menu.theme.darkAriaLabel'))
+const lightLabel = computed(() => t('siteIdentity.menu.theme.lightTooltip'))
+const darkLabel = computed(() => t('siteIdentity.menu.theme.darkTooltip'))
 
 const density = toRef(props, 'density')
 const size = toRef(props, 'size')
 const testId = toRef(props, 'testId')
+const showLabels = toRef(props, 'showLabels')
 </script>
 
 <style scoped lang="sass">
@@ -131,4 +147,20 @@ const testId = toRef(props, 'testId')
     color: rgb(var(--v-theme-text-neutral-strong))
   :deep(.v-btn.v-btn--active)
     color: rgb(var(--v-theme-accent-supporting))
+
+.theme-toggle__content
+  display: flex
+  flex-direction: column
+  align-items: center
+  gap: 0.35rem
+
+.theme-toggle__label
+  font-size: 0.72rem
+  font-weight: 600
+  line-height: 1.1
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.95)
+
+.theme-toggle--labeled
+  :deep(.v-btn)
+    padding-inline: 0.85rem
 </style>

--- a/frontend/app/components/shared/menus/menus-auth.spec.ts
+++ b/frontend/app/components/shared/menus/menus-auth.spec.ts
@@ -266,6 +266,7 @@ describe('Shared menu authentication controls', () => {
     attachTo: document.body,
     global: {
       stubs: {
+        Teleport: true,
         VMenu: vMenuStub,
         SearchSuggestField: {
           template: '<div class="search-suggest-field-stub" />',
@@ -276,6 +277,7 @@ describe('Shared menu authentication controls', () => {
   const mobileMountOptions = {
     global: {
       stubs: {
+        Teleport: true,
         VMenu: vMenuStub,
         SearchSuggestField: {
           template: '<div class="search-suggest-field-stub" />',
@@ -507,19 +509,33 @@ describe('Shared menu authentication controls', () => {
   it('renders theme toggles and synchronises the stored preference', async () => {
     const heroWrapper = await mountSuspended(TheHeroMenu)
 
-    expect(heroWrapper.find('[data-testid="hero-theme-toggle"]').exists()).toBe(
-      true
+    await heroWrapper
+      .get('.accessibility-menu__activator')
+      .trigger('click')
+    await flushPromises()
+
+    const heroToggle = document.body.querySelector(
+      '[data-testid="hero-theme-toggle"]'
     )
+    expect(heroToggle).not.toBeNull()
 
-    const darkToggle = heroWrapper.get('[data-testid="hero-theme-toggle-dark"]')
+    const darkToggle = document.body.querySelector(
+      '[data-testid="hero-theme-toggle-dark"]'
+    )
+    expect(darkToggle).not.toBeNull()
 
-    await darkToggle.trigger('click')
+    darkToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushPromises()
 
     expect(storedThemePreference.value).toBe('dark')
     expect(themeName.value).toBe('dark')
 
     const mobileWrapper = await mountSuspended(TheMobileMenu)
+
+    await mobileWrapper
+      .get('.mobile-menu__accessibility-activator')
+      .trigger('click')
+    await flushPromises()
 
     expect(
       mobileWrapper.find('[data-testid="mobile-theme-toggle"]').exists()


### PR DESCRIPTION
### Motivation
- Expose theme selection and accessibility (zoom) together in a compact dropdown to improve discoverability and mobile UX.
- Show different zoom icons depending on the zoom state (plus / minus) and reuse existing i18n keys for labels to avoid duplicating copy.
- Reuse existing stored state for zoom and theme (Pinia / storage) so toggles remain synchronized across menus.
- Keep menu activators as dropdowns with consistent styling to match other menus.

### Description
- Replace separate theme/zoom buttons in `The-hero-menu.vue` and `The-mobile-menu.vue` with a single accessibility dropdown (`v-menu`) that contains `ThemeToggle` and a zoom `v-switch` wired to the accessibility store.
- Update `ThemeToggle.vue` to accept a new `showLabels` prop and render compact labels (reusing the tooltip translation keys) and adjust styles for the labeled variant.
- Use `useAccessibilityStore` + `storeToRefs` in hero/mobile menus to read/update `isZoomed` and compute `zoomIcon` as `mdi-magnify-plus` or `mdi-magnify-minus` based on state.
- Add scoped styles for the new accessibility dropdown and mobile menu blocks, and remove old `ZoomToggle` usage.
- Update `menus-auth.spec.ts` to stub `Teleport`, open the new dropdowns in the test, and dispatch native click events when necessary so the toggles are exercised in the DOM.

### Testing
- Ran linter with `pnpm --offline lint`; lint completed successfully (no new lint errors introduced).
- Ran unit tests with `pnpm --offline test`; frontend test suite executed and affected spec (`menus-auth.spec.ts`) was updated and re-run.
- Updated tests now open the accessibility menus before asserting toggles and the modified spec passes locally (frontend tests completed successfully during the run).
- All modified and related component specs were exercised during the test run; the test run finished with the suite passing for the executed tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656599eca0832baaf3c12b734683a4)