### PR TITLE
Add opt-in Hotjar recording gate (/?record) with middleware, client plugin, docs and tests

### DIFF
--- a/frontend/app/plugins/hotjar.client.ts
+++ b/frontend/app/plugins/hotjar.client.ts
@@ -1,0 +1,52 @@
+import type { Plugin } from 'vue'
+import Hotjar from 'vue-hotjar'
+
+import { defineNuxtPlugin, useCookie, useRuntimeConfig } from '#imports'
+import {
+  HOTJAR_RECORDING_COOKIE_NAME,
+  isHotjarRecordingCookieEnabled,
+} from '~~/shared/utils/hotjar-recording'
+import { isDoNotTrackEnabled } from '~/utils/do-not-track'
+
+type HotjarPublicConfig = {
+  enabled: boolean
+  siteId: number
+  snippetVersion: number
+}
+
+const isValidSiteId = (siteId: number): boolean =>
+  Number.isFinite(siteId) && siteId > 0
+
+export default defineNuxtPlugin({
+  name: 'hotjar-recording',
+  setup(nuxtApp) {
+    if (isDoNotTrackEnabled()) {
+      return
+    }
+
+    const runtimeConfig = useRuntimeConfig()
+    const hotjarConfig = runtimeConfig.public.hotjar as
+      | HotjarPublicConfig
+      | undefined
+
+    if (!hotjarConfig?.enabled) {
+      return
+    }
+
+    if (!isValidSiteId(hotjarConfig.siteId)) {
+      return
+    }
+
+    const hotjarCookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME)
+
+    if (!isHotjarRecordingCookieEnabled(hotjarCookie.value)) {
+      return
+    }
+
+    nuxtApp.vueApp.use(Hotjar as Plugin, {
+      id: hotjarConfig.siteId,
+      isProduction: hotjarConfig.enabled,
+      snippetVersion: hotjarConfig.snippetVersion,
+    })
+  },
+})

--- a/frontend/app/tests/hotjar.client.spec.ts
+++ b/frontend/app/tests/hotjar.client.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  HOTJAR_RECORDING_COOKIE_NAME,
+  HOTJAR_RECORDING_COOKIE_VALUE,
+} from '~~/shared/utils/hotjar-recording'
+
+type HotjarPluginDefinition = (typeof import('./hotjar.client'))['default']
+
+type HotjarRuntimeConfig = {
+  public: {
+    hotjar: {
+      enabled: boolean
+      siteId: number
+      snippetVersion: number
+    }
+  }
+}
+
+type VueApp = {
+  use: (plugin: unknown, options?: unknown) => void
+}
+
+type NuxtAppStub = {
+  vueApp: VueApp
+}
+
+const useRuntimeConfigMock = vi.hoisted(() => vi.fn())
+const useCookieMock = vi.hoisted(() => vi.fn())
+const isDoNotTrackEnabledMock = vi.hoisted(() => vi.fn())
+const hotjarPlugin = vi.hoisted(() => ({ install: vi.fn() }))
+
+vi.mock('vue-hotjar', () => ({
+  default: hotjarPlugin,
+}))
+
+vi.mock('~/utils/do-not-track', () => ({
+  isDoNotTrackEnabled: isDoNotTrackEnabledMock,
+}))
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (plugin: HotjarPluginDefinition) => plugin,
+  useRuntimeConfig: useRuntimeConfigMock,
+  useCookie: useCookieMock,
+}))
+
+describe('hotjar client plugin', () => {
+  const createNuxtApp = (): NuxtAppStub => ({
+    vueApp: {
+      use: vi.fn(),
+    },
+  })
+
+  const setRuntimeConfig = (config: HotjarRuntimeConfig) => {
+    useRuntimeConfigMock.mockReturnValue(config)
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    useRuntimeConfigMock.mockReset()
+    useCookieMock.mockReset()
+    isDoNotTrackEnabledMock.mockReset()
+    isDoNotTrackEnabledMock.mockReturnValue(false)
+  })
+
+  it('initializes Hotjar when cookie is present and enabled', async () => {
+    const nuxtApp = createNuxtApp()
+    setRuntimeConfig({
+      public: {
+        hotjar: {
+          enabled: true,
+          siteId: 123456,
+          snippetVersion: 6,
+        },
+      },
+    })
+    useCookieMock.mockImplementation(name => {
+      if (name === HOTJAR_RECORDING_COOKIE_NAME) {
+        return { value: HOTJAR_RECORDING_COOKIE_VALUE }
+      }
+      return { value: undefined }
+    })
+
+    const plugin = (await import('./hotjar.client')).default
+
+    plugin.setup?.(nuxtApp)
+
+    expect(nuxtApp.vueApp.use).toHaveBeenCalledWith(hotjarPlugin, {
+      id: 123456,
+      isProduction: true,
+      snippetVersion: 6,
+    })
+  })
+
+  it('skips Hotjar when the cookie is missing', async () => {
+    const nuxtApp = createNuxtApp()
+    setRuntimeConfig({
+      public: {
+        hotjar: {
+          enabled: true,
+          siteId: 123456,
+          snippetVersion: 6,
+        },
+      },
+    })
+    useCookieMock.mockReturnValue({ value: undefined })
+
+    const plugin = (await import('./hotjar.client')).default
+
+    plugin.setup?.(nuxtApp)
+
+    expect(nuxtApp.vueApp.use).not.toHaveBeenCalled()
+  })
+
+  it('skips Hotjar when Do Not Track is enabled', async () => {
+    const nuxtApp = createNuxtApp()
+    setRuntimeConfig({
+      public: {
+        hotjar: {
+          enabled: true,
+          siteId: 123456,
+          snippetVersion: 6,
+        },
+      },
+    })
+    useCookieMock.mockReturnValue({ value: HOTJAR_RECORDING_COOKIE_VALUE })
+    isDoNotTrackEnabledMock.mockReturnValue(true)
+
+    const plugin = (await import('./hotjar.client')).default
+
+    plugin.setup?.(nuxtApp)
+
+    expect(nuxtApp.vueApp.use).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/docs/hotjar-recording.md
+++ b/frontend/docs/hotjar-recording.md
@@ -1,0 +1,28 @@
+# Hotjar recording gate
+
+This frontend uses an opt-in gate for Hotjar recordings that only activates when
+users explicitly land on the homepage with `/?record`.
+
+## How it works
+
+1. When the homepage is requested with `/?record`, the server middleware:
+   - sets a `hotjar_record=true` cookie (90 days),
+   - redirects the request to the canonical `/` URL to avoid indexing the query
+     string.
+2. On the client, the Hotjar plugin runs only when:
+   - the `hotjar_record` cookie is present,
+   - Do Not Track is **not** enabled,
+   - `public.hotjar.enabled` is true and a valid `public.hotjar.siteId` is set.
+
+If the `record` parameter is absent, no cookie is set and Hotjar is not
+initialized.
+
+## Configuration
+
+Hotjar is configured via runtime config values exposed to the client:
+
+- `HOTJAR_ENABLED` (defaults to `true` in production, otherwise `false`)
+- `HOTJAR_SITE_ID` (Hotjar site ID, required to enable recordings)
+- `HOTJAR_SNIPPET_VERSION` (defaults to `6`)
+
+These are surfaced as `runtimeConfig.public.hotjar` in `nuxt.config.ts`.

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -55,6 +55,12 @@ const PLAUSIBLE_API_HOST =
   process.env.PLAUSIBLE_API_HOST || 'https://plausible.nudger.fr'
 const PLAUSIBLE_ENABLED = process.env.NODE_ENV === 'production'
 const PLAUSIBLE_IGNORED_HOSTNAMES = ['localhost', '127.0.0.1']
+const HOTJAR_ENABLED =
+  process.env.HOTJAR_ENABLED !== undefined
+    ? process.env.HOTJAR_ENABLED === 'true'
+    : process.env.NODE_ENV === 'production'
+const HOTJAR_SITE_ID = Number(process.env.HOTJAR_SITE_ID ?? 0)
+const HOTJAR_SNIPPET_VERSION = Number(process.env.HOTJAR_SNIPPET_VERSION ?? 6)
 const navigationOfflineFallbackPlugin = {
   handlerDidError: async () => {
     const offlineResponse = await globalThis.caches?.match('/offline')
@@ -502,6 +508,11 @@ export default defineNuxtConfig({
         autoPageviews: true,
         autoOutboundTracking: true,
         ignoredHostnames: PLAUSIBLE_IGNORED_HOSTNAMES,
+      },
+      hotjar: {
+        enabled: HOTJAR_ENABLED,
+        siteId: HOTJAR_SITE_ID,
+        snippetVersion: HOTJAR_SNIPPET_VERSION,
       },
     },
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "vue": "3.5.26",
     "vue-barcode-reader": "^1.0.3",
     "vue-echarts": "^8.0.0",
+    "vue-hotjar": "^1.4.0",
     "vue-pdf-embed": "^2.1.3",
     "vue3-picture-swipe": "^3.0.6",
     "vuetify-nuxt-module": "^0.19.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       vue-echarts:
         specifier: ^8.0.0
         version: 8.0.1(echarts@6.0.0)(vue@3.5.26(typescript@5.9.3))
+      vue-hotjar:
+        specifier: ^1.4.0
+        version: 1.4.0
       vue-pdf-embed:
         specifier: ^2.1.3
         version: 2.1.3(vue@3.5.26(typescript@5.9.3))
@@ -8902,6 +8905,9 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
+
+  vue-hotjar@1.4.0:
+    resolution: {integrity: sha512-C/4lfjB1R3+eXiC+jSpNn3z0GWicpnADeRWpEHLdP2FSIi/AjupoIBikugHvGV334QYGUueXUyVZz6GHr+3eYQ==}
 
   vue-i18n@11.2.8:
     resolution: {integrity: sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==}
@@ -19226,6 +19232,8 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
+
+  vue-hotjar@1.4.0: {}
 
   vue-i18n@11.2.8(vue@3.5.26(typescript@5.9.3)):
     dependencies:

--- a/frontend/server/middleware/record-entry.spec.ts
+++ b/frontend/server/middleware/record-entry.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  HOTJAR_RECORDING_COOKIE_MAX_AGE,
+  HOTJAR_RECORDING_COOKIE_NAME,
+  HOTJAR_RECORDING_COOKIE_VALUE,
+} from '~~/shared/utils/hotjar-recording'
+
+type RecordEntryHandler = (typeof import('./record-entry'))['default']
+
+const getRequestURLMock = vi.hoisted(() => vi.fn())
+const sendRedirectMock = vi.hoisted(() => vi.fn())
+const setCookieMock = vi.hoisted(() => vi.fn())
+
+vi.mock('h3', async importOriginal => ({
+  ...(await importOriginal<typeof import('h3')>()),
+  defineEventHandler: (fn: RecordEntryHandler) => fn,
+  getRequestURL: getRequestURLMock,
+  sendRedirect: sendRedirectMock,
+  setCookie: setCookieMock,
+}))
+
+describe('record-entry middleware', () => {
+  const event = {} as Parameters<RecordEntryHandler>[0]
+  const originalEnv = process.env.NODE_ENV
+  let handler: RecordEntryHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    getRequestURLMock.mockReset()
+    sendRedirectMock.mockReset()
+    setCookieMock.mockReset()
+    process.env.NODE_ENV = 'test'
+    handler = (await import('./record-entry')).default
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv
+  })
+
+  it('sets the cookie and redirects when record query is present on home', () => {
+    getRequestURLMock.mockReturnValue(new URL('https://nudger.fr/?record'))
+
+    handler(event)
+
+    expect(setCookieMock).toHaveBeenCalledWith(
+      event,
+      HOTJAR_RECORDING_COOKIE_NAME,
+      HOTJAR_RECORDING_COOKIE_VALUE,
+      {
+        httpOnly: false,
+        sameSite: 'lax',
+        secure: false,
+        path: '/',
+        maxAge: HOTJAR_RECORDING_COOKIE_MAX_AGE,
+      }
+    )
+    expect(sendRedirectMock).toHaveBeenCalledWith(event, '/', 302)
+  })
+
+  it('does nothing when the record query is missing', () => {
+    getRequestURLMock.mockReturnValue(new URL('https://nudger.fr/'))
+
+    handler(event)
+
+    expect(setCookieMock).not.toHaveBeenCalled()
+    expect(sendRedirectMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing on non-home paths', () => {
+    getRequestURLMock.mockReturnValue(new URL('https://nudger.fr/about?record'))
+
+    handler(event)
+
+    expect(setCookieMock).not.toHaveBeenCalled()
+    expect(sendRedirectMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/server/middleware/record-entry.ts
+++ b/frontend/server/middleware/record-entry.ts
@@ -1,0 +1,36 @@
+import { defineEventHandler, getRequestURL, sendRedirect, setCookie } from 'h3'
+
+import {
+  HOTJAR_RECORDING_COOKIE_MAX_AGE,
+  HOTJAR_RECORDING_COOKIE_NAME,
+  HOTJAR_RECORDING_COOKIE_VALUE,
+} from '~~/shared/utils/hotjar-recording'
+
+const isHomePath = (pathname: string): boolean => pathname === '/'
+
+export default defineEventHandler(event => {
+  const requestUrl = getRequestURL(event)
+
+  if (!isHomePath(requestUrl.pathname)) {
+    return
+  }
+
+  if (!requestUrl.searchParams.has('record')) {
+    return
+  }
+
+  setCookie(
+    event,
+    HOTJAR_RECORDING_COOKIE_NAME,
+    HOTJAR_RECORDING_COOKIE_VALUE,
+    {
+      httpOnly: false,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+      maxAge: HOTJAR_RECORDING_COOKIE_MAX_AGE,
+    }
+  )
+
+  return sendRedirect(event, requestUrl.pathname, 302)
+})

--- a/frontend/shared/utils/hotjar-recording.ts
+++ b/frontend/shared/utils/hotjar-recording.ts
@@ -1,0 +1,7 @@
+export const HOTJAR_RECORDING_COOKIE_NAME = 'hotjar_record'
+export const HOTJAR_RECORDING_COOKIE_VALUE = 'true'
+export const HOTJAR_RECORDING_COOKIE_MAX_AGE = 60 * 60 * 24 * 90
+
+export const isHotjarRecordingCookieEnabled = (
+  value: string | null | undefined
+): boolean => value === HOTJAR_RECORDING_COOKIE_VALUE


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable opt-in mechanism to enable Hotjar recordings only when a user explicitly visits the site with `/?record` so recordings are never started by default. 
- Ensure Hotjar initialization respects `Do Not Track` and runtime configuration before injecting the recording snippet. 
- Centralize cookie and gating logic in a small shared utility to make behavior easy to test and review. 
- Document the opt-in flow in the frontend docs so the policy and configuration are discoverable.

### Description
- Add a shared helper `frontend/shared/utils/hotjar-recording.ts` that defines the cookie name/value, max age, and `isHotjarRecordingCookieEnabled` helper. 
- Add server middleware `frontend/server/middleware/record-entry.ts` that only sets the recording cookie and issues a redirect when the request is for the home path and the `record` query parameter is present, plus `record-entry.spec.ts` unit tests. 
- Add a client-only Nuxt plugin `frontend/app/plugins/hotjar.client.ts` that reads `runtimeConfig.public.hotjar`, respects `Do Not Track`, checks the recording cookie with the shared helper, and initializes `vue-hotjar` only when all checks pass, plus `hotjar.client.spec.ts` unit tests. 
- Expose Hotjar runtime config in `frontend/nuxt.config.ts`, add `vue-hotjar` to `frontend/package.json`, update the lockfile, and add `frontend/docs/hotjar-recording.md` documenting the opt-in flow and configuration.

### Testing
- Added unit tests for the middleware (`frontend/server/middleware/record-entry.spec.ts`) and the client plugin (`frontend/app/tests/hotjar.client.spec.ts`) to validate the gate logic. 
- Ran `pnpm fast` which fails early during linting due to a pre-existing parsing/ESLint error in `app/components/search/SearchSuggestField.vue`, so the newly added tests were not executed in that run. 
- The lint failure is unrelated to these changes and must be fixed separately before full CI/test runs will succeed. 
- Manual verification in the codebase confirms no cookie is set nor Hotjar initialized when the `record` parameter is absent, per the implemented guards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69659e2a0278832b8805af99883e5592)