### PR TITLE
Fix home solution image asset and rotation

### DIFF
--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-const solutionImageSrc = '/images/home/nudger-screaming.webp'
+import solutionImageSrc from '~/assets/homepage/gain/nudger-screaming.webp'
 
 type SolutionBenefit = {
   emoji: string
@@ -115,6 +115,7 @@ const sectionDescription = computed(() => t('home.solution.description'))
   height: auto
   display: block
   filter: drop-shadow(0 20px 40px rgba(var(--v-theme-shadow-primary-600), 0.15))
+  transform: rotate(10deg)
 
 .home-solution__next-btn
   position: absolute

--- a/frontend/app/composables/useRandomHomepageImages.ts
+++ b/frontend/app/composables/useRandomHomepageImages.ts
@@ -1,3 +1,5 @@
+import gainImageFallback from '~/assets/homepage/gain/nudger-screaming.webp'
+
 const painImages = Object.values(
   import.meta.glob('~/assets/homepage/pain/*.{png,jpg,jpeg,webp,svg}', {
     eager: true,
@@ -25,7 +27,7 @@ export const useRandomHomepageImages = () => {
     pickRandomImage(painImages, '/images/home/nudger-problem.webp')
   )
   const gainImage = useState<string>('home-gain-random-image', () =>
-    pickRandomImage(gainImages, '/images/home/nudger-screaming.webp')
+    pickRandomImage(gainImages, gainImageFallback)
   )
 
   const pickGainImage = () => {


### PR DESCRIPTION
### Motivation
- Use the bundled home "gain" image asset so the home solution visual uses a local import instead of a hardcoded public path to avoid missing-image 404s.  
- Reuse the bundled asset as the fallback in the random homepage image picker to ensure a consistent default.  
- Apply a small rotation to the visual to match the intended design aesthetic.  

### Description
- Replace the string path with a module import of `~/assets/homepage/gain/nudger-screaming.webp` in `HomeSolutionSection.vue`.  
- Add `transform: rotate(10deg)` to the `.home-solution__image` rule to rotate the visual.  
- Import the same asset as `gainImageFallback` in `useRandomHomepageImages.ts` and use it as the fallback for the gain image picker.  
- Keep the existing random-selection logic unchanged while ensuring the fallback is a bundled asset.  

### Testing
- Ran `pnpm --offline lint`, which reported a parsing error in `SearchSuggestField.vue` and a single `vue/attributes-order` warning, so lint did not fully pass.  
- Ran `pnpm --offline test` (Vitest), which failed with multiple test failures caused by the `SearchSuggestField.vue` "Invalid end tag" parsing error.  
- Ran `pnpm --offline generate`, which failed during build for the same `SearchSuggestField.vue` invalid end tag error.  
- A development server run and a Playwright screenshot were produced to visually confirm the updated Home Solution section, but automated test runs above did not pass due to the unrelated parsing error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965a176d91c832b9271381f31cbc4e6)