### PR TITLE
Defer nudge icon random timing until hydration to fix SSR style mismatch

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolAnimatedIcon.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolAnimatedIcon.vue
@@ -92,6 +92,7 @@ const scale = ref(1)
 const easing = ref(EASE_IN_OUT)
 const animationDuration = ref(0)
 const animationDelay = ref(0)
+const isHydrated = ref(false)
 
 let rng = createRng(props.seed)
 
@@ -133,7 +134,7 @@ const resolveMidpoint = (min: number, max: number) =>
 
 const updateAnimationTiming = () => {
   const [min, max] = normalizedFrequencyRange.value
-  if (props.randomizeOnMount) {
+  if (props.randomizeOnMount && isHydrated.value) {
     animationDuration.value = Math.round(randomBetween(min, max))
     animationDelay.value = Math.round(randomBetween(0, min))
     return
@@ -244,6 +245,7 @@ const runPulse = (remaining: number) => {
 // -- Lifecycle --
 onMounted(() => {
   rng = createRng(props.seed)
+  isHydrated.value = true
   updateAnimationTiming()
   if (isPulseVariant.value) {
     scheduleIdle()


### PR DESCRIPTION
### Motivation

- The nudge icon used randomized CSS timing/properties during SSR which produced different `style` attributes on server vs client and triggered hydration mismatch warnings. 
- Randomizing animation timing on the server is nondeterministic and causes visual/style differences that should be avoided. 
- The change defers client-only randomization to hydration time to keep server-rendered styles stable. 

### Description

- Added a `isHydrated` `ref` to `frontend/app/components/nudge-tool/NudgeToolAnimatedIcon.vue` to track client hydration. 
- Guarded `updateAnimationTiming()` so randomization runs only when `isHydrated` is `true`. 
- Set `isHydrated.value = true` inside the `onMounted()` lifecycle hook so timings are deterministic on SSR and randomized after hydration. 

### Testing

- `pnpm lint` was executed and succeeded. 
- `pnpm test` was run but the test runner queued many files and was interrupted/hung (did not complete successfully). 
- `pnpm generate` failed during build due to an unresolved import (`vue-hotjar`) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965af616b2c832bb8aeb34995d4dfcf)