### PR TITLE
Update product impact score presentation

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -56,7 +56,6 @@
           <ProductImpactSection
             :scores="impactScores"
             :radar-data="radarData"
-            :loading="loadingAggregations"
             :product-name="productTitle"
             :product-brand="productBrand"
             :product-model="productModel"

--- a/frontend/app/components/product/ProductImpactSection.vue
+++ b/frontend/app/components/product/ProductImpactSection.vue
@@ -18,8 +18,6 @@
         :radar-axes="radarAxes"
         :chart-series="chartSeries"
         :product-name="productName"
-        :loading="loading"
-        :secondary-scores="secondaryScores"
         :product-brand="productBrand"
         :product-model="productModel"
         :product-image="productImage"
@@ -92,10 +90,6 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  loading: {
-    type: Boolean,
-    default: false,
-  },
   verticalHomeUrl: {
     type: String,
     default: '',
@@ -121,7 +115,6 @@ const subtitleParams = toRef(props, 'subtitleParams')
 const { t } = useI18n()
 
 const primaryScore = computed(() => props.scores[0] ?? null)
-const secondaryScores = computed(() => props.scores.slice(1))
 const detailScores = computed(() =>
   props.scores.filter(score => score.id?.toUpperCase() !== 'ECOSCORE')
 )

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -111,7 +111,11 @@
               {{ lifecycleLabels[stage] ?? stage }}
             </v-chip>
           </template>
-          <span v-else class="impact-details__coefficient-empty">—</span>
+          <span
+            v-else-if="item.rowType !== 'aggregate'"
+            class="impact-details__coefficient-empty"
+            >—</span
+          >
         </div>
       </template>
 
@@ -417,7 +421,7 @@ const buildAggregateRow = (
   return {
     id: aggregateId,
     label,
-    attributeValue: '—',
+    attributeValue: '',
     attributeSourcing: null,
     displayValue: displayValue,
     coefficient: aggregateScore?.coefficient ?? null,

--- a/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactEcoScoreCard.spec.ts
@@ -13,7 +13,6 @@ describe('ProductImpactEcoScoreCard', () => {
       'en-US': {
         product: {
           impact: {
-            primaryScoreLabel: 'Overall impact',
             absoluteValue: 'Absolute value',
             noPrimaryScore: 'No score',
             methodologyLink: 'Access the methodology',
@@ -72,9 +71,6 @@ describe('ProductImpactEcoScoreCard', () => {
           'v-chip-group': true,
           'v-chip': true,
           'v-checkbox': true,
-          'v-btn': true,
-          'v-expand-transition': true,
-          'v-skeleton-loader': true,
         },
       },
     })
@@ -121,9 +117,6 @@ describe('ProductImpactEcoScoreCard', () => {
           'v-chip-group': true,
           'v-chip': true,
           'v-checkbox': true,
-          'v-btn': true,
-          'v-expand-transition': true,
-          'v-skeleton-loader': true,
         },
       },
     })
@@ -157,9 +150,6 @@ describe('ProductImpactEcoScoreCard', () => {
               '<input type="checkbox" :checked="modelValue" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
             props: ['modelValue'],
           },
-          'v-btn': true,
-          'v-expand-transition': true,
-          'v-skeleton-loader': true,
           ProductImpactDetailsTable: {
             props: ['scores'],
             template:

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -16,7 +16,6 @@ describe('ProductImpactSubscoreGenericCard', () => {
           impact: {
             percentile: 'Percentile',
             weightChip: 'Counts for {value}% of the total score',
-            subscoreDetailsToggle: 'View indicator details',
             importanceTitle: 'Why it matters',
             tableHeaders: {
               ranking: 'Rank',
@@ -121,42 +120,6 @@ describe('ProductImpactSubscoreGenericCard', () => {
                 )
             },
           }),
-          'v-expansion-panels': defineComponent({
-            name: 'VExpansionPanelsStub',
-            setup(_, { slots }) {
-              return () =>
-                h('div', { class: 'expansion-panels-stub' }, slots.default?.())
-            },
-          }),
-          'v-expansion-panel': defineComponent({
-            name: 'VExpansionPanelStub',
-            setup(_, { slots }) {
-              return () =>
-                h('div', { class: 'expansion-panel-stub' }, slots.default?.())
-            },
-          }),
-          'v-expansion-panel-title': defineComponent({
-            name: 'VExpansionPanelTitleStub',
-            setup(_, { slots }) {
-              return () =>
-                h(
-                  'div',
-                  { class: 'expansion-panel-title-stub' },
-                  slots.default?.()
-                )
-            },
-          }),
-          'v-expansion-panel-text': defineComponent({
-            name: 'VExpansionPanelTextStub',
-            setup(_, { slots }) {
-              return () =>
-                h(
-                  'div',
-                  { class: 'expansion-panel-text-stub' },
-                  slots.default?.()
-                )
-            },
-          }),
           ClientOnly: defineComponent({
             name: 'ClientOnlyStub',
             setup(_, { slots }) {
@@ -172,7 +135,6 @@ describe('ProductImpactSubscoreGenericCard', () => {
     expect(wrapper.find('.impact-subscore__value-number').text()).toBe('42.5')
     expect(wrapper.text()).toContain('How to read this indicator')
     expect(wrapper.text()).toContain('Lower is better')
-    expect(wrapper.text()).toContain('View indicator details')
     expect(wrapper.text()).not.toContain('Percentile')
     expect(wrapper.text()).toContain('Rank')
     expect(wrapper.text()).toContain('3')
@@ -215,42 +177,6 @@ describe('ProductImpactSubscoreGenericCard', () => {
                   'span',
                   { class: 'coefficient-stub' },
                   `coefficient:${props.value}`
-                )
-            },
-          }),
-          'v-expansion-panels': defineComponent({
-            name: 'VExpansionPanelsStub',
-            setup(_, { slots }) {
-              return () =>
-                h('div', { class: 'expansion-panels-stub' }, slots.default?.())
-            },
-          }),
-          'v-expansion-panel': defineComponent({
-            name: 'VExpansionPanelStub',
-            setup(_, { slots }) {
-              return () =>
-                h('div', { class: 'expansion-panel-stub' }, slots.default?.())
-            },
-          }),
-          'v-expansion-panel-title': defineComponent({
-            name: 'VExpansionPanelTitleStub',
-            setup(_, { slots }) {
-              return () =>
-                h(
-                  'div',
-                  { class: 'expansion-panel-title-stub' },
-                  slots.default?.()
-                )
-            },
-          }),
-          'v-expansion-panel-text': defineComponent({
-            name: 'VExpansionPanelTextStub',
-            setup(_, { slots }) {
-              return () =>
-                h(
-                  'div',
-                  { class: 'expansion-panel-text-stub' },
-                  slots.default?.()
                 )
             },
           }),

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -41,28 +41,17 @@
       :label="score.label"
     />
 
-    <v-expansion-panels
-      v-if="hasDetails"
-      class="impact-subscore__details"
-      variant="accordion"
-    >
-      <v-expansion-panel elevation="0" rounded="lg">
-        <v-expansion-panel-title class="impact-subscore__details-title">
-          {{ $t('product.impact.subscoreDetailsToggle') }}
-        </v-expansion-panel-title>
-        <v-expansion-panel-text class="impact-subscore__details-content">
-          <ProductImpactSubscoreExplanation
-            :score="score"
-            :absolute-value="absoluteValue"
-            :product-name="productName"
-            :product-brand="productBrand"
-            :product-model="productModel"
-            :vertical-title="verticalTitle"
-            :importance-description="importanceDescription"
-          />
-        </v-expansion-panel-text>
-      </v-expansion-panel>
-    </v-expansion-panels>
+    <div v-if="hasDetails" class="impact-subscore__details">
+      <ProductImpactSubscoreExplanation
+        :score="score"
+        :absolute-value="absoluteValue"
+        :product-name="productName"
+        :product-brand="productBrand"
+        :product-model="productModel"
+        :vertical-title="verticalTitle"
+        :importance-description="importanceDescription"
+      />
+    </div>
   </article>
 </template>
 
@@ -255,26 +244,6 @@ const coefficientValue = computed(() => {
   border-radius: 18px;
   background: rgba(var(--v-theme-surface-glass), 0.9);
   box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.05);
-}
-
-.impact-subscore__details-title {
-  font-weight: 600;
-  color: rgb(var(--v-theme-text-neutral-strong));
-}
-
-.impact-subscore__details-content {
-  padding-top: 0;
-}
-
-.impact-subscore__details :deep(.v-expansion-panel-title__overlay) {
-  display: none;
-}
-
-.impact-subscore__details :deep(.v-expansion-panel-title) {
-  padding: 0.75rem 1rem;
-}
-
-.impact-subscore__details :deep(.v-expansion-panel-text__wrapper) {
-  padding: 0 1rem 1rem;
+  padding: 1rem;
 }
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2530,7 +2530,6 @@
           }
         }
       },
-      "primaryScoreLabel": "Overall impact",
       "radarAria": "Impact radar chart for {product}",
       "radarControls": {
         "ariaLabel": "Toggle radar comparison series",
@@ -2563,7 +2562,6 @@
         "DURABILITY": "Durability",
         "ESG": "ESG performance"
       },
-      "showDetails": "Show detailed indicators",
       "hideDetails": "Hide detailed indicators",
       "title": "Environmental impact"
     },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2546,7 +2546,6 @@
           }
         }
       },
-      "primaryScoreLabel": "Score global",
       "radarAria": "Radar des scores pour {product}",
       "radarControls": {
         "ariaLabel": "Afficher ou masquer les produits à comparer sur le radar",
@@ -2579,7 +2578,6 @@
         "DURABILITY": "Durabilité",
         "ESG": "Performance ESG"
       },
-      "showDetails": "Afficher les indicateurs détaillés",
       "hideDetails": "Masquer les indicateurs détaillés",
       "title": "Impact Score"
     },


### PR DESCRIPTION
### Motivation
- Present the primary impact score as a larger badge-only widget and remove the eyebrow label to free visual space.  
- Surface the radar chart directly and remove duplicate subscore cards that are already shown in the details table.  
- Make subscore explanation content always visible (drop the accordion/expansion UI) and blank aggregate placeholders instead of showing dashes.  
- Ensure changes are validated with lint and test runs as part of the rollout.

### Description
- Updated `ProductImpactEcoScoreCard.vue` to remove the eyebrow, render `ImpactScore` with `size="xxlarge"`, `mode="badge"` and `badge-layout="stacked"`, and removed the subscores accordion in favor of always showing the radar when applicable.  
- Simplified wiring by removing `loading`/`secondaryScores` props and related logic from `ProductImpactSection.vue` and the page usage in `ProductPage.vue`.  
- Changed `ProductImpactDetailsTable.vue` so aggregate rows use an empty string for `attributeValue` and only render lifecycle placeholder dashes for non-aggregate rows.  
- Replaced expansion panels in `ProductImpactSubscoreGenericCard.vue` with always-visible `ProductImpactSubscoreExplanation`, adjusted related CSS, and updated unit tests and i18n entries to match the new UI.

### Testing
- Ran `pnpm --offline lint` and lint completed successfully.  
- Ran `pnpm --offline test` (Vitest); the run stalled with many queued tests and was terminated (did not complete successfully).  
- Ran `pnpm --offline generate`; build failed due to a missing external dependency (`vue-hotjar`) unrelated to the UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b63a611c832bbfed732d77e637c0)