### PR TITLE
Add translucent average/product marker columns to subscore distribution chart

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
@@ -16,6 +16,7 @@
 
 <script setup lang="ts">
 import { computed, defineAsyncComponent } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { EChartsOption } from 'echarts'
 import type { DistributionBucket } from './impact-types'
 import { ensureECharts } from '~/utils/echarts-loader'
@@ -25,7 +26,12 @@ let echartsRegistered = false
 const props = defineProps<{
   distribution: DistributionBucket[]
   label: string
+  averageValue?: number | null
+  currentValue?: number | null
+  productName?: string
 }>()
+
+const { t } = useI18n()
 
 const VueECharts = defineAsyncComponent(async () => {
   if (import.meta.client) {
@@ -58,10 +64,228 @@ const filteredDistribution = computed(() =>
 
 const hasData = computed(() => filteredDistribution.value.length > 0)
 
+type BucketRange = {
+  min?: number
+  max?: number
+  exact?: number
+}
+
+const parseNumber = (value: string): number | null => {
+  const normalized = value.replace(/,/g, '.')
+  const match = normalized.match(/-?\d+(\.\d+)?/)
+  if (!match) {
+    return null
+  }
+
+  const parsed = Number.parseFloat(match[0])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const parseBucketRange = (label: string): BucketRange | null => {
+  const trimmed = label.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const rangeMatch = trimmed.match(
+    /(-?\d+(?:[.,]\d+)?)\s*[-–—]\s*(-?\d+(?:[.,]\d+)?)/
+  )
+  if (rangeMatch) {
+    const min = parseNumber(rangeMatch[1])
+    const max = parseNumber(rangeMatch[2])
+    if (min != null && max != null) {
+      return { min, max }
+    }
+  }
+
+  if (trimmed.includes('+')) {
+    const min = parseNumber(trimmed)
+    if (min != null) {
+      return { min }
+    }
+  }
+
+  if (/[<≤]/.test(trimmed)) {
+    const max = parseNumber(trimmed)
+    if (max != null) {
+      return { max }
+    }
+  }
+
+  if (/[>≥]/.test(trimmed)) {
+    const min = parseNumber(trimmed)
+    if (min != null) {
+      return { min }
+    }
+  }
+
+  const exact = parseNumber(trimmed)
+  if (exact != null) {
+    return { exact }
+  }
+
+  return null
+}
+
+const resolveBucketIndex = (
+  value: number | null | undefined,
+  buckets: DistributionBucket[]
+): number | null => {
+  if (value == null || !Number.isFinite(value)) {
+    return null
+  }
+
+  const ranges = buckets.map(bucket => parseBucketRange(bucket.label))
+
+  for (let index = 0; index < ranges.length; index += 1) {
+    const range = ranges[index]
+    if (!range) {
+      continue
+    }
+
+    if (range.exact != null && value === range.exact) {
+      return index
+    }
+
+    if (range.min != null && range.max != null) {
+      if (value >= range.min && value <= range.max) {
+        return index
+      }
+      continue
+    }
+
+    if (range.min != null && range.max == null && value >= range.min) {
+      return index
+    }
+
+    if (range.max != null && range.min == null && value <= range.max) {
+      return index
+    }
+  }
+
+  const numericCandidates = ranges
+    .map((range, index) => {
+      if (!range) {
+        return null
+      }
+
+      if (range.exact != null) {
+        return { index, value: range.exact }
+      }
+
+      if (range.min != null && range.max != null) {
+        return { index, value: (range.min + range.max) / 2 }
+      }
+
+      if (range.min != null) {
+        return { index, value: range.min }
+      }
+
+      if (range.max != null) {
+        return { index, value: range.max }
+      }
+
+      return null
+    })
+    .filter(
+      (candidate): candidate is { index: number; value: number } =>
+        candidate != null
+    )
+
+  if (!numericCandidates.length) {
+    return null
+  }
+
+  const closest = numericCandidates.reduce((best, candidate) =>
+    Math.abs(candidate.value - value) < Math.abs(best.value - value)
+      ? candidate
+      : best
+  )
+
+  return closest.index
+}
+
+const resolveProductName = computed(() => {
+  const candidate = props.productName?.trim()
+  return candidate?.length
+    ? candidate
+    : t('product.impact.subscoreChart.unknownProduct')
+})
+
 const chartOption = computed<EChartsOption | null>(() => {
   if (!hasData.value) {
     return null
   }
+
+  const dataValues = filteredDistribution.value.map(bucket => bucket.value)
+  const maxValue = Math.max(0, ...dataValues)
+  const yAxisMax = Math.max(1, Math.ceil(maxValue * 1.2))
+  const productIndex = resolveBucketIndex(
+    props.currentValue,
+    filteredDistribution.value
+  )
+  const averageIndex = resolveBucketIndex(
+    props.averageValue,
+    filteredDistribution.value
+  )
+
+  const buildMarkerSeries = (
+    name: string,
+    index: number | null,
+    color: string,
+    tooltipKey: string,
+    tooltipParams: Record<string, string>
+  ) => {
+    if (index == null) {
+      return null
+    }
+
+    return {
+      type: 'bar',
+      name,
+      barGap: '-100%',
+      barWidth: '90%',
+      data: filteredDistribution.value.map((_, bucketIndex) =>
+        bucketIndex === index ? yAxisMax : 0
+      ),
+      itemStyle: {
+        color,
+      },
+      emphasis: {
+        itemStyle: {
+          opacity: 0.35,
+        },
+      },
+      tooltip: {
+        trigger: 'item',
+        position: 'top',
+        formatter: () => t(tooltipKey, tooltipParams),
+      },
+      z: 1,
+    }
+  }
+
+  const markerSeries = [
+    buildMarkerSeries(
+      'average',
+      averageIndex,
+      'rgba(148, 163, 184, 0.28)',
+      'product.impact.subscoreChart.markerAverage',
+      { scoreLabel: props.label }
+    ),
+    buildMarkerSeries(
+      'product',
+      productIndex,
+      'rgba(33, 150, 243, 0.22)',
+      'product.impact.subscoreChart.markerProduct',
+      { productName: resolveProductName.value }
+    ),
+  ].filter(
+    (
+      series
+    ): series is NonNullable<ReturnType<typeof buildMarkerSeries>> =>
+      series != null
+  )
 
   return {
     grid: { top: 20, left: 40, right: 20, bottom: 40 },
@@ -71,16 +295,18 @@ const chartOption = computed<EChartsOption | null>(() => {
       data: filteredDistribution.value.map(bucket => bucket.label),
       axisLabel: { rotate: 35 },
     },
-    yAxis: { type: 'value' },
+    yAxis: { type: 'value', max: yAxisMax },
     series: [
       {
         type: 'bar',
         name: props.label,
-        data: filteredDistribution.value.map(bucket => bucket.value),
+        data: dataValues,
         itemStyle: {
           color: 'rgba(33, 150, 243, 0.75)',
         },
+        z: 2,
       },
+      ...markerSeries,
     ],
   }
 })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -39,6 +39,9 @@
       v-if="hasDistribution"
       :distribution="score.distribution ?? []"
       :label="score.label"
+      :average-value="score.absolute?.avg ?? null"
+      :current-value="score.value ?? null"
+      :product-name="productName"
     />
 
     <v-expansion-panels

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2491,6 +2491,11 @@
       "weightTooltip": "The {scoreName} score counts for {value}% of the total score",
       "subscoreDetailsToggle": "View indicator details",
       "subscoreEyebrow": "Impact indicator",
+      "subscoreChart": {
+        "markerAverage": "Average for {scoreLabel} sits here.",
+        "markerProduct": "{productName} sits here.",
+        "unknownProduct": "This product"
+      },
       "importanceTitle": "Why it matters",
       "subscores": {
         "default": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2507,6 +2507,11 @@
       "weightTooltip": "Le score {scoreName} compte pour {value}% de la note totale",
       "subscoreDetailsToggle": "Voir les détails de l'indicateur",
       "subscoreEyebrow": "Indicateur d'impact",
+      "subscoreChart": {
+        "markerAverage": "La moyenne de {scoreLabel} se positionne ici.",
+        "markerProduct": "{productName} se positionne ici.",
+        "unknownProduct": "Ce produit"
+      },
       "importanceTitle": "Pourquoi c'est important ?",
       "subscores": {
         "default": {


### PR DESCRIPTION
### Motivation

- Surface average and current product positions on distribution charts as translucent full-height marker columns for better visual comparison.
- Support varied bucket label formats by parsing ranges, inequalities and exact values to map numeric indicators to buckets robustly.
- Use `score.absolute.avg` for the average and `score.value` for the current product value and fall back to a friendly product name when needed.
- Provide localized tooltip copy for the new markers in English and French.

### Description

- Add `averageValue`, `currentValue` and `productName` props to `ProductImpactSubscoreChart.vue` and compute marker positions via a new `resolveBucketIndex` routine that parses bucket labels. 
- Render translucent marker bar series layered on top of the main distribution bar with localized tooltips using `vue-i18n`, and adjust `yAxis` scaling to accommodate markers. 
- Pass `score.absolute?.avg` and `score.value` and `productName` from `ProductImpactSubscoreGenericCard.vue` into the chart component. 
- Add i18n strings for marker tooltips and an unknown-product fallback in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`.

### Testing

- Ran linter with `pnpm --offline lint`, which completed successfully.  
- Ran unit tests with `pnpm --offline test`, but the Vitest run stalled in queued state and was interrupted (no tests completed).  
- Ran site generation with `pnpm --offline generate`, which failed due to a Rollup build error resolving an external plugin (`vue-hotjar`) unrelated to the chart changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bc35c2f8832bbb9baba970710632)