### PR TITLE
Add localized impact score utility explanations and surface them on product page

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -436,11 +436,15 @@ const availableImpactCriteriaMap = computed(() => {
       map.set(normalizedKey, {
         title: attribute?.scoreTitle ?? attribute?.name ?? normalizedKey,
         description: attribute?.scoreDescription ?? null,
+        utility: attribute?.scoreUtility ?? null,
       })
     }
 
     return map
-  }, new Map<string, { title: string; description: string | null }>())
+  }, new Map<
+    string,
+    { title: string; description: string | null; utility: string | null }
+  >())
 })
 
 if (categorySlug) {
@@ -1125,7 +1129,7 @@ const impactScores = computed(() => {
       unit: attributeConfig?.unit ?? attributeConfig?.suffix ?? null,
       aggregates,
       betterIs: attributeConfig?.betterIs ?? null,
-      importanceDescription: criterion?.description ?? null,
+      importanceDescription: criterion?.utility ?? null,
     }
   })
 })

--- a/verticals/src/main/resources/attributes/BRAND_SUSTAINABILITY.yml
+++ b/verticals/src/main/resources/attributes/BRAND_SUSTAINABILITY.yml
@@ -6,5 +6,8 @@ name:
   default: "Evaluation ESG (Sustainalytics) de la marque"
   fr: "Evaluation ESG de la marque (Sustainalytics)"
 asScore: true
+scoreUtility:
+  fr: "Reflète les engagements globaux de la marque qui influencent l’empreinte de ses produits."
+  en: "Reflects brand-wide commitments that influence the footprint of its products."
 participateInScores:
   - ESG

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY.yml
@@ -12,6 +12,7 @@ scoreDescription:
   fr: "La classe énergétique"
 scoreUtility:
   fr: "Offre un repère immédiat sur l’efficacité globale de l’appareil pendant son utilisation quotidienne."
+  en: "Provides a quick signal of overall energy efficiency during daily use."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY_HDR.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY_HDR.yml
@@ -17,6 +17,7 @@ scoreDescription:
   fr: "La classe énergétique du téléviseur en mode HDR"
 scoreUtility:
   fr: "Met en avant la performance énergétique en HDR, un mode énergivore qui pèse sur l’empreinte d’usage des téléviseurs modernes."
+  en: "Shows energy efficiency in HDR mode, which can meaningfully raise usage impact."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY_SDR.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY_SDR.yml
@@ -16,7 +16,8 @@ scoreTitle:
 scoreDescription:
   fr: "La classe énergétique du téléviseur en mode SDR"
 scoreUtility:
-  fr: "Ce score illustre l’efficacité énergétique en mode SDR, phase la plus fréquente d’usage d’un téléviseur, et oriente vers des modèles moins énergivores pendant toute leur durée de vie."
+  fr: "Résume l’efficacité énergétique en mode SDR, le plus utilisé, pour comparer les modèles et limiter la consommation sur la durée."
+  en: "Summarises SDR energy efficiency, the most common mode, to compare models quickly and reduce lifetime electricity use."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/DATA_QUALITY.yml
+++ b/verticals/src/main/resources/attributes/DATA_QUALITY.yml
@@ -6,3 +6,6 @@ name:
   default: "Data quality"
   fr: "Qualité de la donnée"
 asScore: true
+scoreUtility:
+  fr: "Des données complètes améliorent la fiabilité du score et évitent de pénaliser ou favoriser un produit sur des valeurs manquantes."
+  en: "Complete data improves score reliability and avoids unfair penalties or bonuses from missing values."

--- a/verticals/src/main/resources/attributes/DIAGONALE_POUCES.yml
+++ b/verticals/src/main/resources/attributes/DIAGONALE_POUCES.yml
@@ -16,6 +16,9 @@ suffix:
   fr: "\""
 filteringType: "NUMERIC"
 asScore: true
+scoreUtility:
+  fr: "La diagonale influe sur matériaux et énergie : plus elle est grande, plus l’impact de fabrication, transport et usage augmente."
+  en: "Screen size drives materials and energy; larger sizes usually raise manufacturing, transport, and use impacts."
 participateInACV:
   - MANUFACTURING
   - TRANSPORTATION

--- a/verticals/src/main/resources/attributes/ESG.yml
+++ b/verticals/src/main/resources/attributes/ESG.yml
@@ -14,3 +14,4 @@ scoreDescription:
 scoreUtility:
   default: "Highlights brands with robust ESG commitments contributing to lower lifecycle risks."
   fr: "Met en avant les marques avec des engagements ESG solides, réduisant les risques sur le cycle de vie."
+  en: "Highlights brands with strong ESG commitments that lower lifecycle risks."

--- a/verticals/src/main/resources/attributes/MINAVAILABILITYSOFTWAREUPDATESYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINAVAILABILITYSOFTWAREUPDATESYEARS.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "Durée minimale de disponibilité des mises à jour logicielles"
 scoreUtility:
   fr: "Garantit la sécurité et la compatibilité du produit sur le long terme, prolongeant son usage et évitant un renouvellement prématuré."
+  en: "Long update support keeps security and apps working, extending product life."
 participateInScores:
   - DURABILITY
 participateInACV:

--- a/verticals/src/main/resources/attributes/MINAVAILABILITYSPAREPARTSYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINAVAILABILITYSPAREPARTSYEARS.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "Durée minimale de disponibilité des pièces détachées"
 scoreUtility:
   fr: "Une longue disponibilité des pièces prolonge la réparabilité, évite le remplacement prématuré et limite les déchets en fin de vie."
+  en: "Long spare-parts availability keeps products repairable, avoids premature replacement, and reduces end-of-life waste."
 participateInScores:
   - REPARABILITY
 participateInACV:

--- a/verticals/src/main/resources/attributes/MINGUARANTEEDSUPPORTYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINGUARANTEEDSUPPORTYEARS.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "Durée minimale du support garanti"
 scoreUtility:
   fr: "Assure la maintenance et les correctifs nécessaires pour maintenir l’appareil sûr et fonctionnel sur la durée."
+  en: "Guaranteed support keeps devices secure and functional for longer, reducing early replacement."
 participateInScores:
   - DURABILITY
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_HDR.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_HDR.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "La consommation électrique du téléviseur en mode HDR (haute définition)"
 scoreUtility:
   fr: "Prend en compte l’énergie dépensée dans le mode HDR plus exigeant, important pour les usages intensifs."
+  en: "Captures energy used in demanding HDR mode, which matters for heavy viewing and higher brightness peaks."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_OFF.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_OFF.yml
@@ -9,6 +9,7 @@ scoreDescription:
   fr: "La consommation électrique à l'arrêt, ou en veille"
 scoreUtility:
   fr: "Met en lumière les pertes résiduelles quand l’appareil est éteint pour réduire le gaspillage permanent."
+  en: "Highlights residual losses when the device is off to reduce permanent waste."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_SDR.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_SDR.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "La consommation électrique du téléviseur en mode SDR (basse définition)"
 scoreUtility:
   fr: "Reflète la dépense énergétique sur le mode SDR majoritaire, clé pour réduire l’impact d’usage quotidien."
+  en: "Tracks SDR energy use, the most common viewing mode, to lower everyday impact."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "La consommation électrique de l'appareil en mode veille"
 scoreUtility:
   fr: "Quantifie la consommation continue en veille et met en évidence les gains possibles en limitant l’énergie passive."
+  en: "Shows continuous standby draw and the savings from reducing passive energy use."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY_NETWORKD.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY_NETWORKD.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "La consommation électrique de l'appareil en mode veille ou réseau"
 scoreUtility:
   fr: "Capture l’énergie consommée en veille réseau, souvent continue, pour réduire l’impact cumulé sur toute la durée de vie."
+  en: "Captures energy used in networked standby, often continuous, to reduce cumulative lifetime impact."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_TYPICAL.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_TYPICAL.yml
@@ -9,6 +9,7 @@ scoreDescription:
   fr: "La consommation électrique de l'objet en fonctionnement"
 scoreUtility:
   fr: "Mesure directe de l’énergie consommée en usage réel, principale source d’émissions pendant la phase d’utilisation."
+  en: "Directly measures energy use during operation, the main source of use-phase emissions."
 participateInScores:
   - ENERGY_CONSUMPTION
 participateInACV:

--- a/verticals/src/main/resources/attributes/REPAIRABILITY_INDEX.yml
+++ b/verticals/src/main/resources/attributes/REPAIRABILITY_INDEX.yml
@@ -12,6 +12,7 @@ scoreDescription:
   fr: "L'indice de réparabilité de l'objet"
 scoreUtility:
   fr: "Un indice élevé prolonge la durée de vie, limite les remplacements et réduit les impacts de fabrication et de fin de vie."
+  en: "Higher repairability extends product life, reduces replacements, and cuts manufacturing and waste impacts."
 participateInScores:
   - REPARABILITY
 participateInACV:

--- a/verticals/src/main/resources/attributes/WARRANTY.yml
+++ b/verticals/src/main/resources/attributes/WARRANTY.yml
@@ -20,6 +20,7 @@ scoreDescription:
   fr: "Durée de garantie du produit"
 scoreUtility:
   fr: "Une garantie longue encourage la durabilité en incitant les fabricants à concevoir des produits plus fiables et réparables."
+  en: "Longer warranties encourage durable design, repairs, and fewer early replacements."
 participateInScores:
   - DURABILITY
 participateInACV:

--- a/verticals/src/main/resources/attributes/WEIGHT.yml
+++ b/verticals/src/main/resources/attributes/WEIGHT.yml
@@ -18,6 +18,7 @@ scoreDescription:
   fr: "Le poids de l'objet"
 scoreUtility:
   fr: "Le poids reflète la quantité de matière et l’énergie grise mobilisées, impactant l’extraction, la fabrication et le transport."
+  en: "Weight signals material intensity and embodied energy, affecting extraction, manufacturing, and transport impacts."
 participateInACV:
   - EXTRACTION
   - TRANSPORTATION


### PR DESCRIPTION
### Motivation

- Surface concise “why it matters” copy for impact subscores on product pages by using the attribute `scoreUtility` field.
- Provide localized (French/English) short explanations so the importance copy is available for all scorable attributes.

### Description

- Updated `frontend/app/components/pages/ProductPage.vue` to include `utility` in the `availableImpactCriteriaMap` and to use `criterion?.utility` for the subscore `importanceDescription` shown on product pages. 
- Added `scoreUtility` (with `fr` and `en`) to all attribute YAMLs under `verticals/src/main/resources/attributes/` that have `asScore: true` to provide localized “why it matters” text. 
- Adjusted the return map typing in `ProductPage.vue` so the criteria map includes the new `utility` field. 
- Modified ~20 attribute config files to add the concise `scoreUtility` explanations.

### Testing

- Ran a repository script that checks every `*.yml` with `asScore: true` contains a `scoreUtility` block and an `en` entry, and the check passed. 
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965be505c58832b81bb93c9c3027186)