### PR TITLE
Add percentile fallback for low-entropy impact scores

### DIFF
--- a/docs/scoring_methodology.md
+++ b/docs/scoring_methodology.md
@@ -37,6 +37,29 @@ Scores are mapped linearly within this range:
 2.  **Representativity**: A product with "Average" performance receives an "Average" score (2.5), aligning with user expectations.
 3.  **Automatic Tuning**: The scale adjusts automatically to the diversity (variance) of the products in the category.
 
+## Low-Entropy Distributions: Percentile Scoring Fallback
+
+Some attributes are reported in **coarse buckets** (e.g., 0 W, 0.5 W, 2 W) even when the dataset is large. In these cases, the standard deviation is small and sigma scoring compresses values near the mean, making the "worst" value look average. To preserve meaningful separation, the system switches to **percentile scoring** when the number of distinct values is too low.
+
+### Switching Rule (Configurable)
+
+Sigma scoring remains the default. The fallback is activated when:
+
+```
+distinctValues < impactScoreConfig.minDistinctValuesForSigma
+```
+
+### Percentile Scoring (Mid-rank)
+
+For a given value:
+
+```
+Percentile = (CountBelow + 0.5 * CountAt) / TotalCount
+Score = Percentile * 5
+```
+
+This preserves a smooth ranking even for discrete values while keeping scores on the same 0–5 scale.
+
 ## Technical Implementation
 
 This logic is implemented in `AbstractScoreAggregationService.java`.

--- a/model/src/main/java/org/open4goods/model/vertical/ImpactScoreConfig.java
+++ b/model/src/main/java/org/open4goods/model/vertical/ImpactScoreConfig.java
@@ -12,6 +12,13 @@ public class ImpactScoreConfig {
 	 */
 	private Map<String, Double> criteriasPonderation = new HashMap<>();
 
+	/**
+	 * Minimum number of distinct values required to use sigma scoring.
+	 * When the distribution is too discrete (lower than this threshold),
+	 * percentile scoring is used to preserve meaningful separation.
+	 */
+	private Integer minDistinctValuesForSigma;
+
 	////////////////////////
 	// Audit / justification
 	///////////////////////
@@ -28,6 +35,12 @@ public class ImpactScoreConfig {
 	}
 	public void setCriteriasPonderation(Map<String, Double> criteriasPonderation) {
 		this.criteriasPonderation = criteriasPonderation;
+	}
+	public Integer getMinDistinctValuesForSigma() {
+		return minDistinctValuesForSigma;
+	}
+	public void setMinDistinctValuesForSigma(Integer minDistinctValuesForSigma) {
+		this.minDistinctValuesForSigma = minDistinctValuesForSigma;
 	}
 	public Localisable<String, ImpactScoreTexts> getTexts() {
 		return texts;

--- a/verticals/src/main/java/org/open4goods/verticals/VerticalsConfigService.java
+++ b/verticals/src/main/java/org/open4goods/verticals/VerticalsConfigService.java
@@ -24,6 +24,7 @@ import org.open4goods.model.vertical.AttributeComparisonRule;
 import org.open4goods.model.vertical.AttributeConfig;
 import org.open4goods.model.vertical.AttributeParserConfig;
 import org.open4goods.model.vertical.AttributesConfig;
+import org.open4goods.model.vertical.ImpactScoreConfig;
 import org.open4goods.model.vertical.NudgeToolConfig;
 import org.open4goods.model.vertical.NudgeToolScore;
 import org.open4goods.model.vertical.NudgeToolSubsetGroup;
@@ -285,6 +286,14 @@ public class VerticalsConfigService {
 				mergeStringSet(defaults.getRequiredAttributes(), config.getRequiredAttributes()));
 		config.setBrandsAlias(mergeMap(defaults.getBrandsAlias(), config.getBrandsAlias()));
 		config.setSubsets(mergeByKey(defaults.getSubsets(), config.getSubsets(), VerticalSubset::getId));
+
+		ImpactScoreConfig impactScoreConfig = config.getImpactScoreConfig();
+		ImpactScoreConfig defaultImpactScoreConfig = defaults.getImpactScoreConfig();
+		if (impactScoreConfig != null && defaultImpactScoreConfig != null) {
+			if (impactScoreConfig.getMinDistinctValuesForSigma() == null) {
+				impactScoreConfig.setMinDistinctValuesForSigma(defaultImpactScoreConfig.getMinDistinctValuesForSigma());
+			}
+		}
 
 		AttributesConfig attributesConfig = config.getAttributesConfig();
 		AttributesConfig defaultAttributesConfig = defaults.getAttributesConfig();

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -48,6 +48,13 @@ availableImpactScoreCriterias:
   - DATA_QUALITY
   - BRAND_SUSTAINABILITY
 
+#####################################################################################################################################
+# Impact score normalization safeguards
+#####################################################################################################################################
+
+impactScoreConfig:
+  minDistinctValuesForSigma: 6
+
 subsets:
   ################
   # Impact Score


### PR DESCRIPTION
### Motivation
- Sigma-based relativization compresses values when an attribute has very few distinct values, causing poor ranking separation. 
- Introduce a robust fallback (percentile scoring) to keep meaningful separation for coarse/discrete distributions. 
- Make the switching rule configurable per vertical so defaults can be tuned centrally. 
- Document the behaviour so operators understand when percentile vs sigma scoring is used. 

### Description
- Add frequency tracking and percentile fallback logic to `AbstractScoreAggregationService` via `valueFrequencies`, `relativizeScoreValue`, `shouldUsePercentileScoring` and `relativizeUsingPercentile`. 
- Record value occurrences in `incrementCardinality` and use them to decide between sigma and percentile scoring at relativization time. 
- Expose a new configuration parameter `minDistinctValuesForSigma` on `ImpactScoreConfig` and merge it from the vertical defaults in `VerticalsConfigService`. 
- Add a default `impactScoreConfig.minDistinctValuesForSigma: 6` to `verticals/_default.yml`, update tests in `AbstractScoreAggregationServiceTest`, and update docs (`docs/ImpactScore_Computation.md` and `docs/scoring_methodology.md`). 

### Testing
- Ran `mvn --offline -pl api,verticals,model -am test` and all module unit tests executed successfully. 
- New unit tests in `api/src/test/java/.../AbstractScoreAggregationServiceTest.java` covering percentile and sigma branches passed. 
- Verified configuration merging by adding default to `verticals/_default.yml` and ensuring `VerticalsConfigService` propagates it. 
- Frontend lint `pnpm -C frontend lint` was attempted but failed due to existing unrelated lint errors in the frontend tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d0fbf13c832b95679b19d2c9bc33)