### PR TITLE
Refactor privacy menu: account privacy card UI, user-agent tooltip, and guest icon spacing

### DIFF
--- a/frontend/app/components/shared/menus/AccountPrivacyCard.vue
+++ b/frontend/app/components/shared/menus/AccountPrivacyCard.vue
@@ -5,6 +5,20 @@
     elevation="4"
     data-testid="account-privacy-card"
   >
+    <div class="account-privacy-card__hero">
+      <div class="account-privacy-card__hero-icon">
+        <v-icon icon="mdi-shield-check" size="36" color="primary" />
+      </div>
+      <div class="account-privacy-card__hero-copy">
+        <p class="account-privacy-card__hero-title">
+          {{ t('siteIdentity.menu.account.privacy.hero.title') }}
+        </p>
+        <p class="account-privacy-card__hero-subtitle">
+          {{ t('siteIdentity.menu.account.privacy.hero.subtitle') }}
+        </p>
+      </div>
+    </div>
+
     <div class="account-privacy-card__header">
       <v-avatar
         size="44"
@@ -25,162 +39,225 @@
 
     <v-divider class="my-4" />
 
-    <!-- IP Address -->
     <div class="account-privacy-card__section">
-      <div class="account-privacy-card__section-header">
-        <div>
-          <p class="account-privacy-card__section-title">
-            {{ t('siteIdentity.menu.account.privacy.ip.title') }}
-          </p>
-          <p class="account-privacy-card__section-description">
-            {{ t('siteIdentity.menu.account.privacy.ip.description') }}
-          </p>
-        </div>
-        <v-chip
-          size="small"
-          color="surface-primary-100"
-          variant="flat"
-          class="account-privacy-card__chip font-weight-bold"
-        >
-          {{ ipLabel }}
-        </v-chip>
-      </div>
-    </div>
-
-    <!-- Quotas -->
-    <div class="account-privacy-card__section">
-      <p class="account-privacy-card__section-title mb-2">
-        {{ t('siteIdentity.menu.account.privacy.quotas.title') }}
+      <p class="account-privacy-card__section-label">
+        {{ t('siteIdentity.menu.account.privacy.sections.remote') }}
       </p>
-      <v-list density="compact" nav bg-color="transparent" class="pa-0">
-        <v-list-item v-if="aiQuota !== null" class="px-0">
-          <template #prepend>
-            <v-icon icon="mdi-robot-outline" size="small" class="mr-2" />
-          </template>
-          <div class="d-flex align-center ga-2 w-100">
-            <span class="text-body-2">{{
-              t('siteIdentity.menu.account.privacy.quotas.aiRemaining')
-            }}</span>
-            <v-chip size="x-small" color="primary" variant="flat">{{
-              aiQuota
-            }}</v-chip>
-          </div>
-        </v-list-item>
-        <v-list-item
-          v-if="voteQuota !== null"
-          to="/feedback"
-          class="px-0"
-          color="primary"
-        >
-          <template #prepend>
-            <v-icon icon="mdi-vote-outline" size="small" class="mr-2" />
-          </template>
-          <div class="d-flex align-center ga-2 w-100">
-            <span class="text-body-2">{{
-              t('siteIdentity.menu.account.privacy.quotas.votesRemaining')
-            }}</span>
-            <v-chip size="x-small" color="primary" variant="flat">{{
-              voteQuota
-            }}</v-chip>
-          </div>
-        </v-list-item>
-      </v-list>
-    </div>
 
-    <!-- Cookies -->
-    <div class="account-privacy-card__section">
-      <div
-        class="d-flex justify-space-between align-center mb-2 cursor-pointer"
-        @click="isCookiesListOpen = !isCookiesListOpen"
-      >
-        <div class="d-flex align-center ga-2">
-          <p class="account-privacy-card__section-title">
-            {{ t('siteIdentity.menu.account.privacy.cookies.title') }}
-          </p>
-          <v-icon
-            :icon="isCookiesListOpen ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-            size="small"
-            color="neutral-secondary"
-          />
-        </div>
-        <v-btn
-          color="primary"
-          variant="text"
-          size="x-small"
-          data-testid="privacy-reset-cookies"
-          :disabled="cookieKeys.length === 0"
-          @click.stop="handleClearCookies"
-        >
-          {{ t('siteIdentity.menu.account.privacy.cookies.resetCta') }}
-        </v-btn>
+      <div class="account-privacy-card__subsection">
+        <p class="account-privacy-card__section-title mb-2">
+          {{ t('siteIdentity.menu.account.privacy.quotas.title') }}
+        </p>
+        <v-list density="compact" nav bg-color="transparent" class="pa-0">
+          <v-list-item v-if="aiQuota !== null" class="px-0">
+            <template #prepend>
+              <v-icon icon="mdi-robot-outline" size="small" class="mr-2" />
+            </template>
+            <div class="d-flex align-center ga-2 w-100">
+              <div class="d-flex align-center ga-2">
+                <span class="text-body-2">{{
+                  t('siteIdentity.menu.account.privacy.quotas.aiRemaining')
+                }}</span>
+                <v-tooltip location="top">
+                  <template #activator="{ props }">
+                    <v-icon
+                      v-bind="props"
+                      icon="mdi-information-outline"
+                      size="small"
+                      color="neutral-secondary"
+                    />
+                  </template>
+                  <span>{{
+                    t('siteIdentity.menu.account.privacy.quotas.aiRemainingTooltip')
+                  }}</span>
+                </v-tooltip>
+              </div>
+              <v-chip size="x-small" color="primary" variant="flat">{{
+                aiQuota
+              }}</v-chip>
+            </div>
+          </v-list-item>
+          <v-list-item
+            v-if="voteQuota !== null"
+            to="/feedback"
+            class="px-0"
+            color="primary"
+          >
+            <template #prepend>
+              <v-icon icon="mdi-vote-outline" size="small" class="mr-2" />
+            </template>
+            <div class="d-flex align-center ga-2 w-100">
+              <span class="text-body-2">{{
+                t('siteIdentity.menu.account.privacy.quotas.votesRemaining')
+              }}</span>
+              <v-chip size="x-small" color="primary" variant="flat">{{
+                voteQuota
+              }}</v-chip>
+            </div>
+          </v-list-item>
+        </v-list>
       </div>
 
-      <v-expand-transition>
-        <v-table
-          v-if="isCookiesListOpen"
-          density="compact"
-          class="account-privacy-table"
-        >
-          <tbody>
-            <tr v-for="key in cookieKeys" :key="key">
-              <td class="text-caption text-neutral-secondary">{{ key }}</td>
-            </tr>
-            <tr v-if="cookieKeys.length === 0">
-              <td class="text-caption text-neutral-soft text-center py-2">
-                {{ t('siteIdentity.menu.account.privacy.cookies.empty') }}
-              </td>
-            </tr>
-          </tbody>
-        </v-table>
-      </v-expand-transition>
-    </div>
-
-    <!-- Storage -->
-    <div class="account-privacy-card__section">
-      <div
-        class="d-flex justify-space-between align-center mb-2 cursor-pointer"
-        @click="isStorageListOpen = !isStorageListOpen"
-      >
-        <div class="d-flex align-center ga-2">
-          <p class="account-privacy-card__section-title">
-            {{ t('siteIdentity.menu.account.privacy.storage.title') }}
-          </p>
-          <v-icon
-            :icon="isStorageListOpen ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-            size="small"
-            color="neutral-secondary"
-          />
-        </div>
-        <v-btn
-          color="primary"
-          variant="text"
-          size="x-small"
-          data-testid="privacy-reset-local-storage"
-          :disabled="localStorageKeys.length === 0"
-          @click.stop="handleClearLocalStorage"
-        >
-          {{ t('siteIdentity.menu.account.privacy.storage.resetCta') }}
-        </v-btn>
+      <div class="account-privacy-card__info-row d-flex align-center ga-2">
+        <span class="text-body-2">{{
+          t('siteIdentity.menu.account.privacy.technicalOnly.label')
+        }}</span>
+        <v-tooltip location="top">
+          <template #activator="{ props }">
+            <v-icon
+              v-bind="props"
+              icon="mdi-information-outline"
+              size="small"
+              color="neutral-secondary"
+            />
+          </template>
+          <span>{{
+            t('siteIdentity.menu.account.privacy.technicalOnly.tooltip')
+          }}</span>
+        </v-tooltip>
       </div>
 
-      <v-expand-transition>
-        <v-table
-          v-if="isStorageListOpen"
-          density="compact"
-          class="account-privacy-table"
+      <div class="account-privacy-card__subsection">
+        <div class="account-privacy-card__section-header">
+          <div>
+            <p class="account-privacy-card__section-title">
+              {{ t('siteIdentity.menu.account.privacy.ip.title') }}
+            </p>
+            <p class="account-privacy-card__section-description">
+              {{ t('siteIdentity.menu.account.privacy.ip.description') }}
+            </p>
+            <div class="account-privacy-card__meta">
+              <div class="account-privacy-card__meta-row">
+                <span class="account-privacy-card__meta-label">
+                  {{ t('siteIdentity.menu.account.privacy.userAgent.label') }}
+                </span>
+                <v-tooltip v-if="userAgentFull" location="top">
+                  <template #activator="{ props }">
+                    <span
+                      v-bind="props"
+                      class="account-privacy-card__meta-value"
+                    >
+                      {{ userAgentDisplay }}
+                    </span>
+                  </template>
+                  <span>{{ userAgentFull }}</span>
+                </v-tooltip>
+                <span v-else class="account-privacy-card__meta-value">
+                  {{ t('siteIdentity.menu.account.privacy.userAgent.unavailable') }}
+                </span>
+              </div>
+            </div>
+          </div>
+          <v-chip
+            size="small"
+            color="surface-primary-100"
+            variant="flat"
+            class="account-privacy-card__chip font-weight-bold"
+          >
+            {{ ipLabel }}
+          </v-chip>
+        </div>
+      </div>
+    </div>
+
+    <div class="account-privacy-card__section">
+      <p class="account-privacy-card__section-label">
+        {{ t('siteIdentity.menu.account.privacy.sections.local') }}
+      </p>
+
+      <div class="account-privacy-card__subsection">
+        <div
+          class="d-flex justify-space-between align-center mb-2 cursor-pointer"
+          @click="isCookiesListOpen = !isCookiesListOpen"
         >
-          <tbody>
-            <tr v-for="key in localStorageKeys" :key="key">
-              <td class="text-caption text-neutral-secondary">{{ key }}</td>
-            </tr>
-            <tr v-if="localStorageKeys.length === 0">
-              <td class="text-caption text-neutral-soft text-center py-2">
-                {{ t('siteIdentity.menu.account.privacy.storage.empty') }}
-              </td>
-            </tr>
-          </tbody>
-        </v-table>
-      </v-expand-transition>
+          <div class="d-flex align-center ga-2">
+            <p class="account-privacy-card__section-title">
+              {{ t('siteIdentity.menu.account.privacy.cookies.title') }}
+            </p>
+            <v-icon
+              :icon="isCookiesListOpen ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+              size="small"
+              color="neutral-secondary"
+            />
+          </div>
+          <v-btn
+            color="primary"
+            variant="text"
+            size="x-small"
+            data-testid="privacy-reset-cookies"
+            :disabled="cookieKeys.length === 0"
+            @click.stop="handleClearCookies"
+          >
+            {{ t('siteIdentity.menu.account.privacy.cookies.resetCta') }}
+          </v-btn>
+        </div>
+
+        <v-expand-transition>
+          <v-table
+            v-if="isCookiesListOpen"
+            density="compact"
+            class="account-privacy-table"
+          >
+            <tbody>
+              <tr v-for="key in cookieKeys" :key="key">
+                <td class="text-caption text-neutral-secondary">{{ key }}</td>
+              </tr>
+              <tr v-if="cookieKeys.length === 0">
+                <td class="text-caption text-neutral-soft text-center py-2">
+                  {{ t('siteIdentity.menu.account.privacy.cookies.empty') }}
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-expand-transition>
+      </div>
+
+      <div class="account-privacy-card__subsection">
+        <div
+          class="d-flex justify-space-between align-center mb-2 cursor-pointer"
+          @click="isStorageListOpen = !isStorageListOpen"
+        >
+          <div class="d-flex align-center ga-2">
+            <p class="account-privacy-card__section-title">
+              {{ t('siteIdentity.menu.account.privacy.storage.title') }}
+            </p>
+            <v-icon
+              :icon="isStorageListOpen ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+              size="small"
+              color="neutral-secondary"
+            />
+          </div>
+          <v-btn
+            color="primary"
+            variant="text"
+            size="x-small"
+            data-testid="privacy-reset-local-storage"
+            :disabled="localStorageKeys.length === 0"
+            @click.stop="handleClearLocalStorage"
+          >
+            {{ t('siteIdentity.menu.account.privacy.storage.resetCta') }}
+          </v-btn>
+        </div>
+
+        <v-expand-transition>
+          <v-table
+            v-if="isStorageListOpen"
+            density="compact"
+            class="account-privacy-table"
+          >
+            <tbody>
+              <tr v-for="key in localStorageKeys" :key="key">
+                <td class="text-caption text-neutral-secondary">{{ key }}</td>
+              </tr>
+              <tr v-if="localStorageKeys.length === 0">
+                <td class="text-caption text-neutral-soft text-center py-2">
+                  {{ t('siteIdentity.menu.account.privacy.storage.empty') }}
+                </td>
+              </tr>
+            </tbody>
+          </v-table>
+        </v-expand-transition>
+      </div>
     </div>
 
     <!-- Compare -->
@@ -203,6 +280,28 @@
         </v-btn>
       </div>
     </div>
+
+    <div class="account-privacy-card__cta">
+      <v-divider class="my-3" />
+      <div class="d-flex flex-wrap justify-space-between ga-2">
+        <v-btn
+          :to="openSourcePath"
+          color="primary"
+          variant="flat"
+          size="small"
+        >
+          {{ t('siteIdentity.menu.account.privacy.ctas.openSource') }}
+        </v-btn>
+        <v-btn
+          :to="dataPrivacyPath"
+          color="primary"
+          variant="text"
+          size="small"
+        >
+          {{ t('siteIdentity.menu.account.privacy.ctas.dataPrivacy') }}
+        </v-btn>
+      </div>
+    </div>
   </v-card>
 </template>
 
@@ -213,9 +312,18 @@ import { storeToRefs } from 'pinia'
 import { computed, ref, onMounted } from 'vue'
 import { useIpQuota } from '~/composables/useIpQuota'
 import { useProductCompareStore } from '~/stores/useProductCompareStore'
+import {
+  normalizeLocale,
+  resolveLocalizedRoutePath,
+} from '~~/shared/utils/localized-routes'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const requestHeaders = useRequestHeaders(['x-forwarded-for', 'x-real-ip'])
+const currentLocale = computed(() => normalizeLocale(locale.value))
+const dataPrivacyPath = computed(() =>
+  resolveLocalizedRoutePath('data-privacy', currentLocale.value)
+)
+const openSourcePath = computed(() => '/opensource')
 
 // --- IP Logic ---
 const resolveIpAddress = () => {
@@ -237,6 +345,18 @@ const voteQuotaCategory = IpQuotaCategory.FeedbackVote
 
 const aiQuota = computed(() => getRemaining(aiQuotaCategory))
 const voteQuota = computed(() => getRemaining(voteQuotaCategory))
+const userAgentFull = ref<string | null>(null)
+
+const userAgentDisplay = computed(() => {
+  if (!userAgentFull.value) {
+    return t('siteIdentity.menu.account.privacy.userAgent.unavailable')
+  }
+
+  const maxLength = 38
+  return userAgentFull.value.length > maxLength
+    ? `${userAgentFull.value.slice(0, maxLength)}…`
+    : userAgentFull.value
+})
 
 const loadQuotas = async () => {
   if (import.meta.client) {
@@ -301,6 +421,10 @@ const compareCount = computed(() => compareItems.value.length)
 onMounted(() => {
   refreshStorageSnapshot()
   loadQuotas()
+
+  if (import.meta.client) {
+    userAgentFull.value = window.navigator.userAgent
+  }
 })
 </script>
 
@@ -308,6 +432,41 @@ onMounted(() => {
 .account-privacy-card
   border-radius: 20px
   padding: 20px
+
+  &__hero
+    display: flex
+    align-items: flex-start
+    gap: 16px
+    padding: 16px
+    border-radius: 16px
+    background: rgba(var(--v-theme-surface-primary-080), 0.7)
+    margin-bottom: 16px
+
+  &__hero-icon
+    width: 44px
+    height: 44px
+    border-radius: 12px
+    display: flex
+    align-items: center
+    justify-content: center
+    background: rgba(var(--v-theme-surface-primary-100), 0.9)
+    flex-shrink: 0
+
+  &__hero-copy
+    display: flex
+    flex-direction: column
+    gap: 4px
+
+  &__hero-title
+    margin: 0
+    font-size: 1rem
+    font-weight: 700
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__hero-subtitle
+    margin: 0
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
 
   &__header
     display: flex
@@ -333,6 +492,19 @@ onMounted(() => {
     flex-direction: column
     gap: 12px
     padding: 12px 0
+
+  &__section-label
+    margin: 0
+    font-size: 0.75rem
+    font-weight: 700
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgb(var(--v-theme-text-neutral-soft))
+
+  &__subsection
+    display: flex
+    flex-direction: column
+    gap: 12px
 
   &__section-header
     display: flex
@@ -360,6 +532,35 @@ onMounted(() => {
   &__chip
     font-weight: 500
 
+  &__info-row
+    font-size: 0.875rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+
+  &__meta
+    margin-top: 8px
+    display: flex
+    flex-direction: column
+    gap: 4px
+
+  &__meta-row
+    display: flex
+    flex-wrap: wrap
+    gap: 6px
+    align-items: center
+
+  &__meta-label
+    font-size: 0.75rem
+    font-weight: 600
+    color: rgb(var(--v-theme-text-neutral-soft))
+
+  &__meta-value
+    font-size: 0.75rem
+    color: rgb(var(--v-theme-text-neutral-secondary))
+    word-break: break-word
+
+  &__cta
+    margin-top: 12px
+
   &__action
     text-transform: none
 
@@ -371,6 +572,14 @@ onMounted(() => {
   @media (max-width: 599px)
     padding: 16px
     border-radius: 16px
+
+    &__hero
+      padding: 12px
+      gap: 12px
+
+    &__hero-icon
+      width: 40px
+      height: 40px
 
     &__header
       align-items: flex-start

--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -551,8 +551,10 @@
             variant="text"
             data-testid="hero-account-menu-activator-guest"
           >
-            <v-icon icon="mdi-incognito" />
-            <v-icon :icon="isActive ? 'mdi-menu-up' : 'mdi-menu-down'" end />
+            <span class="account-menu-activator__guest-icons">
+              <v-icon icon="mdi-incognito" />
+              <v-icon :icon="isActive ? 'mdi-menu-up' : 'mdi-menu-down'" />
+            </span>
           </v-btn>
         </template>
 
@@ -1676,6 +1678,11 @@ const isMenuItemActive = (item: MenuItem): boolean => {
   .account-username
     max-width: 140px
     display: inline-block
+
+  &__guest-icons
+    display: inline-flex
+    align-items: center
+    gap: 0.2rem
 
 .account-menu
   background-color: rgb(var(--v-theme-surface-default))

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2741,10 +2741,26 @@
         "privacy": {
           "title": "Privacy-first session",
           "subtitle": "We keep Nudger transparent: you decide what stays on your device.",
+          "hero": {
+            "title": "We respect your data",
+            "subtitle": "Nudger collects no personal data."
+          },
+          "sections": {
+            "remote": "Remote data",
+            "local": "Local data"
+          },
           "ip": {
             "title": "Your IP address",
             "description": "We only use it for technical and security needs on our servers.",
             "unavailable": "Unavailable"
+          },
+          "userAgent": {
+            "label": "User agent",
+            "unavailable": "Unavailable"
+          },
+          "technicalOnly": {
+            "label": "Only data collected",
+            "tooltip": "Only technical data, no personal data."
           },
           "cookies": {
             "title": "Cookies on this device",
@@ -2757,7 +2773,22 @@
             "description": "Stored keys: {count}. These remain only in your browser.",
             "empty": "No local storage entries yet.",
             "resetCta": "Reset local storage"
-          }
+          },
+          "quotas": {
+            "title": "Quotas & Activity",
+            "aiRemaining": "AI generations remaining",
+            "aiRemainingTooltip": "Nudger lets you generate powerful AI summaries shared with everyone.",
+            "votesRemaining": "Votes remaining"
+          },
+          "ctas": {
+            "openSource": "Open source",
+            "dataPrivacy": "Personal data"
+          },
+          "compare": {
+            "count": "{count} product in the comparator | {count} products in the comparator",
+            "cta": "Compare"
+          },
+          "cardTitle": "Account & Privacy"
         }
       },
       "productsMenu": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2758,10 +2758,26 @@
         "privacy": {
           "title": "Session respectueuse de la vie privée",
           "subtitle": "Nudger reste transparent : vous gardez le contrôle sur vos données.",
+          "hero": {
+            "title": "On respecte vos données",
+            "subtitle": "Nudger ne collecte aucune donnée personnelle."
+          },
+          "sections": {
+            "remote": "Données distantes",
+            "local": "Données locales"
+          },
           "ip": {
             "title": "Votre adresse IP",
             "description": "Nous l'utilisons uniquement pour des besoins techniques et de sécurité.",
             "unavailable": "Indisponible"
+          },
+          "userAgent": {
+            "label": "User agent",
+            "unavailable": "Indisponible"
+          },
+          "technicalOnly": {
+            "label": "Les seules données collectées",
+            "tooltip": "Uniquement des données techniques, aucune donnée personnelle."
           },
           "cookies": {
             "title": "Cookies sur cet appareil",
@@ -2778,7 +2794,12 @@
           "quotas": {
             "title": "Quotas & Activité",
             "aiRemaining": "Générations IA restantes",
+            "aiRemainingTooltip": "Nudger vous permet de générer des synthèses IA puissantes, partagées auprès de tous.",
             "votesRemaining": "Votes restants"
+          },
+          "ctas": {
+            "openSource": "Open source",
+            "dataPrivacy": "Données personnelles"
           },
           "compare": {
             "count": "{count} produit dans le comparateur | {count} produits dans le comparateur",


### PR DESCRIPTION
### Motivation
- Reorganize the account privacy widget to clearly separate remote vs local data and reassure users about what is collected.  
- Surface a truncated `User agent` string in the remote data section with a tooltip to reveal the full value for troubleshooting.  
- Add direct CTAs to the Open Source and Data Privacy pages and tighten guest activator icon spacing in the hero menu for visual consistency.

### Description
- Updated the hero menu guest activator in `The-hero-menu.vue` to wrap icons in `account-menu-activator__guest-icons` and added related CSS to tighten spacing.  
- Reworked `AccountPrivacyCard.vue` template to add a hero block, split content into `remote` and `local` sections, move IP and `User agent` metadata into the remote section, and add a short explanatory row (`technicalOnly`) with an info tooltip.  
- Implemented `userAgentFull` and `userAgentDisplay` (truncation to 38 chars) and populate it on mount using `window.navigator.userAgent`, with a tooltip showing the full value.  
- Added quota info enhancements including an `aiRemaining` tooltip and preserved existing cookie/localStorage reset controls under the `local` section.  
- Added computed route helpers using `resolveLocalizedRoutePath` for the `data-privacy` CTA and an `openSource` CTA; updated component SASS for new blocks.  
- Extended i18n resources in `fr-FR.json` and `en-US.json` with new keys (`hero`, `sections`, `userAgent`, `technicalOnly`, `quotas.aiRemainingTooltip`, `ctas`, etc.).

### Testing
- Ran `pnpm lint` which failed due to missing local dependencies and ESLint configuration (`@nuxt/eslint-config`) in the environment.  
- Ran `pnpm test` which failed because `vitest` was not available in the environment.  
- Attempted `pnpm generate` which failed because `nuxt` was not available; all failures are environment/dependency related and not specific to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e02c12908322aee40a6fc6b13a4b)