### PR TITLE
feat(frontend): add reusable NudgerCard and docs

### DIFF
--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -19,5 +19,6 @@ parcourir chaque section.
 - Des références Impact Score avec des métadonnées structurées.
 - Une recherche plein texte rapide dans les contenus.
 - Des blocs réutilisables en rendu inline ou en page complète.
+- Des guides UI comme [`NudgerCard`](./ui/nudger-card.md) pour les composants frontend.
 
 > Astuce : chaque page peut définir des métadonnées SEO, icônes, tags et ordre.

--- a/docs/fr/ui/nudger-card.md
+++ b/docs/fr/ui/nudger-card.md
@@ -1,0 +1,74 @@
+---
+title: "NudgerCard : cartes à coins modulaires"
+description: "Guide d’utilisation du composant NudgerCard pour mutualiser les styles de cartes à coins arrondis."
+tags: ["frontend", "ui", "cartes"]
+icon: "mdi-card-bulleted-outline"
+weight: 20
+updatedAt: "2026-02-10"
+draft: false
+---
+
+# NudgerCard : guide d’usage
+
+Le composant `NudgerCard` centralise les styles de cartes “nudger” afin de garder
+un **rendu homogène** et de **limiter les classes ad-hoc** dans les sections
+frontend.
+
+## Pourquoi l’utiliser ?
+
+- **Cohérence visuelle** : un seul point de vérité pour les rayons et bordures.
+- **Maintenance simplifiée** : les ajustements se font dans un seul composant.
+- **Variantes explicites** : les coins modifiés sont déclarés par props.
+- **Design system** : facilite la revue UX et les ajustements globaux.
+
+## Quand l’utiliser ?
+
+Utilisez `NudgerCard` pour les cartes de contenu qui reprennent le style “nudger”
+dans les sections marketing (home, landing pages, etc.).  
+Évitez de le dupliquer avec des classes globales : préférez les props dédiées.
+
+## API principale
+
+| Prop | Type | Rôle |
+| --- | --- | --- |
+| `border` | `boolean` | Ajoute la bordure primaire. |
+| `accentCorners` | `Array<'top-left'|'top-right'|'bottom-right'|'bottom-left'>` | Applique un rayon “accent” à un ou plusieurs coins. |
+| `flatCorners` | `Array<'top-left'|'top-right'|'bottom-right'|'bottom-left'>` | Force un coin à `0` pour obtenir un angle droit. |
+| `baseRadius` | `string` | Rayon par défaut pour tous les coins. |
+| `accentRadius` | `string` | Rayon appliqué aux coins “accent”. |
+| `padding` | `string` | Padding interne de la carte. |
+| `background` | `string` | Couleur ou gradient de fond. |
+| `elevation` | `number` | Élévation Vuetify optionnelle. |
+
+## Exemples
+
+### Coin haut gauche “carré” + coin bas gauche accentué
+
+```vue
+<NudgerCard
+  border
+  :flat-corners="['top-left']"
+  :accent-corners="['bottom-left']"
+>
+  <p>Contenu</p>
+</NudgerCard>
+```
+
+### Carte “plein écran” personnalisée
+
+```vue
+<NudgerCard
+  background="rgba(var(--v-theme-surface-default), 0.96)"
+  padding="clamp(2rem, 5vw, 3rem)"
+  base-radius="clamp(1.75rem, 4vw, 2.5rem)"
+>
+  <p>CTA</p>
+</NudgerCard>
+```
+
+## Bonnes pratiques
+
+- **Préférez les props** plutôt que d’ajouter de nouvelles classes globales.
+- **Ciblez uniquement les coins nécessaires** (ex. un seul coin accentué).
+- **Centralisez la logique** : si un nouveau style devient récurrent, ajoutez une
+  prop ou une variante dans `NudgerCard` plutôt que de dupliquer.

--- a/frontend/app/assets/sass/main.sass
+++ b/frontend/app/assets/sass/main.sass
@@ -22,58 +22,6 @@
         .theme-toggle
             background-color: transparent!important
 
-.card__nudger 
-    background: #ffffff!important
-    border-radius: 30px!important
-    padding: 1.25rem!important
-
-    &--border
-        border: 1px solid rgb(var(--v-theme-primary))!important
-
-    &--radius_bottom-right_50px
-        border-bottom-right-radius: 50px!important
-
-    &--radius_top-right_0
-        border-top-right-radius: 0!important
-
-    &--radius_bottom-left_50px
-        border-bottom-left-radius: 50px!important
-
-    &--radius_top-left_0
-        border-top-left-radius: 0!important
-
-/*.nudge-option-card
-    @extend .card__nudger
-    padding: 16px 18px!important
-    border-radius: 24px!important
-    box-shadow: 0 8px 22px rgba(var(--v-theme-primary), 0.08)
-    transition: box-shadow 0.22s ease, transform 0.22s ease, border-color 0.22s ease, background-color 0.22s ease
-    text-align: left
-    cursor: pointer
-    position: relative
-
-    &:hover
-        box-shadow: 0 16px 36px rgba(var(--v-theme-primary), 0.14)
-        transform: translateY(-2px)
-
-    &--selected
-        background: rgba(var(--v-theme-primary), 0.08)!important
-        border-color: rgba(var(--v-theme-primary), 0.32)!important
-        box-shadow: 0 20px 44px rgba(var(--v-theme-primary), 0.16)
-
-    &--flat
-        box-shadow: none
-        background: rgb(var(--v-theme-surface-default))!important
-        border-color: rgba(var(--v-theme-primary), 0.1)!important
-
-    &--border
-        border: 1px solid rgba(var(--v-theme-primary), 0.2)!important
-
-    &--radius_bottom-right_50px
-        border-bottom-right-radius: 50px!important
-
-    &--radius_top-right_0
-        border-top-right-radius: 0!important*/
 
 .home-hero__subtitle
     font-size: clamp(1.05rem, 2.6vw, 1.35rem)

--- a/frontend/app/components/home/sections/HomeCtaSection.vue
+++ b/frontend/app/components/home/sections/HomeCtaSection.vue
@@ -4,6 +4,7 @@ import SearchSuggestField, {
   type CategorySuggestionItem,
   type ProductSuggestionItem,
 } from '~/components/search/SearchSuggestField.vue'
+import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
 import { useEventPackI18n } from '~/composables/useEventPackI18n'
 
@@ -62,7 +63,12 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
     <v-container fluid class="home-section__container">
       <v-row justify="center">
         <v-col cols="12" lg="6">
-          <div class="home-cta__content card__nudger">
+          <NudgerCard
+            class="home-cta__content"
+            background="rgba(var(--v-theme-surface-default), 0.96)"
+            padding="clamp(2rem, 5vw, 3rem)"
+            base-radius="clamp(1.75rem, 4vw, 2.5rem)"
+          >
             <p id="home-cta-title" class="home-hero__subtitle">
               {{ t('home.cta.title') }}
             </p>
@@ -133,7 +139,7 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
                 </v-btn>
               </div>
             </div>
-          </div>
+          </NudgerCard>
         </v-col>
       </v-row>
     </v-container>
@@ -152,9 +158,6 @@ const handleProductSelect = (value: ProductSuggestionItem) => {
   display: flex
   flex-direction: column
   gap: clamp(0.875rem, 2vw, 1.25rem);
-  padding: clamp(2rem, 5vw, 3rem)
-  border-radius: clamp(1.75rem, 4vw, 2.5rem)
-  background: rgba(var(--v-theme-surface-default), 0.96)
   box-shadow: 0 24px 36px rgba(var(--v-theme-shadow-primary-600), 0.15)
 
 .home-hero__search

--- a/frontend/app/components/home/sections/HomeFeaturesSection.vue
+++ b/frontend/app/components/home/sections/HomeFeaturesSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 type FeatureCard = {
   icon: string
   title: string
@@ -32,7 +33,7 @@ const { t } = useI18n()
           sm="6"
           lg="4"
         >
-          <v-card class="home-features__card card__nudger" variant="flat">
+          <NudgerCard class="home-features__card">
             <div class="text-center">
               <v-icon
                 class="home-features__icon"
@@ -46,7 +47,7 @@ const { t } = useI18n()
             <p class="home-features__card-description">
               {{ feature.description }}
             </p>
-          </v-card>
+          </NudgerCard>
         </v-col>
       </v-row>
     </div>

--- a/frontend/app/components/home/sections/HomeObjectionsSection.vue
+++ b/frontend/app/components/home/sections/HomeObjectionsSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 type ObjectionItem = {
   icon: string
   question: string
@@ -37,7 +38,7 @@ const { t } = useI18n()
             sm="6"
             lg="4"
           >
-            <v-card class="home-features__card card__nudger" variant="flat">
+            <NudgerCard class="home-features__card">
               <div class="text-center">
                 <v-icon
                   class="home-features__icon _home-objections__icon_"
@@ -53,7 +54,7 @@ const { t } = useI18n()
               <p class="home-features__card-description text-center mt-auto">
                 {{ item.answer }}
               </p>
-            </v-card>
+            </NudgerCard>
           </v-col>
         </v-row>
       </div>

--- a/frontend/app/components/home/sections/HomeProblemsSection.vue
+++ b/frontend/app/components/home/sections/HomeProblemsSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 import HomeSplitSection from './HomeSplitSection.vue'
 
 type ProblemItem = {
@@ -26,18 +27,18 @@ const sectionDescription = computed(() => t('home.problems.description'))
     visual-position="left"
   >
     <v-row class="home-problems__list" dense>
-      <v-col
-        v-for="item in props.items"
-        :key="item.text"
-        cols="12"
-        class="home-problems__list-item card__nudger card__nudger--border card__nudger--radius_top-right_0 card__nudger--radius_bottom-right_50px"
-      >
-        <v-sheet class="home-problems__card" rounded="xl" elevation="0">
+      <v-col v-for="item in props.items" :key="item.text" cols="12">
+        <NudgerCard
+          class="home-problems__card"
+          border
+          :flat-corners="['top-right']"
+          :accent-corners="['bottom-right']"
+        >
           <v-avatar class="home-problems__icon" color="surface" size="64">
             <v-icon :icon="item.icon" size="32" />
           </v-avatar>
           <p class="home-problems__text">{{ item.text }}</p>
-        </v-sheet>
+        </NudgerCard>
       </v-col>
     </v-row>
   </HomeSplitSection>
@@ -54,24 +55,14 @@ const sectionDescription = computed(() => t('home.problems.description'))
 .home-problems
   //background: rgba(var(--v-theme-surface-default), 0.98)
 
-  .card__nudger
-    margin-bottom: 1rem
-
-    &:last-of-type
-      margin-bottom: 0
-
 .home-problems__list
   --v-gutter-y: clamp(1rem, 3vw, 1.5rem)
-
-.home-problems__list-item
-  display: flex
 
 .home-problems__card
   width: 100%
   display: flex
   gap: 1rem
   align-items: center
-  background: transparent!important
 
 .home-problems__icon
   border: 1px solid rgb(var(--v-theme-secondary))

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 
 const solutionImageSrc = '/homepage/gain/nudger-screaming.webp'
 
@@ -39,14 +40,13 @@ const sectionDescription = computed(() => t('home.solution.description'))
             </p>
           </header>
           <v-row class="home-solution__list" dense>
-            <v-col
-              v-for="item in props.benefits"
-              :key="item.label"
-              cols="12"
-              md="6"
-              class="home-solution__list-col card__nudger card__nudger--border card__nudger--radius_top-left_0 card__nudger--radius_bottom-left_50px"
-            >
-              <v-sheet class="home-solution__item" rounded="xl" elevation="0">
+            <v-col v-for="item in props.benefits" :key="item.label" cols="12" md="6">
+              <NudgerCard
+                class="home-solution__item"
+                border
+                :flat-corners="['top-left']"
+                :accent-corners="['bottom-left']"
+              >
                 <v-avatar class="home-solution__icon" size="60" color="surface">
                   <span aria-hidden="true">{{ item.emoji }}</span>
                 </v-avatar>
@@ -56,7 +56,7 @@ const sectionDescription = computed(() => t('home.solution.description'))
                     {{ item.description }}
                   </p>
                 </div>
-              </v-sheet>
+              </NudgerCard>
             </v-col>
           </v-row>
         </v-col>
@@ -91,15 +91,12 @@ const sectionDescription = computed(() => t('home.solution.description'))
     padding: 0
     row-gap: clamp(1rem, 2.5vw, 1.5rem)
 
-  .home-solution__list-col
-    display: flex
 
   .home-solution__item
     width: 100%;
     display: flex;
     gap: 1rem;
     align-items: center;
-    background: transparent !important;
 
   .home-solution__item::after
     display: none

--- a/frontend/app/components/shared/cards/NudgerCard.spec.ts
+++ b/frontend/app/components/shared/cards/NudgerCard.spec.ts
@@ -1,0 +1,48 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import NudgerCard from './NudgerCard.vue'
+
+const createStub = (tag: string, className = '') =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () =>
+        h(
+          tag,
+          { class: [className, attrs.class], ...attrs },
+          slots.default ? slots.default() : []
+        )
+    },
+  })
+
+const mountComponent = (props = {}) =>
+  mountSuspended(NudgerCard, {
+    props,
+    global: {
+      stubs: {
+        VSheet: createStub('div', 'v-sheet-stub'),
+      },
+    },
+  })
+
+describe('NudgerCard', () => {
+  it('sets custom corner radii when configured', async () => {
+    const wrapper = await mountComponent({
+      accentCorners: ['bottom-left'],
+      flatCorners: ['top-left'],
+    })
+
+    const style = wrapper.attributes('style')
+    expect(style).toContain('--nudger-card-bottom-left: 50px;')
+    expect(style).toContain('--nudger-card-top-left: 0;')
+    await wrapper.unmount()
+  })
+
+  it('applies the border class when enabled', async () => {
+    const wrapper = await mountComponent({ border: true })
+
+    expect(wrapper.classes()).toContain('nudger-card--border')
+    await wrapper.unmount()
+  })
+})

--- a/frontend/app/components/shared/cards/NudgerCard.vue
+++ b/frontend/app/components/shared/cards/NudgerCard.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export type NudgerCorner =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-right'
+  | 'bottom-left'
+
+const props = withDefaults(
+  defineProps<{
+    accentCorners?: NudgerCorner[]
+    flatCorners?: NudgerCorner[]
+    baseRadius?: string
+    accentRadius?: string
+    border?: boolean
+    padding?: string
+    background?: string
+    elevation?: number
+  }>(),
+  {
+    accentCorners: () => [],
+    flatCorners: () => [],
+    baseRadius: '30px',
+    accentRadius: '50px',
+    border: false,
+    padding: '1.25rem',
+    background: '#ffffff',
+    elevation: 0,
+  }
+)
+
+const resolvedCorners = computed(() => {
+  const corners: Record<NudgerCorner, string> = {
+    'top-left': props.baseRadius,
+    'top-right': props.baseRadius,
+    'bottom-right': props.baseRadius,
+    'bottom-left': props.baseRadius,
+  }
+
+  props.accentCorners.forEach((corner) => {
+    corners[corner] = props.accentRadius
+  })
+
+  props.flatCorners.forEach((corner) => {
+    corners[corner] = '0'
+  })
+
+  return corners
+})
+
+const styleVars = computed(() => ({
+  '--nudger-card-padding': props.padding,
+  '--nudger-card-background': props.background,
+  '--nudger-card-top-left': resolvedCorners.value['top-left'],
+  '--nudger-card-top-right': resolvedCorners.value['top-right'],
+  '--nudger-card-bottom-right': resolvedCorners.value['bottom-right'],
+  '--nudger-card-bottom-left': resolvedCorners.value['bottom-left'],
+}))
+</script>
+
+<template>
+  <v-sheet
+    class="nudger-card"
+    :class="{ 'nudger-card--border': props.border }"
+    :style="styleVars"
+    :elevation="props.elevation"
+    rounded="0"
+  >
+    <slot />
+  </v-sheet>
+</template>
+
+<style scoped lang="sass">
+.nudger-card
+  padding: var(--nudger-card-padding)
+  background: var(--nudger-card-background)
+  border-radius: var(--nudger-card-top-left) var(--nudger-card-top-right) var(--nudger-card-bottom-right) var(--nudger-card-bottom-left)
+  box-sizing: border-box
+
+.nudger-card--border
+  border: 1px solid rgb(var(--v-theme-primary))
+</style>


### PR DESCRIPTION
### Motivation
- Replace ad-hoc `card__nudger` classes with a single reusable component to centralise corner, padding and border logic.
- Provide an explicit API for accent/flat corner variants to keep visual consistency across home sections.
- Reduce duplication and simplify future UX/design updates by moving styles into a component and documentation.

### Description
- Add `NudgerCard` component (`frontend/app/components/shared/cards/NudgerCard.vue`) with props `accentCorners`, `flatCorners`, `baseRadius`, `accentRadius`, `border`, `padding`, `background` and `elevation`, and CSS variables for runtime corner resolution.
- Add unit tests for the component (`frontend/app/components/shared/cards/NudgerCard.spec.ts`) that validate corner radius resolution and border class application.
- Migrate home sections to use `NudgerCard` (CTA, Features, Objections, Problems, Solution) and remove the legacy `.card__nudger` usage from SASS to consolidate styling.
- Add French documentation and a docs index link (`docs/fr/ui/nudger-card.md`, updated `docs/fr/index.md`) describing the component API and usage patterns.

### Testing
- Ran `pnpm lint --offline`, which completed with a single `vue/attributes-order` warning in an unrelated file.
- Ran `pnpm test` (Vitest) and the test suite passed successfully with all tests green (`Tests 381 passed`).
- Ran `pnpm generate --offline` to build the static output and it completed successfully with a Workbox warning about an unused glob pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b87c001908322bd94ea2a40d82f85)