### PR TITLE
Adjust nudge tool wizard height transitions

### DIFF
--- a/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCategory.vue
@@ -349,8 +349,8 @@ watch(
 .nudge-step-category {
   display: flex;
   flex-direction: column;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-  padding-bottom: 1.5rem;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  padding-bottom: 0.75rem;
 
   &__header {
     display: flex;


### PR DESCRIPTION
### Motivation
- Make the Nudge Tool wizard resize and animate vertically in a responsive, predictable way so content steps can grow/shrink to fit and category steps remain visually compact. 
- Match UI timing and accessibility expectations by using Vuetify-like height transitions and respecting the user's `prefers-reduced-motion` setting.
- Reduce unnecessary vertical spacing in the category selection step to avoid excessive whitespace on larger viewports.

### Description
- Reworked sizing logic in `NudgeToolWizard.vue` to measure the active step element via a `setStepRef` wrapper and `useElementSize`, and compute responsive heights (`categoryHeight`, `lockedContentHeight`) with a `clampHeight` helper and viewport-aware padding calculations.
- Updated the template to wrap each step in an element referenced by `setStepRef`, added `ref`s for header/progress/footer/window/active step, and removed the legacy fixed-lock height code in favor of the new measurement approach.
- Added reduced-motion support using `usePreferredReducedMotion` and a `nudge-wizard--reduced-motion` modifier to disable the height transition when required, and added CSS height/min-height transitions to animate layout changes (`height 280ms cubic-bezier(...)`).
- Minor UI tweaks: added `nudge-wizard--category` modifier to align category content to the top and adjusted spacing in `NudgeToolStepCategory.vue` (reduced `gap` and `padding-bottom`).

### Testing
- Ran `pnpm lint` and resolved attribute-order warnings reported by ESLint (command completed successfully).
- Ran the full test suite with `pnpm test`, which completed successfully (all automated tests passed).
- Ran `pnpm generate` which failed due to a SASS parsing error in a different component: `app/components/home/sections/HomeSolutionSection.vue` (`[sass] Expected identifier`), so static site generation was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b953eaa788322b4302db4ab8af930)