### PR TITLE
Refactor hero highlights into three-card component and add localized highlights

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroHighlights.vue
+++ b/frontend/app/components/home/sections/HomeHeroHighlights.vue
@@ -1,0 +1,464 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useEventPackI18n } from '~/composables/useEventPackI18n'
+import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
+import {
+  DEFAULT_EVENT_PACK,
+  EVENT_PACK_I18N_BASE_KEY,
+} from '~~/config/theme/event-packs'
+import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
+
+type HeroHighlightSegment = {
+  text: string
+  to?: string
+}
+
+type HeroHighlightItem = {
+  title: string
+  segments: HeroHighlightSegment[]
+}
+
+const props = defineProps<{
+  partnersCount?: number
+  openDataMillions?: number
+  productsCount?: number
+  categoriesCount?: number
+}>()
+
+const { t, te, tm, locale } = useI18n()
+const activeEventPack = useSeasonalEventPack()
+const packI18n = useEventPackI18n(activeEventPack)
+
+const partnersLinkPlaceholder = '{partnersLink}'
+const openDataMillionsPlaceholder = '{millions}'
+const productsCountPlaceholder = '{products}'
+const categoriesCountPlaceholder = '{categories}'
+
+const normalizeHighlightSegments = (
+  segments: unknown
+): HeroHighlightSegment[] => {
+  if (!Array.isArray(segments)) {
+    return []
+  }
+
+  return segments
+    .map(segment => {
+      if (typeof segment !== 'object' || segment == null) {
+        return null
+      }
+
+      const { text, to } = segment as { text?: unknown; to?: unknown }
+      const normalizedText = typeof text === 'string' ? text.trim() : ''
+      const normalizedTo =
+        typeof to === 'string' && to.trim().length > 0 ? to.trim() : undefined
+
+      if (!normalizedText) {
+        return null
+      }
+
+      return {
+        text: normalizedText,
+        to: normalizedTo,
+      }
+    })
+    .filter((segment): segment is HeroHighlightSegment => segment != null)
+}
+
+const normalizeHighlightItems = (items: unknown): HeroHighlightItem[] => {
+  if (!Array.isArray(items)) {
+    return []
+  }
+
+  return items
+    .map(rawItem => {
+      if (typeof rawItem !== 'object' || rawItem == null) {
+        return null
+      }
+
+      const { title, segments, descriptionParts } = rawItem as {
+        title?: unknown
+        segments?: unknown
+        descriptionParts?: unknown
+      }
+
+      const normalizedTitle = typeof title === 'string' ? title.trim() : ''
+      const normalizedSegments = normalizeHighlightSegments(
+        segments ?? descriptionParts
+      )
+
+      if (!normalizedTitle || normalizedSegments.length === 0) {
+        return null
+      }
+
+      return {
+        title: normalizedTitle,
+        segments: normalizedSegments,
+      }
+    })
+    .filter((item): item is HeroHighlightItem => item != null)
+}
+
+const heroHighlightItems = computed<HeroHighlightItem[]>(() => {
+  const packItems = packI18n.resolveList('hero.highlights', {
+    fallbackKeys: ['home.hero.highlights'],
+  })
+
+  const itemsToNormalize = Array.isArray(packItems)
+    ? packItems
+    : Object.values(packItems ?? {})
+
+  const translatedItems = normalizeHighlightItems(itemsToNormalize)
+
+  if (translatedItems.length > 0) {
+    return applyOpenDataMillionsPlaceholder(
+      applyProductsCategoriesPlaceholder(
+        applyPartnerLinkPlaceholder(translatedItems)
+      )
+    )
+  }
+
+  const tmItems = tm('home.hero.highlights')
+  if (Array.isArray(tmItems) && tmItems.length > 0) {
+    const directTranslated = normalizeHighlightItems(tmItems)
+    if (directTranslated.length > 0) {
+      return applyOpenDataMillionsPlaceholder(
+        applyProductsCategoriesPlaceholder(
+          applyPartnerLinkPlaceholder(directTranslated)
+        )
+      )
+    }
+  }
+
+  return []
+})
+
+const normalizedPartnersCount = computed(() => {
+  const rawCount = Number(props.partnersCount ?? 0)
+
+  if (!Number.isFinite(rawCount)) {
+    return 0
+  }
+
+  return Math.max(0, Math.round(rawCount))
+})
+
+const formattedPartnersCount = computed(() => {
+  const count = normalizedPartnersCount.value
+
+  if (!count) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(count)
+  } catch {
+    return String(count)
+  }
+})
+
+const heroPartnersLinkText = computed(() => {
+  const count = normalizedPartnersCount.value
+  const formattedCount = formattedPartnersCount.value
+  const fallbackLabel =
+    packI18n
+      .resolveString('hero.search.partnerLinkFallback', {
+        fallbackKeys: ['home.hero.search.partnerLinkFallback'],
+      })
+      ?.trim() ?? ''
+
+  if (!count || !formattedCount) {
+    return fallbackLabel || null
+  }
+
+  const translateKey = (key: string) => {
+    if (!te(key)) {
+      return ''
+    }
+
+    const translated = t(key, { count, formattedCount })
+    const normalized =
+      typeof translated === 'string'
+        ? translated.trim()
+        : String(translated ?? '').trim()
+
+    return normalized && normalized !== key ? normalized : ''
+  }
+
+  const packKey = `${EVENT_PACK_I18N_BASE_KEY}.${activeEventPack.value}.hero.search.partnerLinkLabel`
+  const defaultKey = `${EVENT_PACK_I18N_BASE_KEY}.${DEFAULT_EVENT_PACK}.hero.search.partnerLinkLabel`
+
+  const translated =
+    translateKey(packKey) ||
+    translateKey(defaultKey) ||
+    translateKey('home.hero.search.partnerLinkLabel')
+
+  const normalizedTranslation =
+    typeof translated === 'string'
+      ? translated.trim()
+      : String(translated ?? '').trim()
+
+  if (
+    normalizedTranslation &&
+    normalizedTranslation !== 'home.hero.search.partnerLinkLabel'
+  ) {
+    return normalizedTranslation
+  }
+
+  if (!fallbackLabel) {
+    return formattedCount
+  }
+
+  return `${formattedCount} ${fallbackLabel}`
+})
+
+const formattedOpenDataMillions = computed(() => {
+  const value = props.openDataMillions
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(value)
+  } catch {
+    return String(value)
+  }
+})
+
+const formattedProductsCount = computed(() => {
+  const value = props.productsCount
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(value)
+  } catch {
+    return String(value)
+  }
+})
+
+const formattedCategoriesCount = computed(() => {
+  const value = props.categoriesCount
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null
+  }
+
+  try {
+    return new Intl.NumberFormat(locale.value).format(value)
+  } catch {
+    return String(value)
+  }
+})
+
+const applyPartnerLinkPlaceholder = (items: HeroHighlightItem[]) => {
+  const partnerLinkText = heroPartnersLinkText.value
+
+  if (!partnerLinkText) {
+    return items
+  }
+
+  return items.map(item => {
+    const segmentsWithPartnerLink = item.segments
+      .map(segment => {
+        if (!segment.text.includes(partnersLinkPlaceholder)) {
+          return segment
+        }
+
+        const replacedText = segment.text.replaceAll(
+          partnersLinkPlaceholder,
+          partnerLinkText
+        )
+
+        const normalizedText = replacedText.trim()
+
+        if (!normalizedText) {
+          return null
+        }
+
+        return {
+          ...segment,
+          text: normalizedText,
+        }
+      })
+      .filter((segment): segment is HeroHighlightSegment => segment != null)
+
+    return {
+      ...item,
+      segments:
+        segmentsWithPartnerLink.length > 0
+          ? segmentsWithPartnerLink
+          : item.segments,
+    }
+  })
+}
+
+const applyOpenDataMillionsPlaceholder = (items: HeroHighlightItem[]) => {
+  const millionsLabel = formattedOpenDataMillions.value
+
+  if (!millionsLabel) {
+    return items
+  }
+
+  return items.map(item => {
+    const segmentsWithOpenDataMillions = item.segments
+      .map(segment => {
+        if (!segment.text.includes(openDataMillionsPlaceholder)) {
+          return segment
+        }
+
+        const replacedText = segment.text.replaceAll(
+          openDataMillionsPlaceholder,
+          millionsLabel
+        )
+
+        const normalizedText = replacedText.trim()
+
+        if (!normalizedText) {
+          return null
+        }
+
+        return {
+          ...segment,
+          text: normalizedText,
+        }
+      })
+      .filter((segment): segment is HeroHighlightSegment => segment != null)
+
+    return {
+      ...item,
+      segments:
+        segmentsWithOpenDataMillions.length > 0
+          ? segmentsWithOpenDataMillions
+          : item.segments,
+    }
+  })
+}
+
+const applyProductsCategoriesPlaceholder = (items: HeroHighlightItem[]) => {
+  const productsLabel = formattedProductsCount.value
+  const categoriesLabel = formattedCategoriesCount.value
+
+  if (!productsLabel || !categoriesLabel) {
+    return items
+  }
+
+  return items.map(item => {
+    const segmentsWithCounts = item.segments
+      .map(segment => {
+        if (
+          !segment.text.includes(productsCountPlaceholder) &&
+          !segment.text.includes(categoriesCountPlaceholder)
+        ) {
+          return segment
+        }
+
+        const replacedText = segment.text
+          .replaceAll(productsCountPlaceholder, productsLabel)
+          .replaceAll(categoriesCountPlaceholder, categoriesLabel)
+
+        const normalizedText = replacedText.trim()
+
+        if (!normalizedText) {
+          return null
+        }
+
+        return {
+          ...segment,
+          text: normalizedText,
+        }
+      })
+      .filter((segment): segment is HeroHighlightSegment => segment != null)
+
+    return {
+      ...item,
+      segments: segmentsWithCounts.length > 0 ? segmentsWithCounts : item.segments,
+    }
+  })
+}
+</script>
+
+<template>
+  <div class="home-hero-highlights" role="list">
+    <v-row class="home-hero-highlights__row" align="stretch">
+      <v-col
+        v-for="(item, index) in heroHighlightItems"
+        :key="`hero-highlight-${index}`"
+        cols="12"
+        md="4"
+        class="home-hero-highlights__col"
+      >
+        <RoundedCornerCard
+          class="home-hero-highlights__card"
+          surface="strong"
+          accent-corner="bottom-right"
+          corner-variant="none"
+          corner-size="lg"
+          rounded="lg"
+          :selectable="false"
+          :elevation="10"
+          :hover-elevation="14"
+        >
+          <div class="home-hero-highlights__card-content" role="listitem">
+            <p class="home-hero-highlights__title">{{ item.title }}</p>
+            <p class="home-hero-highlights__description">
+              <template
+                v-for="(segment, segmentIndex) in item.segments"
+                :key="`hero-highlight-${index}-segment-${segmentIndex}`"
+              >
+                <NuxtLink
+                  v-if="segment.to"
+                  class="home-hero-highlights__link"
+                  :to="segment.to"
+                >
+                  {{ segmentIndex > 0 ? ` ${segment.text}` : segment.text }}
+                </NuxtLink>
+                <span v-else>
+                  {{ segmentIndex > 0 ? ` ${segment.text}` : segment.text }}
+                </span>
+              </template>
+            </p>
+          </div>
+        </RoundedCornerCard>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<style scoped lang="sass">
+.home-hero-highlights__row
+  margin: 0
+  gap: clamp(1rem, 3vw, 1.5rem)
+
+.home-hero-highlights__col
+  display: flex
+
+.home-hero-highlights__card
+  height: 100%
+  width: 100%
+
+.home-hero-highlights__card-content
+  display: flex
+  flex-direction: column
+  gap: 0.6rem
+
+.home-hero-highlights__title
+  margin: 0
+  font-weight: 600
+  color: rgb(var(--v-theme-text-neutral-strong))
+  font-size: 1rem
+
+.home-hero-highlights__description
+  margin: 0
+  color: rgb(var(--v-theme-text-neutral-secondary))
+  line-height: 1.35
+
+.home-hero-highlights__link
+  color: rgb(var(--v-theme-text-neutral-strong))
+  font-weight: 600
+  text-decoration: underline
+  text-decoration-thickness: 0.08em
+  text-underline-offset: 0.1em
+</style>

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -7,30 +7,16 @@ import SearchSuggestField, {
   type ProductSuggestionItem,
 } from '~/components/search/SearchSuggestField.vue'
 import type { VerticalConfigDto } from '~~/shared/api-client'
-import RoundedCornerCard from '~/components/shared/cards/RoundedCornerCard.vue'
+import HomeHeroHighlights from '~/components/home/sections/HomeHeroHighlights.vue'
 
 import {
   resolveThemedAssetUrl,
   useHeroBackgroundAsset,
 } from '~~/app/composables/useThemedAsset'
 import { useSeasonalEventPack } from '~~/app/composables/useSeasonalEventPack'
-import {
-  DEFAULT_EVENT_PACK,
-  EVENT_PACK_I18N_BASE_KEY,
-} from '~~/config/theme/event-packs'
 import { useEventPackI18n } from '~/composables/useEventPackI18n'
 import { THEME_ASSETS_FALLBACK } from '~~/config/theme/assets'
 import { resolveThemeName } from '~~/shared/constants/theme'
-
-type HeroHelperSegment = {
-  text: string
-  to?: string
-}
-
-type HeroHelperItem = {
-  icon: string
-  segments: HeroHelperSegment[]
-}
 
 const isHeroImageLoaded = ref(false)
 const heroReadyFallbackDelayMs = 900
@@ -55,7 +41,6 @@ const emit = defineEmits<{
   'select-product': [payload: ProductSuggestionItem]
 }>()
 
-const { t, te, tm, locale } = useI18n()
 const theme = useTheme()
 const heroBackgroundAsset = useHeroBackgroundAsset()
 const activeEventPack = useSeasonalEventPack()
@@ -63,11 +48,6 @@ const packI18n = useEventPackI18n(activeEventPack)
 const themeName = computed(() =>
   resolveThemeName(theme.global.name.value, THEME_ASSETS_FALLBACK)
 )
-
-const partnersLinkPlaceholder = '{partnersLink}'
-const openDataMillionsPlaceholder = '{millions}'
-const productsCountPlaceholder = '{products}'
-const categoriesCountPlaceholder = '{categories}'
 
 const searchQueryValue = computed(() => props.searchQuery)
 
@@ -78,110 +58,6 @@ const updateSearchQuery = (value: string) => {
   emit('update:searchQuery', value)
 }
 
-const normalizeHelperSegments = (segments: unknown): HeroHelperSegment[] => {
-  if (!Array.isArray(segments)) {
-    return []
-  }
-
-  return segments
-    .map(segment => {
-      if (typeof segment !== 'object' || segment == null) {
-        return null
-      }
-
-      const { text, to } = segment as { text?: unknown; to?: unknown }
-      const normalizedText = typeof text === 'string' ? text.trim() : ''
-      const normalizedTo =
-        typeof to === 'string' && to.trim().length > 0 ? to.trim() : undefined
-
-      if (!normalizedText) {
-        return null
-      }
-
-      return {
-        text: normalizedText,
-        to: normalizedTo,
-      }
-    })
-    .filter((segment): segment is HeroHelperSegment => segment != null)
-}
-
-const normalizeHelperItems = (items: unknown): HeroHelperItem[] => {
-  if (!Array.isArray(items)) {
-    return []
-  }
-
-  return items
-    .map(rawItem => {
-      if (typeof rawItem !== 'object' || rawItem == null) {
-        return null
-      }
-
-      const { icon, label, segments, labelParts } = rawItem as {
-        icon?: unknown
-        label?: unknown
-        segments?: unknown
-        labelParts?: unknown
-      }
-
-      const normalizedIcon =
-        typeof icon === 'string' && icon.trim().length > 0 ? icon.trim() : '•'
-      const normalizedSegments = normalizeHelperSegments(segments ?? labelParts)
-
-      if (normalizedSegments.length === 0) {
-        const normalizedLabel = typeof label === 'string' ? label.trim() : ''
-
-        if (!normalizedLabel) {
-          return null
-        }
-
-        normalizedSegments.push({ text: normalizedLabel })
-      }
-
-      return {
-        icon: normalizedIcon,
-        segments: normalizedSegments,
-      }
-    })
-    .filter((item): item is HeroHelperItem => item != null)
-}
-
-const heroHelperItems = computed<HeroHelperItem[]>(() => {
-  const packItems = packI18n.resolveList('hero.search.helpers', {
-    fallbackKeys: ['home.hero.search.helpers'],
-  })
-
-  // Robust check for array/object
-  const itemsToNormalize = Array.isArray(packItems)
-    ? packItems
-    : Object.values(packItems ?? {})
-
-  const translatedItems = normalizeHelperItems(itemsToNormalize)
-
-  if (translatedItems.length > 0) {
-    return applyOpenDataMillionsPlaceholder(
-      applyProductsCategoriesPlaceholder(
-        applyPartnerLinkPlaceholder(translatedItems)
-      )
-    )
-  }
-
-  // Fallback to direct translation if pack resolution failed slightly
-  const tmItems = tm('home.hero.search.helpers')
-  if (Array.isArray(tmItems) && tmItems.length > 0) {
-    const directTranslated = normalizeHelperItems(tmItems)
-    if (directTranslated.length > 0) {
-      return applyOpenDataMillionsPlaceholder(
-        applyProductsCategoriesPlaceholder(
-          applyPartnerLinkPlaceholder(directTranslated)
-        )
-      )
-    }
-  }
-
-  return []
-})
-
 const heroTitleSubtitle = computed(
   () =>
     packI18n.resolveStringVariant('hero.titleSubtitle', {
@@ -189,261 +65,6 @@ const heroTitleSubtitle = computed(
       stateKey: 'home-hero-title-subtitle',
     }) ?? ''
 )
-
-const heroContextTitle = computed(
-  () =>
-    packI18n.resolveString('hero.context.title', {
-      fallbackKeys: ['home.hero.context.title'],
-    }) ?? ''
-)
-
-const normalizedPartnersCount = computed(() => {
-  const rawCount = Number(props.partnersCount ?? 0)
-
-  if (!Number.isFinite(rawCount)) {
-    return 0
-  }
-
-  return Math.max(0, Math.round(rawCount))
-})
-
-const formattedPartnersCount = computed(() => {
-  const count = normalizedPartnersCount.value
-
-  if (!count) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(count)
-  } catch {
-    return String(count)
-  }
-})
-
-const heroPartnersLinkText = computed(() => {
-  const count = normalizedPartnersCount.value
-  const formattedCount = formattedPartnersCount.value
-  const fallbackLabel =
-    packI18n
-      .resolveString('hero.search.partnerLinkFallback', {
-        fallbackKeys: ['home.hero.search.partnerLinkFallback'],
-      })
-      ?.trim() ?? ''
-
-  if (!count || !formattedCount) {
-    return fallbackLabel || null
-  }
-
-  const translateKey = (key: string) => {
-    if (!te(key)) {
-      return ''
-    }
-
-    const translated = t(key, { count, formattedCount })
-    const normalized =
-      typeof translated === 'string'
-        ? translated.trim()
-        : String(translated ?? '').trim()
-
-    return normalized && normalized !== key ? normalized : ''
-  }
-
-  const packKey = `${EVENT_PACK_I18N_BASE_KEY}.${activeEventPack.value}.hero.search.partnerLinkLabel`
-  const defaultKey = `${EVENT_PACK_I18N_BASE_KEY}.${DEFAULT_EVENT_PACK}.hero.search.partnerLinkLabel`
-
-  const translated =
-    translateKey(packKey) ||
-    translateKey(defaultKey) ||
-    translateKey('home.hero.search.partnerLinkLabel')
-
-  const normalizedTranslation =
-    typeof translated === 'string'
-      ? translated.trim()
-      : String(translated ?? '').trim()
-
-  if (
-    normalizedTranslation &&
-    normalizedTranslation !== 'home.hero.search.partnerLinkLabel'
-  ) {
-    return normalizedTranslation
-  }
-
-  if (!fallbackLabel) {
-    return formattedCount
-  }
-
-  return `${formattedCount} ${fallbackLabel}`
-})
-
-const formattedOpenDataMillions = computed(() => {
-  const value = props.openDataMillions
-
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(value)
-  } catch {
-    return String(value)
-  }
-})
-
-const formattedProductsCount = computed(() => {
-  const value = props.productsCount
-
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(value)
-  } catch {
-    return String(value)
-  }
-})
-
-const formattedCategoriesCount = computed(() => {
-  const value = props.categoriesCount
-
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return null
-  }
-
-  try {
-    return new Intl.NumberFormat(locale.value).format(value)
-  } catch {
-    return String(value)
-  }
-})
-
-const applyPartnerLinkPlaceholder = (items: HeroHelperItem[]) => {
-  const partnerLinkText = heroPartnersLinkText.value
-
-  if (!partnerLinkText) {
-    return items
-  }
-
-  return items.map(item => {
-    const segmentsWithPartnerLink = item.segments
-      .map(segment => {
-        if (!segment.text.includes(partnersLinkPlaceholder)) {
-          return segment
-        }
-
-        const replacedText = segment.text.replaceAll(
-          partnersLinkPlaceholder,
-          partnerLinkText
-        )
-
-        const normalizedText = replacedText.trim()
-
-        if (!normalizedText) {
-          return null
-        }
-
-        return {
-          ...segment,
-          text: normalizedText,
-        }
-      })
-      .filter((segment): segment is HeroHelperSegment => segment != null)
-
-    return {
-      ...item,
-      segments:
-        segmentsWithPartnerLink.length > 0
-          ? segmentsWithPartnerLink
-          : item.segments,
-    }
-  })
-}
-
-const applyOpenDataMillionsPlaceholder = (items: HeroHelperItem[]) => {
-  const millionsLabel = formattedOpenDataMillions.value
-
-  if (!millionsLabel) {
-    return items
-  }
-
-  return items.map(item => {
-    const segmentsWithOpenDataMillions = item.segments
-      .map(segment => {
-        if (!segment.text.includes(openDataMillionsPlaceholder)) {
-          return segment
-        }
-
-        const replacedText = segment.text.replaceAll(
-          openDataMillionsPlaceholder,
-          millionsLabel
-        )
-
-        const normalizedText = replacedText.trim()
-
-        if (!normalizedText) {
-          return null
-        }
-
-        return {
-          ...segment,
-          text: normalizedText,
-        }
-      })
-      .filter((segment): segment is HeroHelperSegment => segment != null)
-
-    return {
-      ...item,
-      segments:
-        segmentsWithOpenDataMillions.length > 0
-          ? segmentsWithOpenDataMillions
-          : item.segments,
-    }
-  })
-}
-
-const applyProductsCategoriesPlaceholder = (items: HeroHelperItem[]) => {
-  const productsLabel = formattedProductsCount.value
-  const categoriesLabel = formattedCategoriesCount.value
-
-  if (!productsLabel || !categoriesLabel) {
-    return items
-  }
-
-  return items.map(item => {
-    const segmentsWithCounts = item.segments
-      .map(segment => {
-        if (
-          !segment.text.includes(productsCountPlaceholder) &&
-          !segment.text.includes(categoriesCountPlaceholder)
-        ) {
-          return segment
-        }
-
-        const replacedText = segment.text
-          .replaceAll(productsCountPlaceholder, productsLabel)
-          .replaceAll(categoriesCountPlaceholder, categoriesLabel)
-
-        const normalizedText = replacedText.trim()
-
-        if (!normalizedText) {
-          return null
-        }
-
-        return {
-          ...segment,
-          text: normalizedText,
-        }
-      })
-      .filter((segment): segment is HeroHelperSegment => segment != null)
-
-    return {
-      ...item,
-      segments:
-        segmentsWithCounts.length > 0 ? segmentsWithCounts : item.segments,
-    }
-  })
-}
 
 const showHeroSkeleton = computed(() => !isHeroImageLoaded.value)
 const heroBackgroundI18nKey = computed(
@@ -638,77 +259,12 @@ useHead({
                       </template>
                     </SearchSuggestField>
                   </form>
-                  <RoundedCornerCard
-                    class="home-hero__context-card"
-                    surface="strong"
-                    accent-corner="bottom-right"
-                    corner-variant="none"
-                    corner-size="lg"
-                    rounded="lg"
-                    :selectable="false"
-                    :elevation="10"
-                    :hover-elevation="14"
-                    :aria-label="
-                      packI18n.resolveString('hero.context.ariaLabel', {
-                        fallbackKeys: ['home.hero.context.ariaLabel'],
-                      })
-                    "
-                  >
-                    <div class="home-hero__context">
-                      <p class="home-hero__subtitle text-center">
-                        {{ heroContextTitle }}
-                      </p>
-
-                      <v-row class="home-hero__helper-row" justify="center">
-                        <v-col
-                          v-if="heroHelperItems.length"
-                          cols="12"
-                          class="home-hero__helpers-wrapper"
-                        >
-                          <ul class="home-hero__helpers">
-                            <li
-                              v-for="(item, index) in heroHelperItems"
-                              :key="`hero-helper-${index}`"
-                              class="home-hero__helper"
-                            >
-                              <span
-                                class="home-hero__helper-icon"
-                                aria-hidden="true"
-                                >{{ item.icon }}</span
-                              >
-                              <span class="home-hero__helper-text">
-                                <template
-                                  v-for="(
-                                    segment, segmentIndex
-                                  ) in item.segments"
-                                  :key="`hero-helper-segment-${index}-${segmentIndex}`"
-                                >
-                                  <NuxtLink
-                                    v-if="segment.to"
-                                    class="home-hero__helper-link"
-                                    :to="segment.to"
-                                  >
-                                    {{
-                                      segmentIndex > 0
-                                        ? ` ${segment.text}`
-                                        : segment.text
-                                    }}
-                                  </NuxtLink>
-                                  <span v-else>
-                                    {{
-                                      segmentIndex > 0
-                                        ? ` ${segment.text}`
-                                        : segment.text
-                                    }}
-                                  </span>
-                                </template>
-                              </span>
-                            </li>
-                          </ul>
-                        </v-col>
-                      </v-row>
-                    </div>
-                  </RoundedCornerCard>
+                  <HomeHeroHighlights
+                    :partners-count="partnersCount"
+                    :open-data-millions="openDataMillions"
+                    :products-count="productsCount"
+                    :categories-count="categoriesCount"
+                  />
                 </div>
                 <div class="home-hero__panel-block">
                   <NudgeToolWizard :verticals="wizardVerticals" />
@@ -867,71 +423,6 @@ useHead({
   flex-direction: column
   gap: clamp(1.25rem, 2vw, 1.75rem)
   min-width: 0
-
-.home-hero__context
-  flex-direction: column
-  gap: 0.75rem
-
-.home-hero__context-card
-  height: 100%
-
-.home-hero__helper-row
-  display: flex
-  flex-wrap: wrap
-  align-items: center
-  width: 100%
-
-.home-hero__helpers-wrapper
-  width: 100%
-
-.home-hero__helpers
-  margin: 0
-  padding: 0
-  display: grid
-  gap: clamp(0.4rem, 1.5vw, 0.65rem)
-  list-style: none
-  width: 100%
-
-.home-hero__helper
-  display: inline-flex
-  align-items: center
-  gap: 0.45rem
-  margin: 0
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  font-weight: 500
-
-.home-hero__helper-icon
-  font-size: 1.1rem
-
-.home-hero__helper-text
-  line-height: 1.35
-
-.home-hero__helper-link
-  color: rgb(var(--v-theme-text-neutral-strong))
-  font-weight: 600
-  text-decoration: underline
-  text-decoration-thickness: 0.08em
-  text-underline-offset: 0.1em
-
-.home-hero__context
-  display: flex
-  flex-direction: column
-  gap: 0.75rem
-
-.home-hero__subtitle
-  margin: 0
-  color: rgb(var(--v-theme-text-neutral-strong))
-  text-align: center
-  width: 100%
-
-
-.home-hero__helpers-title
-  font-size: 0.875rem
-  font-weight: 600
-  color: rgb(var(--v-theme-text-neutral-secondary))
-  margin-bottom: 0.5rem
-  display: block
-  letter-spacing: 0.01em
 
 .home-hero__wizard
   width: 100%

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -42,6 +42,51 @@ const messages: Record<string, unknown> = {
       segments: [{ text: '50M references' }],
     },
   ],
+  'packs.default.hero.highlights': [
+    {
+      title: '🌿 ImpactScore: guiding your purchases',
+      segments: [
+        {
+          text: 'An innovative ecological and environmental assessment for {products} products across',
+        },
+        {
+          text: '{categories} categories',
+          to: '/categories',
+        },
+      ],
+    },
+    {
+      title: '🇫🇷 Open & ethical',
+      segments: [
+        {
+          text: '100% independent. Over {millions}M products in',
+        },
+        {
+          text: 'open data.',
+          to: '/opendata',
+        },
+        {
+          text: 'Open-source software',
+          to: '/opensource',
+        },
+      ],
+    },
+    {
+      title: 'Price comparison',
+      segments: [
+        {
+          text: 'Avoid price traps with',
+        },
+        {
+          text: '{partnersLink}.',
+          to: '/partners',
+        },
+        {
+          text: 'Best prices, new and used price history for {products} products',
+        },
+      ],
+    },
+  ],
   'packs.default.hero.search.partnerLinkLabel':
     '{formattedCount} partner | {formattedCount} partners',
   'packs.default.hero.search.partnerLinkFallback': 'our partners',
@@ -91,6 +136,51 @@ const messages: Record<string, unknown> = {
       icon: '⚡',
       label: '50M references',
       segments: [{ text: '50M references' }],
+    },
+  ],
+  'home.hero.highlights': [
+    {
+      title: '🌿 ImpactScore: guiding your purchases',
+      segments: [
+        {
+          text: 'An innovative ecological and environmental assessment for {products} products across',
+        },
+        {
+          text: '{categories} categories',
+          to: '/categories',
+        },
+      ],
+    },
+    {
+      title: '🇫🇷 Open & ethical',
+      segments: [
+        {
+          text: '100% independent. Over {millions}M products in',
+        },
+        {
+          text: 'open data.',
+          to: '/opendata',
+        },
+        {
+          text: 'Open-source software',
+          to: '/opensource',
+        },
+      ],
+    },
+    {
+      title: 'Price comparison',
+      segments: [
+        {
+          text: 'Avoid price traps with',
+        },
+        {
+          text: '{partnersLink}.',
+          to: '/partners',
+        },
+        {
+          text: 'Best prices, new and used price history for {products} products',
+        },
+      ],
     },
   ],
   'home.hero.search.partnerLinkLabel':

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -106,6 +106,51 @@
             "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
             "partnerLinkFallback": "our partners"
           },
+          "highlights": [
+            {
+              "title": "🌿 ImpactScore: guiding your purchases",
+              "segments": [
+                {
+                  "text": "An innovative ecological and environmental assessment for {products} products across"
+                },
+                {
+                  "text": "{categories} categories",
+                  "to": "/categories"
+                }
+              ]
+            },
+            {
+              "title": "🇫🇷 Open & ethical",
+              "segments": [
+                {
+                  "text": "100% independent. Over {millions}M products in"
+                },
+                {
+                  "text": "open data.",
+                  "to": "/opendata"
+                },
+                {
+                  "text": "Open-source software",
+                  "to": "/opensource"
+                }
+              ]
+            },
+            {
+              "title": "Price comparison",
+              "segments": [
+                {
+                  "text": "Avoid price traps with"
+                },
+                {
+                  "text": "{partnersLink}.",
+                  "to": "/partners"
+                },
+                {
+                  "text": "Best prices, new and used price history for {products} products"
+                }
+              ]
+            }
+          ],
           "context": {
             "cornerLabel": "Impact digest",
             "cornerTooltip": "Key highlights from Nudger’s methodology",
@@ -278,6 +323,51 @@
         "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
         "partnerLinkFallback": "our partners"
       },
+      "highlights": [
+        {
+          "title": "🌿 ImpactScore: guiding your purchases",
+          "segments": [
+            {
+              "text": "An innovative ecological and environmental assessment for {products} products across"
+            },
+            {
+              "text": "{categories} categories",
+              "to": "/categories"
+            }
+          ]
+        },
+        {
+          "title": "🇫🇷 Open & ethical",
+          "segments": [
+            {
+              "text": "100% independent. Over {millions}M products in"
+            },
+            {
+              "text": "open data.",
+              "to": "/opendata"
+            },
+            {
+              "text": "Open-source software",
+              "to": "/opensource"
+            }
+          ]
+        },
+        {
+          "title": "Price comparison",
+          "segments": [
+            {
+              "text": "Avoid price traps with"
+            },
+            {
+              "text": "{partnersLink}.",
+              "to": "/partners"
+            },
+            {
+              "text": "Best prices, new and used price history for {products} products"
+            }
+          ]
+        }
+      ],
       "agent": {
         "title": "Any questions?",
         "subtitle": "Ask your question to our expert AI agent Nudger."

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -110,6 +110,51 @@
             "partnerLinkLabel": "{formattedCount} partenaire | {formattedCount} partenaires",
             "partnerLinkFallback": "nos partenaires"
           },
+          "highlights": [
+            {
+              "title": "🌿 ImpactScore : Guider vos achats",
+              "segments": [
+                {
+                  "text": "Une évaluation écologique et environnementale innovante pour {products} produits dans"
+                },
+                {
+                  "text": "{categories} catégories",
+                  "to": "/categories"
+                }
+              ]
+            },
+            {
+              "title": "🇫🇷 Ouvert & éthique",
+              "segments": [
+                {
+                  "text": "100% indépendant. Plus de {millions}M de produits en"
+                },
+                {
+                  "text": "données ouvertes.",
+                  "to": "/opendata"
+                },
+                {
+                  "text": "Logiciel libre",
+                  "to": "/opensource"
+                }
+              ]
+            },
+            {
+              "title": "Comparateur de prix",
+              "segments": [
+                {
+                  "text": "Sans se faire avoir sur les prix avec"
+                },
+                {
+                  "text": "{partnersLink}.",
+                  "to": "/partenaires"
+                },
+                {
+                  "text": "Les meilleurs prix, l'historique neuf et occasion pour {products} produits"
+                }
+              ]
+            }
+          ],
           "context": {
             "cornerLabel": "Résumé impact",
             "cornerTooltip": "Les points forts de la méthodologie Nudger",
@@ -288,6 +333,51 @@
         "partnerLinkLabel": "{formattedCount} partenaire | {formattedCount} partenaires",
         "partnerLinkFallback": "nos partenaires"
       },
+      "highlights": [
+        {
+          "title": "🌿 ImpactScore : Guider vos achats",
+          "segments": [
+            {
+              "text": "Une évaluation écologique et environnementale innovante pour {products} produits dans"
+            },
+            {
+              "text": "{categories} catégories",
+              "to": "/categories"
+            }
+          ]
+        },
+        {
+          "title": "🇫🇷 Ouvert & éthique",
+          "segments": [
+            {
+              "text": "100% indépendant. Plus de {millions}M de produits en"
+            },
+            {
+              "text": "données ouvertes.",
+              "to": "/opendata"
+            },
+            {
+              "text": "Logiciel libre",
+              "to": "/opensource"
+            }
+          ]
+        },
+        {
+          "title": "Comparateur de prix",
+          "segments": [
+            {
+              "text": "Sans se faire avoir sur les prix avec"
+            },
+            {
+              "text": "{partnersLink}.",
+              "to": "/partenaires"
+            },
+            {
+              "text": "Les meilleurs prix, l'historique neuf et occasion pour {products} produits"
+            }
+          ]
+        }
+      ],
       "agent": {
         "title": "Une question ?",
         "subtitle": "Posez votre question à notre agent IA expert Nudger."


### PR DESCRIPTION
### Motivation

- Consolidate the hero page helper/highlight content into a dedicated component to simplify the hero section and make highlights reusable and easier to localize.
- Surface event-pack-aware highlight copy so seasonal packs can override the three card titles/segments.
- Keep the hero UI markup slimmer by removing the old inline context/helper block and delegating rendering to the new component.

### Description

- Added a new component `HomeHeroHighlights.vue` that normalizes i18n lists and renders the hero highlights as three `RoundedCornerCard` items with link segments and placeholder replacement logic.
- Updated `HomeHeroSection.vue` to use the new `HomeHeroHighlights` component and removed the in-file highlight/context rendering logic.
- Added `highlights` keys to the French and English locale files (`frontend/i18n/locales/fr-FR.json`, `frontend/i18n/locales/en-US.json`) and updated the page test fixtures (`frontend/app/pages/index.spec.ts`) to include the new keys.
- Cleaned up associated helper code and CSS that was replaced by the new component (component wiring, props for counts and formatted placeholders remain supported).

### Testing

- Ran lint with `pnpm --offline lint` which completed successfully with one warning (no errors).
- Ran the full unit test suite with `pnpm --offline test` and all tests passed (test run completed successfully).
- Attempted a production generate with `pnpm --offline generate` which failed due to a Sass parsing error (`Expected identifier`) in `app/components/home/sections/HomeSolutionSection.vue`, this appears unrelated to the hero highlights refactor and blocks the static generate step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b94bf9af08322bc690768b55811ea)