### PR TITLE
Restore card styles from previous PR

### DIFF
--- a/docs/fr/ui/nudger-card.md
+++ b/docs/fr/ui/nudger-card.md
@@ -29,16 +29,24 @@ dans les sections marketing (home, landing pages, etc.).
 
 ## API principale
 
-| Prop | Type | Rôle |
-| --- | --- | --- |
-| `border` | `boolean` | Ajoute la bordure primaire. |
-| `accentCorners` | `Array<'top-left'|'top-right'|'bottom-right'|'bottom-left'>` | Applique un rayon “accent” à un ou plusieurs coins. |
-| `flatCorners` | `Array<'top-left'|'top-right'|'bottom-right'|'bottom-left'>` | Force un coin à `0` pour obtenir un angle droit. |
-| `baseRadius` | `string` | Rayon par défaut pour tous les coins. |
-| `accentRadius` | `string` | Rayon appliqué aux coins “accent”. |
-| `padding` | `string` | Padding interne de la carte. |
-| `background` | `string` | Couleur ou gradient de fond. |
-| `elevation` | `number` | Élévation Vuetify optionnelle. |
+| Prop | Type | Défaut | Rôle |
+| --- | --- | --- | --- |
+| `border` | `boolean` | `false` | Ajoute la bordure primaire. |
+| `shadow` | `boolean` | `true` | Active l'ombre portée (box-shadow). |
+| `hoverable` | `boolean` | `true` | Active l'effet de survol (lift + ombre renforcée). |
+| `accentCorners` | `Array<NudgerCorner>` | `[]` | Applique un rayon "accent" à un ou plusieurs coins. |
+| `flatCorners` | `Array<NudgerCorner>` | `[]` | Force un coin à `0` pour obtenir un angle droit. |
+| `baseRadius` | `string` | `'30px'` | Rayon par défaut pour tous les coins. |
+| `accentRadius` | `string` | `'50px'` | Rayon appliqué aux coins "accent". |
+| `topLeftRadius` | `string` | - | Surcharge individuelle du coin haut-gauche. |
+| `topRightRadius` | `string` | - | Surcharge individuelle du coin haut-droit. |
+| `bottomRightRadius` | `string` | - | Surcharge individuelle du coin bas-droit. |
+| `bottomLeftRadius` | `string` | - | Surcharge individuelle du coin bas-gauche. |
+| `padding` | `string` | `'1.25rem'` | Padding interne de la carte. |
+| `background` | `string` | `'#ffffff'` | Couleur ou gradient de fond. |
+| `elevation` | `number` | `0` | Élévation Vuetify optionnelle. |
+
+> **NudgerCorner** = `'top-left' | 'top-right' | 'bottom-right' | 'bottom-left'`
 
 ## Exemples
 
@@ -54,7 +62,7 @@ dans les sections marketing (home, landing pages, etc.).
 </NudgerCard>
 ```
 
-### Carte “plein écran” personnalisée
+### Carte "plein écran" personnalisée
 
 ```vue
 <NudgerCard
@@ -63,6 +71,40 @@ dans les sections marketing (home, landing pages, etc.).
   base-radius="clamp(1.75rem, 4vw, 2.5rem)"
 >
   <p>CTA</p>
+</NudgerCard>
+```
+
+### Surcharge individuelle des coins
+
+Utilisez les props `topLeftRadius`, `topRightRadius`, `bottomRightRadius` et `bottomLeftRadius` pour un contrôle précis :
+
+```vue
+<NudgerCard
+  border
+  top-left-radius="0"
+  bottom-right-radius="60px"
+>
+  <p>Coin haut-gauche carré, coin bas-droit accentué</p>
+</NudgerCard>
+```
+
+### Carte statique (sans hover)
+
+Désactivez les effets de survol pour les cartes informatives :
+
+```vue
+<NudgerCard :hoverable="false">
+  <p>Cette carte ne réagit pas au survol</p>
+</NudgerCard>
+```
+
+### Carte sans ombre
+
+Pour un style plus plat :
+
+```vue
+<NudgerCard :shadow="false" border>
+  <p>Carte avec bordure mais sans ombre</p>
 </NudgerCard>
 ```
 

--- a/frontend/app/components/shared/cards/NudgerCard.spec.ts
+++ b/frontend/app/components/shared/cards/NudgerCard.spec.ts
@@ -45,4 +45,61 @@ describe('NudgerCard', () => {
     expect(wrapper.classes()).toContain('nudger-card--border')
     await wrapper.unmount()
   })
+
+  it('applies shadow class by default', async () => {
+    const wrapper = await mountComponent()
+
+    expect(wrapper.classes()).toContain('nudger-card--shadow')
+    await wrapper.unmount()
+  })
+
+  it('omits shadow class when shadow is false', async () => {
+    const wrapper = await mountComponent({ shadow: false })
+
+    expect(wrapper.classes()).not.toContain('nudger-card--shadow')
+    await wrapper.unmount()
+  })
+
+  it('applies hoverable class by default', async () => {
+    const wrapper = await mountComponent()
+
+    expect(wrapper.classes()).toContain('nudger-card--hoverable')
+    await wrapper.unmount()
+  })
+
+  it('omits hoverable class when hoverable is false', async () => {
+    const wrapper = await mountComponent({ hoverable: false })
+
+    expect(wrapper.classes()).not.toContain('nudger-card--hoverable')
+    await wrapper.unmount()
+  })
+
+  it('uses individual corner radius overrides with highest priority', async () => {
+    const wrapper = await mountComponent({
+      accentCorners: ['top-left'],
+      flatCorners: ['bottom-right'],
+      topLeftRadius: '10px',
+      bottomRightRadius: '20px',
+    })
+
+    const style = wrapper.attributes('style')
+    // Individual overrides should take priority over accent/flat corners
+    expect(style).toContain('--nudger-card-top-left: 10px;')
+    expect(style).toContain('--nudger-card-bottom-right: 20px;')
+    await wrapper.unmount()
+  })
+
+  it('applies individual corner radius without affecting other corners', async () => {
+    const wrapper = await mountComponent({
+      topRightRadius: '15px',
+    })
+
+    const style = wrapper.attributes('style')
+    expect(style).toContain('--nudger-card-top-right: 15px;')
+    // Other corners should use baseRadius (30px by default)
+    expect(style).toContain('--nudger-card-top-left: 30px;')
+    expect(style).toContain('--nudger-card-bottom-right: 30px;')
+    expect(style).toContain('--nudger-card-bottom-left: 30px;')
+    await wrapper.unmount()
+  })
 })

--- a/frontend/app/components/shared/cards/NudgerCard.vue
+++ b/frontend/app/components/shared/cards/NudgerCard.vue
@@ -9,24 +9,50 @@ export type NudgerCorner =
 
 const props = withDefaults(
   defineProps<{
+    /** Array of corners to apply the accent (larger) radius */
     accentCorners?: NudgerCorner[]
+    /** Array of corners to make flat (0 radius) */
     flatCorners?: NudgerCorner[]
+    /** Base border-radius applied to all corners by default */
     baseRadius?: string
+    /** Radius applied to accent corners */
     accentRadius?: string
+    /** Individual override for top-left corner radius */
+    topLeftRadius?: string
+    /** Individual override for top-right corner radius */
+    topRightRadius?: string
+    /** Individual override for bottom-right corner radius */
+    bottomRightRadius?: string
+    /** Individual override for bottom-left corner radius */
+    bottomLeftRadius?: string
+    /** Show primary-colored border */
     border?: boolean
+    /** Internal padding */
     padding?: string
+    /** Background color or gradient */
     background?: string
+    /** Vuetify elevation level */
     elevation?: number
+    /** Enable box-shadow effect */
+    shadow?: boolean
+    /** Enable hover interaction (lift + shadow enhancement) */
+    hoverable?: boolean
   }>(),
   {
     accentCorners: () => [],
     flatCorners: () => [],
     baseRadius: '30px',
     accentRadius: '50px',
+    topLeftRadius: undefined,
+    topRightRadius: undefined,
+    bottomRightRadius: undefined,
+    bottomLeftRadius: undefined,
     border: false,
     padding: '1.25rem',
     background: '#ffffff',
     elevation: 0,
+    shadow: true,
+    hoverable: true,
   }
 )
 
@@ -38,13 +64,21 @@ const resolvedCorners = computed(() => {
     'bottom-left': props.baseRadius,
   }
 
+  // Apply accent corners
   props.accentCorners.forEach((corner) => {
     corners[corner] = props.accentRadius
   })
 
+  // Apply flat corners
   props.flatCorners.forEach((corner) => {
     corners[corner] = '0'
   })
+
+  // Individual overrides take highest priority
+  if (props.topLeftRadius !== undefined) corners['top-left'] = props.topLeftRadius
+  if (props.topRightRadius !== undefined) corners['top-right'] = props.topRightRadius
+  if (props.bottomRightRadius !== undefined) corners['bottom-right'] = props.bottomRightRadius
+  if (props.bottomLeftRadius !== undefined) corners['bottom-left'] = props.bottomLeftRadius
 
   return corners
 })
@@ -62,7 +96,11 @@ const styleVars = computed(() => ({
 <template>
   <v-sheet
     class="nudger-card"
-    :class="{ 'nudger-card--border': props.border }"
+    :class="{
+      'nudger-card--border': props.border,
+      'nudger-card--shadow': props.shadow,
+      'nudger-card--hoverable': props.hoverable,
+    }"
     :style="styleVars"
     :elevation="props.elevation"
     rounded="0"
@@ -77,7 +115,16 @@ const styleVars = computed(() => ({
   background: var(--nudger-card-background)
   border-radius: var(--nudger-card-top-left) var(--nudger-card-top-right) var(--nudger-card-bottom-right) var(--nudger-card-bottom-left)
   box-sizing: border-box
+  color: rgb(var(--v-theme-text-neutral-strong))
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease
 
 .nudger-card--border
   border: 1px solid rgb(var(--v-theme-primary))
+
+.nudger-card--shadow
+  box-shadow: 0 10px 26px rgba(var(--v-theme-primary), 0.06)
+
+.nudger-card--hoverable:hover
+  box-shadow: 0 18px 42px rgba(var(--v-theme-primary), 0.12)
+  transform: translateY(-1px)
 </style>


### PR DESCRIPTION
Restores the missing hover effects and box-shadow from the original card__nudger styles (PR #2602) that were lost when NudgerCard was introduced (PR #2613). Also adds individual corner radius props for more granular control.

Changes:
- Add shadow prop (default: true) for box-shadow effect
- Add hoverable prop (default: true) for hover lift + enhanced shadow
- Add individual corner radius props (topLeftRadius, topRightRadius, bottomRightRadius, bottomLeftRadius) with highest priority override
- Add text color using theme variable
- Add smooth CSS transitions for shadow, transform, and border-color
- Update documentation with new API reference and examples
- Add comprehensive tests for new functionality