### PR TITLE
Centralize home scroll reveals and add blur variant

### DIFF
--- a/frontend/app/assets/sass/components/home-animations.sass
+++ b/frontend/app/assets/sass/components/home-animations.sass
@@ -3,7 +3,8 @@
     .home-reveal-item
       opacity: 0
       transform: var(--reveal-transform, translateY(14px))
-      transition: opacity 0.45s ease, transform 0.45s ease
+      filter: var(--reveal-filter, none)
+      transition: opacity 0.45s ease, transform 0.45s ease, filter 0.45s ease
       transition-delay: var(--reveal-delay, 0ms)
       will-change: opacity, transform
 
@@ -11,10 +12,15 @@
     .home-reveal-item
       opacity: 1
       transform: var(--reveal-transform-visible, translateY(0))
+      filter: var(--reveal-filter-visible, none)
 
 .home-reveal-item--scale
   --reveal-transform: translateY(12px) scale(0.98)
   --reveal-transform-visible: translateY(0) scale(1)
+
+.home-reveal-item--blur
+  --reveal-filter: blur(6px)
+  --reveal-filter-visible: blur(0)
 
 .home-hover-card
   transition: transform 0.25s ease, box-shadow 0.25s ease
@@ -30,6 +36,7 @@
     .home-reveal-item
       opacity: 1 !important
       transform: none !important
+      filter: none !important
       transition: none !important
 
   .home-hover-card
@@ -43,6 +50,7 @@
     .home-reveal-item
       opacity: 1 !important
       transform: none !important
+      filter: none !important
       transition: none !important
 
   .home-hover-card

--- a/frontend/app/components/home/sections/HomeBlogSection.vue
+++ b/frontend/app/components/home/sections/HomeBlogSection.vue
@@ -65,7 +65,7 @@ const fallbackIconSize = 48
               cols="12"
               sm="6"
               md="4"
-              class="home-blog__col home-reveal-item"
+              class="home-blog__col home-reveal-item home-reveal-item--blur"
               :style="{ '--reveal-delay': `${240 + index * 90}ms` }"
             >
               <NuxtLink :to="article.link" class="home-blog__item">

--- a/frontend/app/components/home/sections/HomeFeaturesSection.vue
+++ b/frontend/app/components/home/sections/HomeFeaturesSection.vue
@@ -42,7 +42,7 @@ const isVisible = computed(() => Boolean(props.reveal))
           lg="4"
         >
           <NudgerCard
-            class="home-features__card home-hover-card home-reveal-item"
+            class="home-features__card home-hover-card home-reveal-item home-reveal-item--blur"
             :style="{ '--reveal-delay': `${index * 90}ms` }"
           >
             <div class="text-center">

--- a/frontend/app/components/shared/ui/SectionReveal.vue
+++ b/frontend/app/components/shared/ui/SectionReveal.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { computed, ref, watch, useAttrs } from 'vue'
+import { usePreferredReducedMotion } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
+import { useAccessibilityStore } from '~/stores/useAccessibilityStore'
+
+defineOptions({ inheritAttrs: false })
+
+type TransitionName =
+  | 'fade'
+  | 'slide-y'
+  | 'slide-y-reverse'
+  | 'slide-x'
+  | 'slide-x-reverse'
+  | 'scale'
+  | 'none'
+
+const props = withDefaults(
+  defineProps<{
+    transition?: TransitionName
+    tag?: string
+    once?: boolean
+  }>(),
+  {
+    transition: 'fade',
+    tag: 'div',
+    once: true,
+  }
+)
+
+const attrs = useAttrs()
+const prefersReducedMotion = usePreferredReducedMotion()
+const accessibilityStore = useAccessibilityStore()
+const { prefersReducedMotionOverride } = storeToRefs(accessibilityStore)
+
+const shouldReduceMotion = computed(
+  () =>
+    prefersReducedMotionOverride.value ||
+    prefersReducedMotion.value === 'reduce'
+)
+
+const isVisible = ref(false)
+
+const transitionComponent = computed(() => {
+  switch (props.transition) {
+    case 'slide-y':
+      return 'v-slide-y-transition'
+    case 'slide-y-reverse':
+      return 'v-slide-y-reverse-transition'
+    case 'slide-x':
+      return 'v-slide-x-transition'
+    case 'slide-x-reverse':
+      return 'v-slide-x-reverse-transition'
+    case 'scale':
+      return 'v-scale-transition'
+    case 'none':
+      return null
+    case 'fade':
+    default:
+      return 'v-fade-transition'
+  }
+})
+
+const markVisible = () => {
+  isVisible.value = true
+}
+
+watch(
+  shouldReduceMotion,
+  value => {
+    if (value) {
+      markVisible()
+    }
+  },
+  { immediate: true }
+)
+
+const handleIntersect = (
+  _entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver,
+  isIntersecting: boolean
+) => {
+  if (isVisible.value) {
+    return
+  }
+
+  if (shouldReduceMotion.value || isIntersecting) {
+    markVisible()
+    if (props.once) {
+      observer.disconnect()
+    }
+  }
+}
+</script>
+
+<template>
+  <component
+    :is="props.tag"
+    v-bind="attrs"
+    v-intersect="handleIntersect"
+  >
+    <component
+      :is="transitionComponent || 'div'"
+      :disabled="shouldReduceMotion || !transitionComponent"
+    >
+      <div v-show="isVisible">
+        <slot :reveal="isVisible" />
+      </div>
+    </component>
+  </component>
+</template>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 import { usePreferredReducedMotion } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { useTheme } from 'vuetify'
@@ -18,6 +18,7 @@ import HomeObjectionsSection from '~/components/home/sections/HomeObjectionsSect
 import HomeFaqSection from '~/components/home/sections/HomeFaqSection.vue'
 import HomeCtaSection from '~/components/home/sections/HomeCtaSection.vue'
 import ParallaxWidget from '~/components/shared/ui/ParallaxWidget.vue'
+import SectionReveal from '~/components/shared/ui/SectionReveal.vue'
 import type {
   CategorySuggestionItem,
   ProductSuggestionItem,
@@ -221,16 +222,6 @@ const parallaxAplatObjections = computed(() =>
   resolveAplatVariant(objectionsAplatSuffix.value)
 )
 
-type AnimatedSectionKey =
-  | 'problems'
-  | 'solution'
-  | 'features'
-  | 'blog'
-  | 'objections'
-  | 'faq'
-  | 'faq'
-  | 'cta'
-
 const prefersReducedMotion = usePreferredReducedMotion()
 const accessibilityStore = useAccessibilityStore()
 const { prefersReducedMotionOverride } = storeToRefs(accessibilityStore)
@@ -239,48 +230,6 @@ const shouldReduceMotion = computed(
     prefersReducedMotionOverride.value ||
     prefersReducedMotion.value === 'reduce'
 )
-
-const animatedSections = reactive<Record<AnimatedSectionKey, boolean>>({
-  problems: false,
-  solution: false,
-  features: false,
-  blog: false,
-  objections: false,
-  faq: false,
-  cta: false,
-})
-
-const markAllSectionsVisible = () => {
-  ;(Object.keys(animatedSections) as AnimatedSectionKey[]).forEach(key => {
-    animatedSections[key] = true
-  })
-}
-
-watch(
-  shouldReduceMotion,
-  shouldReduce => {
-    if (shouldReduce) {
-      markAllSectionsVisible()
-    }
-  },
-  { immediate: true }
-)
-
-const createIntersectHandler =
-  (key: AnimatedSectionKey) =>
-  (
-    _entries: IntersectionObserverEntry[],
-    _observer: IntersectionObserver,
-    isIntersecting: boolean
-  ) => {
-    if (animatedSections[key]) {
-      return
-    }
-
-    if (shouldReduceMotion.value || isIntersecting) {
-      animatedSections[key] = true
-    }
-  }
 
 const toSafeString = (value: unknown) => {
   if (typeof value === 'string') {
@@ -843,33 +792,23 @@ useHead(() => ({
             id="home-essentials"
             class="home-page__section-wrapper home-page__stack"
           >
-            <div
-              v-intersect="createIntersectHandler('problems')"
-              class="home-page__section"
-            >
-              <v-slide-y-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.problems">
-                  <HomeProblemsSection
-                    :items="problemItems"
-                    :reveal="animatedSections.problems"
-                  />
-                </div>
-              </v-slide-y-transition>
-            </div>
+            <SectionReveal class="home-page__section" transition="slide-y">
+              <template #default="{ reveal }">
+                <HomeProblemsSection :items="problemItems" :reveal="reveal" />
+              </template>
+            </SectionReveal>
 
-            <div
-              v-intersect="createIntersectHandler('solution')"
+            <SectionReveal
               class="home-page__section"
+              transition="slide-y-reverse"
             >
-              <v-slide-y-reverse-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.solution">
-                  <HomeSolutionSection
-                    :benefits="solutionBenefits"
-                    :reveal="animatedSections.solution"
-                  />
-                </div>
-              </v-slide-y-reverse-transition>
-            </div>
+              <template #default="{ reveal }">
+                <HomeSolutionSection
+                  :benefits="solutionBenefits"
+                  :reveal="reveal"
+                />
+              </template>
+            </SectionReveal>
           </section>
         </ParallaxWidget>
 
@@ -885,19 +824,14 @@ useHead(() => ({
           content-align="center"
         >
           <section id="home-features" class="home-page__section-wrapper">
-            <div
-              v-intersect="createIntersectHandler('features')"
-              class="home-page__section"
-            >
-              <v-scale-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.features">
-                  <HomeFeaturesSection
-                    :features="featureCards"
-                    :reveal="animatedSections.features"
-                  />
-                </div>
-              </v-scale-transition>
-            </div>
+            <SectionReveal class="home-page__section" transition="scale">
+              <template #default="{ reveal }">
+                <HomeFeaturesSection
+                  :features="featureCards"
+                  :reveal="reveal"
+                />
+              </template>
+            </SectionReveal>
           </section>
         </ParallaxWidget>
 
@@ -918,20 +852,15 @@ useHead(() => ({
             id="home-knowledge-blog"
             class="home-page__section-wrapper home-page__stack"
           >
-            <div
-              v-intersect="createIntersectHandler('blog')"
-              class="home-page__section"
-            >
-              <v-slide-x-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.blog">
-                  <HomeBlogSection
-                    :loading="blogLoading"
-                    :items="enrichedBlogItems"
-                    :reveal="animatedSections.blog"
-                  />
-                </div>
-              </v-slide-x-transition>
-            </div>
+            <SectionReveal class="home-page__section" transition="slide-x">
+              <template #default="{ reveal }">
+                <HomeBlogSection
+                  :loading="blogLoading"
+                  :items="enrichedBlogItems"
+                  :reveal="reveal"
+                />
+              </template>
+            </SectionReveal>
           </section>
         </ParallaxWidget>
 
@@ -952,19 +881,14 @@ useHead(() => ({
             id="home-knowledge-objections"
             class="home-page__section-wrapper home-page__stack"
           >
-            <div
-              v-intersect="createIntersectHandler('objections')"
+            <SectionReveal
               class="home-page__section"
+              transition="slide-x-reverse"
             >
-              <v-slide-x-reverse-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.objections">
-                  <HomeObjectionsSection
-                    :items="objectionItems"
-                    :reveal="animatedSections.objections"
-                  />
-                </div>
-              </v-slide-x-reverse-transition>
-            </div>
+              <template #default="{ reveal }">
+                <HomeObjectionsSection :items="objectionItems" :reveal="reveal" />
+              </template>
+            </SectionReveal>
           </section>
         </ParallaxWidget>
 
@@ -983,34 +907,20 @@ useHead(() => ({
             id="home-cta"
             class="home-page__section-wrapper home-page__stack home-page__stack--compact"
           >
-            <div
-              v-intersect="createIntersectHandler('faq')"
-              class="home-page__section"
-            >
-              <v-fade-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.faq">
-                  <HomeFaqSection :items="faqPanels" />
-                </div>
-              </v-fade-transition>
-            </div>
+            <SectionReveal class="home-page__section" transition="fade">
+              <HomeFaqSection :items="faqPanels" />
+            </SectionReveal>
 
-            <div
-              v-intersect="createIntersectHandler('cta')"
-              class="home-page__section"
-            >
-              <v-slide-y-transition :disabled="shouldReduceMotion">
-                <div v-show="animatedSections.cta">
-                  <HomeCtaSection
-                    v-model:search-query="searchQuery"
-                    :categories-landing-url="categoriesLandingUrl"
-                    :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
-                    @submit="handleSearchSubmit"
-                    @select-category="handleCategorySuggestion"
-                    @select-product="handleProductSuggestion"
-                  />
-                </div>
-              </v-slide-y-transition>
-            </div>
+            <SectionReveal class="home-page__section" transition="slide-y">
+              <HomeCtaSection
+                v-model:search-query="searchQuery"
+                :categories-landing-url="categoriesLandingUrl"
+                :min-suggestion-query-length="MIN_SUGGESTION_QUERY_LENGTH"
+                @submit="handleSearchSubmit"
+                @select-category="handleCategorySuggestion"
+                @select-product="handleProductSuggestion"
+              />
+            </SectionReveal>
           </section>
         </ParallaxWidget>
       </div>


### PR DESCRIPTION
### Motivation
- Reduce duplication by centralizing intersection-based scroll reveal logic behind a reusable wrapper that respects reduced-motion preferences. 
- Provide a visually softer reveal option via a blur variant for feature and blog cards to improve the home page entrance animations. 

### Description
- Add new component `frontend/app/components/shared/ui/SectionReveal.vue` which encapsulates `v-*` transition selection, intersection handling, `usePreferredReducedMotion`, and the accessibility store override, and exposes a `reveal` slot prop. 
- Refactor `frontend/app/pages/index.vue` to replace per-section intersection handlers and local animated state with `SectionReveal` usage for all home page sections and remove the old reactive `animatedSections` machinery. 
- Apply the blur modifier by adding `home-reveal-item--blur` to cards in `frontend/app/components/home/sections/HomeFeaturesSection.vue` and `frontend/app/components/home/sections/HomeBlogSection.vue`. 
- Update `frontend/app/assets/sass/components/home-animations.sass` to support `--reveal-filter`/`--reveal-filter-visible`, include `filter` in transitions, add `.home-reveal-item--blur` variables, and ensure reduced-motion rules clear `filter`. 

### Testing
- Ran `pnpm lint --offline`, which failed due to missing `node_modules` and unavailable ESLint config. 
- Ran `pnpm test --offline`, which failed because `vitest` was not found (node modules missing). 
- Ran `pnpm generate --offline`, which failed because `nuxt` was not found (node modules missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696df4167e508322b42607a8b9a08f1d)