### PR TITLE
Add localized preferred product names and ProductDesignation component; use localized titles across front-end and API

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/NamesAggregationService.java
@@ -509,7 +509,7 @@ public class NamesAggregationService extends AbstractAggregationService {
 		}
 
 		// Best computed name
-		String bestName = data.bestName();
+		String bestName = data.preferredName(null);
 		if (StringUtils.isNotBlank(bestName)) {
 			chunks.add(bestName);
 		}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -134,6 +134,25 @@ class ProductMappingServiceTest {
     }
 
     @Test
+    void getProductUsesLocalizedShortNameForPreferredName() throws Exception {
+        long gtin = 777L;
+        Product product = new Product(gtin);
+        ProductTexts names = new ProductTexts();
+        Localisable<String, String> shortName = new Localisable<>();
+        shortName.put("en", "Localized short name");
+        names.setShortName(shortName);
+        product.setNames(names);
+        product.setOfferNames(Set.of("Fallback offer"));
+
+        when(repository.getById(gtin)).thenReturn(product);
+
+        ProductDto dto = service.getProduct(gtin, Locale.ENGLISH, Set.of("base"), DomainLanguage.en);
+
+        assertThat(dto.base()).isNotNull();
+        assertThat(dto.base().bestName()).isEqualTo("Localized short name");
+    }
+
+    @Test
     void scoresIncludeReferencedProducts() throws Exception {
         long gtin = 555L;
         Product product = new Product(gtin);

--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -9,10 +9,7 @@
   >
     <v-col
       v-for="product in products"
-      :key="
-        resolveProductTitle(product, undefined, { preferCardTitle: true }) ??
-        Math.random()
-      "
+      :key="product.gtin ?? resolveCardProductName(product) ?? Math.random()"
       cols="12"
       :sm="normalizedSize === 'small' ? 6 : 6"
       :md="normalizedSize === 'small' ? 4 : normalizedSize === 'big' ? 4 : 6"
@@ -56,8 +53,7 @@
             <v-img
               :src="resolveImage(product)"
               :alt="
-                product.identity?.bestName ??
-                product.identity?.model ??
+                resolveCardProductName(product) ||
                 $t('category.products.untitledProduct')
               "
               contain
@@ -69,16 +65,12 @@
             </v-img>
 
             <div class="category-product-card-grid__title-overlay">
-              <component
-                :is="normalizedSize === 'big' ? 'h2' : 'h3'"
-                class="category-product-card-grid__title"
-              >
-                {{
-                  resolveProductTitle(product, undefined, {
-                    preferCardTitle: true,
-                  })
-                }}
-              </component>
+              <ProductDesignation
+                :product="product"
+                variant="card"
+                :title-tag="normalizedSize === 'big' ? 'h2' : 'h3'"
+                title-class="category-product-card-grid__title"
+              />
             </div>
 
             <div class="category-product-card-grid__corner" role="presentation">
@@ -188,13 +180,14 @@ import { ProductPriceTrendDtoTrendEnum } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import ProductTileCard from '~/components/category/products/ProductTileCard.vue'
 import CategoryProductCompareToggle from './CategoryProductCompareToggle.vue'
+import ProductDesignation from '~/components/product/ProductDesignation.vue'
 import {
   formatAttributeValue,
   resolvePopularAttributes,
 } from '~/utils/_product-attributes'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
-import { resolveProductTitle } from '~/utils/_product-title-resolver'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 const props = defineProps<{
   products: ProductDto[]
@@ -207,8 +200,11 @@ const props = defineProps<{
   nofollowLinks?: boolean
 }>()
 
-const { t, n } = useI18n()
+const { t, n, locale } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
+
+const resolveCardProductName = (product: ProductDto) =>
+  resolveProductShortName(product, locale.value)
 
 const currencySymbolCache = new Map<string, string>()
 const NBSP = '\u00A0'

--- a/frontend/app/components/category/products/CategoryProductCompareToggle.vue
+++ b/frontend/app/components/category/products/CategoryProductCompareToggle.vue
@@ -43,6 +43,7 @@ import {
   useProductCompareStore,
   type CompareListBlockReason,
 } from '~/stores/useProductCompareStore'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 const props = withDefaults(
   defineProps<{
@@ -62,7 +63,7 @@ const emit = defineEmits<{
   (event: 'toggled', product: ProductDto, selected: boolean): void
 }>()
 
-const { t, te } = useI18n()
+const { t, te, locale } = useI18n()
 const compareStore = useProductCompareStore()
 
 const isSelected = computed(() => compareStore.hasProduct(props.product))
@@ -98,10 +99,7 @@ const reasonMessage = (reason: CompareListBlockReason | undefined) => {
 }
 
 const productDisplayName = (product: ProductDto) =>
-  product.identity?.bestName ??
-  product.base?.bestName ??
-  product.identity?.model ??
-  product.identity?.brand ??
+  resolveProductShortName(product, locale.value) ||
   t('category.products.untitledProduct')
 
 const eligibility = computed(() => compareStore.canAddProduct(props.product))

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -2,7 +2,7 @@
   <v-list class="category-product-list" lines="three" density="comfortable">
     <v-list-item
       v-for="product in products"
-      :key="product.gtin ?? product.identity?.bestName ?? Math.random()"
+      :key="product.gtin ?? resolveListProductName(product) ?? Math.random()"
       class="category-product-list__item"
       :to="productLink(product)"
       link
@@ -13,8 +13,7 @@
           <v-img
             :src="resolveImage(product)"
             :alt="
-              product.identity?.bestName ??
-              product.identity?.model ??
+              resolveListProductName(product) ||
               $t('category.products.untitledProduct')
             "
             cover
@@ -31,10 +30,10 @@
           <div class="category-product-list__header">
             <h3 class="category-product-list__title">
               {{
-                product.identity?.bestName ??
-                product.identity?.model ??
-                product.identity?.brand ??
-                '#' + product.gtin
+                resolveListProductName(product) ||
+                (product.gtin
+                  ? '#' + product.gtin
+                  : $t('category.products.untitledProduct'))
               }}
             </h3>
           </div>
@@ -113,16 +112,20 @@ import {
 } from '~/utils/_product-attributes'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 const props = defineProps<{
   products: ProductDto[]
   popularAttributes?: AttributeConfigDto[]
 }>()
 
-const { t, n } = useI18n()
+const { t, n, locale } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
 
 const popularAttributeConfigs = computed(() => props.popularAttributes ?? [])
+
+const resolveListProductName = (product: ProductDto) =>
+  resolveProductShortName(product, locale.value)
 
 const resolveImage = (product: ProductDto) => {
   return (

--- a/frontend/app/components/category/products/CategoryProductTable.vue
+++ b/frontend/app/components/category/products/CategoryProductTable.vue
@@ -31,8 +31,8 @@
         <div class="category-product-table__model-name">
           {{
             value ??
-            item.product.identity?.bestName ??
-            '#' + (item.product.gtin ?? '')
+            (resolveTableProductName(item.product) ||
+              (item.product.gtin ? `#${item.product.gtin}` : ''))
           }}
         </div>
       </div>
@@ -85,6 +85,7 @@ import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
 import { formatBestPrice, formatOffersCount } from '~/utils/_product-pricing'
 import { resolveFilterFieldTitle } from '~/utils/_field-localization'
 import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 type AttributeCellValue = string | null
 
@@ -136,7 +137,7 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
-const { t, n } = useI18n()
+const { t, n, locale } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
 
 const attributeConfigMap = computed<Record<string, AttributeConfigDto>>(
@@ -146,6 +147,9 @@ const attributeKeys = computed(() => props.attributeKeys ?? [])
 const fieldMetadataMap = computed<Record<string, FieldMetadataDto>>(
   () => props.fieldMetadata ?? {}
 )
+
+const resolveTableProductName = (product: ProductDto) =>
+  resolveProductShortName(product, locale.value)
 
 const extractAttributeKeyFromMapping = (
   mapping: string | undefined

--- a/frontend/app/components/category/products/ProductTileCard.vue
+++ b/frontend/app/components/category/products/ProductTileCard.vue
@@ -46,9 +46,12 @@
         <div class="product-tile-card__content">
           <div class="product-tile-card__header">
             <div class="product-tile-card__header-top">
-              <h3 class="product-tile-card__title text-truncate">
-                {{ displayTitle }}
-              </h3>
+              <ProductDesignation
+                :product="product"
+                variant="card"
+                title-tag="h3"
+                title-class="product-tile-card__title text-truncate"
+              />
             </div>
             <div
               v-if="hasAttributes"
@@ -138,9 +141,12 @@
         >
           <div class="product-tile-card__header">
             <div class="product-tile-card__header-top">
-              <h3 class="product-tile-card__title text-truncate">
-                {{ displayTitle }}
-              </h3>
+              <ProductDesignation
+                :product="product"
+                variant="card"
+                title-tag="h3"
+                title-class="product-tile-card__title text-truncate"
+              />
             </div>
             <div
               v-if="hasAttributes"
@@ -254,7 +260,8 @@ import { computed } from 'vue'
 import type { ProductDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import CategoryProductCompareToggle from '~/components/category/products/CategoryProductCompareToggle.vue'
-import { resolveProductTitle } from '~/utils/_product-title-resolver'
+import ProductDesignation from '~/components/product/ProductDesignation.vue'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 export type ProductTileAttribute = {
   key: string
@@ -299,16 +306,20 @@ const props = withDefaults(
   }
 )
 
+const { locale } = useI18n()
+
 const subtitle = computed(
   () =>
     props.product.identity?.model ??
-    props.product.identity?.bestName ??
+    props.product.identity?.brand ??
     (props.product.gtin ? `#${props.product.gtin}` : props.untitledLabel)
 )
 
 const hasAttributes = computed(() => props.attributes.length > 0)
 
-const displayTitle = computed(() => resolveProductTitle(props.product))
+const displayTitle = computed(() =>
+  resolveProductShortName(props.product, locale.value)
+)
 </script>
 
 <style scoped lang="scss">

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -492,6 +492,7 @@ import {
   resolveFilterFieldTitle,
   resolveSortFieldTitle,
 } from '~/utils/_field-localization'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 import { hasAdminAccess } from '~~/shared/utils/_roles'
 
 const route = useRoute()
@@ -1444,9 +1445,7 @@ const productListJsonLd = computed(() => {
 
   const items = products.slice(0, 20).map((product, index) => {
     const name =
-      product.identity?.bestName ??
-      product.identity?.model ??
-      product.identity?.brand ??
+      resolveProductShortName(product, locale.value) ||
       (product.gtin != null ? `GTIN ${product.gtin}` : undefined)
 
     if (!name) {

--- a/frontend/app/components/product/ProductDesignation.spec.ts
+++ b/frontend/app/components/product/ProductDesignation.spec.ts
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { describe, expect, it } from 'vitest'
+import type { ProductDto } from '~~/shared/api-client'
+import ProductDesignation from './ProductDesignation.vue'
+
+const createI18nInstance = () =>
+  createI18n({
+    legacy: false,
+    locale: 'en',
+    messages: { en: {} },
+  })
+
+const buildProduct = (overrides: Partial<ProductDto> = {}): ProductDto =>
+  ({
+    gtin: 1,
+    names: overrides.names,
+    aiReview: overrides.aiReview,
+    identity: overrides.identity,
+    base: overrides.base,
+    attributes: overrides.attributes,
+    resources: overrides.resources,
+    offers: overrides.offers,
+    scores: overrides.scores,
+    datasources: overrides.datasources,
+    slug: overrides.slug,
+    fullSlug: overrides.fullSlug,
+  }) as ProductDto
+
+describe('ProductDesignation', () => {
+  it('renders the short name for card variant', () => {
+    const wrapper = mount(ProductDesignation, {
+      props: {
+        product: buildProduct({
+          names: { shortName: 'Short name', longName: 'Long name' },
+        }),
+        variant: 'card',
+        titleTag: 'h3',
+        titleClass: 'title',
+      },
+      global: {
+        plugins: [createI18nInstance()],
+      },
+    })
+
+    expect(wrapper.find('.title').text()).toBe('Short name')
+    expect(wrapper.find('p').exists()).toBe(false)
+  })
+
+  it('renders the long name and short description on page variant', () => {
+    const wrapper = mount(ProductDesignation, {
+      props: {
+        product: buildProduct({
+          names: { longName: 'Long name', h1Title: 'H1 title' },
+          aiReview: { review: { shortDescription: 'AI short description' } },
+        }),
+        variant: 'page',
+        titleTag: 'h1',
+        titleClass: 'title',
+        descriptionClass: 'description',
+      },
+      global: {
+        plugins: [createI18nInstance()],
+      },
+    })
+
+    expect(wrapper.find('.title').text()).toBe('Long name')
+    expect(wrapper.find('.description').text()).toBe('AI short description')
+  })
+
+  it('hides the short description when not provided', () => {
+    const wrapper = mount(ProductDesignation, {
+      props: {
+        product: buildProduct({
+          names: { longName: 'Long name' },
+        }),
+        variant: 'page',
+      },
+      global: {
+        plugins: [createI18nInstance()],
+      },
+    })
+
+    expect(wrapper.find('p').exists()).toBe(false)
+  })
+})

--- a/frontend/app/components/product/ProductDesignation.vue
+++ b/frontend/app/components/product/ProductDesignation.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="product-designation">
+    <slot
+      :short-name="shortName"
+      :long-name="longName"
+      :short-description="shortDescription"
+      :display-title="displayTitle"
+    >
+      <component :is="titleTag" :class="titleClass">
+        {{ displayTitle }}
+      </component>
+      <p v-if="shouldShowDescription" :class="descriptionClass">
+        {{ shortDescription }}
+      </p>
+    </slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ProductDto } from '~~/shared/api-client'
+import {
+  resolveProductLongName,
+  resolveProductShortName,
+} from '~/utils/_product-title-resolver'
+
+const props = withDefaults(
+  defineProps<{
+    product: ProductDto
+    variant?: 'card' | 'page'
+    titleTag?: keyof HTMLElementTagNameMap
+    titleClass?: string
+    descriptionClass?: string
+    showShortDescription?: boolean
+  }>(),
+  {
+    variant: 'card',
+    titleTag: 'h3',
+    titleClass: 'product-designation__title',
+    descriptionClass: 'product-designation__description',
+    showShortDescription: undefined,
+  }
+)
+
+const { locale } = useI18n()
+
+const shortName = computed(() =>
+  resolveProductShortName(props.product, locale.value)
+)
+const longName = computed(() =>
+  resolveProductLongName(props.product, locale.value)
+)
+const shortDescription = computed(() =>
+  props.product.aiReview?.review?.shortDescription?.trim()
+)
+
+const displayTitle = computed(() =>
+  props.variant === 'page' ? longName.value : shortName.value
+)
+
+const shouldShowDescription = computed(() => {
+  const hasDescription =
+    typeof shortDescription.value === 'string' &&
+    shortDescription.value.length > 0
+  if (props.showShortDescription !== undefined) {
+    return props.showShortDescription && hasDescription
+  }
+
+  return props.variant === 'page' && hasDescription
+})
+</script>
+
+<style scoped lang="scss">
+.product-designation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+
+  &__title {
+    margin: 0;
+  }
+
+  &__description {
+    margin: 0;
+    color: rgb(var(--v-theme-text-neutral-secondary));
+    font-size: 0.95rem;
+  }
+}
+</style>

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -2,7 +2,13 @@
   <section class="product-hero">
     <div class="product-hero__content">
       <header v-if="heroTitle" class="product-hero__heading">
-        <h1 class="product-hero__title text-center">{{ heroTitle }}</h1>
+        <ProductDesignation
+          :product="product"
+          variant="page"
+          title-tag="h1"
+          title-class="product-hero__title text-center"
+          description-class="product-hero__short-description text-center"
+        />
         <CategoryNavigationBreadcrumbs
           v-if="heroBreadcrumbs.length"
           v-bind="heroBreadcrumbProps"
@@ -202,6 +208,7 @@ import { useI18n } from 'vue-i18n'
 import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
+import ProductDesignation from '~/components/product/ProductDesignation.vue'
 import {
   MAX_COMPARE_ITEMS,
   useProductCompareStore,
@@ -213,7 +220,10 @@ import {
   resolvePopularAttributes,
 } from '~/utils/_product-attributes'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
-import { resolveProductTitle } from '~/utils/_product-title-resolver'
+import {
+  resolveProductLongName,
+  resolveProductShortName,
+} from '~/utils/_product-title-resolver'
 
 import type {
   AttributeConfigDto,
@@ -281,11 +291,7 @@ const normalizeString = (value: string | null | undefined) =>
   typeof value === 'string' ? value.trim() : ''
 
 const heroTitle = computed(() => {
-  return resolveProductTitle(props.product, locale.value, {
-    preferLongName: true,
-    preferH1Title: true,
-    uppercaseBrand: true,
-  })
+  return resolveProductLongName(props.product, locale.value)
 })
 
 const productBrandName = computed(() =>
@@ -435,8 +441,8 @@ const compareButtonTitle = computed(() => {
 const compareButtonAriaLabel = computed(() => {
   const productName =
     heroTitle.value ||
-    props.product.identity?.bestName ||
-    props.product.base?.bestName
+    resolveProductShortName(props.product, locale.value) ||
+    ''
 
   if (isCompareSelected.value) {
     if (te('product.hero.compare.ariaSelected')) {
@@ -620,6 +626,14 @@ const impactScoreOn20 = computed(() => resolvePrimaryImpactScore(props.product))
   margin: 0;
   color: rgb(var(--v-theme-text-neutral-strong));
   text-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+}
+
+.product-hero__short-description {
+  margin: 0.65rem auto 0;
+  max-width: 680px;
+  font-size: 1.05rem;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  text-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
 }
 
 .product-hero__breadcrumbs {

--- a/frontend/app/services/compare/CompareService.ts
+++ b/frontend/app/services/compare/CompareService.ts
@@ -5,6 +5,7 @@ import type {
   AiReviewDto,
 } from '~~/shared/api-client'
 import { resolvePrimaryImpactScore } from '~/utils/_product-scores'
+import { resolveProductTitle } from '~/utils/_product-title-resolver'
 
 export interface CompareProductReview {
   description: string | null
@@ -91,12 +92,11 @@ const normaliseReview = (
 
 const resolveTitle = (product: ProductDto): string => {
   return (
-    product.identity?.bestName ??
-    product.base?.bestName ??
-    product.names?.h1Title ??
-    product.names?.longestOfferName ??
-    product.identity?.model ??
-    product.identity?.brand ??
+    resolveProductTitle(product, undefined, {
+      preferLongName: true,
+      preferH1Title: true,
+    }) ||
+    product.names?.longestOfferName ||
     '#'
   )
 }

--- a/frontend/app/stores/useProductCompareStore.ts
+++ b/frontend/app/stores/useProductCompareStore.ts
@@ -2,6 +2,7 @@ import { useLocalStorage } from '@vueuse/core'
 import { computed } from 'vue'
 import { defineStore } from 'pinia'
 import type { ProductDto } from '~~/shared/api-client'
+import { resolveProductShortName } from '~/utils/_product-title-resolver'
 
 export const MAX_COMPARE_ITEMS = 4
 const STORAGE_KEY = 'open4goods:compare-list'
@@ -37,12 +38,8 @@ const getProductIdentifier = (product: ProductDto): string | null => {
 
 const resolveProductName = (product: ProductDto): string => {
   return (
-    product.identity?.bestName ??
-    product.base?.bestName ??
-    product.identity?.model ??
-    product.identity?.brand ??
-    product.names?.h1Title ??
-    product.names?.longestOfferName ??
+    resolveProductShortName(product) ||
+    product.names?.longestOfferName ||
     '#'
   )
 }

--- a/frontend/app/utils/_product-title-resolver.ts
+++ b/frontend/app/utils/_product-title-resolver.ts
@@ -126,3 +126,22 @@ export const resolveProductTitle = (
 
   return ''
 }
+
+export const resolveProductShortName = (
+  product: ProductDto,
+  locale?: string
+): string =>
+  resolveProductTitle(product, locale, {
+    preferShortName: true,
+    preferPrettyName: true,
+  })
+
+export const resolveProductLongName = (
+  product: ProductDto,
+  locale?: string
+): string =>
+  resolveProductTitle(product, locale, {
+    preferLongName: true,
+    preferH1Title: true,
+    uppercaseBrand: true,
+  })

--- a/model/src/main/java/org/open4goods/model/product/Product.java
+++ b/model/src/main/java/org/open4goods/model/product/Product.java
@@ -584,6 +584,62 @@ public class Product implements Standardisable {
 	}
 
 	/**
+	 * Returns the preferred localized name for this product.
+	 * <p>
+	 * Resolution order:
+	 * <ol>
+	 *     <li>short name</li>
+	 *     <li>long name</li>
+	 *     <li>H1 title</li>
+	 *     <li>pretty name</li>
+	 *     <li>{@link #bestName()}</li>
+	 * </ol>
+	 * </p>
+	 *
+	 * @param language language key (e.g. "en", "fr", or {@code null} for default)
+	 * @return the preferred name, never {@code null}
+	 */
+	public String preferredName(final String language) {
+		String resolved = resolveLocalisedName(names == null ? null : names.getShortName(), language);
+		if (StringUtils.isNotBlank(resolved)) {
+			return resolved;
+		}
+
+		resolved = resolveLocalisedName(names == null ? null : names.getLongName(), language);
+		if (StringUtils.isNotBlank(resolved)) {
+			return resolved;
+		}
+
+		resolved = resolveLocalisedName(names == null ? null : names.getH1Title(), language);
+		if (StringUtils.isNotBlank(resolved)) {
+			return resolved;
+		}
+
+		resolved = resolveLocalisedName(names == null ? null : names.getPrettyName(), language);
+		if (StringUtils.isNotBlank(resolved)) {
+			return resolved;
+		}
+
+		return bestName();
+	}
+
+	/**
+	 * Resolve a localized string from the provided {@link Localisable} container.
+	 *
+	 * @param localisable localized content
+	 * @param language language key (e.g. "en" or "fr")
+	 * @return resolved string or empty when missing
+	 */
+	private String resolveLocalisedName(final Localisable<String, String> localisable, final String language) {
+		if (localisable == null || localisable.isEmpty()) {
+			return "";
+		}
+
+		String resolved = localisable.i18n(language);
+		return resolved == null ? "" : resolved.trim();
+	}
+
+	/**
 	 *
 	 * @return All categories in an IHM purpose, without the shortest one
 	 */


### PR DESCRIPTION
### Motivation
- Provide a single, deterministic way to resolve a product’s preferred (localized) name across model, API mapping and frontend so clients show consistent titles.
- Prefer short/long/H1/pretty name variants depending on context (card vs page) and expose a reusable component to render designation and short descriptions.
- Use localized product names in aggregations and product references to improve SEO/UX and downstream clients.

### Description
- Model: added `preferredName(String)` and `resolveLocalisedName(...)` to `Product.java` to resolve short/long/H1/pretty names with a fallback to `bestName()`.
- API: updated `NamesAggregationService` to use `data.preferredName(null)` when building name chunks.
- Front-API: extended `ProductMappingService` to resolve a preferred localized name (`resolvePreferredName`) from `ProductTexts` and use it in `ProductReferenceDto`, `ProductBaseDto` and `ProductIdentityDto`, and added a unit test exercising short-name resolution.
- Frontend: added `ProductDesignation.vue` + spec; extended `_product-title-resolver.ts` with `resolveProductShortName`/`resolveProductLongName`; updated many list/card/table/hero/compare components and the compare store to use the new resolvers and the `ProductDesignation` component; updated `CompareService` to use `resolveProductTitle` for consistent long-title fallback.

### Testing
- Ran frontend lint: `pnpm lint` and `pnpm lint:forbidden` (no forbidden patterns detected) and addressed issues; lint passed.
- Executed the frontend unit test suite: `pnpm test` (Vitest) and iterated on fixes; newly added/modified component tests (`ProductDesignation.spec.ts`) and updated specs pass locally; the frontend test run completed with the project test suite executing and the updated tests passing.
- No full Maven build was executed in this run; Java changes include unit test additions under `front-api` and should be validated with `mvn --offline -pl nudger-front-api -am test` or a full `mvn --offline clean install` before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e0a671b5c832289d019f88a6fbf63)