### PR TITLE
Search: hero filters, date-range filters, i18n keys and semantic ranking boost

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -390,7 +390,10 @@ public class ProductController {
         filterDto = filterValidation.value();
 
         String normalizedQuery = StringUtils.hasText(query) ? query.trim() : null;
-        boolean semanticSearch = StringUtils.hasText(normalizedQuery);
+        Boolean requestedSemanticSearch = searchPayload != null ? searchPayload.semanticSearch() : null;
+        boolean semanticSearch = requestedSemanticSearch != null
+                ? requestedSemanticSearch.booleanValue()
+                : StringUtils.hasText(normalizedQuery);
         Set<String> requestedComponents = include == null ? Set.of() : include;
 
         ProductSearchResponseDto body = service.searchProducts(effectivePageable, locale, requestedComponents, aggDto,

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductDto.java
@@ -67,7 +67,9 @@ public record ProductDto(
                 offersCount("offersCount"),
                 brand("attributes.referentielAttributes.BRAND"),
                 model("attributes.referentielAttributes.MODEL"),
-                ecoscore("scores.ECOSCORE.value");
+                ecoscore("scores.ECOSCORE.value"),
+                creationDate("creationDate"),
+                lastChange("lastChange");
 
 
                 private final String text;
@@ -105,7 +107,9 @@ public record ProductDto(
                 condition(FilterField.condition),
                 brand(FilterField.brand),
                 country(FilterField.country),
-                ecoscore(FilterField.ecoscore);
+                ecoscore(FilterField.ecoscore),
+                creationDate(FilterField.creationDate),
+                lastChange(FilterField.lastChange);
 
                 private final FilterField delegate;
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AllowedGlobalFilters.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/AllowedGlobalFilters.java
@@ -16,7 +16,11 @@ public enum AllowedGlobalFilters {
     @Schema(description = "Filter on the minimum aggregated price", example = "price.minPrice.price")
     minPrice("price.minPrice.price", FilterRequestDto.FilterValueType.numeric),
     @Schema(description = "Filter on the product condition (NEW, USED)", example = "price.conditions")
-    productCondition("price.conditions", FilterRequestDto.FilterValueType.keyword);
+    productCondition("price.conditions", FilterRequestDto.FilterValueType.keyword),
+    @Schema(description = "Filter on the product creation date (epoch millis)", example = "creationDate")
+    creationDate("creationDate", FilterRequestDto.FilterValueType.numeric),
+    @Schema(description = "Filter on the last product update date (epoch millis)", example = "lastChange")
+    lastChange("lastChange", FilterRequestDto.FilterValueType.numeric);
 
     private final String fieldPath;
     private final FilterRequestDto.FilterValueType valueType;

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/FilterRequestDto.java
@@ -76,7 +76,11 @@ public record FilterRequestDto(
         @Schema(description = "Filter on the moderation causes applied to the product", example = "excludedCauses")
         excludedCauses("excludedCauses", FilterValueType.keyword),
         @Schema(description = "Filter on the product impact score", example = "ecoscore")
-        ecoscore("scores.ECOSCORE.value", FilterValueType.numeric);
+        ecoscore("scores.ECOSCORE.value", FilterValueType.numeric),
+        @Schema(description = "Filter on the product creation date (epoch millis)", example = "1704067200000")
+        creationDate("creationDate", FilterValueType.numeric),
+        @Schema(description = "Filter on the last modification date (epoch millis)", example = "1706659200000")
+        lastChange("lastChange", FilterValueType.numeric);
 
         private final String fieldPath;
         private final FilterValueType valueType;

--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -1,21 +1,22 @@
 <template>
-  <nav
-    id="container-main-menu"
-    class="d-none d-md-block"
-    :aria-label="t('siteIdentity.menu.ariaLabel')"
-  >
-    <!-- Desktop menu -->
-    <div class="d-flex justify-space-between align-center ga-4 w-100">
-      <div
-        class="flex-grow-1 d-flex justify-center px-4"
-        style="max-width: 100%"
-      >
+  <div class="the-hero-menu">
+    <nav
+      id="container-main-menu"
+      class="d-none d-md-block"
+      :aria-label="t('siteIdentity.menu.ariaLabel')"
+    >
+      <!-- Desktop menu -->
+      <div class="d-flex justify-space-between align-center ga-4 w-100">
         <div
-          v-if="showMenuSearch"
-          ref="menuSearchRef"
-          class="main-menu-search"
-          :class="{ 'main-menu-search--open': isSearchOpen }"
+          class="flex-grow-1 d-flex justify-center px-4"
+          style="max-width: 100%"
         >
+          <div
+            v-if="showMenuSearch"
+            ref="menuSearchRef"
+            class="main-menu-search"
+            :class="{ 'main-menu-search--open': isSearchOpen }"
+          >
           <v-btn
             v-if="!isSearchOpen"
             class="main-menu-search__activator"
@@ -642,28 +643,29 @@
           </v-card>
           </v-menu>
         </div>
+        </div>
       </div>
-    </div>
-  </nav>
+    </nav>
 
-  <v-dialog
-    v-model="isNudgeWizardOpen"
-    max-width="980"
-    scrollable
-    transition="dialog-bottom-transition"
-  >
-    <NudgeToolWizard @navigate="isNudgeWizardOpen = false" />
-  </v-dialog>
-
-  <!-- Mobile menu command -->
-  <div class="d-flex justify-end d-md-none">
-    <v-btn
-      icon
-      :aria-label="t('siteIdentity.menu.openLabel')"
-      @click="$emit('toggle-drawer')"
+    <v-dialog
+      v-model="isNudgeWizardOpen"
+      max-width="980"
+      scrollable
+      transition="dialog-bottom-transition"
     >
-      <v-icon icon="mdi-menu" />
-    </v-btn>
+      <NudgeToolWizard @navigate="isNudgeWizardOpen = false" />
+    </v-dialog>
+
+    <!-- Mobile menu command -->
+    <div class="d-flex justify-end d-md-none">
+      <v-btn
+        icon
+        :aria-label="t('siteIdentity.menu.openLabel')"
+        @click="$emit('toggle-drawer')"
+      >
+        <v-icon icon="mdi-menu" />
+      </v-btn>
+    </div>
   </div>
 </template>
 

--- a/frontend/app/utils/_field-localization.spec.ts
+++ b/frontend/app/utils/_field-localization.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import type { FieldMetadataDto } from '~~/shared/api-client'
+import { resolveFilterFieldTitle } from './_field-localization'
+
+describe('resolveFilterFieldTitle', () => {
+  const t = (key: string) =>
+    ({
+      'category.filters.fields.creationDate': 'Creation date',
+      'category.filters.fields.lastChange': 'Last updated',
+    })[key] ?? key
+
+  it('uses i18n mappings for date filters', () => {
+    const creationField: FieldMetadataDto = {
+      mapping: 'creationDate',
+      title: '',
+      valueType: 'numeric',
+    }
+
+    const lastChangeField: FieldMetadataDto = {
+      mapping: 'lastChange',
+      title: '',
+      valueType: 'numeric',
+    }
+
+    expect(resolveFilterFieldTitle(creationField, t)).toBe('Creation date')
+    expect(resolveFilterFieldTitle(lastChangeField, t)).toBe('Last updated')
+  })
+})

--- a/frontend/app/utils/_field-localization.ts
+++ b/frontend/app/utils/_field-localization.ts
@@ -7,10 +7,13 @@ const FILTER_FIELD_TRANSLATION_KEYS: Record<string, string> = {
   'price.minPrice.price': 'category.filters.fields.price',
   offersCount: 'category.filters.fields.offersCount',
   'price.conditions': 'category.filters.fields.condition',
+  creationDate: 'category.filters.fields.creationDate',
+  lastChange: 'category.filters.fields.lastChange',
   googleTaxonomyId: 'category.filters.fields.googleTaxonomyId',
   'attributes.referentielAttributes.BRAND': 'category.filters.fields.brand',
   'gtinInfos.country': 'category.filters.fields.country',
   datasourceCodes: 'category.filters.fields.datasource',
+  'scores.ECOSCORE.value': 'category.filters.fields.ecoscore',
 }
 
 const SORT_FIELD_TRANSLATION_KEYS: Record<string, string> = {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -869,8 +869,11 @@
         "brand": "Brand",
         "condition": "Offer condition",
         "country": "GTIN country code",
+        "creationDate": "Creation date",
         "datasource": "Data sources",
+        "ecoscore": "Impact score",
         "googleTaxonomyId": "Google product category",
+        "lastChange": "Last updated",
         "offersCount": "Number of offers",
         "price": "Price range"
       },
@@ -891,6 +894,11 @@
       "showMoreTechnical": "Show more technical filters",
       "technicalTitle": "Technical filters",
       "options": {
+        "price.conditions": {
+          "NEW": "New",
+          "OCCASION": "Used",
+          "USED": "Used"
+        },
         "excludedCauses": {
           "ES-UNKNOWN": "Unknown cause"
         }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -880,8 +880,11 @@
         "brand": "Marque",
         "condition": "État des offres",
         "country": "Code pays du GTIN",
+        "creationDate": "Date de création",
         "datasource": "Sources de données",
+        "ecoscore": "Impact score",
         "googleTaxonomyId": "Catégorie produit Google",
+        "lastChange": "Dernière mise à jour",
         "offersCount": {
           "one": "{count} offre",
           "other": "{count} offres"
@@ -906,6 +909,11 @@
       "showMoreTechnical": "Plus de filtres",
       "technicalTitle": "Filtres techniques",
       "options": {
+        "price.conditions": {
+          "NEW": "Neuf",
+          "OCCASION": "Occasion",
+          "USED": "Occasion"
+        },
         "excludedCauses": {
           "ES-UNKNOWN": "Cause inconnue"
         }


### PR DESCRIPTION
### Motivation
- Surface filters earlier in the search experience by exposing a filter banner in the hero to help users refine results without opening the drawer.  
- Support creation/last-change date filters and condition labels so date-based and stateful filtering is possible and properly localized.  
- Make semantic search behaviour controllable from the client while slightly improving semantic ranking by favouring products with more offers.

### Description
- Move filter UI into the search hero, keep mobile drawer behaviour, add baseline aggregation fetch for a latest-products fallback, and switch product group display to list views (`frontend/app/pages/search/index.vue`, hero menu structure update in `The-hero-menu.vue`).
- Add creationDate and lastChange to filter/sort contracts and global filter enums, expose them in `ProductDto`, `FilterRequestDto` and `AllowedGlobalFilters` so the API and frontend agree on mappings (changes in `front-api/src/main/java/...`).
- Add date-aware numeric filter handling and localized labels: date slider step, parsing and formatting in `CategoryFilterNumeric.vue`, new i18n keys and mapping entries in `_field-localization.ts` and locale files (`frontend/i18n/locales/en-US.json`, `fr-FR.json`), plus a small unit test for field localization (`_field-localization.spec.ts`).
- Make semantic search opt-in via the search payload (honour `semanticSearch` when supplied) and compute a light offers-count boost for semantic scores in the search service (`SearchService.java`) to nudge higher-offer products upward.

### Testing
- `pnpm lint` (frontend): failed due to unused variables reported in `ProductAttributesSection.vue` (2 eslint errors).  
- `pnpm test` (frontend, Vitest): executed full test suite; the majority of tests passed but the run ended with failing tests (several specs failed, including product attribute- and AI-review related specs) and the test job exited with failure.  
- `pnpm generate` (frontend): completed successfully with a PWA warning about a non-matching glob pattern for `_payload.json` but produced a build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8375c4b4832b9aa8b37ada29aeb4)