### PR TITLE
Add datasources admin tab and enable authenticated AI review generation (captcha bypass & force)

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ReviewGenerationClient.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ReviewGenerationClient.java
@@ -61,8 +61,22 @@ public class ReviewGenerationClient {
      * @return echoed UPC once the job is scheduled
      */
     public long triggerGeneration(long upc) {
+        return triggerGeneration(upc, false);
+    }
+
+    /**
+     * Trigger review generation for the provided UPC with optional force flag.
+     *
+     * @param upc   product identifier forwarded to the back-office API
+     * @param force whether to force generation on the back-office side
+     * @return echoed UPC once the job is scheduled
+     */
+    public long triggerGeneration(long upc, boolean force) {
         Long response = restClient.post()
-                .uri(builder -> builder.path(properties.getReviewPath()).path("/{id}").build(upc))
+                .uri(builder -> builder.path(properties.getReviewPath())
+                        .path("/{id}")
+                        .queryParamIfPresent("force", force ? java.util.Optional.of(true) : java.util.Optional.empty())
+                        .build(upc))
                 .retrieve()
                 .body(Long.class);
         return response == null ? upc : response;

--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -152,6 +152,8 @@
             :product="product"
             :panel-id="sectionIds.adminPanel"
             :json-section-id="sectionIds.adminJson"
+            :datasources-section-id="sectionIds.adminDatasources"
+            :vertical-config="categoryDetail"
           />
         </section>
       </main>
@@ -1640,6 +1642,8 @@ const sectionIds = {
   docs: 'documentation',
   adminPanel: 'admin-panel',
   adminJson: 'admin-json',
+  adminDatasources: 'admin-datasources',
+  adminRawApi: 'admin-raw-api',
 } as const
 
 const subSectionIds = {
@@ -1657,6 +1661,10 @@ type NavigableSection = {
   subsections?: Array<{ id: string; label: string; icon?: string }>
 }
 type ConditionalSection = NavigableSection & { condition: boolean }
+type AdminNavigableSection = NavigableSection & {
+  href?: string
+  target?: string
+}
 
 const impactSubsections = computed(() => {
   if (!impactScores.value.length) {
@@ -1771,7 +1779,14 @@ const primarySections = computed<NavigableSection[]>(() =>
     .map(({ condition: _condition, ...rest }) => rest)
 )
 
-const adminSections = computed<NavigableSection[]>(() => {
+const adminApiPayloadUrl = computed(() => {
+  const gtinValue = product.value?.gtin ?? gtin
+  return gtinValue
+    ? `https://api.nudger.fr/product/?gtin=${gtinValue}`
+    : 'https://api.nudger.fr/product/'
+})
+
+const adminSections = computed<AdminNavigableSection[]>(() => {
   if (!showAdminSection.value) {
     return []
   }
@@ -1783,16 +1798,32 @@ const adminSections = computed<NavigableSection[]>(() => {
       icon: 'mdi-format-list-bulleted',
     },
     {
+      id: sectionIds.adminDatasources,
+      label: t('product.navigation.adminPanel.items.datasources'),
+      icon: 'mdi-database-outline',
+    },
+    {
       id: sectionIds.adminJson,
       label: t('product.navigation.adminPanel.items.productJson'),
       icon: 'mdi-code-json',
     },
+    {
+      id: sectionIds.adminRawApi,
+      label: t('product.navigation.adminPanel.items.rawApi'),
+      icon: 'mdi-open-in-new',
+      href: adminApiPayloadUrl.value,
+      target: '_blank',
+    },
   ]
 })
 
+const adminScrollSections = computed<NavigableSection[]>(() =>
+  adminSections.value.filter(section => !section.href)
+)
+
 const sections = computed<NavigableSection[]>(() => [
   ...primarySections.value,
-  ...adminSections.value,
+  ...adminScrollSections.value,
 ])
 
 const navigableSections = computed(() => primarySections.value)

--- a/frontend/app/components/product/ProductAdminSection.vue
+++ b/frontend/app/components/product/ProductAdminSection.vue
@@ -10,9 +10,14 @@
 
       <v-tabs v-model="activeTab" bg-color="transparent" color="primary">
         <v-tab value="local">{{
-          $t('product.admin.sections.productJson.title')
+          $t('product.admin.sections.productJson.tab')
         }}</v-tab>
-        <v-tab value="payload">Payload JSON du produit</v-tab>
+        <v-tab value="payload">{{
+          $t('product.admin.sections.payloadJson.tab')
+        }}</v-tab>
+        <v-tab value="datasources">{{
+          $t('product.admin.sections.datasources.tab')
+        }}</v-tab>
       </v-tabs>
 
       <v-window v-model="activeTab">
@@ -48,18 +53,106 @@
           <article class="product-admin__block">
             <header class="product-admin__block-header">
               <h3 class="product-admin__block-title">
-                Payload JSON du produit
+                {{ $t('product.admin.sections.payloadJson.title') }}
               </h3>
               <p class="product-admin__block-helper">
-                Données JSON brutes via l'API Nudger
+                {{ $t('product.admin.sections.payloadJson.helper') }}
               </p>
             </header>
             <div class="product-admin__iframe-wrapper">
               <iframe
                 :src="apiPayloadUrl"
                 class="product-admin__iframe"
-                title="API Payload"
+                :title="$t('product.admin.sections.payloadJson.iframeTitle')"
               />
+            </div>
+          </article>
+        </v-window-item>
+
+        <v-window-item value="datasources">
+          <article
+            :id="datasourcesSectionId"
+            class="product-admin__block"
+            role="region"
+            :aria-label="$t('product.admin.sections.datasources.title')"
+          >
+            <header class="product-admin__block-header">
+              <h3 class="product-admin__block-title">
+                {{ $t('product.admin.sections.datasources.title') }}
+              </h3>
+              <p class="product-admin__block-helper">
+                {{ $t('product.admin.sections.datasources.helper') }}
+              </p>
+            </header>
+
+            <v-table density="compact" class="product-admin__table">
+              <thead>
+                <tr>
+                  <th scope="col">
+                    {{ $t('product.admin.sections.datasources.table.name') }}
+                  </th>
+                  <th scope="col">
+                    {{ $t('product.admin.sections.datasources.table.code') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in datasourceRows" :key="row.name">
+                  <td>{{ row.name }}</td>
+                  <td>{{ row.code }}</td>
+                </tr>
+              </tbody>
+            </v-table>
+            <p
+              v-if="!datasourceRows.length"
+              class="product-admin__block-helper"
+            >
+              {{ $t('product.admin.sections.datasources.empty') }}
+            </p>
+
+            <div class="product-admin__yaml">
+              <v-tabs
+                v-model="yamlTab"
+                bg-color="transparent"
+                color="primary"
+              >
+                <v-tab value="product">{{
+                  $t('product.admin.sections.datasources.yaml.product')
+                }}</v-tab>
+                <v-tab value="vertical">{{
+                  $t('product.admin.sections.datasources.yaml.vertical')
+                }}</v-tab>
+              </v-tabs>
+              <v-window v-model="yamlTab">
+                <v-window-item value="product">
+                  <pre class="product-admin__code" aria-live="polite">
+                    <code
+                      v-if="highlightedDatasourceYaml"
+                      class="hljs language-yaml"
+                      v-html="highlightedDatasourceYaml"
+                    />
+                    <code
+                      v-else
+                      class="product-admin__code-fallback"
+                      >{{ formattedDatasourceYaml }}</code
+                    >
+                  </pre>
+                </v-window-item>
+                <v-window-item value="vertical">
+                  <pre class="product-admin__code" aria-live="polite">
+                    <code
+                      v-if="highlightedVerticalYaml"
+                      class="hljs language-yaml"
+                      v-html="highlightedVerticalYaml"
+                    />
+                    <code
+                      v-else
+                      class="product-admin__code-fallback"
+                      >{{ formattedVerticalYaml }}</code
+                    >
+                  </pre>
+                </v-window-item>
+              </v-window>
             </div>
           </article>
         </v-window-item>
@@ -71,7 +164,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import type { PropType } from 'vue'
-import type { ProductDto } from '~~/shared/api-client'
+import type { ProductDto, VerticalConfigFullDto } from '~~/shared/api-client'
 import { useAuth } from '~/composables/useAuth'
 import { loadHighlightJs } from '~/utils/highlight-loader'
 
@@ -84,23 +177,157 @@ const props = defineProps({
     type: String,
     default: 'admin-json',
   },
+  datasourcesSectionId: {
+    type: String,
+    default: 'admin-datasources',
+  },
   product: {
     type: Object as PropType<ProductDto>,
     required: true,
+  },
+  verticalConfig: {
+    type: Object as PropType<VerticalConfigFullDto | null>,
+    default: null,
   },
 })
 
 const { isLoggedIn } = useAuth()
 
 const showAdmin = computed(() => isLoggedIn.value)
+const formatAsYaml = (value: unknown): string => {
+  const normalizeValue = (input: unknown): unknown => {
+    if (input instanceof Set) {
+      return Array.from(input)
+    }
+
+    if (Array.isArray(input)) {
+      return input.map(item => normalizeValue(item))
+    }
+
+    if (input && typeof input === 'object') {
+      return Object.fromEntries(
+        Object.entries(input as Record<string, unknown>).map(([key, val]) => [
+          key,
+          normalizeValue(val),
+        ])
+      )
+    }
+
+    return input
+  }
+
+  const isPlainObject = (input: unknown): input is Record<string, unknown> =>
+    Boolean(input) && typeof input === 'object' && !Array.isArray(input)
+
+  const formatScalar = (input: unknown): string => {
+    if (input === null || input === undefined) {
+      return 'null'
+    }
+
+    if (typeof input === 'string') {
+      const needsQuotes = /[:\n#]/.test(input) || input.trim() !== input
+      return needsQuotes ? JSON.stringify(input) : input
+    }
+
+    if (typeof input === 'number' || typeof input === 'boolean') {
+      return String(input)
+    }
+
+    return JSON.stringify(input)
+  }
+
+  const buildYaml = (input: unknown, indent = 0): string => {
+    const padding = ' '.repeat(indent)
+
+    if (Array.isArray(input)) {
+      if (!input.length) {
+        return `${padding}[]`
+      }
+      return input
+        .map(item => {
+          if (isPlainObject(item) || Array.isArray(item)) {
+            return `${padding}-\n${buildYaml(item, indent + 2)}`
+          }
+          return `${padding}- ${formatScalar(item)}`
+        })
+        .join('\n')
+    }
+
+    if (isPlainObject(input)) {
+      const entries = Object.entries(input)
+      if (!entries.length) {
+        return `${padding}{}`
+      }
+
+      return entries
+        .map(([key, val]) => {
+          if (isPlainObject(val) || Array.isArray(val)) {
+            return `${padding}${key}:\n${buildYaml(val, indent + 2)}`
+          }
+          return `${padding}${key}: ${formatScalar(val)}`
+        })
+        .join('\n')
+    }
+
+    return `${padding}${formatScalar(input)}`
+  }
+
+  return buildYaml(normalizeValue(value))
+}
+
 const formatted = computed(() => JSON.stringify(props.product, null, 2))
 
 const activeTab = ref('local')
+const yamlTab = ref<'product' | 'vertical'>('product')
 const apiPayloadUrl = computed(
   () => `https://api.nudger.fr/product/?gtin=${props.product.gtin}`
 )
+const datasourceRows = computed(() => {
+  const datasources = props.product.datasources?.datasourceCodes ?? {}
+  return Object.entries(datasources)
+    .map(([name, code]) => ({
+      name,
+      code,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+})
+
+const formattedDatasourceYaml = computed(() =>
+  formatAsYaml({
+    datasources: props.product.datasources ?? null,
+  })
+)
+const formattedVerticalYaml = computed(() =>
+  formatAsYaml(props.verticalConfig ?? null)
+)
 
 const highlightedJson = ref(formatted.value)
+const highlightedDatasourceYaml = ref(formattedDatasourceYaml.value)
+const highlightedVerticalYaml = ref(formattedVerticalYaml.value)
+
+const highlightYamlContent = async (
+  content: string,
+  target: { value: string | null }
+) => {
+  if (!content) {
+    target.value = ''
+    return
+  }
+
+  target.value = content
+
+  try {
+    const hljs = await loadHighlightJs(['yaml'])
+
+    if (hljs) {
+      target.value = hljs.highlight(content, {
+        language: 'yaml',
+      }).value
+    }
+  } catch (error) {
+    console.warn('Unable to highlight YAML in admin section', error)
+  }
+}
 
 const highlightJson = async () => {
   const content = formatted.value
@@ -131,11 +358,28 @@ watch(
   },
   { immediate: true }
 )
+
+watch(
+  formattedDatasourceYaml,
+  content => {
+    highlightYamlContent(content, highlightedDatasourceYaml)
+  },
+  { immediate: true }
+)
+
+watch(
+  formattedVerticalYaml,
+  content => {
+    highlightYamlContent(content, highlightedVerticalYaml)
+  },
+  { immediate: true }
+)
 </script>
 
 <style scoped>
 .product-admin {
-  background: rgba(var(--v-theme-surface-glass-strong), 0.96);
+  background: rgba(var(--v-theme-error), 0.08);
+  border: 1px solid rgba(var(--v-theme-error), 0.3);
   border-radius: 24px;
   padding: 1.75rem;
   display: flex;
@@ -213,6 +457,18 @@ watch(
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
   font-size: 0.88rem;
   color: #e2e8f0;
+}
+
+.product-admin__table {
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 12px;
+  color: #e2e8f0;
+}
+
+.product-admin__yaml {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 @media (max-width: 960px) {

--- a/frontend/app/components/product/ProductSummaryNavigation.vue
+++ b/frontend/app/components/product/ProductSummaryNavigation.vue
@@ -104,7 +104,25 @@
           :key="admin.id"
           class="product-summary-navigation__admin-item"
         >
+          <a
+            v-if="admin.href"
+            class="product-summary-navigation__admin-link"
+            :href="admin.href"
+            :target="admin.target"
+            :rel="resolveExternalRel(admin)"
+          >
+            <v-icon
+              v-if="admin.icon"
+              :icon="admin.icon"
+              size="18"
+              class="product-summary-navigation__admin-icon"
+            />
+            <span class="product-summary-navigation__admin-label">{{
+              admin.label
+            }}</span>
+          </a>
           <button
+            v-else
             type="button"
             class="product-summary-navigation__admin-link"
             :class="{
@@ -149,7 +167,13 @@ const _props = defineProps({
   },
   adminSections: {
     type: Array as PropType<
-      Array<{ id: string; label: string; icon?: string }>
+      Array<{
+        id: string
+        label: string
+        icon?: string
+        href?: string
+        target?: string
+      }>
     >,
     default: () => [],
   },
@@ -181,6 +205,14 @@ const openSectionId = ref<string | null>(null)
 
 const onNavigate = (sectionId: string) => {
   emit('navigate', sectionId)
+}
+
+const resolveExternalRel = (admin: { href?: string; target?: string }) => {
+  if (!admin.href) {
+    return undefined
+  }
+
+  return admin.target === '_blank' ? 'noopener' : undefined
 }
 
 const hasSubsections = (section: { subsections?: Array<{ id: string }> }) =>
@@ -389,13 +421,9 @@ watch(
 
 .product-summary-navigation__admin-panel {
   margin-top: 1.5rem;
-  padding: 1rem 0.875rem 1.25rem;
-  border-radius: 14px;
-  border: 1px solid rgba(var(--v-theme-error), 0.35);
-  background: rgba(var(--v-theme-error), 0.08);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .product-summary-navigation__admin-eyebrow {
@@ -419,7 +447,7 @@ watch(
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .product-summary-navigation__admin-item {
@@ -431,32 +459,33 @@ watch(
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.6rem 0.75rem;
+  padding: 0.625rem 0.75rem;
   border-radius: 12px;
-  border: 1px solid rgba(var(--v-theme-error), 0.45);
-  background: rgba(var(--v-theme-error), 0.12);
+  border: 1px solid transparent;
+  background: transparent;
   color: rgb(var(--v-theme-error));
   font-weight: 600;
   font-size: 0.9rem;
   transition: all 0.25s ease;
+  text-decoration: none;
 }
 
 .product-summary-navigation__admin-link:hover,
 .product-summary-navigation__admin-link:focus-visible {
-  background: rgba(var(--v-theme-error), 0.18);
-  border-color: rgba(var(--v-theme-error), 0.6);
+  background: rgba(var(--v-theme-error), 0.12);
+  border-color: rgba(var(--v-theme-error), 0.5);
 }
 
 .product-summary-navigation__admin-link--active {
-  background: rgba(var(--v-theme-error), 0.28);
-  color: rgb(var(--v-theme-surface-default));
-  border-color: rgba(var(--v-theme-error), 0.9);
-  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-error), 0.35);
+  background: rgba(var(--v-theme-error), 0.24);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  border-color: rgba(var(--v-theme-error), 0.7);
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-error), 0.25);
 }
 
 .product-summary-navigation__admin-link--active
   .product-summary-navigation__admin-icon {
-  color: rgb(var(--v-theme-surface-default));
+  color: rgb(var(--v-theme-error));
 }
 
 .product-summary-navigation__admin-icon {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2340,7 +2340,28 @@
       "sections": {
         "productJson": {
           "title": "Product JSON payload",
-          "helper": "Inspect the raw ProductDto returned by the API."
+          "helper": "Inspect the raw ProductDto returned by the API.",
+          "tab": "Product JSON"
+        },
+        "payloadJson": {
+          "title": "Raw API payload",
+          "helper": "Raw JSON fetched directly from the Nudger API.",
+          "iframeTitle": "Raw API payload preview",
+          "tab": "API payload"
+        },
+        "datasources": {
+          "title": "Datasources",
+          "helper": "Review datasource codes and the vertical configuration used for mapping.",
+          "tab": "Datasources",
+          "empty": "No datasource codes are available for this product yet.",
+          "table": {
+            "name": "Datasource",
+            "code": "Code"
+          },
+          "yaml": {
+            "product": "Product datasources",
+            "vertical": "Vertical config"
+          }
         }
       }
     },
@@ -2692,6 +2713,8 @@
         "title": "Admin tools",
         "helper": "Restricted utilities visible only to authenticated teammates.",
         "items": {
+          "datasources": "Datasources",
+          "rawApi": "Raw API",
           "productJson": "Product JSON"
         }
       },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2356,7 +2356,28 @@
       "sections": {
         "productJson": {
           "title": "Payload JSON du produit",
-          "helper": "Inspecter le ProductDto brut renvoyé par l'API."
+          "helper": "Inspecter le ProductDto brut renvoyé par l'API.",
+          "tab": "JSON du produit"
+        },
+        "payloadJson": {
+          "title": "Payload brut API",
+          "helper": "Données JSON brutes récupérées via l'API Nudger.",
+          "iframeTitle": "Aperçu du payload brut API",
+          "tab": "API brute"
+        },
+        "datasources": {
+          "title": "Datasources",
+          "helper": "Consultez les codes datasource et la configuration verticale associée.",
+          "tab": "Datasources",
+          "empty": "Aucun code datasource n'est disponible pour ce produit.",
+          "table": {
+            "name": "Datasource",
+            "code": "Code"
+          },
+          "yaml": {
+            "product": "Datasources produit",
+            "vertical": "Config verticale"
+          }
         }
       }
     },
@@ -2709,6 +2730,8 @@
         "title": "Outils d'administration",
         "helper": "Fonctionnalités restreintes visibles uniquement pour les membres authentifiés.",
         "items": {
+          "datasources": "Datasources",
+          "rawApi": "API brute",
           "productJson": "JSON du produit"
         }
       },

--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -253,7 +253,8 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
 
   const triggerReviewGeneration = async (
     gtin: string | number,
-    hcaptchaResponse: string
+    hcaptchaResponse?: string | null,
+    options: { force?: boolean; authToken?: string | null } = {}
   ): Promise<number> => {
     const parsedGtin =
       typeof gtin === 'number' ? gtin : Number.parseInt(gtin, 10)
@@ -262,7 +263,7 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
       throw new TypeError('GTIN must be a number.')
     }
 
-    if (!hcaptchaResponse) {
+    if (!hcaptchaResponse && !options.force) {
       throw new TypeError(
         'hCaptcha response is required to trigger review generation.'
       )
@@ -277,9 +278,13 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
         method: 'POST',
         headers: {
           ...(config.headers ?? {}),
+          ...(options.authToken
+            ? { Authorization: `Bearer ${options.authToken}` }
+            : {}),
         },
         query: {
-          hcaptchaResponse,
+          ...(hcaptchaResponse ? { hcaptchaResponse } : {}),
+          ...(options.force ? { force: true } : {}),
           domainLanguage,
         },
       })


### PR DESCRIPTION
### Motivation

- Surface datasource information and provide a quick raw-API link in the product admin panel for debugging and support. 
- Improve developer/admin ergonomics by adding YAML previews and a compact datasources table inside the product admin section.
- Allow authenticated users to request AI review generation without solving hCaptcha and to force scheduling on the back-office when appropriate.

### Description

- Add datasources debug tab and YAML previews in the product admin UI by extending `ProductAdminSection.vue` with a datasources table, YAML formatter/highlighting and a vertical config preview, and update styles to visually separate the admin area. 
- Add external "raw API" link to the admin navigation and make admin menu items support external `href`/`target` in `ProductSummaryNavigation.vue` and `ProductPage.vue`. 
- Make AI review flow bypass the captcha for logged-in users and send a `force` flag and `Authorization` header when applicable by updating `ProductAiReviewSection.vue`, the server route `frontend/server/api/products/[gtin]/review.post.ts`, and the client `frontend/shared/api-client/services/products.services.ts`. 
- Update front-api to support authenticated forcing of generation by adding optional `force` handling in `ProductController` (auth check and OpenAPI param), extending `ProductMappingService.createReview` to accept `authenticatedUser`/`force` and conditionally enforce captcha/quotas, and adding a `force`-aware `ReviewGenerationClient.triggerGeneration(upc, force)` that forwards the query parameter. 
- Add i18n strings for the new admin tabs and labels in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`. 
- Update unit tests in `front-api/src/test/java/.../ProductMappingServiceTest.java` to reflect the new method signature and the authenticated bypass behavior.

### Testing

- No automated test suite was executed in this rollout; unit tests were updated (`ProductMappingServiceTest`) but not run here. 
- Manual verification steps are suggested: run the frontend (`pnpm dev`) and backend tests with `mvn test` and exercise the admin panel and review generation endpoints to confirm captcha bypass/force behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5916753c832bb768097bb596d324)