### PR TITLE
Add batch review generation scheduling and API endpoints

### DIFF
--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
@@ -1,5 +1,6 @@
 package org.open4goods.services.reviewgeneration.config;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -81,6 +82,11 @@ public class ReviewGenerationConfig {
      * Flag to enable the grounded prompt flow.
      */
     private boolean useGroundedPrompt = false;
+
+    /**
+     * Interval between batch status scans for review generation jobs.
+     */
+    private Duration batchPollInterval = Duration.ofMinutes(5);
 
     // ---------------------- Getters/Setters ---------------------- //
 
@@ -191,6 +197,12 @@ public class ReviewGenerationConfig {
     }
     public void setUseGroundedPrompt(boolean useGroundedPrompt) {
         this.useGroundedPrompt = useGroundedPrompt;
+    }
+    public Duration getBatchPollInterval() {
+        return batchPollInterval;
+    }
+    public void setBatchPollInterval(Duration batchPollInterval) {
+        this.batchPollInterval = batchPollInterval;
     }
 	public int getMinGlobalTokens() {
 		return minGlobalTokens;

--- a/services/review-generation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/review-generation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -102,6 +102,12 @@
       "type": "java.lang.Boolean",
       "description": "Enable model-native web search prompt flow.",
       "defaultValue": false
+    },
+    {
+      "name": "review.generation.batch-poll-interval",
+      "type": "java.time.Duration",
+      "description": "Interval between batch status scans for review generation jobs.",
+      "defaultValue": "PT5M"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a way to enqueue and track batch AI review generation for a full vertical and process the batch outputs asynchronously or on-demand.  
- Improve observability and traceability by persisting product IDs/GTINs for batch jobs and updating status metrics for each item.

### Description
- Add two API endpoints: `POST /review/batch` to schedule a batch by vertical (optional `top` limit) and `POST /review/batch/process` to trigger processing of a specific job ID in `ReviewGenerationController`.
- Update batch submission in `ReviewGenerationService.generateReviewBatchRequest` to collect `productIds` and `gtins`, call `batchPromptRequest` with product IDs, and write a JSON tracking file containing `jobId`, `productIds`, `gtins`, `verticalId` and `createdAt`.
- Add scheduled polling with `@Scheduled(fixedDelayString = "${review.generation.batch-poll-interval:PT5M}")` in `ReviewGenerationService.checkBatchJobStatuses` to scan tracking files and process completed jobs via `batchPromptResponse`.
- Update batch result handling to use the custom ID as product ID, to update product reviews, and to record per-product statuses via a new `updateBatchStatus` helper that updates `processStatusMap` and metrics; add `batch-poll-interval` configuration property (`Duration`) to `ReviewGenerationConfig` and document it in `additional-spring-configuration-metadata.json`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f79691a30832bbd8a56ed5c1b70ff)