### PR TITLE
Schedule and trigger impact-score-based review generation batches

### DIFF
--- a/api/src/main/java/org/open4goods/api/controller/api/ReviewGenerationController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/ReviewGenerationController.java
@@ -157,6 +157,28 @@ public class ReviewGenerationController {
     }
 
     /**
+     * Trigger batch review generation for the next top impact score products.
+     *
+     * @param verticalId optional vertical identifier; when omitted, all enabled verticals are processed
+     * @param limit number of products to include in each batch
+     * @return list of batch job identifiers
+     * @throws IOException when batch submission fails
+     */
+    @PostMapping("/review/batch/impactscore")
+    @Operation(summary = "Schedule AI review generation for top impact score products",
+            description = "Launch a batch review generation job for the next top impact score products without existing AI reviews.")
+    public ResponseEntity<List<String>> generateImpactScoreBatch(
+            @RequestParam(value = "verticalId", required = false) String verticalId,
+            @RequestParam(value = "limit", defaultValue = "20") int limit) throws IOException {
+        if (verticalId != null && !verticalId.isBlank()) {
+            String jobId = reviewGenerationService.triggerNextTopImpactScoreBatch(verticalId, limit);
+            return ResponseEntity.ok(List.of(jobId));
+        }
+        List<String> jobIds = reviewGenerationService.triggerNextTopImpactScoreBatches(limit);
+        return ResponseEntity.ok(jobIds);
+    }
+
+    /**
      * Trigger batch result handling for a given job identifier.
      *
      * @param jobId the batch job identifier

--- a/services/prompt/src/main/java/org/open4goods/services/prompt/exceptions/BatchJobFailedException.java
+++ b/services/prompt/src/main/java/org/open4goods/services/prompt/exceptions/BatchJobFailedException.java
@@ -1,0 +1,15 @@
+package org.open4goods.services.prompt.exceptions;
+
+/**
+ * Exception thrown when a batch prompt job fails on the provider side.
+ */
+public class BatchJobFailedException extends RuntimeException {
+
+    public BatchJobFailedException(String message) {
+        super(message);
+    }
+
+    public BatchJobFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/review-generation/pom.xml
+++ b/services/review-generation/pom.xml
@@ -78,6 +78,12 @@
             <version>${global.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.open4goods</groupId>
+            <artifactId>verticals</artifactId>
+            <version>${global.version}</version>
+        </dependency>
+
 
         <dependency>
         	<groupId>org.springframework.boot</groupId>

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
@@ -86,7 +86,17 @@ public class ReviewGenerationConfig {
     /**
      * Interval between batch status scans for review generation jobs.
      */
-    private Duration batchPollInterval = Duration.ofMinutes(5);
+    private Duration batchPollInterval = Duration.ofHours(1);
+
+    /**
+     * Cron schedule for daily batch review generation.
+     */
+    private String batchScheduleCron = "0 0 6 * * *";
+
+    /**
+     * Number of products to include in the scheduled batch.
+     */
+    private int batchScheduleSize = 20;
 
     // ---------------------- Getters/Setters ---------------------- //
 
@@ -203,6 +213,18 @@ public class ReviewGenerationConfig {
     }
     public void setBatchPollInterval(Duration batchPollInterval) {
         this.batchPollInterval = batchPollInterval;
+    }
+    public String getBatchScheduleCron() {
+        return batchScheduleCron;
+    }
+    public void setBatchScheduleCron(String batchScheduleCron) {
+        this.batchScheduleCron = batchScheduleCron;
+    }
+    public int getBatchScheduleSize() {
+        return batchScheduleSize;
+    }
+    public void setBatchScheduleSize(int batchScheduleSize) {
+        this.batchScheduleSize = batchScheduleSize;
     }
 	public int getMinGlobalTokens() {
 		return minGlobalTokens;

--- a/services/review-generation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/review-generation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -107,7 +107,19 @@
       "name": "review.generation.batch-poll-interval",
       "type": "java.time.Duration",
       "description": "Interval between batch status scans for review generation jobs.",
-      "defaultValue": "PT5M"
+      "defaultValue": "PT1H"
+    },
+    {
+      "name": "review.generation.batch-schedule-cron",
+      "type": "java.lang.String",
+      "description": "Cron expression for scheduled batch review generation.",
+      "defaultValue": "0 0 6 * * *"
+    },
+    {
+      "name": "review.generation.batch-schedule-size",
+      "type": "java.lang.Integer",
+      "description": "Number of products to include in scheduled batch review generation.",
+      "defaultValue": 20
     }
   ]
 }

--- a/services/review-generation/src/test/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationReproductionTest.java
+++ b/services/review-generation/src/test/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationReproductionTest.java
@@ -21,6 +21,7 @@ import org.open4goods.services.prompt.service.BatchPromptService;
 import org.open4goods.services.prompt.service.PromptService;
 import org.open4goods.services.reviewgeneration.config.ReviewGenerationConfig;
 import org.open4goods.services.urlfetching.service.UrlFetchingService;
+import org.open4goods.verticals.VerticalsConfigService;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
@@ -42,6 +43,7 @@ class ReviewGenerationReproductionTest {
     @Mock private PromptService genAiService;
     @Mock private BatchPromptService batchAiService;
     @Mock private ProductRepository productRepository;
+    @Mock private VerticalsConfigService verticalsConfigService;
     private MeterRegistry meterRegistry;
 
     // We can use a real TemplateEngine to verify the template expression evaluation
@@ -72,7 +74,8 @@ class ReviewGenerationReproductionTest {
                 batchAiService,
                 meterRegistry,
                 productRepository,
-                preprocessingService
+                preprocessingService,
+                verticalsConfigService
         );
 
         // Setup template engine similar to production


### PR DESCRIPTION
### Motivation

- Add a scheduled and manual flow to generate AI reviews for the top products by impact score while avoiding products that already have an AI review or are currently being processed.
- Improve batch handling by surfacing provider-side batch failures and marking per-product review generation status accordingly.

### Description

- Introduces `exportVerticalWithValidDateOrderByImpactScore` in `ProductRepository` to select products ordered by `scores.IMPACTSCORE.value` for batch submission. 
- Adds impact-score batch orchestration in `ReviewGenerationService` including `scheduleDailyBatchReviewGeneration`, `triggerNextTopImpactScoreBatches`, `triggerNextTopImpactScoreBatch`, and selection/filtering helpers that exclude items already having an AI review or active processes. 
- Adds a new API endpoint `POST /review/batch/impactscore` in `ReviewGenerationController` to manually trigger a single-vertical or all-enabled-verticals impact-score batch run. 
- Improves batch failure handling by adding `BatchJobFailedException`, updating `BatchPromptService` to mark provider-side failed jobs and throw the exception, and updating `ReviewGenerationService` to mark per-product statuses as `FAILED`, delete tracking files, and set health signalling; also adds config properties `review.generation.batch-schedule-cron` and `review.generation.batch-schedule-size` and changes `review.generation.batch-poll-interval` to hourly. 

### Testing

- Ran a full build and test suite with `mvn --offline clean install`, which completed successfully and the added/updated unit tests in `review-generation` passed. 
- Added unit tests covering impact-score selection (`loadNextTopImpactScoreProducts`) and handling of a failed batch tracking file (`handleTrackingFile_MarksFailureWhenBatchJobFails`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a03558b8832b9b9525b07111ede3)