### PR TITLE
Improve search fallback and embeddings; centralize time-ago & product utilities

### DIFF
--- a/docs/text_embeddings.md
+++ b/docs/text_embeddings.md
@@ -19,8 +19,8 @@ Provided by the shared `embedding-djl` module in `org.open4goods.embedding.servi
 
 The embedding is computed during the product aggregation phase (`onProduct`).
 
-- **Trigger**: Only runs if the product has a valid `vertical` assigned.
-- **Input Text**: Construction of `Vertical Prefix (Category) + Product Name`.
+- **Trigger**: Runs whenever a product has enough descriptive text (vertical is optional).
+- **Input Text**: Construction of `Vertical Prefix (Category) + Product Name + Top Offer Names + Popular Attribute name/value pairs`.
 - **Throttling**: Text truncated to 1000 characters (model limit ~512 tokens).
 
 ### 3. Product Model & Storage

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java
@@ -351,7 +351,7 @@ public class SearchService {
 					return new GlobalSearchResult(groups, List.of(), List.of(), verticalCta, mode, fallbackTriggered);
 				}
 			} else if (mode == SearchMode.global) {
-				SearchHits<Product> fallbackHits = executeGlobalSearch(sanitizedQuery, false, true);
+				SearchHits<Product> fallbackHits = executeGlobalSearch(sanitizedQuery, false, false);
 				List<GlobalSearchHit> fallback = mapHits(fallbackHits, domainLanguage, false);
 				if (fallback != null && !fallback.isEmpty()) {
 					return new GlobalSearchResult(List.of(), fallback, List.of(), verticalCta, mode, fallbackTriggered);

--- a/frontend/app/pages/search/index.vue
+++ b/frontend/app/pages/search/index.vue
@@ -330,6 +330,7 @@ import type {
   FieldMetadataDto,
   AggregationResponseDto,
   SortDto,
+  SearchType,
 } from '~~/shared/api-client'
 import SearchSuggestField, {
   type CategorySuggestionItem,
@@ -362,7 +363,7 @@ const routeQuery = computed(() =>
   typeof route.query.q === 'string' ? route.query.q : ''
 )
 const searchInput = ref(routeQuery.value)
-const requestedSearchType = ref<'semantic'>('semantic')
+const requestedSearchType = ref<SearchType>('auto')
 
 const filtersOpen = ref(false)
 const filterRequest = ref<FilterRequestDto>({ filters: [], filterGroups: [] })

--- a/model/src/main/java/org/open4goods/model/price/AggregatedPrice.java
+++ b/model/src/main/java/org/open4goods/model/price/AggregatedPrice.java
@@ -4,18 +4,16 @@ package org.open4goods.model.price;
 import java.text.DecimalFormat;
 import java.util.Locale;
 
-import org.joda.time.DurationFieldType;
-import org.joda.time.Period;
-import org.joda.time.PeriodType;
-import org.joda.time.format.PeriodFormat;
-import org.joda.time.format.PeriodFormatter;
 import org.open4goods.model.datafragment.DataFragment;
 import org.open4goods.model.product.ProductCondition;
+import org.open4goods.model.util.TimeAgoFormatter;
 import org.springframework.data.annotation.Transient;
 
 public class AggregatedPrice extends Price {
 
-	//TODO : shared, ugly
+	/**
+	 * Shared formatter for prices with a single decimal (max).
+	 */
 	public static final DecimalFormat numberFormater = new DecimalFormat("0.#");
 
 	private String datasourceName;
@@ -26,7 +24,6 @@ public class AggregatedPrice extends Price {
 	/**
 	 * The state of the product (new, occasion, ...)
 	 */
-	//TODO : Rename to productCondition
 	private ProductCondition productState;
 
 	/**
@@ -81,36 +78,16 @@ public class AggregatedPrice extends Price {
 	}
 
 	/**
-	 * TODO : merge with the one on price()
 	 * @return a localised formated duration of when the product was last indexed
 	 */
 	public String ago(Locale locale) {
 
 		long duration = System.currentTimeMillis() - getTimeStamp();
-
-
-
-		Period period;
-		if (duration < 3600000) {
-			DurationFieldType[] min = { DurationFieldType.minutes(), DurationFieldType.seconds() };
-			period = new Period(duration, PeriodType.forFields(min)).normalizedStandard();
-		} else {
-			DurationFieldType[] full = { DurationFieldType.days(), DurationFieldType.hours() };
-			period = new Period(duration, PeriodType.forFields(full)).normalizedStandard();
-
-		}
-
-		PeriodFormatter formatter = PeriodFormat.wordBased();
-
-		String ret = (formatter. print(period));
-
-
-		return ret;
+		return TimeAgoFormatter.formatDuration(locale, duration);
 	}
 
 	public String formatedDuration() {
-		// TODO : LOCALIZE
-		return ago(Locale.FRANCE);
+		return ago(Locale.getDefault());
 	}
 
 

--- a/model/src/main/java/org/open4goods/model/price/PriceTrend.java
+++ b/model/src/main/java/org/open4goods/model/price/PriceTrend.java
@@ -3,11 +3,7 @@ package org.open4goods.model.price;
 import java.util.List;
 import java.util.Locale;
 
-import org.joda.time.DurationFieldType;
-import org.joda.time.Period;
-import org.joda.time.PeriodType;
-import org.joda.time.format.PeriodFormat;
-import org.joda.time.format.PeriodFormatter;
+import org.open4goods.model.util.TimeAgoFormatter;
 
 /**
  * Represents the price trend of a product, including price variation,
@@ -64,7 +60,7 @@ public record PriceTrend(
 	 * @return A localized string describing the time since the last price change.
 	 */
         public String formatedDuration() {
-                return ago(Locale.FRANCE, period); // TODO: localize dynamically
+                return ago(Locale.getDefault(), period);
         }
 
 	/**
@@ -75,18 +71,7 @@ public record PriceTrend(
 	 * @return A localized string like "2 days", "3 minutes", etc.
 	 */
 	public String ago(Locale locale, long duration) {
-		Period period;
-
-		if (duration < 3_600_000) { // less than 1 hour
-			DurationFieldType[] min = { DurationFieldType.minutes(), DurationFieldType.seconds() };
-			period = new Period(duration, PeriodType.forFields(min)).normalizedStandard();
-		} else {
-			DurationFieldType[] full = { DurationFieldType.days(), DurationFieldType.hours() };
-			period = new Period(duration, PeriodType.forFields(full)).normalizedStandard();
-		}
-
-		PeriodFormatter formatter = PeriodFormat.wordBased(locale);
-		return formatter.print(period);
+		return TimeAgoFormatter.formatDuration(locale, duration);
 	}
 
 	/**

--- a/model/src/main/java/org/open4goods/model/util/TimeAgoFormatter.java
+++ b/model/src/main/java/org/open4goods/model/util/TimeAgoFormatter.java
@@ -1,0 +1,41 @@
+package org.open4goods.model.util;
+
+import java.util.Locale;
+
+import org.joda.time.DurationFieldType;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+import org.joda.time.format.PeriodFormat;
+import org.joda.time.format.PeriodFormatter;
+
+/**
+ * Shared utility to format "time ago" durations in a locale-aware way.
+ */
+public final class TimeAgoFormatter {
+
+	private TimeAgoFormatter() {
+	}
+
+	/**
+	 * Formats a duration in milliseconds into a localized, human-friendly string.
+	 *
+	 * @param locale   preferred locale (falls back to {@link Locale#getDefault()} when null)
+	 * @param duration duration in milliseconds
+	 * @return localized duration label (e.g. "2 days", "5 minutes")
+	 */
+	public static String formatDuration(Locale locale, long duration) {
+		Locale resolvedLocale = locale != null ? locale : Locale.getDefault();
+		Period period;
+
+		if (duration < 3_600_000) {
+			DurationFieldType[] min = { DurationFieldType.minutes(), DurationFieldType.seconds() };
+			period = new Period(duration, PeriodType.forFields(min)).normalizedStandard();
+		} else {
+			DurationFieldType[] full = { DurationFieldType.days(), DurationFieldType.hours() };
+			period = new Period(duration, PeriodType.forFields(full)).normalizedStandard();
+		}
+
+		PeriodFormatter formatter = PeriodFormat.wordBased(resolvedLocale);
+		return formatter.print(period);
+	}
+}


### PR DESCRIPTION
### Motivation
- Make global search fallbacks broader and default the frontend search mode to automatic to improve result coverage. 
- Expand embedding inputs so semantic vectors better capture product identity and important attributes. 
- Centralize "time ago" formatting to avoid duplicated logic and ensure consistent localized output. 
- Harden product utilities (images, GTIN, model extraction) for configurability and caching.

### Description
- Frontend: defaulted requested search type to `auto` in `frontend/app/pages/search/index.vue` so searches start in automatic mode. 
- Search fallback: `SearchService` now calls `executeGlobalSearch(sanitizedQuery, false, false)` so the global fallback queries all products rather than only missing-vertical items. 
- Embeddings: `NamesAggregationService` now computes embeddings whenever descriptive text is available (vertical no longer required), adds popular attribute name/value pairs (whitelisted per `VerticalConfig.getPopularAttributes()`) to the embedding payload, and includes a small template-based `computeTemplate` resolver. 
- Documentation: `docs/text_embeddings.md` updated to reflect the new embedding trigger and input composition. 
- Time-ago: added `TimeAgoFormatter` and refactored `Product.ago`, `AggregatedPrice.ago`, and `PriceTrend.ago` to use it for localized duration formatting. 
- Product utilities: enhanced `Product` with GTIN padding using `open4goods.product.gtin.pad-length`, model splitting configurable via `open4goods.product.model.splitters-regex`, configurable image extensions, `isSupportedImageResource` helper, image list caching with invalidation on resource changes, and small cleanups for formatting and defaults. 

### Testing
- No automated tests were executed as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a57664d4832bbdf20dbfe9405648)