### PR TITLE
Redesign Curieux menu layout and soften product menu borders

### DIFF
--- a/frontend/app/components/shared/menus/The-hero-menu.vue
+++ b/frontend/app/components/shared/menus/The-hero-menu.vue
@@ -331,7 +331,9 @@
                         <v-icon icon="mdi-account-group" color="primary" />
                       </v-avatar>
                       <div>
-                        <p class="community-menu__title">{{ item.label }}</p>
+                        <p class="community-menu__title">
+                          {{ communityHeaderTitle }}
+                        </p>
                         <p class="community-menu__subtitle">
                           {{ t('siteIdentity.menu.community.tagline') }}
                         </p>
@@ -340,81 +342,237 @@
 
                     <v-divider class="community-menu__divider" />
 
-                    <v-row
-                      class="community-menu__sections"
-                      justify="space-between"
-                      align="stretch"
-                    >
+                    <v-row class="community-menu__sections" align="stretch">
+                      <v-col cols="12" sm="6" class="community-menu__section">
+                        <template v-if="communitySectionsById.resources">
+                          <p class="community-menu__section-title">
+                            {{ communitySectionsById.resources.title }}
+                          </p>
+                          <p class="community-menu__section-description">
+                            {{ communitySectionsById.resources.description }}
+                          </p>
+
+                          <v-list
+                            class="community-menu__section-list"
+                            bg-color="transparent"
+                            density="comfortable"
+                            nav
+                            lines="one"
+                          >
+                            <v-list-item
+                              v-for="link in communitySectionsById.resources
+                                .links"
+                              :key="link.id"
+                              class="community-menu__link"
+                              :class="{
+                                'community-menu__link--external': link.external,
+                              }"
+                              :to="link.to"
+                              :href="link.href"
+                              :target="link.external ? '_blank' : undefined"
+                              :rel="
+                                link.external ? 'noopener noreferrer' : undefined
+                              "
+                              role="menuitem"
+                            >
+                              <template #prepend>
+                                <v-avatar
+                                  size="34"
+                                  class="community-menu__link-icon"
+                                >
+                                  <v-icon
+                                    :icon="link.icon"
+                                    size="20"
+                                    color="accent-primary-highlight"
+                                  />
+                                </v-avatar>
+                              </template>
+
+                              <v-list-item-title
+                                class="community-menu__link-label"
+                              >
+                                {{ link.label }}
+                              </v-list-item-title>
+                              <v-list-item-subtitle
+                                v-if="link.description"
+                                class="community-menu__link-description"
+                              >
+                                {{ link.description }}
+                              </v-list-item-subtitle>
+
+                              <template v-if="link.external" #append>
+                                <v-icon
+                                  icon="mdi-open-in-new"
+                                  size="18"
+                                  class="community-menu__external-icon"
+                                />
+                              </template>
+                            </v-list-item>
+                          </v-list>
+                        </template>
+                      </v-col>
+
+                      <v-col cols="12" sm="6" class="community-menu__section">
+                        <template v-if="communitySectionsById.connect">
+                          <p class="community-menu__section-title">
+                            {{ communitySectionsById.connect.title }}
+                          </p>
+                          <p class="community-menu__section-description">
+                            {{ communitySectionsById.connect.description }}
+                          </p>
+
+                          <v-list
+                            class="community-menu__section-list"
+                            bg-color="transparent"
+                            density="comfortable"
+                            nav
+                            lines="one"
+                          >
+                            <v-list-item
+                              v-for="link in communitySectionsById.connect
+                                .links"
+                              :key="link.id"
+                              class="community-menu__link"
+                              :class="{
+                                'community-menu__link--external': link.external,
+                              }"
+                              :to="link.to"
+                              :href="link.href"
+                              :target="link.external ? '_blank' : undefined"
+                              :rel="
+                                link.external ? 'noopener noreferrer' : undefined
+                              "
+                              role="menuitem"
+                            >
+                              <template #prepend>
+                                <v-avatar
+                                  size="34"
+                                  class="community-menu__link-icon"
+                                >
+                                  <v-icon
+                                    :icon="link.icon"
+                                    size="20"
+                                    color="accent-primary-highlight"
+                                  />
+                                </v-avatar>
+                              </template>
+
+                              <v-list-item-title
+                                class="community-menu__link-label"
+                              >
+                                {{ link.label }}
+                              </v-list-item-title>
+                              <v-list-item-subtitle
+                                v-if="link.description"
+                                class="community-menu__link-description"
+                              >
+                                {{ link.description }}
+                              </v-list-item-subtitle>
+
+                              <template v-if="link.external" #append>
+                                <v-icon
+                                  icon="mdi-open-in-new"
+                                  size="18"
+                                  class="community-menu__external-icon"
+                                />
+                              </template>
+                            </v-list-item>
+                          </v-list>
+                        </template>
+                      </v-col>
+
+                      <v-col cols="12" sm="6" class="community-menu__section">
+                        <template v-if="communitySectionsById.collaborate">
+                          <p class="community-menu__section-title">
+                            {{ communitySectionsById.collaborate.title }}
+                          </p>
+                          <p class="community-menu__section-description">
+                            {{ communitySectionsById.collaborate.description }}
+                          </p>
+
+                          <v-list
+                            class="community-menu__section-list"
+                            bg-color="transparent"
+                            density="comfortable"
+                            nav
+                            lines="one"
+                          >
+                            <v-list-item
+                              v-for="link in communitySectionsById.collaborate
+                                .links"
+                              :key="link.id"
+                              class="community-menu__link"
+                              :class="{
+                                'community-menu__link--external': link.external,
+                              }"
+                              :to="link.to"
+                              :href="link.href"
+                              :target="link.external ? '_blank' : undefined"
+                              :rel="
+                                link.external ? 'noopener noreferrer' : undefined
+                              "
+                              role="menuitem"
+                            >
+                              <template #prepend>
+                                <v-avatar
+                                  size="34"
+                                  class="community-menu__link-icon"
+                                >
+                                  <v-icon
+                                    :icon="link.icon"
+                                    size="20"
+                                    color="accent-primary-highlight"
+                                  />
+                                </v-avatar>
+                              </template>
+
+                              <v-list-item-title
+                                class="community-menu__link-label"
+                              >
+                                {{ link.label }}
+                              </v-list-item-title>
+                              <v-list-item-subtitle
+                                v-if="link.description"
+                                class="community-menu__link-description"
+                              >
+                                {{ link.description }}
+                              </v-list-item-subtitle>
+
+                              <template v-if="link.external" #append>
+                                <v-icon
+                                  icon="mdi-open-in-new"
+                                  size="18"
+                                  class="community-menu__external-icon"
+                                />
+                              </template>
+                            </v-list-item>
+                          </v-list>
+                        </template>
+                      </v-col>
+
                       <v-col
-                        v-for="section in item.sections"
-                        :key="section.id"
                         cols="12"
-                        sm="5"
-                        class="community-menu__section"
+                        sm="6"
+                        class="community-menu__section community-menu__cta"
                       >
                         <p class="community-menu__section-title">
-                          {{ section.title }}
+                          {{ communityCtaTitle }}
                         </p>
                         <p class="community-menu__section-description">
-                          {{ section.description }}
+                          {{ communityCtaDescription }}
                         </p>
-
-                        <v-list
-                          class="community-menu__section-list"
-                          bg-color="transparent"
-                          density="comfortable"
-                          nav
-                          lines="one"
-                        >
-                          <v-list-item
-                            v-for="link in section.links"
+                        <div class="community-menu__cta-actions">
+                          <v-btn
+                            v-for="link in communityCtaLinks"
                             :key="link.id"
-                            class="community-menu__link"
-                            :class="{
-                              'community-menu__link--external': link.external,
-                            }"
-                            :to="link.to"
-                            :href="link.href"
-                            :target="link.external ? '_blank' : undefined"
-                            :rel="
-                              link.external ? 'noopener noreferrer' : undefined
-                            "
-                            role="menuitem"
+                            color="primary"
+                            variant="flat"
+                            class="community-menu__cta-action"
+                            @click="navigateToPage(link.to ?? '/')"
                           >
-                            <template #prepend>
-                              <v-avatar
-                                size="34"
-                                class="community-menu__link-icon"
-                              >
-                                <v-icon
-                                  :icon="link.icon"
-                                  size="20"
-                                  color="accent-primary-highlight"
-                                />
-                              </v-avatar>
-                            </template>
-
-                            <v-list-item-title
-                              class="community-menu__link-label"
-                            >
-                              {{ link.label }}
-                            </v-list-item-title>
-                            <v-list-item-subtitle
-                              v-if="link.description"
-                              class="community-menu__link-description"
-                            >
-                              {{ link.description }}
-                            </v-list-item-subtitle>
-
-                            <template v-if="link.external" #append>
-                              <v-icon
-                                icon="mdi-open-in-new"
-                                size="18"
-                                class="community-menu__external-icon"
-                              />
-                            </template>
-                          </v-list-item>
-                        </v-list>
+                            {{ link.label }}
+                          </v-btn>
+                        </div>
                       </v-col>
                     </v-row>
                   </v-card>
@@ -1246,6 +1404,38 @@ interface CommunityMenuItem {
 type MenuItem = LinkMenuItem | CommunityMenuItem | ProductsMenuItem
 const { sections: communitySections, activePaths: communityActivePaths } =
   useCommunityMenu(t, currentLocale)
+const communitySectionsById = computed(() => {
+  const byId: Record<string, CommunitySection | undefined> = {}
+
+  communitySections.value.forEach(section => {
+    byId[section.id] = section
+  })
+
+  return {
+    connect: byId.connect,
+    collaborate: byId.collaborate,
+    resources: byId.resources,
+  }
+})
+const communityCtaTitle = computed(() =>
+  t('siteIdentity.menu.community.cta.title')
+)
+const communityCtaDescription = computed(() =>
+  t('siteIdentity.menu.community.cta.description')
+)
+const communityHeaderTitle = computed(() =>
+  t('siteIdentity.menu.community.headerTitle')
+)
+const communityCtaLinks = computed(() => {
+  const connect = communitySectionsById.value.connect
+  if (!connect) {
+    return []
+  }
+
+  return connect.links.filter(link =>
+    ['feedback', 'contact'].includes(link.id)
+  )
+})
 
 const baseMenuItems: MenuItemDefinition[] = [
   {
@@ -1269,7 +1459,7 @@ const baseMenuItems: MenuItemDefinition[] = [
   {
     id: 'community',
     type: 'community',
-    labelKey: 'siteIdentity.menu.items.contact',
+    labelKey: 'siteIdentity.menu.items.community',
   },
 ]
 
@@ -1479,6 +1669,23 @@ const isMenuItemActive = (item: MenuItem): boolean => {
     padding: 0
     background: transparent
 
+  &__cta
+    background: rgba(var(--v-theme-surface-glass-strong), 0.8)
+    border-radius: 1rem
+    padding: 0.75rem
+    display: flex
+    flex-direction: column
+    gap: 0.75rem
+
+  &__cta-actions
+    display: flex
+    flex-wrap: wrap
+    gap: 0.75rem
+
+  &__cta-action
+    text-transform: none
+    box-shadow: 0 10px 24px rgba(var(--v-theme-shadow-primary-600), 0.18)
+
   &__link
     border-radius: 0.75rem
     transition: background-color 0.2s ease, transform 0.2s ease
@@ -1567,7 +1774,6 @@ const isMenuItemActive = (item: MenuItem): boolean => {
     border-radius: 1rem
     text-decoration: none
     background: rgba(var(--v-theme-surface-primary-080), 0.85)
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
     color: rgb(var(--v-theme-text-neutral-strong))
     transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease
 
@@ -1607,7 +1813,6 @@ const isMenuItemActive = (item: MenuItem): boolean => {
     padding: 0.75rem
     border-radius: 1rem
     background: rgba(var(--v-theme-surface-primary-080), 0.5)
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.2)
 
   &__taxonomy-label
     margin: 0 0 0.35rem
@@ -1646,7 +1851,6 @@ const isMenuItemActive = (item: MenuItem): boolean => {
     margin-top: 0.75rem
     padding: 0.85rem
     border-radius: 1rem
-    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.18)
     background: rgba(var(--v-theme-surface-primary-080), 0.65)
     display: flex
     flex-direction: column

--- a/frontend/app/components/shared/menus/The-mobile-menu.vue
+++ b/frontend/app/components/shared/menus/The-mobile-menu.vue
@@ -381,7 +381,7 @@ const {
 const { sections: communitySections, activePaths: communityActivePaths } =
   useCommunityMenu(t, currentLocale)
 const communityLabel = computed(() =>
-  String(t('siteIdentity.menu.items.contact'))
+  String(t('siteIdentity.menu.items.community'))
 )
 const isCommunityExpanded = ref(false)
 

--- a/frontend/app/components/shared/menus/useCommunityMenu.ts
+++ b/frontend/app/components/shared/menus/useCommunityMenu.ts
@@ -136,6 +136,16 @@ export const useCommunityMenu = (
 
     return [
       {
+        id: 'resources',
+        title: String(
+          t('siteIdentity.menu.community.sections.resources.title')
+        ),
+        description: String(
+          t('siteIdentity.menu.community.sections.resources.description')
+        ),
+        links: [openDataLink, openSourceLink],
+      },
+      {
         id: 'connect',
         title: String(t('siteIdentity.menu.community.sections.connect.title')),
         description: String(
@@ -152,16 +162,6 @@ export const useCommunityMenu = (
           t('siteIdentity.menu.community.sections.collaborate.description')
         ),
         links: [teamLink, partnersLink],
-      },
-      {
-        id: 'resources',
-        title: String(
-          t('siteIdentity.menu.community.sections.resources.title')
-        ),
-        description: String(
-          t('siteIdentity.menu.community.sections.resources.description')
-        ),
-        links: [openDataLink, openSourceLink],
       },
     ]
   })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2884,6 +2884,7 @@
       "items": {
         "blog": "Blog",
         "contact": "Community",
+        "community": "Curious?",
         "impactScore": "Impact Score",
         "products": "Products"
       },
@@ -2980,7 +2981,12 @@
         "submitLabel": "Search"
       },
       "community": {
+        "headerTitle": "Go further",
         "tagline": "Connect with the people and open resources behind Nudger.",
+        "cta": {
+          "title": "Take action",
+          "description": "Share feedback or reach out to the team."
+        },
         "sections": {
           "connect": {
             "title": "Stay in touch",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2900,6 +2900,7 @@
       "items": {
         "blog": "Blog",
         "contact": "Plus",
+        "community": "Curieux ?",
         "impactScore": "Impact Score",
         "products": "Les produits"
       },
@@ -2996,7 +2997,12 @@
         "submitLabel": "Lancer la recherche"
       },
       "community": {
+        "headerTitle": "aller plus loin",
         "tagline": "Nudger est une aventure collective",
+        "cta": {
+          "title": "Passer à l'action",
+          "description": "Partagez vos retours ou contactez-nous directement."
+        },
         "sections": {
           "connect": {
             "title": "Rester en lien",


### PR DESCRIPTION
### Motivation
- Improve the community/menu UX by splitting the menu label from the card header, surfacing resource links first and adding a clear CTA area to drive feedback/contact actions.
- Keep mobile and hero menus consistent by aligning the menu label and localized strings.
- Soften visual weight of the products submenu by removing some heavy borders and adding a gentler CTA style.

### Description
- Reworked `The-hero-menu.vue` to render the community menu as a 2x2 grid with a dedicated CTA block and to display a localized header title via new computed helpers (`communityHeaderTitle`, `communityCtaTitle`, `communityCtaDescription`, `communityCtaLinks`, `communitySectionsById`).
- Updated `useCommunityMenu.ts` to change section ordering (resources first) and provide the links used by the new hero layout.
- Switched the base menu item label key from `siteIdentity.menu.items.contact` to `siteIdentity.menu.items.community` and updated `The-mobile-menu.vue` to use the same `community` i18n key.
- Added and adjusted SCSS in `The-hero-menu.vue` to introduce CTA styles and removed borders from product menu elements (`popular-card`, `taxonomy-group`, `nudge`) to soften styling.
- Added i18n strings in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` for `siteIdentity.menu.items.community`, `siteIdentity.menu.community.headerTitle`, and `siteIdentity.menu.community.cta` text.

### Testing
- Ran `pnpm lint --offline`, which completed successfully with two existing `vue/no-v-html` warnings in an unrelated file.
- Attempted `pnpm test --offline`, which fails because `vitest` does not accept the `--offline` flag.
- Ran `pnpm test` (full suite); the test runner executed many files and hundreds of tests successfully but the run was manually aborted due to the long execution time (the suite was exercising ~60+ test files before stopping).
- Ran `pnpm generate`, which completed successfully and produced the static output with a Workbox glob warning about a missing `_payload.json` pattern.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d983bd94832ba451d403ddb7d3bf)