### PR TITLE
Capture raw GTIN strings during aggregation

### DIFF
--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationService.java
@@ -624,6 +624,7 @@ public class AttributeRealtimeAggregationService extends AbstractAggregationServ
 		///////////////////////
 		String gtin = fragment.gtin();
 		if (!StringUtils.isEmpty(gtin)) {
+            output.getGtinInfos().addGtinString(gtin);
 			String existing = output.gtin();
 
 			if (!existing.equals(gtin)) {

--- a/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/IdentityAggregationService.java
+++ b/api/src/main/java/org/open4goods/api/services/aggregation/services/realtime/IdentityAggregationService.java
@@ -46,6 +46,11 @@ public class IdentityAggregationService extends AbstractAggregationService {
 		// Validating barcodes
 		/////////////////////////////
 
+        if (StringUtils.isNotBlank(input.gtin()))
+        {
+            output.getGtinInfos().addGtinString(input.gtin());
+        }
+
 		if (null == output.getId()) {
 			// TODO(p2, features) : Should store the GTIN type when encountered in gtin infos, and then render with appropriate leading 0
 			output.setId(Long.valueOf(input.gtin()));

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
@@ -12,6 +12,7 @@ import org.open4goods.brand.service.BrandService;
 import org.open4goods.icecat.services.IcecatService;
 import org.open4goods.model.attribute.ProductAttribute;
 import org.open4goods.model.attribute.ReferentielKey;
+import org.open4goods.model.datafragment.DataFragment;
 import org.open4goods.model.eprel.EprelProduct;
 import org.open4goods.model.product.Product;
 import org.open4goods.model.vertical.AttributeConfig;
@@ -56,6 +57,19 @@ class AttributeRealtimeAggregationServiceTest {
 
                 assertThat(product.isExcluded()).isTrue();
                 assertThat(product.getExcludedCauses()).containsExactly("missing_attr_required_attr");
+        }
+
+        @Test
+        void handleReferentielAttributesCapturesRawGtin() throws Exception {
+                Product product = new Product(123456789012L);
+                DataFragment fragment = new DataFragment();
+                fragment.getReferentielAttributes().put(ReferentielKey.GTIN, "0123456789012");
+
+                Method method = AttributeRealtimeAggregationService.class.getDeclaredMethod("handleReferentielAttributes", DataFragment.class, Product.class, VerticalConfig.class);
+                method.setAccessible(true);
+                method.invoke(service, fragment, product, verticalConfig);
+
+                assertThat(product.getGtinInfos().getGtinStrings()).containsExactly("0123456789012");
         }
 
         private Product buildBaseProduct() {
@@ -178,4 +192,3 @@ class AttributeRealtimeAggregationServiceTest {
 		assertThat(result).isEqualTo("0.5");
 	}
 }
-

--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/IdentityAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/IdentityAggregationServiceTest.java
@@ -1,0 +1,49 @@
+package org.open4goods.api.services.aggregation.services.realtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.AbstractMap.SimpleEntry;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.commons.services.BarcodeValidationService;
+import org.open4goods.commons.services.Gs1PrefixService;
+import org.open4goods.model.attribute.ReferentielKey;
+import org.open4goods.model.datafragment.DataFragment;
+import org.open4goods.model.product.BarcodeType;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.slf4j.LoggerFactory;
+
+class IdentityAggregationServiceTest
+{
+
+    @Test
+    void onDataFragmentCapturesRawGtinBeforeSanitization() throws Exception
+    {
+        Gs1PrefixService gs1Service = Mockito.mock(Gs1PrefixService.class);
+        BarcodeValidationService validationService = Mockito.mock(BarcodeValidationService.class);
+        IdentityAggregationService service = new IdentityAggregationService(
+                LoggerFactory.getLogger(IdentityAggregationServiceTest.class),
+                gs1Service,
+                validationService
+        );
+
+        DataFragment fragment = new DataFragment();
+        fragment.getReferentielAttributes().put(ReferentielKey.GTIN, "0123456789012");
+
+        Product product = new Product();
+        VerticalConfig verticalConfig = new VerticalConfig();
+
+        Mockito.when(validationService.sanitize("123456789012"))
+                .thenReturn(new SimpleEntry<>(BarcodeType.GTIN_12, "123456789012"));
+        Mockito.when(gs1Service.detectCountry("123456789012"))
+                .thenReturn("FR");
+
+        service.onDataFragment(fragment, product, verticalConfig);
+
+        assertThat(product.getGtinInfos().getGtinStrings())
+                .containsExactly("0123456789012");
+        assertThat(product.gtin()).isEqualTo("123456789012");
+    }
+}

--- a/model/src/main/java/org/open4goods/model/product/GtinInfo.java
+++ b/model/src/main/java/org/open4goods/model/product/GtinInfo.java
@@ -1,36 +1,147 @@
 package org.open4goods.model.product;
 
-public class GtinInfo {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
+public class GtinInfo
+{
 
-	private BarcodeType upcType;
+    private BarcodeType upcType;
 
-	/**
-	 * Manufacturer country, from the gtin
-	 */
-	private String country;
+    /**
+     * Manufacturer country, from the gtin
+     */
+    private String country;
 
+    /**
+     * Raw GTINs encountered before any padding or sanitization.
+     */
+    private List<String> gtinStrings = new ArrayList<>();
 
+    public String getCountry()
+    {
+        return country;
+    }
 
-	public String getCountry() {
-		return country;
-	}
+    public void setCountry(String country)
+    {
+        this.country = country;
+    }
 
+    public BarcodeType getUpcType()
+    {
+        return upcType;
+    }
 
-	public void setCountry(String country) {
-		this.country = country;
-	}
+    public void setUpcType(BarcodeType upcType)
+    {
+        this.upcType = upcType;
+    }
 
+    public List<String> getGtinStrings()
+    {
+        return gtinStrings;
+    }
 
-	public BarcodeType getUpcType() {
-		return upcType;
-	}
+    public void setGtinStrings(List<String> gtinStrings)
+    {
+        this.gtinStrings = gtinStrings == null ? new ArrayList<>() : new ArrayList<>(gtinStrings);
+    }
 
+    /**
+     * Adds a raw GTIN string if it is non-blank and not already present.
+     *
+     * @param gtin the raw GTIN string to store
+     */
+    public void addGtinString(String gtin)
+    {
+        if (gtin == null) {
+            return;
+        }
+        String trimmed = gtin.trim();
+        if (trimmed.isBlank()) {
+            return;
+        }
+        if (!gtinStrings.contains(trimmed)) {
+            gtinStrings.add(trimmed);
+        }
+    }
 
-	public void setUpcType(BarcodeType upcType) {
-		this.upcType = upcType;
-	}
+    /**
+     * Detects the original barcode type from the smallest raw GTIN length, while
+     * considering leading-zero variants that may have been padded.
+     *
+     * @return the inferred barcode type, if any
+     */
+    public Optional<BarcodeType> detectOriginalBarcodeType()
+    {
+        if (gtinStrings == null || gtinStrings.isEmpty()) {
+            return Optional.empty();
+        }
 
+        int minLength = Integer.MAX_VALUE;
+        int minStrippedLength = Integer.MAX_VALUE;
+        boolean hasLeadingZero = false;
 
+        for (String gtin : gtinStrings) {
+            if (gtin == null) {
+                continue;
+            }
+            String trimmed = gtin.trim();
+            if (trimmed.isBlank()) {
+                continue;
+            }
+            minLength = Math.min(minLength, trimmed.length());
+            if (trimmed.startsWith("0")) {
+                hasLeadingZero = true;
+            }
+            String stripped = stripLeadingZeros(trimmed);
+            if (!stripped.isEmpty()) {
+                minStrippedLength = Math.min(minStrippedLength, stripped.length());
+            }
+        }
+
+        if (minLength == Integer.MAX_VALUE) {
+            return Optional.empty();
+        }
+
+        int candidateLength = minLength;
+        if (hasLeadingZero && minStrippedLength < candidateLength && isKnownGtinLength(minStrippedLength)) {
+            candidateLength = minStrippedLength;
+        }
+
+        return barcodeTypeForLength(candidateLength);
+    }
+
+    private String stripLeadingZeros(String value)
+    {
+        int index = 0;
+        while (index < value.length() && value.charAt(index) == '0') {
+            index++;
+        }
+        return index == value.length() ? "" : value.substring(index);
+    }
+
+    private boolean isKnownGtinLength(int length)
+    {
+        return length == 8 || length == 12 || length == 13 || length == 14;
+    }
+
+    private Optional<BarcodeType> barcodeTypeForLength(int length)
+    {
+        switch (length) {
+            case 8:
+                return Optional.of(BarcodeType.GTIN_8);
+            case 12:
+                return Optional.of(BarcodeType.GTIN_12);
+            case 13:
+                return Optional.of(BarcodeType.GTIN_13);
+            case 14:
+                return Optional.of(BarcodeType.GTIN_14);
+            default:
+                return Optional.empty();
+        }
+    }
 
 }

--- a/model/src/main/resources/product-mappings.json
+++ b/model/src/main/resources/product-mappings.json
@@ -335,6 +335,10 @@
         "country": {
           "type": "keyword"
         },
+        "gtinStrings": {
+          "type": "object",
+          "enabled": false
+        },
         "upcType": {
           "type": "keyword",
           "index": false

--- a/model/src/test/java/org/open4goods/model/product/GtinInfoTest.java
+++ b/model/src/test/java/org/open4goods/model/product/GtinInfoTest.java
@@ -1,0 +1,41 @@
+package org.open4goods.model.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GtinInfoTest
+{
+
+    @Test
+    void addGtinStringDeduplicatesAndTrims()
+    {
+        GtinInfo gtinInfo = new GtinInfo();
+
+        gtinInfo.addGtinString(" 0123456789012 ");
+        gtinInfo.addGtinString("0123456789012");
+
+        assertThat(gtinInfo.getGtinStrings()).containsExactly("0123456789012");
+    }
+
+    @Test
+    void detectOriginalBarcodeTypeUsesStrippedLengthWhenLeadingZeroPresent()
+    {
+        GtinInfo gtinInfo = new GtinInfo();
+        gtinInfo.addGtinString("0123456789012");
+
+        assertThat(gtinInfo.detectOriginalBarcodeType())
+                .contains(BarcodeType.GTIN_12);
+    }
+
+    @Test
+    void detectOriginalBarcodeTypeUsesSmallestRawLength()
+    {
+        GtinInfo gtinInfo = new GtinInfo();
+        gtinInfo.addGtinString("12345670");
+        gtinInfo.addGtinString("12345678901234");
+
+        assertThat(gtinInfo.detectOriginalBarcodeType())
+                .contains(BarcodeType.GTIN_8);
+    }
+}


### PR DESCRIPTION
### Motivation
- Preserve raw GTIN strings observed in incoming data before sanitization to enable detection of original barcode length/type and avoid losing leading-zero variants.
- Provide a small helper in the model to infer the original barcode type from observed raw GTIN forms for downstream logic and diagnostics.
- Ensure raw GTINs are available in the product ES mapping without being indexed to avoid increasing index footprint.

### Description
- Augmented `GtinInfo` with `gtinStrings` storage, `addGtinString(...)`, and `detectOriginalBarcodeType()` plus helper methods to strip leading zeros and infer barcode type lengths.
- Updated `product-mappings.json` to include `gtinStrings` as a non-indexed object under `gtinInfos`.
- Captured raw GTINs by calling `addGtinString(...)` from `IdentityAggregationService.onDataFragment(...)` and `AttributeRealtimeAggregationService.handleReferentielAttributes(...)` prior to sanitization/overrides.
- Added unit tests covering raw GTIN capture and original-type detection under `model/src/test/java/org/open4goods/model/product/GtinInfoTest.java` and integration-style tests in `api/src/test/...` validating capture during aggregation.

### Testing
- No automated test run was executed in this change; new unit tests were added at `model/src/test/java/org/open4goods/model/product/GtinInfoTest.java` and `api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/*` but they were not run as part of this rollout.
- Local compile/tests were not reported, so automated test status is unknown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697130d26570832b9d8ffd171a4d1365)