### PR TITLE
Harden aggregation pipelines and make ordering configurable

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfig.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.AggregationPipelineProperties;
 import org.open4goods.api.services.AggregationFacadeService;
 import org.open4goods.api.services.BatchService;
 import org.open4goods.api.services.CompletionFacadeService;
@@ -301,9 +302,9 @@ public class ApiConfig {
 	AggregationFacadeService realtimeAggregationService(@Autowired EvaluationService evaluationService, StandardiserService standardiserService, AutowireCapableBeanFactory autowireBeanFactory, @Autowired ProductRepository aggregatedDataRepository, ApiProperties apiProperties,
 			@Autowired Gs1PrefixService gs1prefixService, DataSourceConfigService dataSourceConfigService, VerticalsConfigService configService, BarcodeValidationService barcodeValidationService, BrandService brandservice, GoogleTaxonomyService gts, BlablaService blablaService,
 			IcecatService icecatFeatureService, SerialisationService serialisationService, BrandScoreService brandScoreService, DjlTextEmbeddingService embeddingService,
-			DjlEmbeddingProperties embeddingProperties) {
+			DjlEmbeddingProperties embeddingProperties, AggregationPipelineProperties aggregationPipelineProperties) {
 		return new AggregationFacadeService(evaluationService, standardiserService, autowireBeanFactory, aggregatedDataRepository, apiProperties, gs1prefixService, dataSourceConfigService, configService, barcodeValidationService, brandservice, gts, blablaService, icecatFeatureService,
-				serialisationService, brandScoreService, embeddingService, embeddingProperties);
+				serialisationService, brandScoreService, embeddingService, embeddingProperties, aggregationPipelineProperties);
 	}
 
 	//////////////////////////////////////////////////////////

--- a/api/src/main/java/org/open4goods/api/config/yml/AggregationPipelineProperties.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/AggregationPipelineProperties.java
@@ -1,0 +1,103 @@
+package org.open4goods.api.config.yml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties describing aggregation pipeline ordering.
+ *
+ * <p>The lists are service identifiers used by {@code AggregationFacadeService}
+ * to assemble realtime, sanitisation, classification, and scoring pipelines.</p>
+ */
+@Configuration
+@ConfigurationProperties(prefix = "open4goods.aggregation")
+public class AggregationPipelineProperties
+{
+
+    private Pipelines pipelines = new Pipelines();
+
+    public Pipelines getPipelines()
+    {
+        return pipelines;
+    }
+
+    public void setPipelines(Pipelines pipelines)
+    {
+        this.pipelines = pipelines;
+    }
+
+    public static class Pipelines
+    {
+
+        private List<String> realtime = new ArrayList<>(List.of(
+                "identity",
+                "taxonomy",
+                "attributes",
+                "names",
+                "price",
+                "media"));
+
+        private List<String> sanitisation = new ArrayList<>(List.of(
+                "identity",
+                "taxonomy",
+                "attributes",
+                "names",
+                "price",
+                "media"));
+
+        private List<String> classification = new ArrayList<>(List.of(
+                "identity",
+                "taxonomy"));
+
+        private List<String> scoring = new ArrayList<>(List.of(
+                "clean-score",
+                "attribute-score",
+                "sustainalytics",
+                "data-quality",
+                "eco-score",
+                "participating"));
+
+        public List<String> getRealtime()
+        {
+            return realtime;
+        }
+
+        public void setRealtime(List<String> realtime)
+        {
+            this.realtime = realtime;
+        }
+
+        public List<String> getSanitisation()
+        {
+            return sanitisation;
+        }
+
+        public void setSanitisation(List<String> sanitisation)
+        {
+            this.sanitisation = sanitisation;
+        }
+
+        public List<String> getClassification()
+        {
+            return classification;
+        }
+
+        public void setClassification(List<String> classification)
+        {
+            this.classification = classification;
+        }
+
+        public List<String> getScoring()
+        {
+            return scoring;
+        }
+
+        public void setScoring(List<String> scoring)
+        {
+            this.scoring = scoring;
+        }
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -23,6 +23,34 @@ logging:
 
 aggregationLogLevel: warn
 
+open4goods:
+  aggregation:
+    pipelines:
+      realtime:
+        - identity
+        - taxonomy
+        - attributes
+        - names
+        - price
+        - media
+      sanitisation:
+        - identity
+        - taxonomy
+        - attributes
+        - names
+        - price
+        - media
+      classification:
+        - identity
+        - taxonomy
+      scoring:
+        - clean-score
+        - attribute-score
+        - sustainalytics
+        - data-quality
+        - eco-score
+        - participating
+
 
 management:
   health:
@@ -85,5 +113,4 @@ remote-file-caching:
 google-taxonomy:
   fr: https://www.google.com/basepages/producttype/taxonomy-with-ids.fr-FR.txt
   en: https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt
-
 

--- a/api/src/test/java/org/open4goods/api/services/AggregationFacadeServiceParticipatingScoresIT.java
+++ b/api/src/test/java/org/open4goods/api/services/AggregationFacadeServiceParticipatingScoresIT.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.AggregationPipelineProperties;
 import org.open4goods.api.services.aggregation.aggregator.ScoringBatchedAggregator;
 import org.open4goods.commons.services.BarcodeValidationService;
 import org.open4goods.commons.services.DataSourceConfigService;
@@ -84,7 +85,8 @@ class AggregationFacadeServiceParticipatingScoresIT {
                 mock(SerialisationService.class),
                 mock(BrandScoreService.class),
                 mock(DjlTextEmbeddingService.class),
-                new DjlEmbeddingProperties());
+                new DjlEmbeddingProperties(),
+                new AggregationPipelineProperties());
     }
 
     private VerticalConfig verticalConfig() {

--- a/api/src/test/java/org/open4goods/api/services/AggregationFacadeServicePipelineTest.java
+++ b/api/src/test/java/org/open4goods/api/services/AggregationFacadeServicePipelineTest.java
@@ -1,0 +1,93 @@
+package org.open4goods.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.api.config.yml.AggregationPipelineProperties;
+import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.services.aggregation.AbstractAggregationService;
+import org.open4goods.api.services.aggregation.aggregator.StandardAggregator;
+import org.open4goods.api.services.aggregation.services.realtime.IdentityAggregationService;
+import org.open4goods.api.services.aggregation.services.realtime.PriceAggregationService;
+import org.open4goods.commons.services.BarcodeValidationService;
+import org.open4goods.commons.services.DataSourceConfigService;
+import org.open4goods.commons.services.Gs1PrefixService;
+import org.open4goods.commons.services.textgen.BlablaService;
+import org.open4goods.embedding.config.DjlEmbeddingProperties;
+import org.open4goods.embedding.service.DjlTextEmbeddingService;
+import org.open4goods.icecat.services.IcecatService;
+import org.open4goods.services.evaluation.service.EvaluationService;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.open4goods.verticals.GoogleTaxonomyService;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.open4goods.brand.service.BrandScoreService;
+import org.open4goods.brand.service.BrandService;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+
+class AggregationFacadeServicePipelineTest
+{
+
+    @Test
+    void standardAggregatorUsesConfiguredPipelineOrder() throws Exception
+    {
+        AggregationPipelineProperties pipelineProperties = new AggregationPipelineProperties();
+        AggregationPipelineProperties.Pipelines pipelines = pipelineProperties.getPipelines();
+        pipelines.setRealtime(List.of("price", "identity"));
+
+        AggregationFacadeService facade = aggregationFacadeService(pipelineProperties);
+
+        StandardAggregator aggregator = facade.getStandardAggregator("realtime");
+        List<AbstractAggregationService> services = getServices(aggregator);
+
+        assertThat(services).hasSize(2);
+        assertThat(services.get(0)).isInstanceOf(PriceAggregationService.class);
+        assertThat(services.get(1)).isInstanceOf(IdentityAggregationService.class);
+    }
+
+    private AggregationFacadeService aggregationFacadeService(AggregationPipelineProperties pipelineProperties)
+    {
+        EvaluationService evaluationService = mock(EvaluationService.class);
+        ProductRepository repository = mock(ProductRepository.class);
+        ApiProperties apiProperties = new ApiProperties();
+        apiProperties.setRootFolder("/tmp/open4goods/");
+
+        AutowireCapableBeanFactory beanFactory = mock(AutowireCapableBeanFactory.class);
+        doAnswer(invocation -> null).when(beanFactory).autowireBean(any());
+
+        return new AggregationFacadeService(
+                evaluationService,
+                mock(org.open4goods.model.StandardiserService.class),
+                beanFactory,
+                repository,
+                apiProperties,
+                mock(Gs1PrefixService.class),
+                mock(DataSourceConfigService.class),
+                mock(VerticalsConfigService.class),
+                mock(BarcodeValidationService.class),
+                mock(BrandService.class),
+                mock(GoogleTaxonomyService.class),
+                mock(BlablaService.class),
+                mock(IcecatService.class),
+                mock(SerialisationService.class),
+                mock(BrandScoreService.class),
+                mock(DjlTextEmbeddingService.class),
+                new DjlEmbeddingProperties(),
+                pipelineProperties);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<AbstractAggregationService> getServices(StandardAggregator aggregator) throws Exception
+    {
+        Field field = org.open4goods.api.services.aggregation.aggregator.AbstractAggregator.class
+                .getDeclaredField("services");
+        field.setAccessible(true);
+        return (List<AbstractAggregationService>) field.get(aggregator);
+    }
+}

--- a/api/src/test/java/org/open4goods/api/services/aggregation/aggregator/StandardAggregatorTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/aggregator/StandardAggregatorTest.java
@@ -1,0 +1,96 @@
+package org.open4goods.api.services.aggregation.aggregator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.api.services.aggregation.AbstractAggregationService;
+import org.open4goods.commons.exceptions.AggregationSkipException;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.LoggerFactory;
+
+class StandardAggregatorTest
+{
+
+    @Test
+    void onProductsRunsLifecycleHooks() throws AggregationSkipException
+    {
+        CountingAggregationService service = new CountingAggregationService();
+        VerticalsConfigService verticals = mock(VerticalsConfigService.class);
+        VerticalConfig vertical = new VerticalConfig();
+        vertical.setId("vertical-test");
+        when(verticals.getConfigByIdOrDefault("vertical-test")).thenReturn(vertical);
+
+        StandardAggregator aggregator = new StandardAggregator(List.of(service), verticals);
+
+        Product first = new Product(1L);
+        first.setVertical("vertical-test");
+        Product second = new Product(2L);
+        second.setVertical("vertical-test");
+
+        aggregator.onProducts(List.of(first, second), vertical);
+
+        assertThat(service.getInitCount()).isEqualTo(1);
+        assertThat(service.getOnProductCount()).isEqualTo(2);
+        assertThat(service.getDoneCount()).isEqualTo(1);
+        assertThat(service.getLastVertical()).isSameAs(vertical);
+    }
+
+    private static class CountingAggregationService extends AbstractAggregationService
+    {
+
+        private int initCount;
+        private int onProductCount;
+        private int doneCount;
+        private VerticalConfig lastVertical;
+
+        CountingAggregationService()
+        {
+            super(LoggerFactory.getLogger(CountingAggregationService.class));
+        }
+
+        @Override
+        public void init(java.util.Collection<Product> datas)
+        {
+            initCount += 1;
+        }
+
+        @Override
+        public void onProduct(Product data, VerticalConfig vConf)
+        {
+            onProductCount += 1;
+            lastVertical = vConf;
+        }
+
+        @Override
+        public void done(java.util.Collection<Product> datas, VerticalConfig vConf)
+        {
+            doneCount += 1;
+        }
+
+        int getInitCount()
+        {
+            return initCount;
+        }
+
+        int getOnProductCount()
+        {
+            return onProductCount;
+        }
+
+        int getDoneCount()
+        {
+            return doneCount;
+        }
+
+        VerticalConfig getLastVertical()
+        {
+            return lastVertical;
+        }
+    }
+}

--- a/docs/aggregation-pipeline.md
+++ b/docs/aggregation-pipeline.md
@@ -1,0 +1,63 @@
+<!--
+  Aggregation pipeline audit & hardening
+  Scope: /api module aggregation services (realtime + batch)
+-->
+
+# Aggregation Pipelines Audit
+
+## Functionality
+
+### Realtime aggregation
+- **Ingress**: `DataFragmentStoreService` validates and standardizes incoming `DataFragment` objects, then enqueues them for async processing.
+- **Worker**: `DataFragmentAggregationWorker` dequeues fragments and calls `aggregateAndstore`.
+- **Aggregation**: `AggregationFacadeService.updateOne(...)` applies the realtime pipeline by calling `StandardAggregator.onDatafragment(...)`.
+- **Realtime pipeline order** (configurable via YAML):
+  1. Identity (GTIN validation, barcode country/type)
+  2. Taxonomy (categories → vertical + taxonomy)
+  3. Attributes (indexing + brand/model cleaning)
+  4. Names (i18n names + embeddings)
+  5. Price (offers + history)
+  6. Media (resources + Icecat URL cleaning)
+
+### Batch aggregation
+- **Entry points**: `BatchService.batch(...)` (scheduled) and admin endpoints in `BatchController`.
+- **Steps**:
+  1. Classification (identity + taxonomy)
+  2. Completion (external data enrichment)
+  3. Sanitisation aggregation
+  4. Scoring pipeline (clean → attribute → sustainalytics → data quality → eco score → aggregated scores)
+- **Batch scoring** uses `ScoringBatchedAggregator` which runs lifecycle hooks (`init` → `onProduct` → `done`).
+
+## Design
+
+### Hardening changes implemented
+- **Non-blocking worker batching**: The realtime worker now polls with a timeout and drains remaining items without waiting for a full batch, preventing indefinite blocking when traffic is low and preserving fragment order.
+- **Lifecycle-aware sanitisation**: `StandardAggregator` now offers a batch entry point that triggers `init/done` hooks so sanitisation steps can safely accumulate state when needed.
+- **YAML-driven pipeline composition**: `AggregationFacadeService` now reads service ordering from `open4goods.aggregation.pipelines.*`, allowing per-environment tuning without code changes.
+- **Strict pipeline validation**: Unknown/blank service IDs are rejected at startup to avoid silent misconfiguration.
+
+### Functional enhancements & checks
+- **Fragment loss avoidance**: Replacing `HashSet` with ordered `List` buffers prevents accidental de-duplication of fragments during aggregation.
+- **Configuration-first design**: Pipelines can now be re-ordered, extended, or trimmed via YAML without rewiring Java constructors.
+
+## Guides
+
+### How to add an aggregation service
+1. **Create the service**
+   - Implement `AbstractAggregationService`.
+   - Add `onDataFragment` for realtime updates and/or `onProduct` for product-level aggregation.
+2. **Register the service**
+   - Add a new service identifier in `AggregationFacadeService`’s `buildService(...)` switch.
+   - Add the identifier to the appropriate pipeline list in `application.yml`.
+3. **Verify with tests**
+   - Add or extend unit tests to confirm service ordering and lifecycle hooks are respected.
+
+### How to use it in batch
+1. Add your service ID to `open4goods.aggregation.pipelines.sanitisation` if it is a product-cleanup step.
+2. For scoring logic, add your service ID to `open4goods.aggregation.pipelines.scoring`.
+3. Trigger batch via `/batch/` or `/score/{vertical}` in `BatchController` to verify behavior.
+
+### How to use it in realtime
+1. Add your service ID to `open4goods.aggregation.pipelines.realtime`.
+2. Run the ingestion pipeline; the realtime worker will apply the service to each incoming `DataFragment`.
+


### PR DESCRIPTION
### Motivation
- Make aggregation pipelines configurable and safer to operate in both realtime and batch modes by moving ordering out of code into YAML and validating configuration at startup.
- Improve throughput and resilience of realtime ingestion by preventing indefinite blocking and accidental fragment de-duplication during batching.
- Provide lifecycle-aware batch processing so aggregation services can `init`/`done` across product batches instead of only per-product.
- Add tests and documentation to lock intended behavior and ease future maintenance.

### Description
- Add `AggregationPipelineProperties` (`open4goods.aggregation`) and default pipeline lists, and expose them in `application.yml` to drive pipeline ordering at runtime.
- Wire pipeline properties into `AggregationFacadeService` via `ApiConfig`, implement `validatePipelineConfiguration()`, pipeline resolution, and a `buildPipeline(...)`/`buildService(...)` factory that composes services by identifier rather than hard-coded lists.
- Implement batch lifecycle support in `StandardAggregator` with a new `onProducts(Collection<Product>, VerticalConfig)` entry that calls `init`, `onProduct`, and `done` for each registered service.
- Harden `DataFragmentAggregationWorker` so it polls with a timeout, collects an ordered `List` (no HashSet de-duplication) via `poll()` + `drainTo()`, and handles interrupts cleanly before calling `aggregateAndstore`.
- Add unit tests `StandardAggregatorTest` and `AggregationFacadeServicePipelineTest` covering lifecycle hooks and pipeline ordering, and document the pipeline design and how to add services in `docs/aggregation-pipeline.md`.

### Testing
- Ran full build and tests with `mvn --offline clean install`, which completed successfully (multi-module build finished and reported `BUILD SUCCESS`).
- New unit tests `StandardAggregatorTest` and `AggregationFacadeServicePipelineTest` were executed as part of the build and passed.
- Existing test suite across modules ran during the build; the reactor completed with all modules built and tests green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69717497b1b8832bb5f6006511ae3e5d)