### PR TITLE
feat(frontend): add commercial event band for new price chart

### DIFF
--- a/frontend/app/components/product/ProductPriceSection.spec.ts
+++ b/frontend/app/components/product/ProductPriceSection.spec.ts
@@ -46,6 +46,14 @@ const i18nMessages = {
           highest: 'Prix le plus haut',
           viewOffer: "Ouvrir l'offre chez {source}",
         },
+        events: {
+          detailsTitle: 'Événement commercial',
+          clearSelection: 'Effacer la sélection',
+          dateLabel: 'Dates :',
+          dateRange: '{start} au {end}',
+          singleDay: '{date}',
+          untitled: 'Événement commercial',
+        },
         noHistory:
           "L'historique des prix n'est pas encore disponible pour ce produit.",
         headers: {
@@ -86,6 +94,14 @@ const i18nMessages = {
           average: 'Average price',
           highest: 'Highest price',
           viewOffer: 'Open offer from {source}',
+        },
+        events: {
+          detailsTitle: 'Commercial event',
+          clearSelection: 'Clear selection',
+          dateLabel: 'Dates:',
+          dateRange: '{start} to {end}',
+          singleDay: '{date}',
+          untitled: 'Commercial event',
         },
         noHistory: 'Price history is not yet available for this product.',
         headers: {
@@ -271,12 +287,18 @@ describe('ProductPriceSection', () => {
 
     const chart = wrapper.find('.echart-stub')
     const option = JSON.parse(chart.attributes('data-option') ?? '{}')
-    const markAreaLabel =
-      option?.series?.[0]?.markArea?.data?.[0]?.[1]?.label?.formatter
-    expect(markAreaLabel).toBe('Summer sales')
-    expect(option?.series?.[0]?.type).toBe('line')
-    expect(option?.series?.[0]?.showSymbol).toBe(false)
-    expect(option?.series?.[0]?.smooth).toBe(true)
+    const lineSeries = option?.series?.find(
+      (series: { type?: string }) => series.type === 'line'
+    )
+    const eventSeries = option?.series?.find(
+      (series: { type?: string }) => series.type === 'custom'
+    )
+    expect(option?.grid?.length).toBe(2)
+    expect(option?.xAxis?.length).toBe(2)
+    expect(eventSeries?.data?.[0]?.value?.[3]).toBe('Summer sales')
+    expect(lineSeries?.type).toBe('line')
+    expect(lineSeries?.showSymbol).toBe(false)
+    expect(lineSeries?.smooth).toBe(true)
 
     await wrapper.unmount()
   })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2791,6 +2791,14 @@
         "viewOffer": "Open offer from {source}",
         "unknownSource": "Unknown source"
       },
+      "events": {
+        "detailsTitle": "Commercial event",
+        "clearSelection": "Clear selection",
+        "dateLabel": "Dates:",
+        "dateRange": "{start} to {end}",
+        "singleDay": "{date}",
+        "untitled": "Commercial event"
+      },
       "historyTitle": "Price history",
       "noHistory": "Price history is not yet available for this product.",
       "subtitle": "Track price evolution and compare offers.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2807,6 +2807,14 @@
         "viewOffer": "Ouvrir l'offre chez {source}",
         "unknownSource": "Source inconnue"
       },
+      "events": {
+        "detailsTitle": "Événement commercial",
+        "clearSelection": "Effacer la sélection",
+        "dateLabel": "Dates :",
+        "dateRange": "{start} au {end}",
+        "singleDay": "{date}",
+        "untitled": "Événement commercial"
+      },
       "historyTitle": "Historique des prix",
       "noHistory": "Pas assez de données pour afficher l'historique des prix.",
       "subtitle": "Suivez l’évolution des prix et comparez les offres.",


### PR DESCRIPTION
### Motivation
- Provide visual context for commercial events on product price charts so users can correlate price trends with promotions and sales.
- Avoid overlapping event labels by packing events into multiple rows and allow users to inspect an event in detail.
- Ensure the feature is localized and covered by component-level tests.

### Description
- Render commercial events as a dedicated event band using a custom ECharts `custom` series with a packing algorithm to place overlapping events into rows and a tooltip/label renderer for each band.
- Add selection handling: clicking an event highlights it and shows a compact event details card with localized date range and a clear action.
- Include helper utilities: deterministic color resolution, date formatting using `date-fns`, `hexToRgb`, and `packCommercialEvents` for row allocation; enable ECharts custom rendering via `ensureECharts` and include `CustomChart` in the loader.
- Add i18n entries for English and French, update `ProductPriceSection.vue` styles, and update `ProductPriceSection.spec.ts` to assert the new custom event series and grid layout.

### Testing
- Ran `pnpm lint` with ESLint which completed successfully (two existing `vue/no-v-html` warnings in other files only). (succeeded)
- Ran `pnpm test -- app/components/product/ProductPriceSection.spec.ts` and the spec passed; the component tests were exercised in the full suite run as well. (succeeded)
- Ran `pnpm generate` to validate production generation; site generation completed successfully with a non-blocking PWA glob warning. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69717e52bc68832b8d61e0bbeee23dd6)