### PR TITLE
Add technicalShortReview to AI review pipeline and surface AI summaries in UI

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/AiReviewDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/AiReviewDto.java
@@ -24,6 +24,9 @@ public record AiReviewDto(
         @Schema(description = "Technical analysis extracted from trustworthy sources")
         String technicalReview,
 
+        @Schema(description = "Short technical summary in 2-3 sentences")
+        String technicalShortReview,
+
         @Schema(description = "Ecological assessment derived from the available documentation")
         String ecologicalReview,
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -847,6 +847,7 @@ public class ProductMappingService {
                 review.getMediumTitle(),
                 review.getShortTitle(),
                 review.getTechnicalReview(),
+                review.getTechnicalShortReview(),
                 review.getEcologicalReview(),
                 review.getSummary(),
                 pros,

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -5,7 +5,7 @@
         {{ $t('product.aiReview.title', titleParams) }}
       </h2>
       <p class="product-ai-review__subtitle">
-        {{ $t('product.aiReview.subtitle') }}
+        {{ subtitleLabel }}
       </p>
     </header>
 
@@ -317,6 +317,7 @@ import type {
 import { IpQuotaCategory } from '~~/shared/api-client'
 import { useAuth } from '~/composables/useAuth'
 import { useIpQuota } from '~/composables/useIpQuota'
+import { usePluralizedTranslation } from '~/composables/usePluralizedTranslation'
 import ProductAiReviewRequestDialog from '~/components/product/ProductAiReviewRequestDialog.vue'
 
 interface ReviewContent {
@@ -365,10 +366,11 @@ const props = defineProps({
   },
 })
 
-const { locale, t } = useI18n()
+const { locale, t, n } = useI18n()
 const theme = useTheme()
 const { isLoggedIn } = useAuth()
 const { getRemaining, refreshQuota, recordUsage } = useIpQuota()
+const { translatePlural } = usePluralizedTranslation()
 
 const review = ref<ReviewContent | null>(normalizeReview(props.initialReview))
 const createdMs = ref<number | null>(props.reviewCreatedAt ?? null)
@@ -425,6 +427,12 @@ const captchaLocale = computed(() =>
 )
 
 const reviewContent = computed(() => review.value)
+const sourcesCount = computed(() => reviewContent.value?.sources?.length ?? 0)
+const subtitleLabel = computed(() =>
+  translatePlural('product.aiReview.subtitle', sourcesCount.value, {
+    count: n(sourcesCount.value),
+  })
+)
 
 const createdDate = computed(() => {
   if (!createdMs.value) {

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -4,7 +4,12 @@
       <h2 class="product-attributes__title">
         {{ $t('product.attributes.title', titleParams) }}
       </h2>
-      <p class="product-attributes__subtitle">
+      <p
+        v-if="technicalShortReviewHtml"
+        class="product-attributes__subtitle"
+        v-html="technicalShortReviewHtml"
+      />
+      <p v-else class="product-attributes__subtitle">
         {{ $t('product.attributes.subtitle') }}
       </p>
     </header>
@@ -713,6 +718,7 @@ import { useAuth } from '~/composables/useAuth'
 import ProductAttributeSourcingLabel from '~/components/product/attributes/ProductAttributeSourcingLabel.vue'
 import ProductAttributesDetailCard from '~/components/product/attributes/ProductAttributesDetailCard.vue'
 import ProductLifeTimeline from '~/components/product/ProductLifeTimeline.vue'
+import { _sanitizeHtml } from '~~/shared/utils/sanitizer'
 import type {
   AttributeConfigDto,
   ProductAttributeDto,
@@ -776,6 +782,17 @@ const resolvedAttributes = computed<ProductAttributesDto | null>(() => {
 const timeline = computed(() => props.product?.timeline ?? null)
 const identity = computed(() => props.product?.identity ?? null)
 const gtin = computed(() => props.product?.gtin ?? props.product?.base?.gtin ?? null)
+const technicalShortReview = computed(() =>
+  props.product?.aiReview?.review?.technicalShortReview?.trim() ?? ''
+)
+const technicalShortReviewHtml = computed(() => {
+  if (!technicalShortReview.value) {
+    return ''
+  }
+
+  const { sanitizedHtml } = _sanitizeHtml(technicalShortReview.value)
+  return sanitizedHtml.value || technicalShortReview.value
+})
 
 const normalizeIdentityValue = (value: string | null | undefined): string | null => {
   if (typeof value !== 'string') {

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -78,7 +78,14 @@
                           size="small"
                           class="product-hero__ai-summary-icon"
                         />
-                        <span>{{ aiReview.technicalOneline }}</span>
+                        <div class="product-hero__ai-summary-content">
+                          <span class="product-hero__ai-summary-label">
+                            {{ t('product.hero.aiSummary.technical') }}
+                          </span>
+                          <span class="product-hero__ai-summary-text">
+                            {{ aiReview.technicalOneline }}
+                          </span>
+                        </div>
                       </li>
                       <li
                         v-if="aiReview?.ecologicalOneline"
@@ -89,7 +96,14 @@
                           size="small"
                           class="product-hero__ai-summary-icon"
                         />
-                        <span>{{ aiReview.ecologicalOneline }}</span>
+                        <div class="product-hero__ai-summary-content">
+                          <span class="product-hero__ai-summary-label">
+                            {{ t('product.hero.aiSummary.ecological') }}
+                          </span>
+                          <span class="product-hero__ai-summary-text">
+                            {{ aiReview.ecologicalOneline }}
+                          </span>
+                        </div>
                       </li>
                       <li
                         v-if="aiReview?.communityOneline"
@@ -100,7 +114,14 @@
                           size="small"
                           class="product-hero__ai-summary-icon"
                         />
-                        <span>{{ aiReview.communityOneline }}</span>
+                        <div class="product-hero__ai-summary-content">
+                          <span class="product-hero__ai-summary-label">
+                            {{ t('product.hero.aiSummary.community') }}
+                          </span>
+                          <span class="product-hero__ai-summary-text">
+                            {{ aiReview.communityOneline }}
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </template>
@@ -118,67 +139,45 @@
                     v-if="attribute.key !== 'ai-summary'"
                     class="product-hero__attribute-value"
                   >
-                    <template v-if="attribute.tooltip">
-                      <v-tooltip location="bottom" :text="attribute.tooltip">
-                        <template #activator="{ props: tooltipProps }">
-                          <ProductAttributeSourcingLabel
-                            class="product-hero__attribute-value-label"
-                            :sourcing="attribute.sourcing"
-                            :value="attribute.value"
-                            :enable-tooltip="attribute.enableTooltip !== false"
-                          >
-                            <template #default="{ displayValue, displayHtml }">
-                              <span
-                                class="product-hero__attribute-value-content"
-                                v-bind="tooltipProps"
-                              >
-                                <NuxtImg
-                                  v-if="attribute.flag"
-                                  :src="attribute.flag"
-                                  :alt="displayValue"
-                                  width="32"
-                                  height="24"
-                                  class="product-hero__flag"
-                                />
-                                <!-- eslint-disable-next-line vue/no-v-html -->
-                                <span v-if="displayHtml" v-html="displayHtml" />
-                                <span v-else>{{ displayValue }}</span>
-                              </span>
-                            </template>
-                          </ProductAttributeSourcingLabel>
-                        </template>
-                      </v-tooltip>
-                    </template>
-                    <template v-else>
-                      <ProductAttributeSourcingLabel
-                        class="product-hero__attribute-value-label"
-                        :sourcing="attribute.sourcing"
-                        :value="attribute.value"
-                        :enable-tooltip="attribute.enableTooltip !== false"
-                      >
-                        <template #default="{ displayValue, displayHtml }">
-                          <span class="product-hero__attribute-value-content">
-                            <NuxtImg
-                              v-if="attribute.flag"
-                              :src="attribute.flag"
-                              :alt="displayValue"
-                              width="32"
-                              height="24"
-                              class="product-hero__flag"
-                            />
-                            <v-icon
-                              v-if="attribute.icon"
-                              :icon="attribute.icon"
-                              size="small"
-                              class="product-hero__icon mr-2"
-                            />
-                            <!-- eslint-disable-next-line vue/no-v-html -->
-                            <span v-if="displayHtml" v-html="displayHtml" />
-                            <span v-else>{{ displayValue }}</span>
-                          </span>
-                        </template>
-                      </ProductAttributeSourcingLabel>
-                    </template>
+                    <ProductAttributeSourcingLabel
+                      class="product-hero__attribute-value-label"
+                      :sourcing="attribute.sourcing"
+                      :value="attribute.value"
+                      :enable-tooltip="attribute.enableTooltip !== false"
+                    >
+                      <template #default="{ displayValue, displayHtml }">
+                        <v-tooltip
+                          location="bottom"
+                          :text="attribute.tooltip"
+                          :disabled="!attribute.tooltip"
+                        >
+                          <template #activator="{ props: tooltipProps }">
+                            <span
+                              class="product-hero__attribute-value-content"
+                              v-bind="tooltipProps"
+                            >
+                              <NuxtImg
+                                v-if="attribute.flag"
+                                :src="attribute.flag"
+                                :alt="displayValue"
+                                width="32"
+                                height="24"
+                                class="product-hero__flag"
+                              />
+                              <v-icon
+                                v-if="attribute.icon"
+                                :icon="attribute.icon"
+                                size="small"
+                                class="product-hero__icon mr-2"
+                              />
+                              <!-- eslint-disable-next-line vue/no-v-html -->
+                              <span v-if="displayHtml" v-html="displayHtml" />
+                              <span v-else>{{ displayValue }}</span>
+                            </span>
+                          </template>
+                        </v-tooltip>
+                      </template>
+                    </ProductAttributeSourcingLabel>
                   </span>
                 </li>
               </ul>
@@ -290,8 +289,8 @@ const { t, te, n, locale } = useI18n()
 
 // AI Review Logic
 
-const aiReview = computed(() => props.product.aiReview)
-const hasAiReview = computed(() => Boolean(aiReview.value?.review))
+const aiReview = computed(() => props.product.aiReview?.review ?? null)
+const hasAiReview = computed(() => Boolean(aiReview.value))
 
 const handleAiReviewClick = () => {
   const element =
@@ -827,7 +826,7 @@ const impactScoreOn20 = computed(() => resolvePrimaryImpactScore(props.product))
 
 .product-hero__ai-summary-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   font-size: 0.95rem;
   color: rgb(var(--v-theme-text-neutral-strong));
@@ -835,6 +834,25 @@ const impactScoreOn20 = computed(() => resolvePrimaryImpactScore(props.product))
 
 .product-hero__ai-summary-icon {
   color: rgb(var(--v-theme-primary));
+}
+
+.product-hero__ai-summary-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.product-hero__ai-summary-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.9);
+}
+
+.product-hero__ai-summary-text {
+  font-size: 0.95rem;
+  color: rgb(var(--v-theme-text-neutral-strong));
 }
 
 .product-hero__compare-button {

--- a/frontend/app/utils/_product-title-resolver.ts
+++ b/frontend/app/utils/_product-title-resolver.ts
@@ -53,7 +53,19 @@ export const resolveProductTitle = (
   const finalizeTitle = (title: string): string =>
     uppercaseBrand ? applyBrandCasing(title, brand, locale) : title
 
-  // 1. New Fields Priorities
+  const aiShortTitle = normalizeString(product.aiReview?.review?.shortTitle)
+  const aiMediumTitle = normalizeString(product.aiReview?.review?.mediumTitle)
+
+  // 1. AI Titles (highest priority)
+  if (preferLongName || preferH1Title) {
+    if (aiMediumTitle) return finalizeTitle(aiMediumTitle)
+  }
+
+  if (preferCardTitle || preferShortName || preferPrettyName) {
+    if (aiShortTitle) return finalizeTitle(aiShortTitle)
+  }
+
+  // 2. New Fields Priorities
   if (preferCardTitle) {
     const cardTitle = normalizeString(product.names?.cardTitle)
     if (cardTitle) return finalizeTitle(cardTitle)
@@ -89,9 +101,8 @@ export const resolveProductTitle = (
     if (prettyName) return finalizeTitle(prettyName)
   }
 
-  // 4. AI Title
-  const aiTitle = normalizeString(product.aiReview?.review?.mediumTitle)
-  if (aiTitle) return finalizeTitle(aiTitle)
+  // 4. AI Title (fallback)
+  if (aiMediumTitle) return finalizeTitle(aiMediumTitle)
 
   // 5. Best Name (Identity -> Base)
   const identityBestName = normalizeString(product.identity?.bestName)

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2416,7 +2416,10 @@
         "running": "Generation in progress ({step})",
         "success": "Summary available"
       },
-      "subtitle": "An AI-written synthesis built from verified sources.",
+      "subtitle": {
+        "one": "An AI-written synthesis built from {count} verified source.",
+        "other": "An AI-written synthesis built from {count} verified sources."
+      },
       "title": "Test & review summary"
     },
     "attributes": {
@@ -2565,6 +2568,11 @@
       }
     },
     "hero": {
+      "aiSummary": {
+        "community": "Experts say",
+        "ecological": "Environmentally",
+        "technical": "Technically"
+      },
       "bestPriceTitle": "Best price",
       "breadcrumbAriaLabel": "Product breadcrumb",
       "compare": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2431,7 +2431,10 @@
         "running": "Génération en cours ({step})",
         "success": "Synthèse disponible"
       },
-      "subtitle": "Une synthèse rédigée par notre IA à partir de sources vérifiées.",
+      "subtitle": {
+        "one": "Une synthèse rédigée par notre IA à partir de {count} source vérifiée.",
+        "other": "Une synthèse rédigée par notre IA à partir de {count} sources vérifiées."
+      },
       "title": "Synthèse des tests et avis"
     },
     "attributes": {
@@ -2580,6 +2583,11 @@
       }
     },
     "hero": {
+      "aiSummary": {
+        "community": "Les experts",
+        "ecological": "Écologiquement",
+        "technical": "Techniquement"
+      },
       "bestPriceTitle": "Meilleur prix",
       "breadcrumbAriaLabel": "Fil d'Ariane du produit",
       "compare": {

--- a/frontend/shared/api-client/models/AiReviewDto.ts
+++ b/frontend/shared/api-client/models/AiReviewDto.ts
@@ -65,6 +65,12 @@ export interface AiReviewDto {
      */
     technicalReview?: string;
     /**
+     * Short technical summary in 2-3 sentences
+     * @type {string}
+     * @memberof AiReviewDto
+     */
+    technicalShortReview?: string;
+    /**
      * Ecological assessment derived from the available documentation
      * @type {string}
      * @memberof AiReviewDto
@@ -148,6 +154,7 @@ export function AiReviewDtoFromJSONTyped(json: any, ignoreDiscriminator: boolean
         'mediumTitle': json['mediumTitle'] == null ? undefined : json['mediumTitle'],
         'shortTitle': json['shortTitle'] == null ? undefined : json['shortTitle'],
         'technicalReview': json['technicalReview'] == null ? undefined : json['technicalReview'],
+        'technicalShortReview': json['technicalShortReview'] == null ? undefined : json['technicalShortReview'],
         'ecologicalReview': json['ecologicalReview'] == null ? undefined : json['ecologicalReview'],
         'summary': json['summary'] == null ? undefined : json['summary'],
         'pros': json['pros'] == null ? undefined : json['pros'],
@@ -177,6 +184,7 @@ export function AiReviewDtoToJSONTyped(value?: AiReviewDto | null, ignoreDiscrim
         'mediumTitle': value['mediumTitle'],
         'shortTitle': value['shortTitle'],
         'technicalReview': value['technicalReview'],
+        'technicalShortReview': value['technicalShortReview'],
         'ecologicalReview': value['ecologicalReview'],
         'summary': value['summary'],
         'pros': value['pros'],
@@ -189,4 +197,3 @@ export function AiReviewDtoToJSONTyped(value?: AiReviewDto | null, ignoreDiscrim
         'communityOneline': value['communityOneline'],
     };
 }
-

--- a/model/src/main/java/org/open4goods/model/ai/AiReview.java
+++ b/model/src/main/java/org/open4goods/model/ai/AiReview.java
@@ -24,15 +24,16 @@ public class AiReview {
 
 
 
-	    public AiReview(String description, String technicalOneline, String ecologicalOneline, String communityOneline,
-			String shortDescription, String mediumTitle, String shortTitle, String manufacturingCountry,
-			String technicalReview, String ecologicalReview, String communityReview, String summary, List<String> pros,
-			List<String> cons, List<AiSource> sources, List<AiAttribute> attributes, String dataQuality,
-			List<AiRating> ratings, List<String> pdfs, List<String> images, List<String> videos,
-			List<String> socialLinks) {
+	    public AiReview(String description, String technicalOneline, String technicalShortReview, String ecologicalOneline,
+			String communityOneline, String shortDescription, String mediumTitle, String shortTitle,
+			String manufacturingCountry, String technicalReview, String ecologicalReview, String communityReview,
+			String summary, List<String> pros, List<String> cons, List<AiSource> sources,
+			List<AiAttribute> attributes, String dataQuality, List<AiRating> ratings, List<String> pdfs,
+			List<String> images, List<String> videos, List<String> socialLinks) {
 		super();
 		this.description = description;
 		this.technicalOneline = technicalOneline;
+		this.technicalShortReview = technicalShortReview;
 		this.ecologicalOneline = ecologicalOneline;
 		this.communityOneline = communityOneline;
 		this.shortDescription = shortDescription;
@@ -57,21 +58,27 @@ public class AiReview {
 
 		/** A detailed description of the product. */
     @JsonProperty(required = true, value = "description")
-    @AiGeneratedField(instruction = "Description du produit, 150 mots maximum")
+    @AiGeneratedField(instruction = "Write a neutral product overview (max 150 words). Use complete sentences, avoid marketing tone, and do not use lists or markdown.")
     @Schema(description = "Detailed description of the product")
     private String description;
 
 
     /** A detailed description of the product. */
     @JsonProperty(required = true, value = "technicalOneline")
-    @AiGeneratedField(instruction = "Description technique du produit, aux vues de ces caracteristiques principales. 20 mots maximum")
+    @AiGeneratedField(instruction = "One sentence (max 20 words) summarising the key technical specs. Plain text only.")
     @Schema(description = "Detailed description of the product")
     private String technicalOneline;
+
+    /** A short technical summary of the product. */
+    @JsonProperty(required = true, value = "technicalShortReview")
+    @AiGeneratedField(instruction = "Short technical summary in 2–3 sentences. Mention the most important specs and performance. Minimal HTML is allowed (<strong>, <em>, <br>), no lists or markdown.")
+    @Schema(description = "Short technical summary of the product")
+    private String technicalShortReview;
 
 
     /** A detailed description of the product. */
     @JsonProperty(required = true, value = "ecologicalOneline")
-    @AiGeneratedField(instruction = "Description de l'impact écologique et du positionnement du téléviseur, au regard des informations environnementales et du positionnement de ce produit le classement obtenu grâce à l'impactscore, 20 mots maximum")
+    @AiGeneratedField(instruction = "One sentence (max 20 words) describing environmental impact, repairability, and energy class if available. Plain text only.")
     @Schema(description = "Detailed description of the product")
     private String ecologicalOneline;
 
@@ -79,7 +86,7 @@ public class AiReview {
 
     /** A detailed description of the product. */
     @JsonProperty(required = true, value = "communityOneline")
-    @AiGeneratedField(instruction = "Retours d'utilisateurs, synthèse d'avis. 20 mots maximum")
+    @AiGeneratedField(instruction = "One sentence (max 20 words) summarising user and expert feedback. Plain text only.")
     @Schema(description = "Detailed description of the product")
     private String communityOneline;
 
@@ -87,45 +94,45 @@ public class AiReview {
 
     /** A brief summary of the product. */
     @JsonProperty(required = true, value = "short_description")
-    @AiGeneratedField(instruction = "Deux ou trois phrases dur la description générale du produit, un bilan objectif de ses performances, de son impact environnemental et des retours utilisateurs et / ou sites spécialisés")
+    @AiGeneratedField(instruction = "Write 2–3 sentences covering performance, environmental impact, and feedback. Minimal HTML is allowed (<strong>, <em>, <br>), no lists or markdown.")
     @Schema(description = "Brief summary of the product")
     private String shortDescription;
 
     /** A medium-length title summarizing the product. */
     @JsonProperty(required = true, value = "mediumTitle")
-    @AiGeneratedField(instruction = "Titre de longueur moyenne, 10 mots maximum")
+    @AiGeneratedField(instruction = "Medium-length factual title (max 10 words). No quotes or ending punctuation.")
     @Schema(description = "Medium-length title")
     private String mediumTitle;
 
     /** A short title for the product. */
     @JsonProperty(required = true, value = "shortTitle")
-    @AiGeneratedField(instruction = "Titre court, 5 mots maximum")
+    @AiGeneratedField(instruction = "Short factual title (max 5 words). No quotes or ending punctuation.")
     @Schema(description = "Short title")
     private String shortTitle;
 
 
     @JsonProperty(required = true, value = "manufacturingCountry")
-    @AiGeneratedField(instruction = "Le ou les lieux de fabrication si connus, séparés par des virgules")
+    @AiGeneratedField(instruction = "Comma-separated manufacturing countries if known (e.g., \"France, Germany\"). Return an empty string when unknown.")
     @Schema(description = "Probable manufacturing countries of this product")
     private String manufacturingCountry;
 
 
     /** The technical review of the product. */
     @JsonProperty(required = true, value = "technicalReview")
-    @AiGeneratedField(instruction = "Revue technique approfondie du produit, axée sur les performances et la qualité.")
+    @AiGeneratedField(instruction = "Detailed technical review in 2–4 paragraphs. Cite sources as [n] for specific claims. Minimal HTML allowed (<strong>, <em>, <br>, <p>), no lists or markdown.")
     @Schema(description = "Technical review of the product")
     private String technicalReview;
 
     /** The ecological review of the product. */
     @JsonProperty(required = true, value = "ecologicalReview")
-    @AiGeneratedField(instruction = "Revue écologique du produit, incluant réparabilité, durabilité, efficacité énergétique et toutes informations contenues dans les sources ou dans les scores fournis permettant d'orienter le jugement. ")
+    @AiGeneratedField(instruction = "Environmental review in 2–4 paragraphs: repairability, durability, energy efficiency, and sustainability signals. Cite sources as [n]. Minimal HTML allowed (<strong>, <em>, <br>, <p>), no lists or markdown.")
     @Schema(description = "Ecological review of the product")
     private String ecologicalReview;
 
 
     /** The ecological review of the product. */
     @JsonProperty(required = true, value = "communityReview")
-    @AiGeneratedField(instruction = "Synthèse des retours de sites experts et utilisateurs")
+    @AiGeneratedField(instruction = "Synthesis of expert and user feedback in 1–2 paragraphs. Cite sources as [n]. Minimal HTML allowed (<strong>, <em>, <br>), no lists or markdown.")
     @Schema(description = "Community review of the product")
     private String communityReview;
 
@@ -134,19 +141,19 @@ public class AiReview {
     /** A summary of the product review. */
     // TODO : Remove
     @JsonProperty(required = true, value = "summary")
-    @AiGeneratedField(instruction = "Synthèse des évaluations et tests réalisés sur ce produit")
+    @AiGeneratedField(instruction = "Concise overall summary in 2–3 sentences. Include key takeaways and cite sources as [n]. Minimal HTML allowed (<strong>, <em>, <br>), no lists or markdown.")
     @Schema(description = "Summary of the product review")
     private String summary;
 
     /** The pros of the product. */
     @JsonProperty(required = true, value = "pros")
-    @AiGeneratedField(instruction = "Les avantages du produit")
+    @AiGeneratedField(instruction = "List 3–6 short pros. Each entry is a concise phrase. Minimal HTML allowed (<strong>, <em>), no numbering or markdown.")
     @Schema(description = "List of pros")
     private List<String> pros = new ArrayList<>();
 
     /** The cons of the product. */
     @JsonProperty(required = true, value = "cons")
-    @AiGeneratedField(instruction = "Les inconvénients du produit")
+    @AiGeneratedField(instruction = "List 3–6 short cons. Each entry is a concise phrase. Minimal HTML allowed (<strong>, <em>), no numbering or markdown.")
     @Schema(description = "List of cons")
     private List<String> cons = new ArrayList<>();
 
@@ -164,7 +171,7 @@ public class AiReview {
 
     /** The quality of data used for the review. */
     @JsonProperty(required = true, value = "dataQuality")
-    @AiGeneratedField(instruction = "Analyse de la qualité et de la richesse des contenus, références, évaluations externes qui te sont fournis")
+    @AiGeneratedField(instruction = "1–2 sentences describing data coverage, reliability, and gaps. Plain text only.")
     @Schema(description = "Quality of external data used for the review")
     private String dataQuality;
 
@@ -177,7 +184,7 @@ public class AiReview {
 
     /** The pdfs found in the sources. */
     @JsonProperty(required = false, value = "pdfs")
-    @AiGeneratedField(instruction = "Liste des urls des documents PDFs trouvés (manuels, fiches techniques, réparabilité ...)")
+    @AiGeneratedField(instruction = "List of PDF URLs only (manuals, datasheets, repairability docs). No extra text.")
     @Schema(description = "List of PDF's url's for this product")
     private List<String> pdfs = new ArrayList<>();
 
@@ -185,20 +192,20 @@ public class AiReview {
 
     /** The pdfs found in the sources. */
     @JsonProperty(required = false, value = "images")
-    @AiGeneratedField(instruction = "Liste des urls des images produit trouvées (haute qualité de préférence)")
+    @AiGeneratedField(instruction = "List of product image URLs only (prefer high quality). No extra text.")
     @Schema(description = "List of quality images url's for this product")
     private List<String> images = new ArrayList<>();
 
 
     /** The pdfs found in the sources. */
     @JsonProperty(required = false, value = "videos")
-    @AiGeneratedField(instruction = "Liste des urls des vidéos trouvées (youtube, dailymotion, vimeo ...)")
+    @AiGeneratedField(instruction = "List of video URLs only (YouTube, Vimeo, Dailymotion, direct files). No extra text.")
     @Schema(description = "List of product related videos (vide platform, like youtube, direct file, daylymotion, ... social networks, )")
     private List<String> videos = new ArrayList<>();
 
     /** The social network references */
     @JsonProperty(required = false, value = "social")
-    @AiGeneratedField(instruction = "Liste des urls des posts réseaux sociaux trouvés (facebook, twitter, instagram ...)")
+    @AiGeneratedField(instruction = "List of social post URLs only (Facebook, X/Twitter, Instagram, etc.). No extra text.")
     @Schema(description = "List of social networks references")
     private List<String> socialLinks = new ArrayList<>();
 
@@ -232,6 +239,14 @@ public class AiReview {
 
     public void setEcologicalOneline(String ecologicalOneline) {
         this.ecologicalOneline = ecologicalOneline;
+    }
+
+    public String getTechnicalShortReview() {
+        return technicalShortReview;
+    }
+
+    public void setTechnicalShortReview(String technicalShortReview) {
+        this.technicalShortReview = technicalShortReview;
     }
 
     public String getCommunityOneline() {
@@ -394,19 +409,19 @@ public class AiReview {
     @Schema(description = "Source information for the review")
     public static record AiSource(
             @JsonProperty(required = true, value = "number")
-            @AiGeneratedField(instruction = "Le numéro de la source documentaire fournie")
+            @AiGeneratedField(instruction = "Source number (must match provided sources). Plain text only.")
             @Schema(description = "Source number")
             Integer number,
             @JsonProperty(required = true, value = "name")
-            @AiGeneratedField(instruction = "Le nom de la source documentaire fournie")
+            @AiGeneratedField(instruction = "Source name as provided. Plain text only.")
             @Schema(description = "Source name")
             String name,
             @JsonProperty(required = true, value = "description")
-            @AiGeneratedField(instruction = "Courte description de la source documentaire fournie")
+            @AiGeneratedField(instruction = "Short description of the source as provided. Plain text only.")
             @Schema(description = "Source description")
             String description,
             @JsonProperty(required = true, value = "url")
-            @AiGeneratedField(instruction = "URL de la source documentaire fournie")
+            @AiGeneratedField(instruction = "Source URL as provided. No extra text.")
             @Schema(description = "Source URL")
             String url) {
 
@@ -423,15 +438,15 @@ public class AiReview {
     @Schema(description = "Product attribute derived from review")
     public static record AiAttribute(
             @JsonProperty(required = true, value = "name")
-            @AiGeneratedField(instruction = "Le nom de l'attribut")
+            @AiGeneratedField(instruction = "Attribute name. Plain text only.")
             @Schema(description = "Attribute name")
             String name,
             @JsonProperty(required = true, value = "value")
-            @AiGeneratedField(instruction = "La valeur de l'attribut")
+            @AiGeneratedField(instruction = "Attribute value. Plain text only (no HTML).")
             @Schema(description = "Attribute value")
             String value,
             @JsonProperty(required = true, value = "number")
-            @AiGeneratedField(instruction = "La référence de la source qui indique cet attribut")
+            @AiGeneratedField(instruction = "Source number that supports this attribute.")
             @Schema(description = "Reference source number")
             Integer number) {
 
@@ -446,23 +461,23 @@ public class AiReview {
     @Schema(description = "Rating found in a source")
     public static record AiRating(
             @JsonProperty(required = true, value = "source")
-            @AiGeneratedField(instruction = "Le nom de la source qui donne la note")
+            @AiGeneratedField(instruction = "Name of the source that provides the rating.")
             @Schema(description = "Source providing the rating")
             String source,
             @JsonProperty(required = true, value = "score")
-            @AiGeneratedField(instruction = "La note donnée")
+            @AiGeneratedField(instruction = "Score value exactly as stated by the source.")
             @Schema(description = "The score value")
             String score,
             @JsonProperty(required = true, value = "max")
-            @AiGeneratedField(instruction = "La note maximale possible (ex: 5, 10, 20)")
+            @AiGeneratedField(instruction = "Maximum possible score (e.g., 5, 10, 20).")
             @Schema(description = "The maximum possible score")
             String max,
              @JsonProperty(required = true, value = "comment")
-            @AiGeneratedField(instruction = "Court commentaire associé à la note, si disponible")
+            @AiGeneratedField(instruction = "Short comment associated with the rating if available. Plain text only.")
             @Schema(description = "Short comment associated with the rating")
             String comment,
             @JsonProperty(required = true, value = "number")
-            @AiGeneratedField(instruction = "Le numéro de la source documentaire correspondante")
+            @AiGeneratedField(instruction = "Source number that supports this rating.")
             @Schema(description = "Reference source number")
             Integer number) {
     }

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationService.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationService.java
@@ -903,6 +903,7 @@ public class ReviewGenerationService implements HealthIndicator {
 		return new AiReview(
 				normalization.description(),
 				normalization.technicalOneline(),
+				normalization.technicalShortReview(),
 				normalization.ecologicalOneline(),
 				normalization.communityOneline(),
 				normalization.shortDescription(),
@@ -950,6 +951,7 @@ public class ReviewGenerationService implements HealthIndicator {
 						.toList(),
 				normalizeText(review.getDataQuality()),
 				normalizeText(review.getTechnicalOneline()),
+				normalizeText(review.getTechnicalShortReview()),
 				normalizeText(review.getEcologicalOneline()),
 				normalizeText(review.getCommunityOneline()),
 				resolveUrlList(review.getPdfs()),
@@ -1294,6 +1296,7 @@ public class ReviewGenerationService implements HealthIndicator {
 				.toList();
 
 		String technicalOneline = normalizer.normalize(review.getTechnicalOneline());
+		String technicalShortReview = normalizer.normalize(review.getTechnicalShortReview());
 		String ecologicalOneline = normalizer.normalize(review.getEcologicalOneline());
 		String communityOneline = normalizer.normalize(review.getCommunityOneline());
 
@@ -1304,8 +1307,9 @@ public class ReviewGenerationService implements HealthIndicator {
 					"Certaines références ont été retirées car elles ne correspondaient à aucune source.");
 		}
 		return new ReferenceNormalization(description, shortDescription, mediumTitle, shortTitle, technicalReview,
-				ecologicalReview, summary, pros, cons, attributes, dataQuality, technicalOneline, ecologicalOneline, communityOneline,
-				review.getPdfs(), review.getImages(), review.getVideos(), review.getSocialLinks());
+				ecologicalReview, summary, pros, cons, attributes, dataQuality, technicalOneline, technicalShortReview,
+				ecologicalOneline, communityOneline, review.getPdfs(), review.getImages(), review.getVideos(),
+				review.getSocialLinks());
 	}
 
 	private String appendDataQuality(String dataQuality, String note) {
@@ -1321,7 +1325,7 @@ public class ReviewGenerationService implements HealthIndicator {
 	private record ReferenceNormalization(String description, String shortDescription, String mediumTitle,
 			String shortTitle, String technicalReview, String ecologicalReview, String summary, List<String> pros,
 			List<String> cons, List<AiReview.AiAttribute> attributes, String dataQuality,
-			String technicalOneline, String ecologicalOneline, String communityOneline,
+			String technicalOneline, String technicalShortReview, String ecologicalOneline, String communityOneline,
 			List<String> pdfs, List<String> images, List<String> videos, List<String> socialLinks) {
 	}
 


### PR DESCRIPTION
### Motivation
- Introduce a short technical review field to carry a 2–3 sentence technical summary through the AI review pipeline and expose it to clients. 
- Improve presentation of AI one-line summaries in the product hero and attributes area and make the AI review subtitle pluralization reflect source count.

### Description
- Add `technicalShortReview` to the core model `AiReview` and update generated instructions (`@AiGeneratedField`) to clarify allowed minimal HTML and plain-text constraints for fields.  
- Wire the new field through normalization and citation logic in `ReviewGenerationService` so it is normalized and preserved when references are applied.  
- Expose the field in the front API DTO `AiReviewDto` and map it inside `ProductMappingService`.  
- Update frontend types (`frontend/shared/api-client/models/AiReviewDto.ts`) and UI to: show labeled AI one-line summaries in `ProductHero.vue`, display the `technicalShortReview` under the attributes subtitle (sanitised) in `ProductAttributesSection.vue`, and prioritize AI-generated titles in `_product-title-resolver.ts`.  
- Add localized labels and pluralized subtitle strings in `en-US` and `fr-FR` locale files and simplify tooltip handling in the hero attribute rendering.

### Testing
- No automated tests were executed as part of this change.  
- Local frontend tasks were exercised: `pnpm --dir frontend install --offline` completed and `nuxt dev` was started to preview UI changes, but an attempted Playwright screenshot run crashed with a Chromium SIGSEGV in this environment so no UI screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723223f95c8322aa67d2b5d0ee20c2)