### PR TITLE
Add reusable Category CTA card, assistant CTA, and sorting fallback

### DIFF
--- a/frontend/app/components/category/CategoryCtaCard.vue
+++ b/frontend/app/components/category/CategoryCtaCard.vue
@@ -1,0 +1,165 @@
+<template>
+  <v-card
+    v-bind="mergedProps"
+    :class="['category-cta-card', attrs.class]"
+    variant="text"
+    :ripple="false"
+    rounded="lg"
+    :aria-label="ariaLabel"
+    :role="clickableRole"
+    :tabindex="clickableTabIndex"
+    @click="onActivate"
+    @keydown="onKeydown"
+  >
+    <div v-if="icon" class="category-cta-card__icon-wrapper">
+      <v-icon :icon="icon" size="24" class="category-cta-card__icon" />
+    </div>
+
+    <div class="category-cta-card__content">
+      <p class="category-cta-card__title">
+        {{ title }}
+      </p>
+      <p v-if="subtitle" class="category-cta-card__subtitle">
+        {{ subtitle }}
+      </p>
+    </div>
+
+    <v-icon
+      v-if="showArrow"
+      icon="mdi-arrow-right"
+      class="category-cta-card__arrow"
+      size="20"
+    />
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    subtitle?: string | null
+    icon?: string | null
+    to?: string | null
+    ariaLabel: string
+    showArrow?: boolean
+    clickable?: boolean
+  }>(),
+  {
+    subtitle: null,
+    icon: null,
+    to: null,
+    showArrow: true,
+    clickable: false,
+  }
+)
+
+const emit = defineEmits<{
+  (event: 'click', payload: Event): void
+}>()
+
+const attrs = useAttrs()
+
+const isClickable = computed(() => Boolean(props.to) || props.clickable)
+
+const cardProps = computed(() => (props.to ? { to: props.to } : {}))
+const mergedProps = computed(() => ({
+  ...attrs,
+  ...cardProps.value,
+}))
+
+const clickableRole = computed(() =>
+  isClickable.value && !props.to ? 'button' : undefined
+)
+const clickableTabIndex = computed(() =>
+  isClickable.value && !props.to ? 0 : undefined
+)
+
+const onActivate = (event: Event) => {
+  if (props.to || !isClickable.value) {
+    return
+  }
+
+  emit('click', event)
+}
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (!isClickable.value || props.to) {
+    return
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    emit('click', event)
+  }
+}
+</script>
+
+<style scoped lang="sass">
+.category-cta-card
+  display: flex
+  align-items: center
+  gap: 1rem
+  padding: 0.75rem 1rem
+  width: 100%
+  min-height: auto
+  background-color: transparent
+  border: 1px solid rgba(var(--v-theme-border-primary), 0.15)
+  transition: all 0.2s ease
+  cursor: pointer
+  color: rgb(var(--v-theme-text-neutral-strong))
+
+  &:hover
+    background-color: rgba(var(--v-theme-surface-active), 0.4)
+    border-color: rgba(var(--v-theme-primary), 0.3)
+    transform: translateY(-1px)
+
+  &:focus-visible
+    outline: 2px solid rgb(var(--v-theme-accent-primary-highlight))
+    outline-offset: 2px
+
+  &__icon-wrapper
+    display: flex
+    align-items: center
+    justify-content: center
+    width: 40px
+    height: 40px
+    border-radius: 8px
+    background: rgba(var(--v-theme-primary), 0.1)
+    color: rgb(var(--v-theme-primary))
+    flex-shrink: 0
+
+  &__content
+    display: flex
+    flex-direction: column
+    gap: 0.125rem
+    flex: 1
+    min-width: 0
+
+  &__title
+    font-size: 0.95rem
+    font-weight: 600
+    line-height: 1.2
+    margin: 0
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+  &__subtitle
+    font-size: 0.8rem
+    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+    margin: 0
+    font-weight: 500
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+
+  &__arrow
+    color: rgba(var(--v-theme-text-neutral-disabled), 0.8)
+    transition: transform 0.2s ease, color 0.2s ease
+
+  &:hover &__arrow
+    transform: translateX(2px)
+    color: rgb(var(--v-theme-primary))
+</style>

--- a/frontend/app/components/category/CategoryEcoscoreCard.vue
+++ b/frontend/app/components/category/CategoryEcoscoreCard.vue
@@ -1,42 +1,23 @@
 <template>
-  <v-card
+  <CategoryCtaCard
     v-if="ecoscoreUrl"
     :to="ecoscoreUrl"
-    class="category-ecoscore-card"
-    variant="text"
-    :ripple="false"
-    rounded="lg"
-    data-test="category-ecoscore-card"
+    icon="mdi-leaf"
+    :title="t('category.filters.ecoscore.title')"
+    :subtitle="
+      t('category.filters.ecoscore.cta', {
+        category: normalizedCategoryName,
+      })
+    "
     :aria-label="t('category.filters.ecoscore.ariaLabel')"
-  >
-    <div class="category-ecoscore-card__icon-wrapper">
-      <v-icon icon="mdi-leaf" size="24" class="category-ecoscore-card__icon" />
-    </div>
-
-    <div class="category-ecoscore-card__content">
-      <p class="category-ecoscore-card__title">
-        {{ t('category.filters.ecoscore.title') }}
-      </p>
-      <p class="category-ecoscore-card__subtitle">
-        {{
-          t('category.filters.ecoscore.cta', {
-            category: normalizedCategoryName,
-          })
-        }}
-      </p>
-    </div>
-
-    <v-icon
-      icon="mdi-arrow-right"
-      class="category-ecoscore-card__arrow"
-      size="20"
-    />
-  </v-card>
+    data-test="category-ecoscore-card"
+  />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import CategoryCtaCard from '~/components/category/CategoryCtaCard.vue'
 
 const props = defineProps<{
   verticalHomeUrl?: string | null
@@ -65,65 +46,3 @@ const ecoscoreUrl = computed(() => {
   return `${normalizedBase}/ecoscore`
 })
 </script>
-
-<style scoped lang="sass">
-.category-ecoscore-card
-  display: flex
-  align-items: center
-  gap: 1rem
-  padding: 0.75rem 1rem
-  width: 100%
-  min-height: auto
-  background-color: transparent
-  border: 1px solid rgba(var(--v-theme-border-primary), 0.15)
-  transition: all 0.2s ease
-  cursor: pointer
-  color: rgb(var(--v-theme-text-neutral-strong))
-
-  &:hover
-    background-color: rgba(var(--v-theme-surface-active), 0.4)
-    border-color: rgba(var(--v-theme-primary), 0.3)
-    transform: translateY(-1px)
-
-  &__icon-wrapper
-    display: flex
-    align-items: center
-    justify-content: center
-    width: 40px
-    height: 40px
-    border-radius: 8px
-    background: rgba(var(--v-theme-primary), 0.1)
-    color: rgb(var(--v-theme-primary))
-    flex-shrink: 0
-
-  &__content
-    display: flex
-    flex-direction: column
-    gap: 0.125rem
-    flex: 1
-    min-width: 0
-
-  &__title
-    font-size: 0.95rem
-    font-weight: 600
-    line-height: 1.2
-    margin: 0
-    color: rgb(var(--v-theme-text-neutral-strong))
-
-  &__subtitle
-    font-size: 0.8rem
-    color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
-    margin: 0
-    font-weight: 500
-    white-space: nowrap
-    overflow: hidden
-    text-overflow: ellipsis
-
-  &__arrow
-    color: rgba(var(--v-theme-text-neutral-disabled), 0.8)
-    transition: transform 0.2s ease, color 0.2s ease
-
-  &:hover &__arrow
-    transform: translateX(2px)
-    color: rgb(var(--v-theme-primary))
-</style>

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -124,16 +124,15 @@
                     :vertical-home-url="category?.verticalHomeUrl"
                     :category-name="categoryDisplayName"
                   />
-                  <v-btn
-                    block
-                    color="primary"
-                    variant="flat"
-                    prepend-icon="mdi-robot-love"
-                    class="category-page__nudge-cta"
+                  <CategoryCtaCard
+                    class="category-page__assistant-cta"
+                    icon="mdi-robot-outline"
+                    :title="$t('category.filters.assistant.title')"
+                    :subtitle="$t('category.filters.assistant.description')"
+                    :aria-label="$t('category.filters.assistant.ariaLabel')"
+                    clickable
                     @click="isNudgeWizardOpen = true"
-                  >
-                    {{ $t('category.hero.nudge.cta') }}
-                  </v-btn>
+                  />
                 </div>
               </template>
             </CategoryFiltersSidebar>
@@ -181,16 +180,15 @@
                     :vertical-home-url="category?.verticalHomeUrl"
                     :category-name="categoryDisplayName"
                   />
-                  <v-btn
-                    block
-                    color="primary"
-                    variant="flat"
-                    prepend-icon="mdi-robot-love"
-                    class="category-page__nudge-cta"
+                  <CategoryCtaCard
+                    class="category-page__assistant-cta"
+                    icon="mdi-robot-outline"
+                    :title="$t('category.filters.assistant.title')"
+                    :subtitle="$t('category.filters.assistant.description')"
+                    :aria-label="$t('category.filters.assistant.ariaLabel')"
+                    clickable
                     @click="isNudgeWizardOpen = true"
-                  >
-                    {{ $t('category.hero.nudge.cta') }}
-                  </v-btn>
+                  />
                 </div>
               </template>
             </CategoryFiltersSidebar>
@@ -250,6 +248,7 @@
                         item-title="title"
                         item-value="value"
                         clearable
+                        :disabled="sortItems.length === 0"
                         hide-details
                         density="comfortable"
                       />
@@ -468,10 +467,12 @@ import CategoryProductCardGrid from '~/components/category/products/CategoryProd
 import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
 import CategoryProductTable from '~/components/category/products/CategoryProductTable.vue'
 import NudgeToolWizard from '~/components/nudge-tool/NudgeToolWizard.vue'
+import CategoryCtaCard from '~/components/category/CategoryCtaCard.vue'
 import {
   CATEGORY_DEFAULT_VIEW_MODE,
   CATEGORY_PAGE_SIZES,
 } from '~/constants/category'
+import { ECOSCORE_RELATIVE_FIELD } from '~/constants/scores'
 import { useCategories } from '~/composables/categories/useCategories'
 import { useAuth } from '~/composables/useAuth'
 import { useAnalytics } from '~/composables/useAnalytics'
@@ -1380,13 +1381,26 @@ const combinedFilters = computed<FilterRequestDto | undefined>(() =>
 
 const pageSize = computed(() => CATEGORY_PAGE_SIZES[viewMode.value])
 
+const hasSortOptions = computed(() => {
+  const options = sortOptions.value
+  return Boolean(
+    options?.global?.length ||
+      options?.impact?.length ||
+      options?.technical?.length
+  )
+})
+
 const defaultSortField = computed<string | null>(() => {
   const impactFields = sortOptions.value?.impact ?? []
   const candidate = impactFields.find(
     field => typeof field.mapping === 'string'
   )
 
-  return candidate?.mapping ? String(candidate.mapping) : null
+  if (candidate?.mapping) {
+    return String(candidate.mapping)
+  }
+
+  return hasSortOptions.value ? null : ECOSCORE_RELATIVE_FIELD
 })
 
 const applyDefaultSort = () => {
@@ -1411,16 +1425,29 @@ const sortItems = computed(() => {
   ]
 
   const seen = new Set<string>()
-
-  return fields
-    .filter(field => field.mapping && !seen.has(field.mapping))
+  const options = fields
+    .filter(
+      field => typeof field.mapping === 'string' && !seen.has(field.mapping)
+    )
     .map(field => {
-      seen.add(field.mapping as string)
+      const mapping = field.mapping as string
+      seen.add(mapping)
       return {
-        value: field.mapping as string,
+        value: mapping,
         title: resolveSortFieldTitle(field, t),
       }
     })
+
+  if (options.length) {
+    return options
+  }
+
+  return [
+    {
+      value: ECOSCORE_RELATIVE_FIELD,
+      title: t('category.products.sort.fields.impactScore'),
+    },
+  ]
 })
 
 watch(defaultSortField, (value, previous) => {
@@ -2435,7 +2462,7 @@ const clearAllFilters = () => {
     flex-direction: column
     gap: 0.75rem
 
-  &__nudge-cta
+  &__assistant-cta
     box-shadow: 0 14px 28px -22px rgba(var(--v-theme-shadow-primary-600), 0.45)
 
   &__results

--- a/frontend/app/components/product/ProductDesignation.vue
+++ b/frontend/app/components/product/ProductDesignation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="product-designation">
+  <div class="product-designation" :class="rootClass">
     <slot
       :short-name="shortName"
       :long-name="longName"
@@ -54,6 +54,12 @@ const shortDescription = computed(() =>
 const displayTitle = computed(() =>
   props.variant === 'page' ? longName.value : shortName.value
 )
+
+const rootClass = computed(() =>
+  props.variant === 'card'
+    ? 'product-designation--card'
+    : 'product-designation--page'
+)
 </script>
 
 <style scoped lang="scss">
@@ -64,6 +70,10 @@ const displayTitle = computed(() =>
 
   &__title {
     margin: 0;
+  }
+
+  &--card &__title {
+    text-align: center;
   }
 
   &__description {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -912,6 +912,11 @@
         "description": "Understand how the eco-score is calculated for {category}",
         "cta": "Methodology {category}",
         "ariaLabel": "Open the Eco-score guide"
+      },
+      "assistant": {
+        "title": "Our assistant",
+        "description": "Let us guide you",
+        "ariaLabel": "Open the Nudger assistant"
       }
     },
     "admin": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -926,6 +926,11 @@
         "description": "Comprendre comment est calculé l'écoscore des {category}",
         "cta": "Méthodologie {category}",
         "ariaLabel": "Ouvrir le guide Eco-score"
+      },
+      "assistant": {
+        "title": "Notre assistant",
+        "description": "Laissez vous guider",
+        "ariaLabel": "Ouvrir l'assistant Nudger"
       }
     },
     "admin": {


### PR DESCRIPTION
### Motivation
- Provide a single reusable CTA component for category-side CTAs to ensure consistent visuals and behavior across eco-score and assistant links.
- Keep the category sort control usable when backend returns no sortable fields by providing a sensible fallback.
- Improve product card presentation by centering titles in the card variant and surface the assistant copy in locales.

### Description
- Add a new reusable component `CategoryCtaCard.vue` used to render CTA cards with optional icon, link, keyboard accessibility and click handler.  (`frontend/app/components/category/CategoryCtaCard.vue`).
- Replace the previous ecoscore CTA markup with the new `CategoryCtaCard` and reuse it for the assistant CTA in the category filters sidebar. (`frontend/app/components/category/CategoryEcoscoreCard.vue`, `frontend/app/components/pages/CategoryPage.vue`).
- Add a fallback sort behavior so when no sortable fields are returned the UI shows a fallback option `ECOSCORE_RELATIVE_FIELD` and the default sort selects that fallback; add `:disabled="sortItems.length === 0"` to the sort control. (`frontend/app/components/pages/CategoryPage.vue`, `frontend/app/constants/scores.ts`).
- Make product title alignment conditional on the `variant` by centering titles for `card` variant (`frontend/app/components/product/ProductDesignation.vue`).
- Add assistant localization strings in `en-US.json` and `fr-FR.json` for the assistant CTA (`frontend/i18n/locales/en-US.json`, `frontend/i18n/locales/fr-FR.json`).
- Fix attribute merging in the CTA component to avoid duplicate attributes when binding `attrs` and internal props.

### Testing
- Ran unit tests with `pnpm test`, all tests passed: `389 passed (389)`. 
- Built site with `pnpm generate`, which completed successfully but emitted a PWA warning about a missing `**/_payload.json` glob. 
- Ran linter with `pnpm lint`; it reported existing unrelated errors (unused vars in `app/pages/index.vue`) that pre-existed this change and are unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733909dc708322bee729c846a67e43)