### PR TITLE
Link AI review citations to sources

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.spec.ts
+++ b/frontend/app/components/product/ProductAiReviewSection.spec.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, nextTick } from 'vue'
 import ProductAiReviewSection from './ProductAiReviewSection.vue'
 import type {
   AiReviewAttributeDto,
@@ -469,5 +469,35 @@ describe('ProductAiReviewSection', () => {
       'Unavailable'
     )
     expect(wrapper.find('.product-ai-review__content').exists()).toBe(false)
+  })
+
+  it('expands the sources list when clicking on a hidden reference', async () => {
+    const sources = Array.from({ length: 6 }, (_, index) => ({
+      number: index + 1,
+      name: `Source ${index + 1}`,
+      description: `Source ${index + 1} description`,
+      url: `https://example.com/source-${index + 1}`,
+    }))
+
+    const review: AiReviewDto = {
+      summary:
+        'See details <a class="review-ref" href="#review-ref-6">[6]</a>.',
+      pros: ['Good image'],
+      cons: ['Limited ports'],
+      technicalReview: '<p>Specs</p>',
+      ecologicalReview: '<p>Eco</p>',
+      sources,
+    }
+
+    const wrapper = await mountComponent({ initialReview: review })
+    await nextTick()
+
+    expect(wrapper.find('#review-ref-6').exists()).toBe(false)
+
+    await wrapper.find('a.review-ref').trigger('click')
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('#review-ref-6').exists()).toBe(true)
   })
 })

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -21,6 +21,7 @@
 
     <div
       v-if="reviewContent"
+      ref="descriptionRef"
       class="product-ai-review__content"
       itemscope
       itemtype="https://schema.org/Review"
@@ -39,9 +40,12 @@
                     {{ $t('product.aiReview.sections.overall') }}
                   </h3>
                 </header>
-                <p class="product-ai-review__card-text">
-                  {{ reviewContent.summary }}
-                </p>
+                <!-- eslint-disable vue/no-v-html -->
+                <p
+                  class="product-ai-review__card-text"
+                  v-html="reviewContent.summary"
+                />
+                <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
             </v-card>
           </v-col>
@@ -317,7 +321,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useTheme } from 'vuetify'
@@ -584,7 +588,7 @@ function normalizeReview(reviewData: AiReviewDto | null): ReviewContent | null {
     shortTitle: reviewData.shortTitle ?? null,
     technicalReview: sanitizeHtml(reviewData.technicalReview ?? null),
     ecologicalReview: sanitizeHtml(reviewData.ecologicalReview ?? null),
-    summary: reviewData.summary ?? null,
+    summary: sanitizeHtml(reviewData.summary ?? null),
     pros,
     cons,
     sources,
@@ -758,7 +762,7 @@ watch(
   { immediate: true }
 )
 
-const handleReferenceClick = (event: Event) => {
+const handleReferenceClick = async (event: Event) => {
   const target = event.target as HTMLElement | null
   if (!target) {
     return
@@ -767,7 +771,14 @@ const handleReferenceClick = (event: Event) => {
   const anchor = target.closest('.review-ref') as HTMLAnchorElement | null
   if (anchor?.hash) {
     event.preventDefault()
-    const element = document.querySelector(anchor.hash) as HTMLElement | null
+    let element = document.querySelector(anchor.hash) as HTMLElement | null
+
+    if (!element && hasMoreSources.value && !showAllSources.value) {
+      showAllSources.value = true
+      await nextTick()
+      element = document.querySelector(anchor.hash) as HTMLElement | null
+    }
+
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' })
     }

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -66,7 +66,7 @@
                   <template v-if="attribute.key === 'ai-summary'">
                     <ul class="product-hero__ai-summary-list">
                       <li
-                        v-if="aiReview?.technicalOneline"
+                        v-if="technicalOnelineHtml"
                         class="product-hero__ai-summary-item"
                       >
                         <v-icon
@@ -78,13 +78,16 @@
                           <span class="product-hero__ai-summary-label">
                             {{ t('product.hero.aiSummary.technical') }}
                           </span>
-                          <span class="product-hero__ai-summary-text">
-                            {{ aiReview.technicalOneline }}
-                          </span>
+                          <!-- eslint-disable vue/no-v-html -->
+                          <span
+                            class="product-hero__ai-summary-text"
+                            v-html="technicalOnelineHtml"
+                          />
+                          <!-- eslint-enable vue/no-v-html -->
                         </div>
                       </li>
                       <li
-                        v-if="aiReview?.ecologicalOneline"
+                        v-if="ecologicalOnelineHtml"
                         class="product-hero__ai-summary-item"
                       >
                         <v-icon
@@ -96,13 +99,16 @@
                           <span class="product-hero__ai-summary-label">
                             {{ t('product.hero.aiSummary.ecological') }}
                           </span>
-                          <span class="product-hero__ai-summary-text">
-                            {{ aiReview.ecologicalOneline }}
-                          </span>
+                          <!-- eslint-disable vue/no-v-html -->
+                          <span
+                            class="product-hero__ai-summary-text"
+                            v-html="ecologicalOnelineHtml"
+                          />
+                          <!-- eslint-enable vue/no-v-html -->
                         </div>
                       </li>
                       <li
-                        v-if="aiReview?.communityOneline"
+                        v-if="communityOnelineHtml"
                         class="product-hero__ai-summary-item"
                       >
                         <v-icon
@@ -114,9 +120,12 @@
                           <span class="product-hero__ai-summary-label">
                             {{ t('product.hero.aiSummary.community') }}
                           </span>
-                          <span class="product-hero__ai-summary-text">
-                            {{ aiReview.communityOneline }}
-                          </span>
+                          <!-- eslint-disable vue/no-v-html -->
+                          <span
+                            class="product-hero__ai-summary-text"
+                            v-html="communityOnelineHtml"
+                          />
+                          <!-- eslint-enable vue/no-v-html -->
                         </div>
                       </li>
                     </ul>
@@ -226,6 +235,7 @@
 
 <script setup lang="ts">
 import { computed, defineAsyncComponent, type PropType } from 'vue'
+import DOMPurify from 'isomorphic-dompurify'
 import { useI18n } from 'vue-i18n'
 import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
 import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
@@ -287,6 +297,26 @@ const heroBackground = useThemedAsset('product/product-hero-background.svg')
 
 const aiReview = computed(() => props.product.aiReview?.review ?? null)
 const hasAiReview = computed(() => Boolean(aiReview.value))
+
+const sanitizeAiReviewHtml = (content: string | null | undefined): string => {
+  if (!content) {
+    return ''
+  }
+
+  return DOMPurify.sanitize(content, {
+    ADD_ATTR: ['class', 'target', 'rel'],
+  })
+}
+
+const technicalOnelineHtml = computed(() =>
+  sanitizeAiReviewHtml(aiReview.value?.technicalOneline ?? null)
+)
+const ecologicalOnelineHtml = computed(() =>
+  sanitizeAiReviewHtml(aiReview.value?.ecologicalOneline ?? null)
+)
+const communityOnelineHtml = computed(() =>
+  sanitizeAiReviewHtml(aiReview.value?.communityOneline ?? null)
+)
 
 const handleAiReviewClick = () => {
   const element =

--- a/frontend/server/utils/ai-review-references.spec.ts
+++ b/frontend/server/utils/ai-review-references.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { AiReviewDto } from '~~/shared/api-client'
+import { applyAiReviewReferenceLinks } from './ai-review-references'
+
+describe('applyAiReviewReferenceLinks', () => {
+  it('links only references that exist in the sources list', () => {
+    const review: AiReviewDto = {
+      summary: 'Highlights [1, 2, 3].',
+      technicalOneline: 'Specs [2].',
+      sources: [
+        { number: 1, url: 'https://example.com/1' },
+        { number: 3, url: 'https://example.com/3' },
+      ],
+    }
+
+    applyAiReviewReferenceLinks(review)
+
+    expect(review.summary).toBe(
+      'Highlights <a class="review-ref" href="#review-ref-1">[1]</a>, <a class="review-ref" href="#review-ref-3">[3]</a>.'
+    )
+    expect(review.technicalOneline).toBe('Specs .')
+  })
+
+  it('drops reference markers when no source matches', () => {
+    const review: AiReviewDto = {
+      ecologicalReview: 'Eco notes [4].',
+      sources: [{ number: 2, url: 'https://example.com/2' }],
+    }
+
+    applyAiReviewReferenceLinks(review)
+
+    expect(review.ecologicalReview).toBe('Eco notes .')
+  })
+})

--- a/frontend/server/utils/ai-review-references.ts
+++ b/frontend/server/utils/ai-review-references.ts
@@ -1,0 +1,122 @@
+import type { AiReviewDto, AiReviewSourceDto } from '~~/shared/api-client'
+
+const referencePattern = /\[(\s*\d+(?:\s*,\s*\d+)*)\]/g
+
+const buildReferenceAnchor = (referenceNumber: number): string =>
+  `<a class="review-ref" href="#review-ref-${referenceNumber}">[${referenceNumber}]</a>`
+
+const collectAvailableReferences = (
+  sources?: AiReviewSourceDto[] | null
+): Set<number> => {
+  const available = new Set<number>()
+
+  sources?.forEach(source => {
+    if (typeof source.number === 'number' && Number.isFinite(source.number)) {
+      available.add(source.number)
+    }
+  })
+
+  return available
+}
+
+const replaceReferences = (content: string, available: Set<number>): string =>
+  content.replace(referencePattern, (_, group: string) => {
+    const references = group
+      .split(',')
+      .map(value => Number.parseInt(value.trim(), 10))
+      .filter(value => Number.isFinite(value) && available.has(value))
+
+    if (!references.length) {
+      return ''
+    }
+
+    return references.map(buildReferenceAnchor).join(', ')
+  })
+
+const replaceIfString = (
+  content: string | null | undefined,
+  available: Set<number>
+): string | undefined => {
+  if (typeof content !== 'string') {
+    return content ?? undefined
+  }
+
+  return replaceReferences(content, available)
+}
+
+const replaceArray = (
+  values: Array<string> | null | undefined,
+  available: Set<number>
+): Array<string> | undefined => {
+  if (!Array.isArray(values)) {
+    return values ?? undefined
+  }
+
+  return values
+    .map(value => replaceIfString(value, available) ?? '')
+    .filter(value => value.length > 0)
+}
+
+export const applyAiReviewReferenceLinks = (
+  review: AiReviewDto | null | undefined
+): void => {
+  if (!review) {
+    return
+  }
+
+  const available = collectAvailableReferences(review.sources)
+
+  review.description = replaceIfString(review.description, available)
+  review.shortDescription = replaceIfString(review.shortDescription, available)
+  review.mediumTitle = replaceIfString(review.mediumTitle, available)
+  review.shortTitle = replaceIfString(review.shortTitle, available)
+  review.technicalReview = replaceIfString(review.technicalReview, available)
+  review.technicalReviewNovice = replaceIfString(
+    review.technicalReviewNovice,
+    available
+  )
+  review.technicalReviewIntermediate = replaceIfString(
+    review.technicalReviewIntermediate,
+    available
+  )
+  review.technicalReviewAdvanced = replaceIfString(
+    review.technicalReviewAdvanced,
+    available
+  )
+  review.technicalShortReview = replaceIfString(
+    review.technicalShortReview,
+    available
+  )
+  review.ecologicalReview = replaceIfString(review.ecologicalReview, available)
+  review.ecologicalReviewNovice = replaceIfString(
+    review.ecologicalReviewNovice,
+    available
+  )
+  review.ecologicalReviewIntermediate = replaceIfString(
+    review.ecologicalReviewIntermediate,
+    available
+  )
+  review.ecologicalReviewAdvanced = replaceIfString(
+    review.ecologicalReviewAdvanced,
+    available
+  )
+  review.communityReviewNovice = replaceIfString(
+    review.communityReviewNovice,
+    available
+  )
+  review.communityReviewIntermediate = replaceIfString(
+    review.communityReviewIntermediate,
+    available
+  )
+  review.communityReviewAdvanced = replaceIfString(
+    review.communityReviewAdvanced,
+    available
+  )
+  review.summary = replaceIfString(review.summary, available)
+  review.dataQuality = replaceIfString(review.dataQuality, available)
+  review.technicalOneline = replaceIfString(review.technicalOneline, available)
+  review.ecologicalOneline = replaceIfString(review.ecologicalOneline, available)
+  review.communityOneline = replaceIfString(review.communityOneline, available)
+  review.pros = replaceArray(review.pros, available)
+  review.cons = replaceArray(review.cons, available)
+}

--- a/frontend/server/utils/normalise-product-sourcing.ts
+++ b/frontend/server/utils/normalise-product-sourcing.ts
@@ -6,6 +6,7 @@ import type {
   ProductIndexedAttributeDto,
   ProductSourcedAttributeDto,
 } from '~~/shared/api-client'
+import { applyAiReviewReferenceLinks } from './ai-review-references'
 
 const normaliseSourcesSet = (
   sourcing: ProductAttributeSourceDto | null | undefined
@@ -69,6 +70,10 @@ export const normaliseProductDto = <T extends ProductDto | null | undefined>(
 ): T => {
   if (!product) {
     return product
+  }
+
+  if (product.aiReview?.review) {
+    applyAiReviewReferenceLinks(product.aiReview.review)
   }
 
   const { attributes } = product


### PR DESCRIPTION
### Motivation
- AI-generated reviews include numeric citation markers that should link to the review sources in the UI so readers can jump from an inline marker to the corresponding source entry. 
- Citations can be present in multiple aiReview fields (summary/onelines/technical/ecological/pros/cons/etc.) and should be normalized once on the server side so UI components can render safe HTML anchors. 

### Description
- Added server-side parsing to convert bracketed citation markers (e.g. `[1]` or `[1, 3]`) into anchor links only for references that exist in `review.sources` via `frontend/server/utils/ai-review-references.ts`. 
- Applied the reference-linker during product normalization in `frontend/server/utils/normalise-product-sourcing.ts` so the UI always receives review fields with anchors when sources exist. 
- Updated `ProductAiReviewSection.vue` to render the review `summary` as sanitized HTML, attach a delegated click handler to the content wrapper, expand the hidden sources list when a reference points to a source outside the visible slice, and then smooth-scroll to the source row. 
- Updated `ProductHero.vue` to sanitize and render the AI onelines (`technicalOneline`, `ecologicalOneline`, `communityOneline`) as HTML so injected anchors display correctly. 
- Added unit tests: `frontend/server/utils/ai-review-references.spec.ts` for the reference parsing logic and extended `ProductAiReviewSection.spec.ts` to validate expanding hidden sources on citation click. 

### Testing
- Ran `pnpm --offline lint` which passed, with a single non-blocking warning about an unused eslint-disable directive. 
- Ran `pnpm --offline test` where the added tests for the reference linker passed but the full suite reported remaining failures in impact-related tests: `ProductImpactDetailsTable.spec.ts` (two failing cases) and `ProductImpactEcoScoreCard.spec.ts` (one failing case). 
- Ran `pnpm --offline generate`, which completed successfully (with a non-blocking glob warning during asset collection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737f22a1ac832bab11becce3692b3b)