### PR TITLE
Add Impact Score Available Criteria panel and composable

### DIFF
--- a/frontend/app/components/impact-score/ImpactScoreAvailableCriteria.vue
+++ b/frontend/app/components/impact-score/ImpactScoreAvailableCriteria.vue
@@ -1,0 +1,57 @@
+<template>
+  <section class="impact-score-available-criteria">
+    <header class="impact-score-available-criteria__header">
+      <v-chip
+        class="impact-score-available-criteria__eyebrow"
+        color="accent-primary-highlight"
+        variant="tonal"
+      >
+        {{ t('impactScorePage.availableCriteria.eyebrow') }}
+      </v-chip>
+      <h2 class="impact-score-available-criteria__title">
+        {{ t('impactScorePage.availableCriteria.title') }}
+      </h2>
+      <p class="impact-score-available-criteria__subtitle">
+        {{ t('impactScorePage.availableCriteria.subtitle') }}
+      </p>
+    </header>
+
+    <ImpactScoreCriteriaPanel />
+  </section>
+</template>
+
+<script setup lang="ts">
+import ImpactScoreCriteriaPanel from '~/components/impact-score/ImpactScoreCriteriaPanel.vue'
+
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.impact-score-available-criteria {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.impact-score-available-criteria__header {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.impact-score-available-criteria__eyebrow {
+  width: fit-content;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.impact-score-available-criteria__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 1.4vw + 1rem, 2rem);
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-score-available-criteria__subtitle {
+  margin: 0;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+</style>

--- a/frontend/app/components/impact-score/ImpactScoreCriteriaPanel.vue
+++ b/frontend/app/components/impact-score/ImpactScoreCriteriaPanel.vue
@@ -1,0 +1,303 @@
+<template>
+  <section class="impact-score-criteria-panel">
+    <div v-if="showFilters" class="impact-score-criteria-panel__filters">
+      <span class="impact-score-criteria-panel__filters-label">
+        {{ t('impactScoreCriteriaPanel.filters.label') }}
+      </span>
+      <v-chip-group
+        v-model="selectedFilter"
+        class="impact-score-criteria-panel__filters-group"
+        column
+        selected-class="impact-score-criteria-panel__filters-chip--active"
+      >
+        <v-chip
+          v-for="filter in filters"
+          :key="filter.id"
+          :value="filter.id"
+          class="impact-score-criteria-panel__filters-chip"
+          variant="tonal"
+        >
+          {{ filter.label }}
+        </v-chip>
+      </v-chip-group>
+    </div>
+
+    <v-table
+      v-if="variant === 'table' && hasCriteria"
+      class="impact-score-criteria-panel__table"
+      density="comfortable"
+    >
+      <thead>
+        <tr>
+          <th scope="col" class="text-left">
+            {{ t('impactScoreCriteriaPanel.table.name') }}
+          </th>
+          <th scope="col" class="text-left">
+            {{ t('impactScoreCriteriaPanel.table.utility') }}
+          </th>
+          <th scope="col" class="text-left">
+            {{ t('impactScoreCriteriaPanel.table.icon') }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="criterion in displayedCriteria" :key="criterion.key">
+          <th scope="row">{{ criterion.name }}</th>
+          <td>{{ criterion.utility || emptyFallback }}</td>
+          <td>
+            <v-icon
+              v-if="criterion.icon"
+              :icon="criterion.icon"
+              size="20"
+            />
+            <span
+              v-else
+              class="impact-score-criteria-panel__icon-fallback"
+              aria-hidden="true"
+            >
+              {{ criterion.name.charAt(0).toUpperCase() }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </v-table>
+
+    <v-row
+      v-else-if="variant === 'cards' && hasCriteria"
+      class="impact-score-criteria-panel__grid"
+      align="stretch"
+      dense
+    >
+      <v-col
+        v-for="criterion in displayedCriteria"
+        :key="criterion.key"
+        cols="12"
+        sm="6"
+        md="4"
+      >
+        <v-card
+          class="impact-score-criteria-panel__card"
+          elevation="0"
+          rounded="xl"
+          border
+        >
+          <div class="impact-score-criteria-panel__card-header">
+            <v-avatar
+              size="44"
+              class="impact-score-criteria-panel__icon"
+              color="surface-primary-120"
+            >
+              <v-icon
+                v-if="criterion.icon"
+                :icon="criterion.icon"
+                size="22"
+                color="primary"
+              />
+              <span
+                v-else
+                class="impact-score-criteria-panel__icon-fallback"
+              >
+                {{ criterion.name.charAt(0).toUpperCase() }}
+              </span>
+            </v-avatar>
+            <h3 class="impact-score-criteria-panel__card-title">
+              {{ criterion.name }}
+            </h3>
+          </div>
+          <p class="impact-score-criteria-panel__card-utility">
+            {{ criterion.utility || emptyFallback }}
+          </p>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <p v-else class="impact-score-criteria-panel__empty">
+      {{ t('impactScoreCriteriaPanel.empty') }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  useImpactScoreCriteria,
+  type ImpactScoreCriterion,
+} from '~/composables/impact-score/useImpactScoreCriteria'
+
+const props = withDefaults(
+  defineProps<{
+    variant?: 'cards' | 'table'
+    verticalId?: string | null
+    criteria?: ImpactScoreCriterion[]
+  }>(),
+  {
+    variant: 'cards',
+    verticalId: null,
+    criteria: undefined,
+  }
+)
+
+const { t } = useI18n()
+const {
+  allCriteria,
+  criteriaByVerticalId,
+  verticalOptions,
+  loadAllCriteria,
+  loadCriteriaForVertical,
+} = useImpactScoreCriteria()
+
+const selectedFilter = ref<string>('all')
+
+const showFilters = computed(() => !props.verticalId)
+
+const filters = computed(() => [
+  { id: 'all', label: t('impactScoreCriteriaPanel.filters.all') },
+  ...verticalOptions.value.map(option => ({
+    id: option.id,
+    label: option.label,
+  })),
+])
+
+const displayedCriteria = computed<ImpactScoreCriterion[]>(() => {
+  if (props.criteria?.length) {
+    return props.criteria
+  }
+
+  if (props.verticalId) {
+    return criteriaByVerticalId.value[props.verticalId] ?? []
+  }
+
+  if (selectedFilter.value === 'all') {
+    return allCriteria.value
+  }
+
+  return criteriaByVerticalId.value[selectedFilter.value] ?? []
+})
+
+const hasCriteria = computed(() => displayedCriteria.value.length > 0)
+const emptyFallback = computed(() =>
+  t('impactScoreCriteriaPanel.utilityFallback')
+)
+
+const loadCriteria = async () => {
+  if (props.criteria?.length) {
+    return
+  }
+
+  if (props.verticalId) {
+    await loadCriteriaForVertical(props.verticalId)
+    return
+  }
+
+  await loadAllCriteria()
+}
+
+onMounted(() => {
+  loadCriteria()
+})
+
+watch(
+  () => props.verticalId,
+  async () => {
+    if (props.verticalId) {
+      selectedFilter.value = props.verticalId
+    } else {
+      selectedFilter.value = 'all'
+    }
+    await loadCriteria()
+  }
+)
+</script>
+
+<style scoped>
+.impact-score-criteria-panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.impact-score-criteria-panel__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.impact-score-criteria-panel__filters-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+}
+
+.impact-score-criteria-panel__filters-group {
+  gap: 0.5rem;
+}
+
+.impact-score-criteria-panel__filters-chip {
+  font-weight: 600;
+}
+
+.impact-score-criteria-panel__filters-chip--active {
+  color: rgb(var(--v-theme-primary));
+}
+
+.impact-score-criteria-panel__grid {
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+.impact-score-criteria-panel__card {
+  padding: 1.25rem;
+  height: 100%;
+  background: rgba(var(--v-theme-surface-glass), 0.92);
+  border-color: rgba(var(--v-theme-border-primary-strong), 0.2);
+}
+
+.impact-score-criteria-panel__card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.impact-score-criteria-panel__card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.impact-score-criteria-panel__card-utility {
+  margin: 0.85rem 0 0;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  line-height: 1.5;
+}
+
+.impact-score-criteria-panel__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.impact-score-criteria-panel__icon-fallback {
+  font-weight: 700;
+  color: rgb(var(--v-theme-primary));
+}
+
+.impact-score-criteria-panel__table {
+  background: rgba(var(--v-theme-surface-glass), 0.9);
+  border-radius: 16px;
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12);
+}
+
+.impact-score-criteria-panel__table :deep(th),
+.impact-score-criteria-panel__table :deep(td) {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(var(--v-theme-border-primary-strong), 0.08);
+}
+
+.impact-score-criteria-panel__empty {
+  margin: 0;
+  color: rgb(var(--v-theme-text-neutral-secondary));
+  font-style: italic;
+}
+</style>

--- a/frontend/app/composables/impact-score/useImpactScoreCriteria.ts
+++ b/frontend/app/composables/impact-score/useImpactScoreCriteria.ts
@@ -1,0 +1,172 @@
+import type {
+  AttributeConfigDto,
+  VerticalConfigDto,
+  VerticalConfigFullDto,
+} from '~~/shared/api-client'
+import { useCategories } from '~/composables/categories/useCategories'
+
+export type ImpactScoreCriterion = {
+  key: string
+  name: string
+  utility: string
+  icon: string | null
+}
+
+type CriteriaByVerticalId = Record<string, ImpactScoreCriterion[]>
+
+const buildAttributeMap = (attributes: AttributeConfigDto[]) => {
+  return attributes.reduce((map, attribute) => {
+    if (attribute.key) {
+      map.set(attribute.key, attribute)
+    }
+    return map
+  }, new Map<string, AttributeConfigDto>())
+}
+
+export const buildCriteriaFromCategory = (
+  category: VerticalConfigFullDto
+): ImpactScoreCriterion[] => {
+  const available = category.availableImpactScoreCriterias ?? []
+  const attributeConfigs = category.attributesConfig?.configs ?? []
+  const attributeMap = buildAttributeMap(attributeConfigs)
+
+  return available.map(key => {
+    const attribute = attributeMap.get(key)
+    const fallbackName = attribute?.scoreTitle ?? attribute?.name ?? key
+
+    return {
+      key,
+      name: fallbackName,
+      utility: attribute?.scoreUtility ?? '',
+      icon: attribute?.icon ?? null,
+    }
+  })
+}
+
+const mergeCriteria = (
+  target: Map<string, ImpactScoreCriterion>,
+  criteria: ImpactScoreCriterion[]
+) => {
+  criteria.forEach(criterion => {
+    const existing = target.get(criterion.key)
+    if (!existing) {
+      target.set(criterion.key, { ...criterion })
+      return
+    }
+
+    target.set(criterion.key, {
+      ...existing,
+      name: existing.name || criterion.name,
+      utility: existing.utility || criterion.utility,
+      icon: existing.icon || criterion.icon,
+    })
+  })
+}
+
+const normalizeVerticalLabel = (vertical: VerticalConfigDto) =>
+  vertical.verticalHomeTitle?.trim() ||
+  vertical.verticalMetaTitle?.trim() ||
+  vertical.id ||
+  ''
+
+export const useImpactScoreCriteria = () => {
+  const { categories, fetchCategories, fetchCategoryById } = useCategories()
+  const criteriaByVerticalId = useState<CriteriaByVerticalId>(
+    'impact-score-criteria-by-vertical',
+    () => ({})
+  )
+  const loading = useState('impact-score-criteria-loading', () => false)
+  const error = useState<string | null>('impact-score-criteria-error', () => null)
+
+  const verticalOptions = computed(() =>
+    categories.value
+      .filter(vertical => Boolean(vertical.id))
+      .map(vertical => ({
+        id: vertical.id as string,
+        label: normalizeVerticalLabel(vertical),
+        order: vertical.order ?? Number.MAX_SAFE_INTEGER,
+      }))
+      .filter(option => Boolean(option.label))
+      .sort((a, b) => a.order - b.order)
+  )
+
+  const allCriteria = computed(() => {
+    const merged = new Map<string, ImpactScoreCriterion>()
+    Object.values(criteriaByVerticalId.value).forEach(criteria => {
+      mergeCriteria(merged, criteria)
+    })
+    return Array.from(merged.values()).sort((a, b) =>
+      a.name.localeCompare(b.name, 'fr', { sensitivity: 'base' })
+    )
+  })
+
+  const ensureCategories = async () => {
+    if (!categories.value.length) {
+      await fetchCategories()
+    }
+  }
+
+  const loadCriteriaForVertical = async (
+    verticalId: string,
+    options?: { silent?: boolean }
+  ) => {
+    if (criteriaByVerticalId.value[verticalId]) {
+      return
+    }
+
+    if (!options?.silent) {
+      loading.value = true
+      error.value = null
+    }
+
+    try {
+      const category = await fetchCategoryById(verticalId)
+      if (category) {
+        criteriaByVerticalId.value[verticalId] =
+          buildCriteriaFromCategory(category)
+      }
+    } catch (err) {
+      error.value =
+        err instanceof Error ? err.message : 'Failed to load criteria'
+      console.error('Unable to load impact score criteria', err)
+    } finally {
+      if (!options?.silent) {
+        loading.value = false
+      }
+    }
+  }
+
+  const loadAllCriteria = async () => {
+    await ensureCategories()
+
+    const verticalIds = categories.value
+      .map(vertical => vertical.id)
+      .filter((id): id is string => Boolean(id))
+      .filter(id => !criteriaByVerticalId.value[id])
+
+    if (!verticalIds.length) {
+      return
+    }
+
+    loading.value = true
+    error.value = null
+
+    try {
+      await Promise.all(
+        verticalIds.map(id => loadCriteriaForVertical(id, { silent: true }))
+      )
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    criteriaByVerticalId,
+    allCriteria,
+    verticalOptions,
+    loading: readonly(loading),
+    error: readonly(error),
+    loadCriteriaForVertical,
+    loadAllCriteria,
+  }
+}

--- a/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
+++ b/frontend/app/pages/[categorySlug]/ecoscore.spec.ts
@@ -14,11 +14,16 @@ const messages: Record<string, string> = {
   'category.ecoscorePage.breadcrumbLeaf': 'impactscore',
   'category.ecoscorePage.navigation.ariaLabel':
     'Impact Score section navigation',
+  'category.ecoscorePage.navigation.availableCriteria': 'Available criteria',
   'category.ecoscorePage.navigation.overview': 'Overview',
   'category.ecoscorePage.navigation.purpose': 'Purpose & data',
   'category.ecoscorePage.navigation.criteria': 'Criteria',
   'category.ecoscorePage.navigation.transparency': 'Transparency',
   'category.ecoscorePage.navigation.aiAudit': 'AI audit',
+  'category.ecoscorePage.sections.availableCriteria.title':
+    'Available criteria for {category}',
+  'category.ecoscorePage.sections.availableCriteria.subtitle':
+    'Each Impact Score vertical uses criteria tailored to its products.',
   'category.ecoscorePage.sections.overview.title':
     'Impact Score for {category}',
   'category.ecoscorePage.sections.overview.card.title': 'Nudger Impact Score',
@@ -357,6 +362,9 @@ const vuetifyStubs = {
   }),
   'v-divider': { template: '<hr class="v-divider-stub" />' },
   'v-skeleton-loader': { template: '<div class="v-skeleton-loader-stub" />' },
+  ImpactScoreCriteriaPanel: {
+    template: '<div class="impact-score-criteria-panel-stub" />',
+  },
 }
 
 const mountPage = async () => {
@@ -403,8 +411,9 @@ describe('Category ecosystem Impact Score page', () => {
     expect(breadcrumbText).toContain('impactscore')
 
     const navItems = wrapper.findAll('.sticky-nav-stub__item')
-    expect(navItems).toHaveLength(5)
+    expect(navItems).toHaveLength(6)
     expect(navItems.map(item => item.text())).toEqual([
+      'Available criteria',
       'Overview',
       'Purpose & data',
       'Criteria',

--- a/frontend/app/pages/[categorySlug]/ecoscore.vue
+++ b/frontend/app/pages/[categorySlug]/ecoscore.vue
@@ -30,6 +30,46 @@
 
           <main class="category-ecoscore__sections" role="main">
             <section
+              :id="sectionIds.availableCriteria"
+              class="category-ecoscore__section"
+              role="region"
+              :aria-labelledby="`${sectionIds.availableCriteria}-title`"
+            >
+              <v-sheet
+                class="category-ecoscore__surface"
+                elevation="0"
+                rounded="xl"
+              >
+                <header class="category-ecoscore__header">
+                  <h2
+                    :id="`${sectionIds.availableCriteria}-title`"
+                    class="category-ecoscore__title"
+                  >
+                    {{
+                      t(
+                        'category.ecoscorePage.sections.availableCriteria.title',
+                        { category: categoryLabel }
+                      )
+                    }}
+                  </h2>
+                  <p class="category-ecoscore__subtitle">
+                    {{
+                      t(
+                        'category.ecoscorePage.sections.availableCriteria.subtitle',
+                        { category: categoryLabel }
+                      )
+                    }}
+                  </p>
+                </header>
+
+                <ImpactScoreCriteriaPanel
+                  variant="table"
+                  :vertical-id="category?.id ?? null"
+                />
+              </v-sheet>
+            </section>
+
+            <section
               :id="sectionIds.overview"
               class="category-ecoscore__section"
               role="region"
@@ -709,6 +749,7 @@ import CategoryHero from '~/components/category/CategoryHero.vue'
 import CategoryImpactScoreOrbit from '~/components/category/CategoryImpactScoreOrbit.vue'
 import AiAuditDisplay from '~/components/category/AiAuditDisplay.vue'
 import TextContent from '~/components/domains/content/TextContent.vue'
+import ImpactScoreCriteriaPanel from '~/components/impact-score/ImpactScoreCriteriaPanel.vue'
 import StickySectionNavigation from '~/components/shared/ui/StickySectionNavigation.vue'
 import { loadHighlightJs } from '~/utils/highlight-loader'
 import { createError, useRequestURL, useRoute, useSeoMeta } from '#imports'
@@ -1065,6 +1106,7 @@ const navAriaLabel = computed(() =>
 )
 
 const sectionIds = {
+  availableCriteria: 'category-impact-available-criteria',
   overview: 'category-impact-overview',
   purpose: 'category-impact-purpose',
   criteria: 'category-impact-criteria',
@@ -1075,6 +1117,11 @@ const sectionIds = {
 type SectionId = (typeof sectionIds)[keyof typeof sectionIds]
 
 const navigationSections = computed(() => [
+  {
+    id: sectionIds.availableCriteria as SectionId,
+    label: t('category.ecoscorePage.navigation.availableCriteria'),
+    icon: 'mdi-format-list-checks',
+  },
   {
     id: sectionIds.overview as SectionId,
     label: t('category.ecoscorePage.navigation.overview'),
@@ -1359,6 +1406,11 @@ useSeoMeta({
   font-size: clamp(1.65rem, 1.5vw + 1.1rem, 2.25rem)
   line-height: 1.2
   font-weight: 700
+
+.category-ecoscore__subtitle
+  margin: 0
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9)
+  line-height: 1.6
 
 .category-ecoscore__text-block
   margin-bottom: clamp(1.5rem, 3vw, 2.5rem)

--- a/frontend/app/pages/impact-score/index.vue
+++ b/frontend/app/pages/impact-score/index.vue
@@ -8,6 +8,7 @@
         class="impact-score-page__section"
         :verticals="verticals"
       />
+      <ImpactScoreAvailableCriteria class="impact-score-page__section" />
       <ImpactScorePrinciples class="impact-score-page__section" />
       <ImpactScoreSummary class="impact-score-page__section" />
       <ImpactScoreApproach class="impact-score-page__section" />
@@ -37,6 +38,7 @@
 <script setup lang="ts">
 import type { VerticalConfigDto } from '~~/shared/api-client'
 import ImpactScoreApproach from '~/components/impact-score/ImpactScoreApproach.vue'
+import ImpactScoreAvailableCriteria from '~/components/impact-score/ImpactScoreAvailableCriteria.vue'
 import ImpactScoreDetails from '~/components/impact-score/ImpactScoreDetails.vue'
 import ImpactScoreExamples from '~/components/impact-score/ImpactScoreExamples.vue'
 import ImpactScoreHero from '~/components/impact-score/ImpactScoreHero.vue'

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -749,6 +749,7 @@
       "navigation": {
         "aiAudit": "AI audit",
         "ariaLabel": "Impact Score section navigation",
+        "availableCriteria": "Available criteria",
         "criteria": "Criteria",
         "overview": "Overview",
         "purpose": "Purpose & data",
@@ -770,6 +771,10 @@
           "title": "Selected criteria and weights",
           "coefficientPrefix": "Counts for",
           "coefficientSuffix": "in the overall score"
+        },
+        "availableCriteria": {
+          "title": "Available criteria for {category}",
+          "subtitle": "Each Impact Score vertical uses criteria tailored to its products."
         },
         "overview": {
           "card": {
@@ -1462,6 +1467,11 @@
           "weight": "10%"
         }
       }
+    },
+    "availableCriteria": {
+      "eyebrow": "Criteria",
+      "title": "Available criteria",
+      "subtitle": "Explore the criteria used for each Impact Score vertical."
     },
     "principles": {
       "eyebrow": "Our principles",
@@ -3602,6 +3612,19 @@
         "aplat": "parallax-aplats.svg"
       }
     }
+  },
+  "impactScoreCriteriaPanel": {
+    "filters": {
+      "label": "Filter by vertical",
+      "all": "All criteria"
+    },
+    "table": {
+      "name": "Name",
+      "utility": "Utility",
+      "icon": "Icon"
+    },
+    "utilityFallback": "Utility to be clarified",
+    "empty": "No criteria available yet."
   },
   "docs": {
     "labels": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -761,6 +761,7 @@
       "navigation": {
         "aiAudit": "Audit IA",
         "ariaLabel": "Navigation des sections Impact Score",
+        "availableCriteria": "Critères disponibles",
         "criteria": "Critères retenus",
         "overview": "Présentation",
         "purpose": "Objectif & données",
@@ -783,6 +784,10 @@
           "title": "Critères retenus et pondérations",
           "coefficientPrefix": "Compte pour",
           "coefficientSuffix": "dans la note globale"
+        },
+        "availableCriteria": {
+          "title": "Critères disponibles pour {category}",
+          "subtitle": "Chaque verticale Impact Score dispose d’une sélection de critères adaptés."
         },
         "overview": {
           "card": {
@@ -1476,6 +1481,11 @@
           "weight": "10 %"
         }
       }
+    },
+    "availableCriteria": {
+      "eyebrow": "Critères",
+      "title": "Critères disponibles",
+      "subtitle": "Explorez les critères utilisés selon chaque verticale Impact Score."
     },
     "principles": {
       "eyebrow": "Nos principes",
@@ -3650,6 +3660,19 @@
         }
       }
     }
+  },
+  "impactScoreCriteriaPanel": {
+    "filters": {
+      "label": "Afficher par verticale",
+      "all": "Tous les critères"
+    },
+    "table": {
+      "name": "Nom",
+      "utility": "Utilité",
+      "icon": "Icône"
+    },
+    "utilityFallback": "Utilité à préciser",
+    "empty": "Aucun critère disponible pour le moment."
   },
   "docs": {
     "labels": {


### PR DESCRIPTION
### Motivation
- Expose the list of available Impact Score criteria across verticals and let users inspect them per-vertical with icons and utility text.
- Provide a dedicated, reusable section placed before the existing Overview to surface `availableImpactScoreCriterias` (using `attribute.icon` when present) via a new component.

### Description
- Add a composable `useImpactScoreCriteria` that builds criteria lists from `VerticalConfigFullDto.availableImpactScoreCriterias` and `attributesConfig`, merges criteria across verticals and exposes load functions (`frontend/app/composables/impact-score/useImpactScoreCriteria.ts`).
- Add `ImpactScoreCriteriaPanel.vue` (cards/table variants with vertical filter) and `ImpactScoreAvailableCriteria.vue` as a small section wrapper component to render the criteria UI (cards/table, icon fallback handling).
- Wire the new section into the global Impact Score page and category ecoscore page so the Available Criteria section appears before the Overview and is included in the sticky navigation (`frontend/app/pages/impact-score/index.vue`, `frontend/app/pages/[categorySlug]/ecoscore.vue`).
- Extend the categories composable with `fetchCategoryById` and refactor `selectCategoryBySlug` to reuse it, enabling per-vertical criteria loading (`frontend/app/composables/categories/useCategories.ts`).
- Add English and French i18n strings and update the category ecoscore page test to account for the new navigation item and section (`frontend/i18n/locales/en-US.json`, `frontend/i18n/locales/fr-FR.json`, `frontend/app/pages/[categorySlug]/ecoscore.spec.ts`).

### Testing
- `pnpm lint` completed with a single lint warning (an unused eslint-disable directive reported). ✅
- `pnpm test` was run; the suite mostly passed but three tests failed: two assertions in `ProductImpactDetailsTable.spec.ts` and one in `ProductImpactEcoScoreCard.spec.ts`, so the full test run is failing (3 tests failed, 388 passed). ❌
- `pnpm generate` (site generation) completed successfully with a minor PWA glob warning, and a screenshot of the Impact Score page was captured via Playwright during a local dev preview. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973866306b8832b81f41cab44982ae8)