### PR TITLE
Add reading-level toggles to AI review synthese (technical / ecological / community)

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.spec.ts
+++ b/frontend/app/components/product/ProductAiReviewSection.spec.ts
@@ -113,6 +113,29 @@ const VBtnStub = defineComponent({
   },
 })
 
+const VBtnToggleStub = defineComponent({
+  name: 'VBtnToggleStub',
+  inheritAttrs: false,
+  props: {
+    modelValue: { type: [String, Number], default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { attrs, slots }) {
+    const { class: className, ...rest } = attrs
+
+    return () =>
+      h(
+        'div',
+        {
+          ...rest,
+          class: ['v-btn-toggle-stub', className].filter(Boolean).join(' '),
+          'data-value': props.modelValue ?? '',
+        },
+        slots.default?.()
+      )
+  },
+})
+
 const VAlertStub = defineComponent({
   name: 'VAlertStub',
   inheritAttrs: false,
@@ -294,11 +317,18 @@ const i18nMessages = {
           details: 'Details and highlights',
           technical: 'Technical analysis',
           ecological: 'Ecological impact',
+          community: 'Community feedback',
           pros: 'Strengths',
           cons: 'Limitations',
           identity: 'Identity card',
           sources: 'Sources',
           sourcesCount: '{count} sources consulted',
+        },
+        levels: {
+          label: 'Reading level',
+          simple: 'Simple',
+          intermediate: 'Intermediate',
+          advanced: 'Advanced',
         },
         sources: {
           index: '#',
@@ -375,6 +405,8 @@ const mountComponent = (
         'v-table': VTableStub,
         VBtn: VBtnStub,
         'v-btn': VBtnStub,
+        VBtnToggle: VBtnToggleStub,
+        'v-btn-toggle': VBtnToggleStub,
         VAlert: VAlertStub,
         'v-alert': VAlertStub,
         VDialog: VDialogStub,
@@ -406,10 +438,18 @@ describe('ProductAiReviewSection', () => {
         'The product balances vivid visuals with smart integrations for a seamless living room experience.',
       description:
         '<p>The TQ65S90D focuses on brightness control and a <a class="review-ref" href="#review-ref-1">detailed contrast engine</a>.</p>',
-      technicalReview:
+      technicalReviewNovice: '<p>Simple technical recap.</p>',
+      technicalReviewIntermediate:
         '<p>HDMI 2.1 ports, Wi-Fi 6 support and a 120 Hz panel provide future-proof connectivity.</p>',
-      ecologicalReview:
+      technicalReviewAdvanced: '<p>Advanced technical breakdown.</p>',
+      ecologicalReviewNovice: '<p>Simple ecological summary.</p>',
+      ecologicalReviewIntermediate:
         '<p>Packaging uses recycled fibres and the standby consumption stays below 0.5W.</p>',
+      ecologicalReviewAdvanced: '<p>Advanced ecological breakdown.</p>',
+      communityReviewNovice: '<p>Community quick take.</p>',
+      communityReviewIntermediate:
+        '<p>Community feedback highlights balanced brightness.</p>',
+      communityReviewAdvanced: '<p>Community deep dive.</p>',
       pros: ['Excellent brightness calibration', 'Robust gaming features'],
       cons: ['Lacks bundled camera accessories'],
       attributes: defaultAttributes,
@@ -431,7 +471,7 @@ describe('ProductAiReviewSection', () => {
     expect(metadata).toMatch(/2024/)
 
     const cards = wrapper.findAll('.product-ai-review__card')
-    expect(cards).toHaveLength(4)
+    expect(cards).toHaveLength(5)
 
     const summaryCard = cards[0]
     expect(summaryCard.text()).toContain('Overall summary')
@@ -441,6 +481,10 @@ describe('ProductAiReviewSection', () => {
     expect(prosItems).toHaveLength(3)
     expect(prosItems[0].text()).toContain('Excellent brightness calibration')
     expect(prosItems[2].text()).toContain('Lacks bundled camera accessories')
+
+    expect(wrapper.text()).toContain('HDMI 2.1 ports, Wi-Fi 6 support')
+    expect(wrapper.text()).toContain('Packaging uses recycled fibres')
+    expect(wrapper.text()).toContain('Community feedback highlights balanced')
 
     const prosIcon = wrapper
       .findAll('.v-icon-stub')

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -126,45 +126,128 @@
         </v-row>
 
         <v-row>
-          <!-- Row 2: Technical & Ecological -->
-          <v-col v-if="reviewContent.technicalReview" cols="12" md="6">
+          <!-- Row 2: Technical, Ecological & Community -->
+          <v-col v-if="technicalContent" cols="12" md="4">
             <v-card class="product-ai-review__card h-100" elevation="0">
               <v-card-text>
-                <header class="product-ai-review__card-header mb-4">
-                  <div class="product-ai-review__card-icon">
-                    <v-icon icon="mdi-cog-outline" size="24" />
+                <header class="product-ai-review__card-heading mb-4">
+                  <div class="product-ai-review__card-header">
+                    <div class="product-ai-review__card-icon">
+                      <v-icon icon="mdi-cog-outline" size="24" />
+                    </div>
+                    <h3 class="product-ai-review__card-title">
+                      {{ $t('product.aiReview.sections.technical') }}
+                    </h3>
                   </div>
-                  <h3 class="product-ai-review__card-title">
-                    {{ $t('product.aiReview.sections.technical') }}
-                  </h3>
+                  <v-btn-toggle
+                    v-model="technicalLevel"
+                    mandatory
+                    density="compact"
+                    class="product-ai-review__level-toggle"
+                    :aria-label="$t('product.aiReview.levels.label')"
+                  >
+                    <v-btn
+                      v-for="option in levelOptions"
+                      :key="option.value"
+                      :value="option.value"
+                      size="small"
+                      variant="tonal"
+                      :aria-label="option.label"
+                    >
+                      <v-icon :icon="option.icon" size="18" />
+                    </v-btn>
+                  </v-btn-toggle>
                 </header>
                 <!-- eslint-disable vue/no-v-html -->
                 <div
                   class="product-ai-review__card-text"
-                  v-html="reviewContent.technicalReview"
+                  v-html="technicalContent"
                 />
                 <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
             </v-card>
           </v-col>
 
-          <v-col v-if="reviewContent.ecologicalReview" cols="12" md="6">
+          <v-col v-if="ecologicalContent" cols="12" md="4">
             <v-card class="product-ai-review__card h-100" elevation="0">
               <v-card-text>
-                <header class="product-ai-review__card-header mb-4">
-                  <div
-                    class="product-ai-review__card-icon product-ai-review__card-icon--eco"
-                  >
-                    <v-icon icon="mdi-leaf" size="24" />
+                <header class="product-ai-review__card-heading mb-4">
+                  <div class="product-ai-review__card-header">
+                    <div
+                      class="product-ai-review__card-icon product-ai-review__card-icon--eco"
+                    >
+                      <v-icon icon="mdi-leaf" size="24" />
+                    </div>
+                    <h3 class="product-ai-review__card-title">
+                      {{ $t('product.aiReview.sections.ecological') }}
+                    </h3>
                   </div>
-                  <h3 class="product-ai-review__card-title">
-                    {{ $t('product.aiReview.sections.ecological') }}
-                  </h3>
+                  <v-btn-toggle
+                    v-model="ecologicalLevel"
+                    mandatory
+                    density="compact"
+                    class="product-ai-review__level-toggle"
+                    :aria-label="$t('product.aiReview.levels.label')"
+                  >
+                    <v-btn
+                      v-for="option in levelOptions"
+                      :key="option.value"
+                      :value="option.value"
+                      size="small"
+                      variant="tonal"
+                      :aria-label="option.label"
+                    >
+                      <v-icon :icon="option.icon" size="18" />
+                    </v-btn>
+                  </v-btn-toggle>
                 </header>
                 <!-- eslint-disable vue/no-v-html -->
                 <div
                   class="product-ai-review__card-text"
-                  v-html="reviewContent.ecologicalReview"
+                  v-html="ecologicalContent"
+                />
+                <!-- eslint-enable vue/no-v-html -->
+              </v-card-text>
+            </v-card>
+          </v-col>
+
+          <v-col v-if="communityContent" cols="12" md="4">
+            <v-card class="product-ai-review__card h-100" elevation="0">
+              <v-card-text>
+                <header class="product-ai-review__card-heading mb-4">
+                  <div class="product-ai-review__card-header">
+                    <div
+                      class="product-ai-review__card-icon product-ai-review__card-icon--community"
+                    >
+                      <v-icon icon="mdi-account-group-outline" size="24" />
+                    </div>
+                    <h3 class="product-ai-review__card-title">
+                      {{ $t('product.aiReview.sections.community') }}
+                    </h3>
+                  </div>
+                  <v-btn-toggle
+                    v-model="communityLevel"
+                    mandatory
+                    density="compact"
+                    class="product-ai-review__level-toggle"
+                    :aria-label="$t('product.aiReview.levels.label')"
+                  >
+                    <v-btn
+                      v-for="option in levelOptions"
+                      :key="option.value"
+                      :value="option.value"
+                      size="small"
+                      variant="tonal"
+                      :aria-label="option.label"
+                    >
+                      <v-icon :icon="option.icon" size="18" />
+                    </v-btn>
+                  </v-btn-toggle>
+                </header>
+                <!-- eslint-disable vue/no-v-html -->
+                <div
+                  class="product-ai-review__card-text"
+                  v-html="communityContent"
                 />
                 <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
@@ -346,7 +429,16 @@ interface ReviewContent {
   mediumTitle?: string | null
   shortTitle?: string | null
   technicalReview?: string | null
+  technicalReviewNovice?: string | null
+  technicalReviewIntermediate?: string | null
+  technicalReviewAdvanced?: string | null
   ecologicalReview?: string | null
+  ecologicalReviewNovice?: string | null
+  ecologicalReviewIntermediate?: string | null
+  ecologicalReviewAdvanced?: string | null
+  communityReviewNovice?: string | null
+  communityReviewIntermediate?: string | null
+  communityReviewAdvanced?: string | null
   summary?: string | null
   pros?: string[]
   cons?: string[]
@@ -354,6 +446,8 @@ interface ReviewContent {
   attributes?: AiReviewAttributeDto[]
   dataQuality?: string | null
 }
+
+type ReviewLevel = 'novice' | 'intermediate' | 'advanced'
 
 const props = defineProps({
   sectionId: {
@@ -407,6 +501,9 @@ const descriptionRef = ref<HTMLElement | null>(null)
 const isDialogOpen = ref(false)
 const agreementAccepted = ref(true)
 const showAllSources = ref(false)
+const technicalLevel = ref<ReviewLevel>('intermediate')
+const ecologicalLevel = ref<ReviewLevel>('intermediate')
+const communityLevel = ref<ReviewLevel>('intermediate')
 
 const quotaCategory = IpQuotaCategory.ReviewGeneration
 
@@ -474,6 +571,24 @@ const sourcesToggleLabel = computed(() =>
     : t('product.aiReview.sources.showMore')
 )
 
+const levelOptions = computed(() => [
+  {
+    value: 'novice',
+    icon: 'mdi-signal-cellular-1',
+    label: t('product.aiReview.levels.simple'),
+  },
+  {
+    value: 'intermediate',
+    icon: 'mdi-signal-cellular-2',
+    label: t('product.aiReview.levels.intermediate'),
+  },
+  {
+    value: 'advanced',
+    icon: 'mdi-signal-cellular-3',
+    label: t('product.aiReview.levels.advanced'),
+  },
+])
+
 const createdDate = computed(() => {
   if (!createdMs.value) {
     return null
@@ -521,6 +636,32 @@ const statusMessage = computed(() => {
   })
 })
 
+const technicalContent = computed(() =>
+  selectReviewContent(technicalLevel.value, {
+    novice: reviewContent.value?.technicalReviewNovice,
+    intermediate: reviewContent.value?.technicalReviewIntermediate,
+    advanced: reviewContent.value?.technicalReviewAdvanced,
+    legacy: reviewContent.value?.technicalReview,
+  })
+)
+
+const ecologicalContent = computed(() =>
+  selectReviewContent(ecologicalLevel.value, {
+    novice: reviewContent.value?.ecologicalReviewNovice,
+    intermediate: reviewContent.value?.ecologicalReviewIntermediate,
+    advanced: reviewContent.value?.ecologicalReviewAdvanced,
+    legacy: reviewContent.value?.ecologicalReview,
+  })
+)
+
+const communityContent = computed(() =>
+  selectReviewContent(communityLevel.value, {
+    novice: reviewContent.value?.communityReviewNovice,
+    intermediate: reviewContent.value?.communityReviewIntermediate,
+    advanced: reviewContent.value?.communityReviewAdvanced,
+  })
+)
+
 function sanitizeHtml(content: string | null): string | null {
   if (!content) {
     return null
@@ -529,6 +670,39 @@ function sanitizeHtml(content: string | null): string | null {
   return DOMPurify.sanitize(content, {
     ADD_ATTR: ['target', 'rel', 'class'],
   })
+}
+
+function selectReviewContent(
+  level: ReviewLevel,
+  content: {
+    novice?: string | null
+    intermediate?: string | null
+    advanced?: string | null
+    legacy?: string | null
+  }
+): string | null {
+  const selected =
+    level === 'novice'
+      ? content.novice
+      : level === 'advanced'
+        ? content.advanced
+        : content.intermediate
+
+  if (selected) {
+    return selected
+  }
+
+  if (level === 'intermediate' && content.legacy) {
+    return content.legacy
+  }
+
+  return (
+    content.intermediate ??
+    content.legacy ??
+    content.novice ??
+    content.advanced ??
+    null
+  )
 }
 
 function normalizeReview(reviewData: AiReviewDto | null): ReviewContent | null {
@@ -587,7 +761,24 @@ function normalizeReview(reviewData: AiReviewDto | null): ReviewContent | null {
     mediumTitle: reviewData.mediumTitle ?? null,
     shortTitle: reviewData.shortTitle ?? null,
     technicalReview: sanitizeHtml(reviewData.technicalReview ?? null),
+    technicalReviewNovice: sanitizeHtml(reviewData.technicalReviewNovice ?? null),
+    technicalReviewIntermediate: sanitizeHtml(
+      reviewData.technicalReviewIntermediate ?? null
+    ),
+    technicalReviewAdvanced: sanitizeHtml(reviewData.technicalReviewAdvanced ?? null),
     ecologicalReview: sanitizeHtml(reviewData.ecologicalReview ?? null),
+    ecologicalReviewNovice: sanitizeHtml(reviewData.ecologicalReviewNovice ?? null),
+    ecologicalReviewIntermediate: sanitizeHtml(
+      reviewData.ecologicalReviewIntermediate ?? null
+    ),
+    ecologicalReviewAdvanced: sanitizeHtml(
+      reviewData.ecologicalReviewAdvanced ?? null
+    ),
+    communityReviewNovice: sanitizeHtml(reviewData.communityReviewNovice ?? null),
+    communityReviewIntermediate: sanitizeHtml(
+      reviewData.communityReviewIntermediate ?? null
+    ),
+    communityReviewAdvanced: sanitizeHtml(reviewData.communityReviewAdvanced ?? null),
     summary: sanitizeHtml(reviewData.summary ?? null),
     pros,
     cons,
@@ -852,6 +1043,14 @@ const handleReferenceClick = async (event: Event) => {
   gap: 0.75rem;
 }
 
+.product-ai-review__card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .product-ai-review__card-icon {
   display: inline-flex;
   align-items: center;
@@ -868,10 +1067,25 @@ const handleReferenceClick = async (event: Event) => {
   color: rgb(var(--v-theme-accent-supporting));
 }
 
+.product-ai-review__card-icon--community {
+  background: rgba(var(--v-theme-accent-primary-highlight), 0.15);
+  color: rgb(var(--v-theme-accent-primary-highlight));
+}
+
 .product-ai-review__card-title {
   font-size: 1.05rem;
   font-weight: 600;
   margin: 0;
+}
+
+.product-ai-review__level-toggle {
+  background: rgba(var(--v-theme-surface-primary-080), 0.7);
+  border-radius: 999px;
+  padding: 0.1rem;
+}
+
+.product-ai-review__level-toggle :deep(.v-btn) {
+  min-width: 2.25rem;
 }
 
 .product-ai-review__card-text {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2409,6 +2409,7 @@
       "sections": {
         "cons": "Cons",
         "details": "In detail",
+        "community": "Community analysis",
         "ecological": "Environmental analysis",
         "identity": "Identity card",
         "overall": "Overall summary",
@@ -2416,6 +2417,12 @@
         "sources": "Consulted sources",
         "sourcesCount": "{count} sources consulted",
         "technical": "Technical analysis"
+      },
+      "levels": {
+        "label": "Reading level",
+        "simple": "Simple",
+        "intermediate": "Intermediate",
+        "advanced": "Advanced"
       },
       "sources": {
         "description": "Description",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2424,6 +2424,7 @@
       "sections": {
         "cons": "Points faibles",
         "details": "En détail",
+        "community": "Analyse communautaire",
         "ecological": "Analyse écologique",
         "identity": "Fiche d'identité",
         "overall": "Résumé général",
@@ -2431,6 +2432,12 @@
         "sources": "Sources consultées",
         "sourcesCount": "{count} sources consultées",
         "technical": "Analyse technique"
+      },
+      "levels": {
+        "label": "Niveau de lecture",
+        "simple": "Simple",
+        "intermediate": "Intermédiaire",
+        "advanced": "Avancé"
       },
       "sources": {
         "description": "Description",


### PR DESCRIPTION
### Motivation

- Improve the AI "synthèse" mapping on the product page by exposing per-section reading-level controls so users can switch between simple / intermédiaire / avancé views. 
- Provide sensible fallbacks to existing legacy fields when level-specific content is not available while preserving the existing summary and pros/cons layout.
- Keep the hero AI oneline summaries behaviour unchanged (they already render as a list) while surfacing richer, levelled content inside the synthese section.

### Description

- Add per-section Vuetify `v-btn-toggle` controls for Technical, Ecological and Community cards in `ProductAiReviewSection.vue` and default each toggle to `intermediate`.
- Implement `ReviewLevel` type, three reactive level refs, `levelOptions` and `selectReviewContent()` logic plus computed `technicalContent`, `ecologicalContent` and `communityContent` that pick level-specific fields with legacy fallbacks.
- Extend `normalizeReview()` to hydrate novice/intermediate/advanced variants for technical, ecological and community reviews and sanitize HTML with existing DOMPurify usage.
- Add styling for the toggle and new community icon, update i18n in `en-US.json` and `fr-FR.json` for the new section and level labels, and update `ProductAiReviewSection.spec.ts` to stub `VBtnToggle`, provide level-specific test payloads and adjust expectations.

### Testing

- Ran `pnpm lint --offline` and it completed successfully with a single non-blocking eslint warning. 
- Ran `pnpm test --offline` which failed because the `vitest` CLI does not accept a `--offline` flag; running `pnpm test` exercised the suite and the updated `ProductAiReviewSection` component tests passed, but the full test run flagged unrelated failures in `ProductImpactDetailsTable` so the overall suite is red. 
- Ran `pnpm generate --offline` which completed successfully; the build emitted a PWA glob warning about a missing `**/_payload.json` pattern but the generate step finished.
- Updated files: `frontend/app/components/product/ProductAiReviewSection.vue`, `frontend/app/components/product/ProductAiReviewSection.spec.ts`, `frontend/i18n/locales/en-US.json`, and `frontend/i18n/locales/fr-FR.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738da597a4832b820cbcafd55aa265)