### PR TITLE
Improve product AI review UI, empty states and error handling

### DIFF
--- a/frontend/app/components/product/ProductAiReviewInsightBlock.vue
+++ b/frontend/app/components/product/ProductAiReviewInsightBlock.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-row
+    class="product-ai-review-insight"
+    :class="{ 'product-ai-review-insight--right': isRight }"
+  >
+    <v-col cols="12" md="4" class="product-ai-review-insight__media">
+      <div class="product-ai-review-insight__media-frame">
+        <v-img
+          :src="imageSrc"
+          :alt="imageAlt"
+          height="140"
+          width="100%"
+          contain
+        />
+      </div>
+    </v-col>
+    <v-col cols="12" md="8" class="product-ai-review-insight__content">
+      <!-- eslint-disable vue/no-v-html -->
+      <div class="product-ai-review__card-text" v-html="contentHtml" />
+      <!-- eslint-enable vue/no-v-html -->
+    </v-col>
+  </v-row>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps({
+  contentHtml: {
+    type: String,
+    default: '',
+  },
+  imageSrc: {
+    type: String,
+    required: true,
+  },
+  imageAlt: {
+    type: String,
+    default: '',
+  },
+  imagePosition: {
+    type: String as () => 'left' | 'right',
+    default: 'left',
+  },
+})
+
+const isRight = computed(() => props.imagePosition === 'right')
+</script>
+
+<style scoped>
+.product-ai-review-insight {
+  align-items: center;
+  row-gap: 1rem;
+}
+
+.product-ai-review-insight__media-frame {
+  border-radius: 16px;
+  background: rgba(var(--v-theme-surface-primary-050), 0.8);
+  padding: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.08);
+}
+
+.product-ai-review-insight__media :deep(img) {
+  object-fit: contain;
+}
+
+@media (min-width: 960px) {
+  .product-ai-review-insight--right .product-ai-review-insight__media {
+    order: 2;
+  }
+
+  .product-ai-review-insight--right .product-ai-review-insight__content {
+    order: 1;
+  }
+}
+</style>

--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -139,31 +139,39 @@
                       {{ $t('product.aiReview.sections.technical') }}
                     </h3>
                   </div>
-                  <v-btn-toggle
-                    v-model="technicalLevel"
-                    mandatory
-                    density="compact"
-                    class="product-ai-review__level-toggle"
-                    :aria-label="$t('product.aiReview.levels.label')"
-                  >
-                    <v-btn
-                      v-for="option in levelOptions"
-                      :key="option.value"
-                      :value="option.value"
-                      size="small"
-                      variant="tonal"
-                      :aria-label="option.label"
+                  <div class="product-ai-review__level-toggle-wrap">
+                    <v-btn-toggle
+                      v-model="technicalLevel"
+                      mandatory
+                      density="comfortable"
+                      class="product-ai-review__level-toggle"
+                      :aria-label="$t('product.aiReview.levels.label')"
                     >
-                      <v-icon :icon="option.icon" size="18" />
-                    </v-btn>
-                  </v-btn-toggle>
+                      <v-btn
+                        v-for="option in levelOptions"
+                        :key="option.value"
+                        :value="option.value"
+                        size="small"
+                        :variant="
+                          technicalLevel === option.value ? 'tonal' : 'outlined'
+                        "
+                        :color="
+                          technicalLevel === option.value
+                            ? 'primary'
+                            : 'secondary'
+                        "
+                        :aria-label="option.label"
+                      >
+                        <v-icon :icon="option.icon" size="18" />
+                      </v-btn>
+                    </v-btn-toggle>
+                  </div>
                 </header>
-                <!-- eslint-disable vue/no-v-html -->
-                <div
-                  class="product-ai-review__card-text"
-                  v-html="technicalContent"
+                <ProductAiReviewInsightBlock
+                  :content-html="technicalContent ?? ''"
+                  image-src="/images/product/ai-review-technical.svg"
+                  :image-alt="$t('product.aiReview.illustrations.technicalAlt')"
                 />
-                <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
             </v-card>
           </v-col>
@@ -182,31 +190,42 @@
                       {{ $t('product.aiReview.sections.ecological') }}
                     </h3>
                   </div>
-                  <v-btn-toggle
-                    v-model="ecologicalLevel"
-                    mandatory
-                    density="compact"
-                    class="product-ai-review__level-toggle"
-                    :aria-label="$t('product.aiReview.levels.label')"
-                  >
-                    <v-btn
-                      v-for="option in levelOptions"
-                      :key="option.value"
-                      :value="option.value"
-                      size="small"
-                      variant="tonal"
-                      :aria-label="option.label"
+                  <div class="product-ai-review__level-toggle-wrap">
+                    <v-btn-toggle
+                      v-model="ecologicalLevel"
+                      mandatory
+                      density="comfortable"
+                      class="product-ai-review__level-toggle"
+                      :aria-label="$t('product.aiReview.levels.label')"
                     >
-                      <v-icon :icon="option.icon" size="18" />
-                    </v-btn>
-                  </v-btn-toggle>
+                      <v-btn
+                        v-for="option in levelOptions"
+                        :key="option.value"
+                        :value="option.value"
+                        size="small"
+                        :variant="
+                          ecologicalLevel === option.value
+                            ? 'tonal'
+                            : 'outlined'
+                        "
+                        :color="
+                          ecologicalLevel === option.value
+                            ? 'primary'
+                            : 'secondary'
+                        "
+                        :aria-label="option.label"
+                      >
+                        <v-icon :icon="option.icon" size="18" />
+                      </v-btn>
+                    </v-btn-toggle>
+                  </div>
                 </header>
-                <!-- eslint-disable vue/no-v-html -->
-                <div
-                  class="product-ai-review__card-text"
-                  v-html="ecologicalContent"
+                <ProductAiReviewInsightBlock
+                  :content-html="ecologicalContent ?? ''"
+                  image-src="/images/product/ai-review-ecological.svg"
+                  :image-alt="$t('product.aiReview.illustrations.ecologicalAlt')"
+                  image-position="right"
                 />
-                <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
             </v-card>
           </v-col>
@@ -225,31 +244,41 @@
                       {{ $t('product.aiReview.sections.community') }}
                     </h3>
                   </div>
-                  <v-btn-toggle
-                    v-model="communityLevel"
-                    mandatory
-                    density="compact"
-                    class="product-ai-review__level-toggle"
-                    :aria-label="$t('product.aiReview.levels.label')"
-                  >
-                    <v-btn
-                      v-for="option in levelOptions"
-                      :key="option.value"
-                      :value="option.value"
-                      size="small"
-                      variant="tonal"
-                      :aria-label="option.label"
+                  <div class="product-ai-review__level-toggle-wrap">
+                    <v-btn-toggle
+                      v-model="communityLevel"
+                      mandatory
+                      density="comfortable"
+                      class="product-ai-review__level-toggle"
+                      :aria-label="$t('product.aiReview.levels.label')"
                     >
-                      <v-icon :icon="option.icon" size="18" />
-                    </v-btn>
-                  </v-btn-toggle>
+                      <v-btn
+                        v-for="option in levelOptions"
+                        :key="option.value"
+                        :value="option.value"
+                        size="small"
+                        :variant="
+                          communityLevel === option.value
+                            ? 'tonal'
+                            : 'outlined'
+                        "
+                        :color="
+                          communityLevel === option.value
+                            ? 'primary'
+                            : 'secondary'
+                        "
+                        :aria-label="option.label"
+                      >
+                        <v-icon :icon="option.icon" size="18" />
+                      </v-btn>
+                    </v-btn-toggle>
+                  </div>
                 </header>
-                <!-- eslint-disable vue/no-v-html -->
-                <div
-                  class="product-ai-review__card-text"
-                  v-html="communityContent"
+                <ProductAiReviewInsightBlock
+                  :content-html="communityContent ?? ''"
+                  image-src="/images/product/ai-review-community.svg"
+                  :image-alt="$t('product.aiReview.illustrations.communityAlt')"
                 />
-                <!-- eslint-enable vue/no-v-html -->
               </v-card-text>
             </v-card>
           </v-col>
@@ -286,7 +315,11 @@
               :key="source.number"
             >
               <td>
-                <a :href="source.url" target="_blank" rel="noopener">
+                <a
+                  :href="source.url"
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                >
                   [{{ source.number }}]
                 </a>
               </td>
@@ -304,7 +337,11 @@
                 </div>
               </td>
               <td>
-                <a :href="source.url" target="_blank" rel="noopener">
+                <a
+                  :href="source.url"
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                >
                   {{ source.description }}
                 </a>
               </td>
@@ -410,6 +447,7 @@ import { IpQuotaCategory } from '~~/shared/api-client'
 import { useAuth } from '~/composables/useAuth'
 import { useIpQuota } from '~/composables/useIpQuota'
 import { usePluralizedTranslation } from '~/composables/usePluralizedTranslation'
+import ProductAiReviewInsightBlock from '~/components/product/ProductAiReviewInsightBlock.vue'
 import ProductAiReviewRequestPanel from '~/components/product/ProductAiReviewRequestPanel.vue'
 
 interface ReviewContent {
@@ -1039,10 +1077,9 @@ const handleReferenceClick = async (event: Event) => {
 
 .product-ai-review__card-heading {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
+  flex-direction: column;
   gap: 0.75rem;
-  flex-wrap: wrap;
 }
 
 .product-ai-review__card-icon {
@@ -1072,10 +1109,16 @@ const handleReferenceClick = async (event: Event) => {
   margin: 0;
 }
 
+.product-ai-review__level-toggle-wrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
 .product-ai-review__level-toggle {
-  background: rgba(var(--v-theme-surface-primary-080), 0.7);
   border-radius: 999px;
-  padding: 0.1rem;
+  padding: 0.2rem;
+  gap: 0.35rem;
 }
 
 .product-ai-review__level-toggle :deep(.v-btn) {
@@ -1085,6 +1128,7 @@ const handleReferenceClick = async (event: Event) => {
 .product-ai-review__card-text {
   margin: 0;
   line-height: 1.65;
+  font-size: 1.2em;
   color: rgb(var(--v-theme-text-neutral-strong));
 }
 
@@ -1102,6 +1146,10 @@ const handleReferenceClick = async (event: Event) => {
   gap: 0.6rem;
   align-items: flex-start;
   color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-ai-review__list-item span {
+  font-size: 1.2em;
 }
 
 .product-ai-review__list-icon {

--- a/frontend/app/components/product/ProductAttributesSection.vue
+++ b/frontend/app/components/product/ProductAttributesSection.vue
@@ -60,12 +60,15 @@
               </div>
             </div>
 
-            <div v-if="identityModel" class="product-attributes__identity-row">
+            <div
+              v-if="identityModel || akaModels.length"
+              class="product-attributes__identity-row"
+            >
               <span class="product-attributes__identity-label">
                 {{ $t('product.attributes.main.identity.model') }}
               </span>
               <div class="product-attributes__identity-value">
-                <span>{{ identityModel }}</span>
+                <span v-if="identityModel">{{ identityModel }}</span>
                 <div
                   v-if="akaModels.length"
                   class="product-attributes__identity-details"
@@ -1525,6 +1528,8 @@ const toggleDetailGroup = (id: string) => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  align-items: center;
+  text-align: center;
 }
 
 .product-attributes__title {

--- a/frontend/app/components/product/ProductPriceSection.vue
+++ b/frontend/app/components/product/ProductPriceSection.vue
@@ -12,6 +12,14 @@
         <h3 class="product-price__subtitle-h3">
           {{ offersTitle }}
         </h3>
+        <v-alert
+          v-if="showNoOffersBanner"
+          type="info"
+          variant="tonal"
+          class="product-price__no-offers"
+        >
+          {{ $t('product.price.noOffersBanner') }}
+        </v-alert>
 
         <!-- Primary Best Offer Card -->
         <v-card
@@ -830,6 +838,10 @@ const allOffers = computed(() => {
   return list.sort((a, b) => (a.price ?? 0) - (b.price ?? 0))
 })
 
+const showNoOffersBanner = computed(
+  () => !allOffers.value.length && !bestNewOffer.value
+)
+
 const offersTitle = computed(() => {
   if (!allOffers.value.length) {
     return t('product.price.bestOffers', 'Les meilleures offres')
@@ -1318,6 +1330,11 @@ onBeforeUnmount(() => {
 
 .product-price__offers-table {
   border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12);
+}
+
+.product-price__no-offers {
+  margin-top: 1rem;
+  border-radius: 16px;
 }
 
 .product-price__charts {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2396,6 +2396,11 @@
     "partners_link": "our partners",
     "aiReview": {
       "empty": "Summary not requested yet.",
+      "illustrations": {
+        "technicalAlt": "Illustration of the technical analysis",
+        "ecologicalAlt": "Illustration of the environmental analysis",
+        "communityAlt": "Illustration of the community analysis"
+      },
       "errors": {
         "captcha": "Please validate the captcha before continuing.",
         "generic": "An error occurred while generating the summary.",
@@ -2830,6 +2835,7 @@
         "unknown": "Unknown",
         "used": "Second-hand"
       },
+      "noOffersBanner": "No offers available right now!",
       "headers": {
         "condition": "Condition",
         "offer": "Offer",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2411,6 +2411,11 @@
     "partners_link": "nos partenaires",
     "aiReview": {
       "empty": "Synthèse non encore demandée.",
+      "illustrations": {
+        "technicalAlt": "Illustration de l'analyse technique",
+        "ecologicalAlt": "Illustration de l'analyse écologique",
+        "communityAlt": "Illustration de l'analyse communautaire"
+      },
       "errors": {
         "captcha": "Merci de valider le captcha avant de continuer.",
         "generic": "Une erreur est survenue lors de la génération.",
@@ -2848,6 +2853,7 @@
         "unknown": "Inconnu",
         "used": "Occasion"
       },
+      "noOffersBanner": "Pas d'offres actuellement !",
       "headers": {
         "condition": "État",
         "offer": "Offre",

--- a/frontend/public/images/product/ai-review-community.svg
+++ b/frontend/public/images/product/ai-review-community.svg
@@ -1,0 +1,9 @@
+<svg width="240" height="180" viewBox="0 0 240 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="18" width="208" height="144" rx="20" fill="#E8F1FB"/>
+  <circle cx="84" cy="86" r="20" fill="#C6DDF4"/>
+  <circle cx="156" cy="86" r="20" fill="#C6DDF4"/>
+  <circle cx="120" cy="72" r="24" fill="#2196F3"/>
+  <path d="M56 134C60 114 74 104 94 102" stroke="#1976D2" stroke-width="5" stroke-linecap="round"/>
+  <path d="M184 134C180 114 166 104 146 102" stroke="#1976D2" stroke-width="5" stroke-linecap="round"/>
+  <path d="M96 128C100 108 110 96 120 96C130 96 140 108 144 128" stroke="#1976D2" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/images/product/ai-review-ecological.svg
+++ b/frontend/public/images/product/ai-review-ecological.svg
@@ -1,0 +1,9 @@
+<svg width="240" height="180" viewBox="0 0 240 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="18" width="208" height="144" rx="20" fill="#E8F1FB"/>
+  <path d="M72 122C72 92 96 64 128 58C128 98 102 132 72 122Z" fill="#4CAF50"/>
+  <path d="M128 58C158 60 182 84 188 114C156 118 132 92 128 58Z" fill="#22C55E"/>
+  <path d="M98 120C102 96 118 82 138 74" stroke="#166534" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="176" cy="66" r="16" fill="#C6DDF4"/>
+  <path d="M168 66H184" stroke="#1976D2" stroke-width="4" stroke-linecap="round"/>
+  <path d="M176 58V74" stroke="#1976D2" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/frontend/public/images/product/ai-review-technical.svg
+++ b/frontend/public/images/product/ai-review-technical.svg
@@ -1,0 +1,10 @@
+<svg width="240" height="180" viewBox="0 0 240 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="18" width="208" height="144" rx="20" fill="#E8F1FB"/>
+  <rect x="36" y="42" width="168" height="96" rx="14" fill="#FFFFFF"/>
+  <circle cx="80" cy="90" r="24" fill="#C6DDF4"/>
+  <path d="M80 72V108" stroke="#1976D2" stroke-width="6" stroke-linecap="round"/>
+  <path d="M62 90H98" stroke="#1976D2" stroke-width="6" stroke-linecap="round"/>
+  <rect x="120" y="70" width="68" height="12" rx="6" fill="#C6DDF4"/>
+  <rect x="120" y="94" width="48" height="12" rx="6" fill="#E3EFFA"/>
+  <rect x="120" y="118" width="56" height="12" rx="6" fill="#E3EFFA"/>
+</svg>


### PR DESCRIPTION
### Motivation
- Improve the AI review cards UX by introducing a reusable media+text insight block and clearer level controls.  
- Surface clearer empty states when there are no offers and ensure identity/aka model details render correctly.  
- Harden alternatives fetch error handling and add small accessibility / safety improvements for external links.  

### Description
- Add a new reusable component `ProductAiReviewInsightBlock.vue` and wire it into the technical, ecological and community sections of `ProductAiReviewSection.vue`, replacing raw `v-html` blocks.  
- Update level toggle styling to use a centered `v-btn-toggle` wrapper and switch buttons between `tonal` and `outlined` with color changes based on selection, and increase body/list font sizing for the review cards.  
- Add three SVG illustrations for the insight block (`ai-review-technical.svg`, `ai-review-ecological.svg`, `ai-review-community.svg`) and new i18n keys in `en-US.json` and `fr-FR.json` for illustration alt texts and a `product.price.noOffersBanner` string.  
- Surface a no-offers `v-alert` in `ProductPriceSection.vue` controlled by `showNoOffersBanner`, and make the attributes header centered while rendering `akaModels` even if `identityModel` is missing in `ProductAttributesSection.vue`.  
- Harden `ProductAlternatives.vue` error handling by importing `FetchError`, adding `resolveFetchErrorStatus`/`resolveFetchErrorMessage`, richer `console.error` context and returning status-aware user messages.  
- Make external source links in the review sources use `rel="noopener noreferrer nofollow"` for safety/SEO and update related CSS tweaks.  

### Testing
- Ran lint with `pnpm lint` and the checks passed (including the project-specific `lint-forbidden` script).  
- Ran the unit test suite with `pnpm test` (Vitest) and all tests passed: 394 tests across the frontend server and components completed successfully, although the run emitted existing Vue / i18n warnings.  
- Built a production static build with `pnpm generate` which completed successfully (Nuxt build + prerender) and reported a non-critical glob warning about `**/_payload.json`.  
- Attempted a Playwright screenshot to validate the rendered page, but Chromium crashed in the container so no screenshot is available; this does not affect the automated test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973d43cbbec832bb41adbb2cc8a53d2)