### PR TITLE
Update product page AI review layout and baseline

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -113,15 +113,43 @@
           :id="sectionIds.ai"
           class="product-page__section"
         >
-          <ProductAiReviewSection
-            :gtin="product.gtin ?? gtin"
-            :initial-review="product.aiReview?.review ?? null"
-            :review-created-at="product.aiReview?.createdMs ?? undefined"
-            :site-key="hcaptchaSiteKey"
-            :title-params="aiTitleParams"
-            :product-name="productTitle"
-            :product-image="resolvedProductImageSource"
-          />
+          <v-row class="product-page__ai-review-row">
+            <v-col cols="12" :md="aiReviewDataQuality ? 8 : 12">
+              <ProductAiReviewSection
+                :gtin="product.gtin ?? gtin"
+                :initial-review="product.aiReview?.review ?? null"
+                :review-created-at="product.aiReview?.createdMs ?? undefined"
+                :site-key="hcaptchaSiteKey"
+                :title-params="aiTitleParams"
+                :product-name="productTitle"
+                :product-image="resolvedProductImageSource"
+              />
+            </v-col>
+            <v-col v-if="aiReviewDataQuality" cols="12" md="4">
+              <v-card class="product-page__ai-review-quality" elevation="0">
+                <v-card-text>
+                  <header
+                    class="product-page__ai-review-quality-header d-flex align-center mb-3"
+                  >
+                    <v-icon
+                      icon="mdi-shield-check-outline"
+                      size="22"
+                      class="mr-2"
+                    />
+                    <h3 class="text-subtitle-1 font-weight-bold">
+                      {{ $t('product.aiReview.dataQuality.title') }}
+                    </h3>
+                  </header>
+                  <p class="text-body-2 mb-4">
+                    {{ $t('product.aiReview.dataQuality.description') }}
+                  </p>
+                  <div class="product-page__ai-review-quality-value">
+                    {{ aiReviewDataQuality }}
+                  </div>
+                </v-card-text>
+              </v-card>
+            </v-col>
+          </v-row>
         </section>
 
         <section :id="sectionIds.price" class="product-page__section">
@@ -1704,6 +1732,10 @@ const showAlternativesSection = computed(() =>
 const alternativesHydrated = ref(false)
 const hasAlternatives = ref(true)
 const showAiReviewSection = computed(() => Boolean(categoryDetail.value))
+const aiReviewDataQuality = computed(() => {
+  const value = product.value?.aiReview?.review?.dataQuality
+  return typeof value === 'string' ? value.trim() : ''
+})
 
 const sectionIds = {
   hero: 'hero',
@@ -2293,7 +2325,37 @@ useHead(() => {
 
 <style scoped>
 .product-page {
+  position: relative;
   padding: 2rem 0;
+}
+
+.product-page::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      90deg,
+      rgba(var(--v-theme-hero-overlay-strong), 0.95) 0%,
+      rgba(var(--v-theme-hero-overlay-strong), 0) 60%
+    ),
+    linear-gradient(
+      0deg,
+      rgba(var(--v-theme-hero-overlay-strong), 0.9) 0%,
+      rgba(var(--v-theme-hero-overlay-strong), 0) 55%
+    ),
+    linear-gradient(
+      135deg,
+      rgba(var(--v-theme-hero-gradient-start), 0.18),
+      rgba(var(--v-theme-hero-gradient-end), 0.2)
+    );
+}
+
+.product-page > * {
+  position: relative;
+  z-index: 1;
 }
 
 .product-page__layout {
@@ -2324,6 +2386,33 @@ useHead(() => {
 
 .product-page__section {
   scroll-margin-top: 108px; /* Match sticky nav + banner */
+}
+
+.product-page__ai-review-row {
+  margin: 0;
+}
+
+.product-page__ai-review-quality {
+  border-radius: 24px;
+  background: rgba(var(--v-theme-surface-glass-strong), 0.92);
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.35);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  position: sticky;
+  top: 124px;
+}
+
+.product-page__ai-review-quality-header {
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-page__ai-review-quality-value {
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-surface-primary-080), 0.95);
+  color: rgb(var(--v-theme-text-neutral-strong));
+  font-weight: 600;
+  text-transform: none;
+  width: fit-content;
 }
 
 .product-page__hero {
@@ -2387,6 +2476,10 @@ useHead(() => {
 
   .product-page__section {
     scroll-margin-top: 140px;
+  }
+
+  .product-page__ai-review-quality {
+    position: static;
   }
 }
 

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -24,6 +24,14 @@
           v-bind="heroBreadcrumbProps"
           class="product-hero__breadcrumbs text-center"
         />
+        <v-fade-transition>
+          <p
+            v-if="aiBaseline"
+            class="product-hero__baseline text-center"
+          >
+            {{ aiBaseline }}
+          </p>
+        </v-fade-transition>
       </header>
 
       <div class="product-hero__grid">
@@ -320,6 +328,11 @@ const ecologicalOnelineHtml = computed(() =>
 const communityOnelineHtml = computed(() =>
   sanitizeAiReviewHtml(aiReview.value?.communityOneline ?? null)
 )
+const aiBaseline = computed(() => {
+  const baseline = (aiReview.value as { baseLine?: string | null } | null)
+    ?.baseLine
+  return typeof baseline === 'string' ? baseline.trim() : ''
+})
 
 const handleAiReviewClick = () => {
   const element =
@@ -750,6 +763,26 @@ const gtinCountry = computed(() => {
   width: fit-content;
   max-width: 100%;
   margin-inline: auto;
+}
+
+.product-hero__baseline {
+  margin: 0.6rem auto 0;
+  max-width: 680px;
+  font-size: 1rem;
+  font-weight: 500;
+  color: rgba(var(--v-theme-text-neutral-strong), 0.9);
+  animation: baselineFadeIn 0.6s ease 0.2s both;
+}
+
+@keyframes baselineFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .product-hero__grid {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2407,6 +2407,10 @@
         "notEnoughData": "Not enough reliable data was found to generate a summary."
       },
       "generatedAt": "Summary generated on {date}",
+      "dataQuality": {
+        "title": "Data quality",
+        "description": "Assessment of the reliability and completeness of the sources used for this AI summary."
+      },
       "requestButton": "Request the summary",
       "request": {
         "agreement": "I authorize Nudger to research and summarize information about {productName}. In a spirit of sobriety and sharing, I also agree that this data can be shared with all Nudger users.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2422,6 +2422,10 @@
         "notEnoughData": "Pas assez de données fiables pour générer une synthèse."
       },
       "generatedAt": "Synthèse générée le {date}",
+      "dataQuality": {
+        "title": "Qualité des données",
+        "description": "Évaluation de la fiabilité et de la complétude des sources utilisées pour cette synthèse IA."
+      },
       "requestButton": "Demander la synthèse",
       "request": {
         "agreement": "Je mandate Nudger pour rechercher et synthétiser les informations du {productName}. Dans une logique de sobriété et de partage, j'accepte également que ces données soient partagées à tous les utilisateurs de Nudger.",


### PR DESCRIPTION
### Motivation
- Surface AI review metadata (data quality) prominently and improve the readability of AI-generated baseline copy in the product hero. 
- Improve layout responsiveness by splitting the AI review area into main content and an optional side card. 
- Provide localized labels for the new data-quality UI to keep translations consistent.

### Description
- Split the AI review section into an 8/4 responsive layout and add a styled `product-page__ai-review-quality` side card showing `dataQuality` when present, implemented in `frontend/app/components/pages/ProductPage.vue`.
- Added a computed `aiReviewDataQuality` value in the product page to read `product.aiReview.review.dataQuality` and conditionally render the side card in the layout.
- Added an AI baseline line under the hero breadcrumbs with a delayed fade-in and computed `aiBaseline` extraction in `frontend/app/components/product/ProductHero.vue` and corresponding styles.
- Extended the product page background with a full-viewport gradient overlay and added scoped styles for the new elements and responsive behavior in `ProductPage.vue` and `ProductHero.vue`.
- Added localized strings for the data quality panel in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm test` and the test suite completed with all tests passing (`399` tests passed), although the run included existing Vue/i18n warnings and build-time warnings about duplicate object keys reported by the toolchain.
- Ran `pnpm generate` which built the application successfully (client and server builds completed) with existing warnings about PWA glob patterns; generation finished without fatal errors.
- Attempted to capture a Playwright screenshot of the rendered product page, but the Chromium process crashed (TargetClosedError / SIGSEGV) so no screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f3e4fa94832ba953840bcb89cfb3)