### PR TITLE
Refine impact subscore components: explanation layout, chart normalization, i18n & tests

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.spec.ts
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
 import ProductImpactSubscoreExplanation from './ProductImpactSubscoreExplanation.vue'
 import type { ScoreView } from './impact-types'
 import enUS from '../../../../../i18n/locales/en-US.json'
@@ -13,6 +14,26 @@ describe('ProductImpactSubscoreExplanation', () => {
       'en-US': enUS,
     },
   })
+
+  const VIconStub = defineComponent({
+    name: 'VIconStub',
+    props: ['icon'],
+    setup(props) {
+      return () =>
+        h(
+          'span',
+          { class: 'v-icon-stub', 'data-icon': props.icon },
+          props.icon
+        )
+    },
+  })
+
+  const globalOptions = {
+    plugins: [i18n],
+    stubs: {
+      VIcon: VIconStub,
+    },
+  }
 
   // Mock global Nudger objects if needed, or just rely on i18n
   // The component imports 'useI18n' from 'vue-i18n'
@@ -53,9 +74,7 @@ describe('ProductImpactSubscoreExplanation', () => {
   it('renders the explanation title', () => {
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: defaultProps,
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
     expect(wrapper.text()).toContain('How to read this indicator')
   })
@@ -63,9 +82,7 @@ describe('ProductImpactSubscoreExplanation', () => {
   it('displays the average as a pivot score of 10/20 (Sigma scoring)', () => {
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: defaultProps,
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     // Check for the updated text structure
@@ -76,9 +93,7 @@ describe('ProductImpactSubscoreExplanation', () => {
   it('displays the product score on 20 scale using the provided on20 value', () => {
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: defaultProps,
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     const text = wrapper.text()
@@ -90,9 +105,7 @@ describe('ProductImpactSubscoreExplanation', () => {
   it('displays min and max values without claiming they are 0/20 or 20/20', () => {
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: defaultProps,
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     const text = wrapper.text()
@@ -117,9 +130,7 @@ describe('ProductImpactSubscoreExplanation', () => {
 
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: { ...defaultProps, score: scoreLower },
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     const text = wrapper.text()
@@ -137,9 +148,7 @@ describe('ProductImpactSubscoreExplanation', () => {
 
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: { ...defaultProps, score: scoreWithUnit },
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     const text = wrapper.text()
@@ -159,12 +168,10 @@ describe('ProductImpactSubscoreExplanation', () => {
 
     const wrapper = mount(ProductImpactSubscoreExplanation, {
       props: { ...defaultProps, score: scoreWithSigma },
-      global: {
-        plugins: [i18n],
-      },
+      global: globalOptions,
     })
 
     const text = wrapper.text()
-    expect(text).toContain('standard deviation (1.5W)')
+    expect(text).toContain('Standard deviation (1.5W)')
   })
 })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -12,6 +12,18 @@ const VChipStub = defineComponent({
     return () => h('span', { class: 'v-chip-stub' }, slots.default?.())
   },
 })
+const VIconStub = defineComponent({
+  name: 'VIconStub',
+  props: ['icon'],
+  setup(props) {
+    return () =>
+      h(
+        'span',
+        { class: 'v-icon-stub', 'data-icon': props.icon },
+        props.icon
+      )
+  },
+})
 
 describe('ProductImpactSubscoreGenericCard', () => {
   // ... existing i18n setup ...
@@ -117,6 +129,8 @@ describe('ProductImpactSubscoreGenericCard', () => {
         plugins: [i18n],
         stubs: {
           ProductImpactSubscoreChart: true,
+          VChip: VChipStub,
+          VIcon: VIconStub,
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
             props: [
@@ -178,6 +192,8 @@ describe('ProductImpactSubscoreGenericCard', () => {
         plugins: [i18n],
         stubs: {
           ProductImpactSubscoreChart: true,
+          VChip: VChipStub,
+          VIcon: VIconStub,
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
             props: [
@@ -228,9 +244,10 @@ describe('ProductImpactSubscoreGenericCard', () => {
         plugins: [i18n],
         stubs: {
           ProductImpactSubscoreChart: true,
+          VChip: VChipStub,
+          VIcon: VIconStub,
           ImpactCoefficientBadge: true,
           ClientOnly: true,
-          'v-chip': VChipStub,
         },
       },
     })

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -6,7 +6,7 @@
       :lifecycle="score.participateInACV ?? []"
     />
 
-    <div class="impact-subscore__value">
+    <div class="impact-subscore__value mt-8">
       <div class="impact-subscore__value-primary">
         <slot
           name="visual"

--- a/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreHeader.vue
@@ -3,18 +3,18 @@
     <div class="impact-subscore-header__info">
       <h4 class="impact-subscore-header__title">
         {{ title }}
-        <div v-if="lifecycle?.length" class="impact-subscore-header__chips">
-          <v-chip
-            v-for="stage in lifecycle"
-            :key="stage"
-            :color="lifecycleColors[stage] ?? 'surface-ice-100'"
-            size="x-small"
-            variant="tonal"
-          >
-            {{ lifecycleLabels[stage] ?? stage }}
-          </v-chip>
-        </div>
       </h4>
+      <div v-if="lifecycle?.length" class="impact-subscore-header__chips">
+        <v-chip
+          v-for="stage in lifecycle"
+          :key="stage"
+          :color="lifecycleColors[stage] ?? 'surface-ice-100'"
+          size="x-small"
+          variant="tonal"
+        >
+          {{ lifecycleLabels[stage] ?? stage }}
+        </v-chip>
+      </div>
       <p v-if="subtitle" class="impact-subscore-header__subtitle">
         {{ subtitle }}
       </p>
@@ -83,10 +83,6 @@ const lifecycleColors: Record<string, string> = {
 }
 
 .impact-subscore-header__title {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2703,6 +2703,7 @@
       "subscoreChart": {
         "markerAverage": "Average for {scoreLabel} sits here.",
         "markerProduct": "{productName} sits here.",
+        "title": "Criteria distribution",
         "toggleAbsolute": "Values",
         "toggleNormalized": "Scores",
         "unknownProduct": "This product"
@@ -2739,6 +2740,34 @@
               "fixed_mapping": "The score follows a fixed mapping defined in configuration.",
               "binary": "The score is binary based on a threshold.",
               "constant": "The score is set to a constant value defined in configuration."
+            }
+          },
+          "statisticalMethod": {
+            "title": "Statistical method",
+            "sigma": {
+              "bounds": "Normalization spans [{sigmaLower}{unit} ; {sigmaUpper}{unit}] based on {sigmaK}σ around the mean.",
+              "scoring": "The score is computed by comparing the value with the ±{sigmaK}σ bounds around the mean.",
+              "distribution": "Standard deviation ({sigma}{unit}) is used so extreme values do not overshadow common products."
+            },
+            "percentile": {
+              "scoring": "The score is derived from the percentile rank within the distribution.",
+              "value": "This product sits around the {percentile}th percentile."
+            },
+            "minmax_fixed": {
+              "scoring": "The score is scaled between the fixed bounds [{fixedMin}{unit} ; {fixedMax}{unit}]."
+            },
+            "minmax_quantile": {
+              "scoring": "The score is scaled using quantile bounds [{quantileLow}{unit} ; {quantileHigh}{unit}] to limit outliers."
+            },
+            "fixed_mapping": {
+              "scoring": "The score follows a fixed mapping defined in configuration."
+            },
+            "binary": {
+              "scoring_greater": "The score is set to {scaleMax} when the value is ≥ {threshold}{unit}, otherwise {scaleMin}.",
+              "scoring_lower": "The score is set to {scaleMax} when the value is ≤ {threshold}{unit}, otherwise {scaleMin}."
+            },
+            "constant": {
+              "scoring": "The score is fixed at {constantValue} regardless of the value."
             }
           }
         },

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2721,6 +2721,7 @@
       "subscoreChart": {
         "markerAverage": "La moyenne de {scoreLabel} se positionne ici.",
         "markerProduct": "{productName} se positionne ici.",
+        "title": "Répartition des critères",
         "toggleAbsolute": "Valeurs",
         "toggleNormalized": "Scores",
         "unknownProduct": "Ce produit"
@@ -2757,6 +2758,34 @@
               "fixed_mapping": "La note suit un barème fixe défini dans la configuration.",
               "binary": "La note est binaire selon un seuil défini.",
               "constant": "La note est fixée à une valeur constante définie par la configuration."
+            }
+          },
+          "statisticalMethod": {
+            "title": "Méthode statistique",
+            "sigma": {
+              "bounds": "La normalisation couvre l’intervalle [{sigmaLower}{unit} ; {sigmaUpper}{unit}] basé sur {sigmaK}σ autour de la moyenne.",
+              "scoring": "La note est calculée en comparant la valeur aux bornes ±{sigmaK}σ autour de la moyenne.",
+              "distribution": "La notation utilise l'écart-type ({sigma}{unit}) pour s'assurer que les valeurs extrêmes n'écrasent pas les différences entre produits courants."
+            },
+            "percentile": {
+              "scoring": "La note est calculée à partir du rang percentile dans la distribution.",
+              "value": "Ce produit se situe autour du {percentile}ᵉ percentile."
+            },
+            "minmax_fixed": {
+              "scoring": "La note est ramenée à une échelle commune via les bornes fixes [{fixedMin}{unit} ; {fixedMax}{unit}]."
+            },
+            "minmax_quantile": {
+              "scoring": "La note est calculée via des bornes par quantiles [{quantileLow}{unit} ; {quantileHigh}{unit}] pour limiter l'effet des valeurs extrêmes."
+            },
+            "fixed_mapping": {
+              "scoring": "La note suit un barème fixe défini dans la configuration."
+            },
+            "binary": {
+              "scoring_greater": "La note est fixée à {scaleMax} lorsque la valeur est ≥ {threshold}{unit}, sinon {scaleMin}.",
+              "scoring_lower": "La note est fixée à {scaleMax} lorsque la valeur est ≤ {threshold}{unit}, sinon {scaleMin}."
+            },
+            "constant": {
+              "scoring": "La note est fixée à {constantValue} quelle que soit la valeur."
             }
           }
         },


### PR DESCRIPTION
### Motivation
- Improve the readability and structure of the impact subscore UI by moving lifecycle chips, removing card-style blocks for explanation content, and making highlights more scannable.  
- Extend chart normalization support to better represent distributions (add percentile / quantile handling) and provide a clear chart title.  
- Surface the statistical method used to compute normalized scores and ensure translations and tests reflect the new UI and behaviour.

### Description
- Reworked `ProductImpactSubscoreExplanation.vue` to remove card styling, split content into semantic sections, add a bullet-list of highlights, and add a statistical method section with computed translation items and parameters.  
- Enhanced `ProductImpactSubscoreChart.vue` to add a chart title, introduce `normalizationMethod` handling, and implement `PERCENTILE` and `MINMAX_QUANTILE` support in normalization availability, normalization function, and building of the normalized distribution.  
- Adjusted `ProductImpactSubscoreHeader.vue` and `ProductImpactSubscoreGenericCard.vue` to move lifecycle chips under the title and add spacing before the attribute value block.  
- Added/updated i18n strings in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` for the chart title and statistical method explanations, and updated component tests (`*.spec.ts`) to stub Vuetify icons (`VIcon`) and chips as needed.

### Testing
- Ran lint and unit tests with `pnpm --offline lint` and `pnpm --offline test`, both completed successfully.  
- Built the static site with `pnpm --offline generate`, which completed and produced the `.output/public` but emitted warnings about duplicate object keys in existing files and an unmatched glob pattern; the build itself succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697401795398832b93dc99a44262c7b7)