### PR TITLE
Add Google Indexing queue/service and simplify AI review request UI

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -42,6 +42,34 @@ Requests are limited using an in-memory token bucket. Defaults can be changed in
 
 When limits are exceeded the API responds with HTTP `429 Too Many Requests`.
 
+## Google Indexing integration
+
+The front API can submit product review URLs to the Google Indexing API after
+AI review generation completes. The integration is disabled by default and
+relies on a Google service account with the Indexing API enabled.
+
+Configure the credentials and queue behavior in `application.yml`:
+
+```yaml
+front:
+  google-indexing:
+    enabled: true
+    site-base-url: https://nudger.fr
+    service-account-json: ${FRONT_GOOGLE_INDEXING_SERVICE_ACCOUNT_JSON:}
+    # Alternative: service-account-path: /path/to/service-account.json
+    batch-size: 50
+    retry-delay: 30m
+```
+
+Required credentials:
+
+- `FRONT_GOOGLE_INDEXING_SERVICE_ACCOUNT_JSON` – the JSON service account payload
+  (paste the full JSON).
+- `FRONT_GOOGLE_INDEXING_SITE_BASE_URL` – public base URL used to build product URLs.
+
+The integration runs every 30 minutes and can also push immediately when new
+URLs are enqueued if `realtime-enabled` is set to `true`.
+
 ## API documentation
 
 Access to the Swagger UI (`/swagger-ui.html`) and the raw OpenAPI specification

--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -147,6 +147,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-mail</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.29.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/GoogleIndexingConfig.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/GoogleIndexingConfig.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.config;
+
+import java.time.Clock;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration for Google Indexing support.
+ */
+@Configuration
+public class GoogleIndexingConfig {
+
+    /**
+     * Provide a shared UTC clock for Google indexing components.
+     *
+     * @return UTC clock instance
+     */
+    @Bean
+    public Clock googleIndexingClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GoogleIndexingProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GoogleIndexingProperties.java
@@ -1,0 +1,319 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.time.Duration;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Configuration properties for the Google Indexing API integration.
+ */
+@Validated
+@ConfigurationProperties(prefix = "front.google-indexing")
+public class GoogleIndexingProperties {
+
+    /**
+     * Toggle Google Indexing API integration.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Public base URL of the Nuxt frontend used to build canonical product URLs.
+     */
+    @NotBlank(message = "front.google-indexing.site-base-url must be provided")
+    private String siteBaseUrl = "https://nudger.fr";
+
+    /**
+     * Endpoint used to publish URL notifications.
+     */
+    private String apiEndpoint = "https://indexing.googleapis.com/v3/urlNotifications:publish";
+
+    /**
+     * Service account JSON payload used to authenticate with Google APIs.
+     */
+    private String serviceAccountJson;
+
+    /**
+     * Path to a service account JSON file used to authenticate with Google APIs.
+     */
+    private String serviceAccountPath;
+
+    /**
+     * Maximum number of URLs processed per batch execution.
+     */
+    @Positive
+    private int batchSize = 50;
+
+    /**
+     * Duration to wait before retrying a failed URL.
+     */
+    private Duration retryDelay = Duration.ofMinutes(30);
+
+    /**
+     * Maximum number of retry attempts before discarding a URL.
+     */
+    @Positive
+    private int maxAttempts = 5;
+
+    /**
+     * Enable immediate processing when a URL is enqueued.
+     */
+    private boolean realtimeEnabled = true;
+
+    /**
+     * Retention window for indexed and failed URLs history.
+     */
+    private Duration historyRetention = Duration.ofDays(7);
+
+    /**
+     * Maximum queue size before the health indicator reports a degraded status.
+     */
+    @Positive
+    private int maxQueueSize = 500;
+
+    /**
+     * Maximum age for the last successful indexing event before health degrades.
+     */
+    private Duration maxSuccessAge = Duration.ofDays(7);
+
+    /**
+     * File name used to persist pending queue entries on disk.
+     */
+    private String queueFileName = "google-indexing-queue.json";
+
+    /**
+     * Return whether Google Indexing integration is enabled.
+     *
+     * @return {@code true} when indexing is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enable or disable Google Indexing integration.
+     *
+     * @param enabled flag to enable indexing
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Return the public base URL of the Nuxt frontend.
+     *
+     * @return base URL used to build canonical URLs
+     */
+    public String getSiteBaseUrl() {
+        return siteBaseUrl;
+    }
+
+    /**
+     * Define the public base URL of the Nuxt frontend.
+     *
+     * @param siteBaseUrl base URL used to build canonical URLs
+     */
+    public void setSiteBaseUrl(String siteBaseUrl) {
+        this.siteBaseUrl = siteBaseUrl;
+    }
+
+    /**
+     * Return the Google Indexing API endpoint.
+     *
+     * @return API endpoint URL
+     */
+    public String getApiEndpoint() {
+        return apiEndpoint;
+    }
+
+    /**
+     * Define the Google Indexing API endpoint.
+     *
+     * @param apiEndpoint endpoint URL
+     */
+    public void setApiEndpoint(String apiEndpoint) {
+        this.apiEndpoint = apiEndpoint;
+    }
+
+    /**
+     * Return the service account JSON payload.
+     *
+     * @return JSON payload
+     */
+    public String getServiceAccountJson() {
+        return serviceAccountJson;
+    }
+
+    /**
+     * Define the service account JSON payload.
+     *
+     * @param serviceAccountJson JSON payload
+     */
+    public void setServiceAccountJson(String serviceAccountJson) {
+        this.serviceAccountJson = serviceAccountJson;
+    }
+
+    /**
+     * Return the path to the service account JSON file.
+     *
+     * @return JSON file path
+     */
+    public String getServiceAccountPath() {
+        return serviceAccountPath;
+    }
+
+    /**
+     * Define the path to the service account JSON file.
+     *
+     * @param serviceAccountPath JSON file path
+     */
+    public void setServiceAccountPath(String serviceAccountPath) {
+        this.serviceAccountPath = serviceAccountPath;
+    }
+
+    /**
+     * Return the batch size for submissions.
+     *
+     * @return batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Define the batch size for submissions.
+     *
+     * @param batchSize batch size
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Return the retry delay for failed submissions.
+     *
+     * @return retry delay
+     */
+    public Duration getRetryDelay() {
+        return retryDelay;
+    }
+
+    /**
+     * Define the retry delay for failed submissions.
+     *
+     * @param retryDelay retry delay
+     */
+    public void setRetryDelay(Duration retryDelay) {
+        this.retryDelay = retryDelay;
+    }
+
+    /**
+     * Return the maximum number of retry attempts.
+     *
+     * @return max attempts
+     */
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Define the maximum number of retry attempts.
+     *
+     * @param maxAttempts max attempts
+     */
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    /**
+     * Return whether realtime processing is enabled.
+     *
+     * @return realtime enabled flag
+     */
+    public boolean isRealtimeEnabled() {
+        return realtimeEnabled;
+    }
+
+    /**
+     * Define whether realtime processing is enabled.
+     *
+     * @param realtimeEnabled flag enabling realtime processing
+     */
+    public void setRealtimeEnabled(boolean realtimeEnabled) {
+        this.realtimeEnabled = realtimeEnabled;
+    }
+
+    /**
+     * Return the retention duration for indexing history.
+     *
+     * @return retention duration
+     */
+    public Duration getHistoryRetention() {
+        return historyRetention;
+    }
+
+    /**
+     * Define the retention duration for indexing history.
+     *
+     * @param historyRetention retention duration
+     */
+    public void setHistoryRetention(Duration historyRetention) {
+        this.historyRetention = historyRetention;
+    }
+
+    /**
+     * Return the maximum queue size tolerated by the health indicator.
+     *
+     * @return queue size limit
+     */
+    public int getMaxQueueSize() {
+        return maxQueueSize;
+    }
+
+    /**
+     * Define the maximum queue size tolerated by the health indicator.
+     *
+     * @param maxQueueSize queue size limit
+     */
+    public void setMaxQueueSize(int maxQueueSize) {
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    /**
+     * Return the maximum allowed age for the last success.
+     *
+     * @return max success age
+     */
+    public Duration getMaxSuccessAge() {
+        return maxSuccessAge;
+    }
+
+    /**
+     * Define the maximum allowed age for the last success.
+     *
+     * @param maxSuccessAge max success age
+     */
+    public void setMaxSuccessAge(Duration maxSuccessAge) {
+        this.maxSuccessAge = maxSuccessAge;
+    }
+
+    /**
+     * Return the queue file name used for persistence.
+     *
+     * @return queue file name
+     */
+    public String getQueueFileName() {
+        return queueFileName;
+    }
+
+    /**
+     * Define the queue file name used for persistence.
+     *
+     * @param queueFileName queue file name
+     */
+    public void setQueueFileName(String queueFileName) {
+        this.queueFileName = queueFileName;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexingMetricsController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexingMetricsController.java
@@ -1,0 +1,93 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.GoogleIndexingMetricsDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleIndexingService;
+import org.open4goods.nudgerfrontapi.service.dto.GoogleIndexingMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing Google Indexing queue metrics.
+ */
+@RestController
+@RequestMapping("/metrics/google-indexing")
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Google Indexing", description = "Expose metrics for the Google Indexing queue.")
+public class GoogleIndexingMetricsController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexingMetricsController.class);
+
+    private final GoogleIndexingService googleIndexingService;
+
+    /**
+     * Create the controller.
+     *
+     * @param googleIndexingService service providing indexing metrics
+     */
+    public GoogleIndexingMetricsController(GoogleIndexingService googleIndexingService) {
+        this.googleIndexingService = googleIndexingService;
+    }
+
+    /**
+     * Return the current Google Indexing queue metrics.
+     *
+     * @param domainLanguage domain language hint (required by API contract)
+     * @return metrics response
+     */
+    @GetMapping
+    @Operation(
+            summary = "Get Google Indexing metrics",
+            description = "Return queue metrics and activity timestamps for Google Indexing.",
+            security = @SecurityRequirement(name = "bearer-jwt"),
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+                            required = true,
+                            description = "Language driving localisation of responses.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Metrics returned",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = GoogleIndexingMetricsDto.class))),
+                    @ApiResponse(responseCode = "401", description = "Authentication required"),
+                    @ApiResponse(responseCode = "403", description = "Access forbidden")
+            }
+    )
+    public ResponseEntity<GoogleIndexingMetricsDto> metrics(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Entering metrics(domainLanguage={})", domainLanguage);
+        GoogleIndexingMetrics metrics = googleIndexingService.metrics();
+        GoogleIndexingMetricsDto payload = new GoogleIndexingMetricsDto(
+                metrics.enabled(),
+                metrics.pendingCount(),
+                metrics.indexedCount(),
+                metrics.deadLetterCount(),
+                metrics.lastSuccessAt(),
+                metrics.lastFailureAt(),
+                metrics.batchSize(),
+                metrics.retryDelay(),
+                metrics.maxAttempts(),
+                metrics.realtimeEnabled());
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(payload);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProductController.java
@@ -1398,10 +1398,11 @@ public class ProductController {
             }
     )
     public ResponseEntity<ReviewGenerationStatus> reviewStatus(@PathVariable Long gtin,
-                                                               @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
-        LOGGER.info("Entering reviewStatus(gtin={}, domainLanguage={})", gtin, domainLanguage);
+                                                               @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+                                                               Locale locale) {
+        LOGGER.info("Entering reviewStatus(gtin={}, domainLanguage={}, locale={})", gtin, domainLanguage, locale);
         try {
-            ReviewGenerationStatus status = service.getReviewStatus(gtin);
+            ReviewGenerationStatus status = service.getReviewStatus(gtin, domainLanguage, locale);
             return ResponseEntity.ok()
                     .cacheControl(CacheControl.noCache())
                     .header("X-Locale", domainLanguage.languageTag())

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/GoogleIndexingMetricsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/GoogleIndexingMetricsDto.java
@@ -1,0 +1,32 @@
+package org.open4goods.nudgerfrontapi.dto;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO representing Google Indexing queue metrics exposed to the frontend.
+ */
+public record GoogleIndexingMetricsDto(
+        @Schema(description = "Whether Google Indexing is enabled")
+        boolean enabled,
+        @Schema(description = "Number of URLs waiting to be submitted")
+        int pendingCount,
+        @Schema(description = "Number of URLs recently indexed")
+        int indexedCount,
+        @Schema(description = "Number of URLs dropped after exceeding max attempts")
+        int deadLetterCount,
+        @Schema(description = "Timestamp of the last successful submission", format = "date-time")
+        Instant lastSuccessAt,
+        @Schema(description = "Timestamp of the last failed submission", format = "date-time")
+        Instant lastFailureAt,
+        @Schema(description = "Configured batch size", example = "50")
+        int batchSize,
+        @Schema(description = "Delay between retries", example = "PT30M")
+        Duration retryDelay,
+        @Schema(description = "Maximum retry attempts", example = "5")
+        int maxAttempts,
+        @Schema(description = "Whether realtime processing is enabled")
+        boolean realtimeEnabled) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/model/GoogleIndexingQueueItem.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/model/GoogleIndexingQueueItem.java
@@ -1,0 +1,18 @@
+package org.open4goods.nudgerfrontapi.model;
+
+import java.time.Instant;
+
+/**
+ * Represents a single URL awaiting submission to the Google Indexing API.
+ *
+ * @param url          absolute URL to index
+ * @param createdAt    timestamp of the enqueue action
+ * @param lastAttemptAt timestamp of the most recent submission attempt
+ * @param attemptCount number of submission attempts performed so far
+ */
+public record GoogleIndexingQueueItem(
+        String url,
+        Instant createdAt,
+        Instant lastAttemptAt,
+        int attemptCount) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/model/GoogleIndexingQueueState.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/model/GoogleIndexingQueueState.java
@@ -1,0 +1,109 @@
+package org.open4goods.nudgerfrontapi.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Persistent snapshot of the Google Indexing queue and its historical metadata.
+ */
+public class GoogleIndexingQueueState {
+
+    private List<GoogleIndexingQueueItem> pendingItems = new ArrayList<>();
+    private Map<String, Instant> indexedUrls = new LinkedHashMap<>();
+    private Map<String, Instant> deadLetterUrls = new LinkedHashMap<>();
+    private Instant lastSuccessAt;
+    private Instant lastFailureAt;
+
+    /**
+     * Return the list of pending URLs.
+     *
+     * @return pending queue entries
+     */
+    public List<GoogleIndexingQueueItem> getPendingItems() {
+        return pendingItems;
+    }
+
+    /**
+     * Replace the pending queue entries.
+     *
+     * @param pendingItems new pending queue entries
+     */
+    public void setPendingItems(List<GoogleIndexingQueueItem> pendingItems) {
+        this.pendingItems = pendingItems;
+    }
+
+    /**
+     * Return the URLs that were recently indexed.
+     *
+     * @return map of URL to last successful submission timestamp
+     */
+    public Map<String, Instant> getIndexedUrls() {
+        return indexedUrls;
+    }
+
+    /**
+     * Replace the map of indexed URLs.
+     *
+     * @param indexedUrls map of URL to timestamp
+     */
+    public void setIndexedUrls(Map<String, Instant> indexedUrls) {
+        this.indexedUrls = indexedUrls;
+    }
+
+    /**
+     * Return the URLs that reached the maximum retry count.
+     *
+     * @return map of URL to dead-letter timestamp
+     */
+    public Map<String, Instant> getDeadLetterUrls() {
+        return deadLetterUrls;
+    }
+
+    /**
+     * Replace the map of dead-letter URLs.
+     *
+     * @param deadLetterUrls map of URL to timestamp
+     */
+    public void setDeadLetterUrls(Map<String, Instant> deadLetterUrls) {
+        this.deadLetterUrls = deadLetterUrls;
+    }
+
+    /**
+     * Return the timestamp of the last successful submission.
+     *
+     * @return last success timestamp
+     */
+    public Instant getLastSuccessAt() {
+        return lastSuccessAt;
+    }
+
+    /**
+     * Set the last success timestamp.
+     *
+     * @param lastSuccessAt timestamp of the last success
+     */
+    public void setLastSuccessAt(Instant lastSuccessAt) {
+        this.lastSuccessAt = lastSuccessAt;
+    }
+
+    /**
+     * Return the timestamp of the last failed submission.
+     *
+     * @return last failure timestamp
+     */
+    public Instant getLastFailureAt() {
+        return lastFailureAt;
+    }
+
+    /**
+     * Set the last failure timestamp.
+     *
+     * @param lastFailureAt timestamp of the last failure
+     */
+    public void setLastFailureAt(Instant lastFailureAt) {
+        this.lastFailureAt = lastFailureAt;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexingQueueRepository.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexingQueueRepository.java
@@ -1,0 +1,272 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.open4goods.nudgerfrontapi.config.properties.CacheProperties;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.open4goods.nudgerfrontapi.model.GoogleIndexingQueueItem;
+import org.open4goods.nudgerfrontapi.model.GoogleIndexingQueueState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/**
+ * File-backed repository storing pending Google Indexing URLs and submission history.
+ */
+@Repository
+public class GoogleIndexingQueueRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexingQueueRepository.class);
+
+    private final ObjectMapper objectMapper;
+    private final Path queueFilePath;
+    private final Clock clock;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private GoogleIndexingQueueState state;
+
+    /**
+     * Create the repository and load persisted queue state when available.
+     *
+     * @param cacheProperties cache configuration providing the base folder
+     * @param properties      Google Indexing configuration
+     * @param objectMapper    mapper used to serialize queue data
+     * @param clock           clock used for timestamps
+     */
+    public GoogleIndexingQueueRepository(CacheProperties cacheProperties,
+                                         GoogleIndexingProperties properties,
+                                         ObjectMapper objectMapper,
+                                         Clock clock) {
+        this.objectMapper = objectMapper;
+        this.clock = clock;
+        this.queueFilePath = Path.of(cacheProperties.getPath(), properties.getQueueFileName());
+        this.state = loadState().orElseGet(GoogleIndexingQueueState::new);
+    }
+
+    /**
+     * Return a snapshot of the queue state.
+     *
+     * @return immutable snapshot of the current queue
+     */
+    public GoogleIndexingQueueSnapshot snapshot() {
+        lock.lock();
+        try {
+            return new GoogleIndexingQueueSnapshot(
+                    List.copyOf(state.getPendingItems()),
+                    Map.copyOf(state.getIndexedUrls()),
+                    Map.copyOf(state.getDeadLetterUrls()),
+                    state.getLastSuccessAt(),
+                    state.getLastFailureAt());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Enqueue a new URL if it is not already pending or recently indexed.
+     *
+     * @param url        absolute URL to enqueue
+     * @param retention retention window for indexed history
+     * @return {@code true} when the URL was added
+     */
+    public boolean enqueue(String url, Duration retention) {
+        if (!StringUtils.hasText(url)) {
+            return false;
+        }
+        lock.lock();
+        try {
+            Instant now = clock.instant();
+            cleanupHistory(retention, now);
+            if (state.getPendingItems().stream().anyMatch(item -> url.equals(item.url()))
+                    || state.getIndexedUrls().containsKey(url)) {
+                return false;
+            }
+            state.getPendingItems().add(new GoogleIndexingQueueItem(url, now, null, 0));
+            persistState();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Reserve a batch of items that are ready for submission.
+     *
+     * @param batchSize  maximum number of items to return
+     * @param retryDelay delay required between attempts
+     * @param maxAttempts maximum number of attempts before discarding an entry
+     * @param retention retention duration for history cleanup
+     * @return list of reserved queue items
+     */
+    public List<GoogleIndexingQueueItem> reserveBatch(int batchSize,
+                                                      Duration retryDelay,
+                                                      int maxAttempts,
+                                                      Duration retention) {
+        lock.lock();
+        try {
+            Instant now = clock.instant();
+            cleanupHistory(retention, now);
+            List<GoogleIndexingQueueItem> eligible = state.getPendingItems().stream()
+                    .filter(item -> item.attemptCount() < maxAttempts)
+                    .filter(item -> item.lastAttemptAt() == null
+                            || item.lastAttemptAt().plus(retryDelay).isBefore(now)
+                            || item.lastAttemptAt().plus(retryDelay).equals(now))
+                    .limit(batchSize)
+                    .toList();
+            if (eligible.isEmpty()) {
+                return List.of();
+            }
+            Map<String, GoogleIndexingQueueItem> updated = eligible.stream()
+                    .collect(Collectors.toMap(GoogleIndexingQueueItem::url, item -> new GoogleIndexingQueueItem(
+                            item.url(),
+                            item.createdAt(),
+                            now,
+                            item.attemptCount() + 1)));
+            List<GoogleIndexingQueueItem> refreshed = new ArrayList<>(state.getPendingItems().size());
+            for (GoogleIndexingQueueItem item : state.getPendingItems()) {
+                refreshed.add(updated.getOrDefault(item.url(), item));
+            }
+            state.setPendingItems(refreshed);
+            persistState();
+            return eligible.stream()
+                    .map(item -> updated.getOrDefault(item.url(), item))
+                    .toList();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Mark a queue entry as successfully indexed.
+     *
+     * @param url URL that was indexed
+     */
+    public void markSuccess(String url) {
+        lock.lock();
+        try {
+            Instant now = clock.instant();
+            state.setLastSuccessAt(now);
+            state.getPendingItems().removeIf(item -> url.equals(item.url()));
+            state.getIndexedUrls().put(url, now);
+            persistState();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Mark a queue entry as failed and move to dead-letter storage if needed.
+     *
+     * @param item        item that failed to index
+     * @param maxAttempts maximum number of retry attempts
+     */
+    public void markFailure(GoogleIndexingQueueItem item, int maxAttempts) {
+        lock.lock();
+        try {
+            Instant now = clock.instant();
+            state.setLastFailureAt(now);
+            if (item.attemptCount() >= maxAttempts) {
+                state.getPendingItems().removeIf(entry -> entry.url().equals(item.url()));
+                state.getDeadLetterUrls().put(item.url(), now);
+            }
+            persistState();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Remove expired history entries from indexed and dead-letter collections.
+     *
+     * @param retention retention window used to keep history
+     * @param now       current timestamp
+     */
+    private void cleanupHistory(Duration retention, Instant now) {
+        Instant cutoff = now.minus(retention);
+        pruneHistoryMap(state.getIndexedUrls(), cutoff);
+        pruneHistoryMap(state.getDeadLetterUrls(), cutoff);
+    }
+
+    /**
+     * Remove map entries that are older than the cutoff time.
+     *
+     * @param map    map to prune
+     * @param cutoff cutoff timestamp
+     */
+    private void pruneHistoryMap(Map<String, Instant> map, Instant cutoff) {
+        Iterator<Map.Entry<String, Instant>> iterator = map.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Instant> entry = iterator.next();
+            if (entry.getValue() != null && entry.getValue().isBefore(cutoff)) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * Load the queue state from disk when present.
+     *
+     * @return optional loaded state
+     */
+    private Optional<GoogleIndexingQueueState> loadState() {
+        if (!Files.exists(queueFilePath)) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(queueFilePath.toFile(), GoogleIndexingQueueState.class));
+        } catch (IOException ex) {
+            LOGGER.warn("Failed to read Google indexing queue state: {}", ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Persist the queue state to disk.
+     */
+    private void persistState() {
+        try {
+            Files.createDirectories(queueFilePath.getParent());
+            Path tmp = queueFilePath.resolveSibling(queueFilePath.getFileName() + ".tmp");
+            objectMapper.writeValue(tmp.toFile(), state);
+            try {
+                Files.move(tmp, queueFilePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException ex) {
+                Files.move(tmp, queueFilePath, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException ex) {
+            LOGGER.warn("Failed to persist Google indexing queue state: {}", ex.getMessage());
+        }
+    }
+
+    /**
+     * Snapshot object describing the current queue state.
+     *
+     * @param pendingItems  list of pending entries
+     * @param indexedUrls   map of recently indexed URLs
+     * @param deadLetterUrls map of URLs dropped after max attempts
+     * @param lastSuccessAt timestamp of last success
+     * @param lastFailureAt timestamp of last failure
+     */
+    public record GoogleIndexingQueueSnapshot(
+            List<GoogleIndexingQueueItem> pendingItems,
+            Map<String, Instant> indexedUrls,
+            Map<String, Instant> deadLetterUrls,
+            Instant lastSuccessAt,
+            Instant lastFailureAt) {
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingClient.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingClient.java
@@ -1,0 +1,15 @@
+package org.open4goods.nudgerfrontapi.service;
+
+/**
+ * Client interface used to publish URLs to the Google Indexing API.
+ */
+public interface GoogleIndexingClient {
+
+    /**
+     * Publish a URL to the Indexing API.
+     *
+     * @param url absolute URL to publish
+     * @return {@code true} when the request succeeds
+     */
+    boolean publish(String url);
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingHealthIndicator.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingHealthIndicator.java
@@ -1,0 +1,84 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.open4goods.nudgerfrontapi.service.dto.GoogleIndexingMetrics;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator for the Google Indexing integration.
+ */
+@Component
+public class GoogleIndexingHealthIndicator implements HealthIndicator {
+
+    private final GoogleIndexingService googleIndexingService;
+    private final GoogleIndexingProperties properties;
+    private final Clock clock;
+
+    /**
+     * Create the health indicator.
+     *
+     * @param googleIndexingService service providing indexing metrics
+     * @param properties            configuration properties
+     * @param clock                 clock used to evaluate staleness
+     */
+    public GoogleIndexingHealthIndicator(GoogleIndexingService googleIndexingService,
+                                         GoogleIndexingProperties properties,
+                                         Clock clock) {
+        this.googleIndexingService = googleIndexingService;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    /**
+     * Build a health snapshot for the indexing service.
+     *
+     * @return health status
+     */
+    @Override
+    public Health health() {
+        GoogleIndexingMetrics metrics = googleIndexingService.metrics();
+        if (!metrics.enabled()) {
+            return Health.up()
+                    .withDetail("enabled", false)
+                    .build();
+        }
+        if (!googleIndexingService.isConfigured()) {
+            return Health.down()
+                    .withDetail("enabled", true)
+                    .withDetail("error", "Missing Google Indexing credentials")
+                    .build();
+        }
+        Health.Builder builder = Health.up()
+                .withDetail("enabled", true)
+                .withDetail("pendingCount", metrics.pendingCount())
+                .withDetail("deadLetterCount", metrics.deadLetterCount())
+                .withDetail("lastSuccessAt", metrics.lastSuccessAt())
+                .withDetail("lastFailureAt", metrics.lastFailureAt());
+
+        if (metrics.pendingCount() > properties.getMaxQueueSize()) {
+            return builder.down()
+                    .withDetail("queueLimit", properties.getMaxQueueSize())
+                    .build();
+        }
+
+        Instant now = clock.instant();
+        Duration maxAge = properties.getMaxSuccessAge();
+        if (metrics.pendingCount() > 0 && metrics.lastSuccessAt() != null) {
+            Duration age = Duration.between(metrics.lastSuccessAt(), now);
+            if (age.compareTo(maxAge) > 0) {
+                return builder.down()
+                        .withDetail("lastSuccessAge", age)
+                        .withDetail("maxSuccessAge", maxAge)
+                        .build();
+            }
+        }
+
+        return builder.build();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingHttpClient.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingHttpClient.java
@@ -1,0 +1,136 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * HTTP client that authenticates with Google and publishes URL notifications.
+ */
+@Service
+public class GoogleIndexingHttpClient implements GoogleIndexingClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexingHttpClient.class);
+    private static final String INDEXING_SCOPE = "https://www.googleapis.com/auth/indexing";
+
+    private final GoogleIndexingProperties properties;
+    private final RestClient restClient;
+    private final Clock clock;
+
+    private GoogleCredentials credentials;
+    private Instant tokenExpiry;
+
+    /**
+     * Create the Indexing API client.
+     *
+     * @param properties configuration properties for Google Indexing
+     * @param clock      clock used for token expiry
+     */
+    public GoogleIndexingHttpClient(GoogleIndexingProperties properties, Clock clock) {
+        this.properties = properties;
+        this.clock = clock;
+        this.restClient = RestClient.builder().build();
+    }
+
+    /**
+     * Publish a URL notification to Google.
+     *
+     * @param url absolute URL to publish
+     * @return {@code true} when the request succeeds
+     */
+    @Override
+    public boolean publish(String url) {
+        if (!StringUtils.hasText(url)) {
+            return false;
+        }
+        try {
+            AccessToken accessToken = getAccessToken();
+            restClient.post()
+                    .uri(properties.getApiEndpoint())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.getTokenValue())
+                    .body(new GoogleIndexingRequest(url, "URL_UPDATED"))
+                    .retrieve()
+                    .toBodilessEntity();
+            return true;
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to publish URL {} to Google Indexing API: {}", url, ex.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Resolve a valid OAuth access token for the service account.
+     *
+     * @return access token used to authenticate API calls
+     * @throws IOException when credentials cannot be loaded
+     */
+    private AccessToken getAccessToken() throws IOException {
+        if (credentials == null) {
+            credentials = loadCredentials();
+        }
+        if (tokenExpiry == null || tokenExpiry.isBefore(clock.instant().plusSeconds(60))) {
+            credentials.refreshIfExpired();
+            AccessToken token = credentials.getAccessToken();
+            if (token != null) {
+                tokenExpiry = token.getExpirationTime() != null
+                        ? token.getExpirationTime().toInstant()
+                        : clock.instant().plusSeconds(300);
+            }
+        }
+        AccessToken token = credentials.getAccessToken();
+        if (token == null) {
+            token = credentials.refreshAccessToken();
+            tokenExpiry = token.getExpirationTime() != null
+                    ? token.getExpirationTime().toInstant()
+                    : clock.instant().plusSeconds(300);
+        }
+        return token;
+    }
+
+    /**
+     * Load Google credentials from JSON or file path.
+     *
+     * @return configured Google credentials
+     * @throws IOException when the credentials cannot be loaded
+     */
+    private GoogleCredentials loadCredentials() throws IOException {
+        String json = properties.getServiceAccountJson();
+        String path = properties.getServiceAccountPath();
+        if (StringUtils.hasText(json)) {
+            return GoogleCredentials.fromStream(
+                    new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))
+                    .createScoped(INDEXING_SCOPE);
+        }
+        if (StringUtils.hasText(path)) {
+            Path jsonPath = Path.of(path);
+            return GoogleCredentials.fromStream(Files.newInputStream(jsonPath))
+                    .createScoped(INDEXING_SCOPE);
+        }
+        throw new IOException("Missing service account credentials for Google Indexing API");
+    }
+
+    /**
+     * Payload sent to the Indexing API.
+     *
+     * @param url  absolute URL to notify
+     * @param type notification type
+     */
+    private record GoogleIndexingRequest(String url, String type) {
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingService.java
@@ -1,0 +1,205 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexingQueueRepository;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexingQueueRepository.GoogleIndexingQueueSnapshot;
+import org.open4goods.nudgerfrontapi.service.dto.GoogleIndexingMetrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Orchestrates Google Indexing API submissions, including batching and retries.
+ */
+@Service
+public class GoogleIndexingService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexingService.class);
+
+    private final GoogleIndexingProperties properties;
+    private final GoogleIndexingQueueRepository queueRepository;
+    private final GoogleIndexingClient client;
+    private final ReentrantLock processingLock = new ReentrantLock();
+
+    /**
+     * Create the Google Indexing service.
+     *
+     * @param properties      configuration properties
+     * @param queueRepository repository storing queued URLs
+     * @param client          client used to call the Google Indexing API
+     */
+    public GoogleIndexingService(GoogleIndexingProperties properties,
+                                 GoogleIndexingQueueRepository queueRepository,
+                                 GoogleIndexingClient client) {
+        this.properties = properties;
+        this.queueRepository = queueRepository;
+        this.client = client;
+    }
+
+    /**
+     * Enqueue an absolute URL for indexing and optionally process immediately.
+     *
+     * @param url absolute URL to index
+     */
+    public void enqueueUrl(String url) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        if (!StringUtils.hasText(url)) {
+            return;
+        }
+        boolean enqueued = queueRepository.enqueue(url, properties.getHistoryRetention());
+        if (enqueued && properties.isRealtimeEnabled()) {
+            processQueueOnce();
+        }
+    }
+
+    /**
+     * Enqueue a URL path by combining it with the configured site base URL.
+     *
+     * @param path URL path (e.g. "/products/example")
+     */
+    public void enqueuePath(String path) {
+        if (!StringUtils.hasText(path)) {
+            return;
+        }
+        resolveAbsoluteUrl(path).ifPresent(this::enqueueUrl);
+    }
+
+    /**
+     * Return a snapshot of indexing metrics.
+     *
+     * @return metrics snapshot
+     */
+    public GoogleIndexingMetrics metrics() {
+        GoogleIndexingQueueSnapshot snapshot = queueRepository.snapshot();
+        return new GoogleIndexingMetrics(
+                properties.isEnabled(),
+                snapshot.pendingItems().size(),
+                snapshot.indexedUrls().size(),
+                snapshot.deadLetterUrls().size(),
+                snapshot.lastSuccessAt(),
+                snapshot.lastFailureAt(),
+                properties.getBatchSize(),
+                properties.getRetryDelay(),
+                properties.getMaxAttempts(),
+                properties.isRealtimeEnabled());
+    }
+
+    /**
+     * Execute scheduled batch processing for pending URLs.
+     */
+    @Scheduled(fixedDelayString = "PT30M")
+    public void processQueue() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        processQueueOnce();
+    }
+
+    /**
+     * Process a single batch of queued URLs.
+     */
+    public void processQueueOnce() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        if (!processingLock.tryLock()) {
+            return;
+        }
+        try {
+            List<org.open4goods.nudgerfrontapi.model.GoogleIndexingQueueItem> batch =
+                    queueRepository.reserveBatch(properties.getBatchSize(),
+                            properties.getRetryDelay(),
+                            properties.getMaxAttempts(),
+                            properties.getHistoryRetention());
+            if (batch.isEmpty()) {
+                return;
+            }
+            LOGGER.info("Processing {} Google indexing URLs", batch.size());
+            for (org.open4goods.nudgerfrontapi.model.GoogleIndexingQueueItem item : batch) {
+                boolean success = client.publish(item.url());
+                if (success) {
+                    queueRepository.markSuccess(item.url());
+                } else {
+                    queueRepository.markFailure(item, properties.getMaxAttempts());
+                }
+            }
+        } finally {
+            processingLock.unlock();
+        }
+    }
+
+    /**
+     * Resolve an absolute URL using the configured base URL.
+     *
+     * @param path URL path or absolute URL
+     * @return resolved absolute URL if configuration is valid
+     */
+    public Optional<String> resolveAbsoluteUrl(String path) {
+        if (!StringUtils.hasText(path)) {
+            return Optional.empty();
+        }
+        String baseUrl = normalizeBaseUrl(properties.getSiteBaseUrl());
+        if (!StringUtils.hasText(baseUrl)) {
+            return Optional.empty();
+        }
+        if (path.startsWith("http://") || path.startsWith("https://")) {
+            return Optional.of(path);
+        }
+        String normalizedPath = path.startsWith("/") ? path : "/" + path;
+        return Optional.of(baseUrl + normalizedPath);
+    }
+
+    /**
+     * Determine whether the service is correctly configured for use.
+     *
+     * @return {@code true} when the service can authenticate to Google
+     */
+    public boolean isConfigured() {
+        if (!properties.isEnabled()) {
+            return true;
+        }
+        return StringUtils.hasText(properties.getServiceAccountJson())
+                || StringUtils.hasText(properties.getServiceAccountPath());
+    }
+
+    /**
+     * Determine the age of the last successful submission.
+     *
+     * @param now current timestamp
+     * @return optional duration since last success
+     */
+    public Optional<Duration> ageSinceLastSuccess(Instant now) {
+        GoogleIndexingQueueSnapshot snapshot = queueRepository.snapshot();
+        if (snapshot.lastSuccessAt() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(Duration.between(snapshot.lastSuccessAt(), now));
+    }
+
+    /**
+     * Normalize the base URL by removing trailing slashes.
+     *
+     * @param baseUrl configured base URL
+     * @return normalized base URL
+     */
+    private String normalizeBaseUrl(String baseUrl) {
+        if (!StringUtils.hasText(baseUrl)) {
+            return baseUrl;
+        }
+        String trimmed = baseUrl.trim();
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/dto/GoogleIndexingMetrics.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/dto/GoogleIndexingMetrics.java
@@ -1,0 +1,31 @@
+package org.open4goods.nudgerfrontapi.service.dto;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Internal metrics snapshot for Google Indexing activity.
+ *
+ * @param enabled           whether indexing is enabled
+ * @param pendingCount      number of queued URLs
+ * @param indexedCount      number of URLs recently indexed
+ * @param deadLetterCount   number of URLs dropped after max attempts
+ * @param lastSuccessAt     timestamp of last success
+ * @param lastFailureAt     timestamp of last failure
+ * @param batchSize         configured batch size
+ * @param retryDelay        configured retry delay
+ * @param maxAttempts       configured max attempts
+ * @param realtimeEnabled   whether realtime processing is enabled
+ */
+public record GoogleIndexingMetrics(
+        boolean enabled,
+        int pendingCount,
+        int indexedCount,
+        int deadLetterCount,
+        Instant lastSuccessAt,
+        Instant lastFailureAt,
+        int batchSize,
+        Duration retryDelay,
+        int maxAttempts,
+        boolean realtimeEnabled) {
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -42,6 +42,82 @@
       "defaultValue": "24h"
     },
     {
+      "name": "front.google-indexing.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the Google Indexing API integration.",
+      "defaultValue": false
+    },
+    {
+      "name": "front.google-indexing.site-base-url",
+      "type": "java.lang.String",
+      "description": "Public base URL of the Nuxt frontend used to build canonical product URLs.",
+      "defaultValue": "https://nudger.fr"
+    },
+    {
+      "name": "front.google-indexing.api-endpoint",
+      "type": "java.lang.String",
+      "description": "Endpoint used to publish URL notifications.",
+      "defaultValue": "https://indexing.googleapis.com/v3/urlNotifications:publish"
+    },
+    {
+      "name": "front.google-indexing.service-account-json",
+      "type": "java.lang.String",
+      "description": "Service account JSON payload used to authenticate with Google APIs."
+    },
+    {
+      "name": "front.google-indexing.service-account-path",
+      "type": "java.lang.String",
+      "description": "Path to a service account JSON file used to authenticate with Google APIs."
+    },
+    {
+      "name": "front.google-indexing.batch-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of URLs processed per batch execution.",
+      "defaultValue": 50
+    },
+    {
+      "name": "front.google-indexing.retry-delay",
+      "type": "java.time.Duration",
+      "description": "Duration to wait before retrying a failed URL.",
+      "defaultValue": "30m"
+    },
+    {
+      "name": "front.google-indexing.max-attempts",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of retry attempts before discarding a URL.",
+      "defaultValue": 5
+    },
+    {
+      "name": "front.google-indexing.realtime-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable immediate processing when a URL is enqueued.",
+      "defaultValue": true
+    },
+    {
+      "name": "front.google-indexing.history-retention",
+      "type": "java.time.Duration",
+      "description": "Retention window for indexed and failed URL history.",
+      "defaultValue": "7d"
+    },
+    {
+      "name": "front.google-indexing.max-queue-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum queue size before the health indicator reports a degraded status.",
+      "defaultValue": 500
+    },
+    {
+      "name": "front.google-indexing.max-success-age",
+      "type": "java.time.Duration",
+      "description": "Maximum age for the last successful indexing event before health degrades.",
+      "defaultValue": "7d"
+    },
+    {
+      "name": "front.google-indexing.queue-file-name",
+      "type": "java.lang.String",
+      "description": "File name used to persist pending queue entries on disk.",
+      "defaultValue": "google-indexing-queue.json"
+    },
+    {
       "name": "front.search.suggest.semantic-fallback-enabled",
       "type": "java.lang.Boolean",
       "description": "Enable semantic fallback for product suggestions when prefix search yields no results.",

--- a/front-api/src/main/resources/application-local.yml
+++ b/front-api/src/main/resources/application-local.yml
@@ -28,3 +28,7 @@ front:
     quota:
       max-per-ip: 3
       window: 24h
+  google-indexing:
+    enabled: false
+    site-base-url: "https://nudger.fr"
+    service-account-json: ""

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -67,6 +67,20 @@ front:
     quota:
       max-per-ip: ${FRONT_REVIEW_GENERATION_MAX_PER_IP:3}
       window: ${FRONT_REVIEW_GENERATION_WINDOW:24h}
+  google-indexing:
+    enabled: ${FRONT_GOOGLE_INDEXING_ENABLED:false}
+    site-base-url: ${FRONT_GOOGLE_INDEXING_SITE_BASE_URL:https://nudger.fr}
+    api-endpoint: ${FRONT_GOOGLE_INDEXING_API_ENDPOINT:https://indexing.googleapis.com/v3/urlNotifications:publish}
+    service-account-json: ${FRONT_GOOGLE_INDEXING_SERVICE_ACCOUNT_JSON:}
+    service-account-path: ${FRONT_GOOGLE_INDEXING_SERVICE_ACCOUNT_PATH:}
+    batch-size: ${FRONT_GOOGLE_INDEXING_BATCH_SIZE:50}
+    retry-delay: ${FRONT_GOOGLE_INDEXING_RETRY_DELAY:30m}
+    max-attempts: ${FRONT_GOOGLE_INDEXING_MAX_ATTEMPTS:5}
+    realtime-enabled: ${FRONT_GOOGLE_INDEXING_REALTIME_ENABLED:true}
+    history-retention: ${FRONT_GOOGLE_INDEXING_HISTORY_RETENTION:7d}
+    max-queue-size: ${FRONT_GOOGLE_INDEXING_MAX_QUEUE_SIZE:500}
+    max-success-age: ${FRONT_GOOGLE_INDEXING_MAX_SUCCESS_AGE:7d}
+    queue-file-name: ${FRONT_GOOGLE_INDEXING_QUEUE_FILE_NAME:google-indexing-queue.json}
   search:
     suggest:
       semantic-fallback-enabled: true

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/GoogleIndexingMetricsControllerIT.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/GoogleIndexingMetricsControllerIT.java
@@ -1,0 +1,72 @@
+package org.open4goods.nudgerfrontapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.config.TestTextEmbeddingConfig;
+import org.open4goods.nudgerfrontapi.controller.api.GoogleIndexingMetricsController;
+import org.open4goods.nudgerfrontapi.service.GoogleIndexingService;
+import org.open4goods.nudgerfrontapi.service.dto.GoogleIndexingMetrics;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"front.cache.path=${java.io.tmpdir}",
+        "front.security.enabled=true",
+        "front.security.shared-token=test-token",
+        "front.google-indexing.site-base-url=https://example.org"})
+@AutoConfigureMockMvc
+@Import(TestTextEmbeddingConfig.class)
+class GoogleIndexingMetricsControllerIT {
+
+    private static final String SHARED_TOKEN = "test-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GoogleIndexingMetricsController controller;
+
+    @MockBean
+    private GoogleIndexingService googleIndexingService;
+
+    @Test
+    void metricsEndpointReturnsSnapshot() throws Exception {
+        GoogleIndexingMetrics metrics = new GoogleIndexingMetrics(
+                true,
+                2,
+                4,
+                1,
+                Instant.parse("2024-05-01T10:15:30Z"),
+                Instant.parse("2024-05-02T10:15:30Z"),
+                50,
+                Duration.ofMinutes(30),
+                5,
+                true);
+        given(googleIndexingService.metrics()).willReturn(metrics);
+
+        mockMvc.perform(get("/metrics/google-indexing")
+                        .param("domainLanguage", "fr")
+                        .header("X-Shared-Token", SHARED_TOKEN)
+                        .with(jwt().jwt(jwt -> jwt.claim("roles", List.of(RolesConstants.ROLE_XWIKI_ALL)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.pendingCount").value(2))
+                .andExpect(jsonPath("$.indexedCount").value(4))
+                .andExpect(jsonPath("$.deadLetterCount").value(1))
+                .andExpect(jsonPath("$.batchSize").value(50))
+                .andExpect(jsonPath("$.maxAttempts").value(5));
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexingQueueRepositoryTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexingQueueRepositoryTest.java
@@ -1,0 +1,112 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.open4goods.nudgerfrontapi.config.properties.CacheProperties;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.open4goods.nudgerfrontapi.model.GoogleIndexingQueueItem;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class GoogleIndexingQueueRepositoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void enqueueDeduplicatesUrls() {
+        MutableClock clock = new MutableClock(Instant.parse("2024-01-01T00:00:00Z"));
+        GoogleIndexingQueueRepository repository = createRepository(clock);
+
+        boolean first = repository.enqueue("https://example.org/products/1", Duration.ofDays(1));
+        boolean second = repository.enqueue("https://example.org/products/1", Duration.ofDays(1));
+
+        GoogleIndexingQueueRepository.GoogleIndexingQueueSnapshot snapshot = repository.snapshot();
+        assertThat(first).isTrue();
+        assertThat(second).isFalse();
+        assertThat(snapshot.pendingItems()).hasSize(1);
+    }
+
+    @Test
+    void reserveBatchHonorsRetryDelayAndAttempts() {
+        MutableClock clock = new MutableClock(Instant.parse("2024-01-01T00:00:00Z"));
+        GoogleIndexingQueueRepository repository = createRepository(clock);
+        repository.enqueue("https://example.org/products/1", Duration.ofDays(1));
+
+        List<GoogleIndexingQueueItem> firstBatch = repository.reserveBatch(5, Duration.ofMinutes(30), 3, Duration.ofDays(1));
+        assertThat(firstBatch).hasSize(1);
+        assertThat(firstBatch.get(0).attemptCount()).isEqualTo(1);
+
+        List<GoogleIndexingQueueItem> secondBatch = repository.reserveBatch(5, Duration.ofMinutes(30), 3, Duration.ofDays(1));
+        assertThat(secondBatch).isEmpty();
+
+        clock.advance(Duration.ofMinutes(31));
+        List<GoogleIndexingQueueItem> thirdBatch = repository.reserveBatch(5, Duration.ofMinutes(30), 3, Duration.ofDays(1));
+        assertThat(thirdBatch).hasSize(1);
+        assertThat(thirdBatch.get(0).attemptCount()).isEqualTo(2);
+    }
+
+    @Test
+    void markFailureMovesToDeadLetterAfterMaxAttempts() {
+        MutableClock clock = new MutableClock(Instant.parse("2024-01-01T00:00:00Z"));
+        GoogleIndexingQueueRepository repository = createRepository(clock);
+        repository.enqueue("https://example.org/products/1", Duration.ofDays(1));
+
+        List<GoogleIndexingQueueItem> batch = repository.reserveBatch(5, Duration.ZERO, 1, Duration.ofDays(1));
+        repository.markFailure(batch.get(0), 1);
+
+        GoogleIndexingQueueRepository.GoogleIndexingQueueSnapshot snapshot = repository.snapshot();
+        assertThat(snapshot.pendingItems()).isEmpty();
+        assertThat(snapshot.deadLetterUrls()).containsKey("https://example.org/products/1");
+    }
+
+    private GoogleIndexingQueueRepository createRepository(Clock clock) {
+        CacheProperties cacheProperties = new CacheProperties();
+        cacheProperties.setPath(tempDir.toString());
+        GoogleIndexingProperties properties = new GoogleIndexingProperties();
+        properties.setQueueFileName("queue.json");
+        properties.setSiteBaseUrl("https://example.org");
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        return new GoogleIndexingQueueRepository(cacheProperties, properties, mapper, clock);
+    }
+
+    /**
+     * Mutable clock for testing time-dependent logic.
+     */
+    private static final class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(java.time.ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexingServiceTest.java
@@ -1,0 +1,93 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.open4goods.nudgerfrontapi.config.properties.CacheProperties;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexingProperties;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexingQueueRepository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class GoogleIndexingServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void enqueuePathTriggersRealtimeProcessing() {
+        GoogleIndexingProperties properties = buildProperties();
+        properties.setRealtimeEnabled(true);
+        RecordingClient client = new RecordingClient(true);
+        GoogleIndexingQueueRepository repository = createRepository(properties);
+        GoogleIndexingService service = new GoogleIndexingService(properties, repository, client);
+
+        service.enqueuePath("/products/example");
+
+        GoogleIndexingQueueRepository.GoogleIndexingQueueSnapshot snapshot = repository.snapshot();
+        assertThat(snapshot.pendingItems()).isEmpty();
+        assertThat(snapshot.indexedUrls()).containsKey("https://example.org/products/example");
+        assertThat(client.publishedUrls).containsExactly("https://example.org/products/example");
+    }
+
+    @Test
+    void processQueueMovesFailedItemsToDeadLetter() {
+        GoogleIndexingProperties properties = buildProperties();
+        properties.setRealtimeEnabled(false);
+        properties.setMaxAttempts(1);
+        RecordingClient client = new RecordingClient(false);
+        GoogleIndexingQueueRepository repository = createRepository(properties);
+        GoogleIndexingService service = new GoogleIndexingService(properties, repository, client);
+
+        repository.enqueue("https://example.org/products/fail", Duration.ofDays(1));
+        service.processQueueOnce();
+
+        GoogleIndexingQueueRepository.GoogleIndexingQueueSnapshot snapshot = repository.snapshot();
+        assertThat(snapshot.pendingItems()).isEmpty();
+        assertThat(snapshot.deadLetterUrls()).containsKey("https://example.org/products/fail");
+    }
+
+    private GoogleIndexingQueueRepository createRepository(GoogleIndexingProperties properties) {
+        CacheProperties cacheProperties = new CacheProperties();
+        cacheProperties.setPath(tempDir.toString());
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        return new GoogleIndexingQueueRepository(cacheProperties, properties, mapper, Clock.systemUTC());
+    }
+
+    private GoogleIndexingProperties buildProperties() {
+        GoogleIndexingProperties properties = new GoogleIndexingProperties();
+        properties.setEnabled(true);
+        properties.setSiteBaseUrl("https://example.org");
+        properties.setBatchSize(10);
+        properties.setRetryDelay(Duration.ZERO);
+        properties.setHistoryRetention(Duration.ofDays(1));
+        properties.setQueueFileName("queue.json");
+        return properties;
+    }
+
+    /**
+     * Test client that records published URLs.
+     */
+    private static final class RecordingClient implements GoogleIndexingClient {
+
+        private final boolean success;
+        private final List<String> publishedUrls = new ArrayList<>();
+
+        private RecordingClient(boolean success) {
+            this.success = success;
+        }
+
+        @Override
+        public boolean publish(String url) {
+            publishedUrls.add(url);
+            return success;
+        }
+    }
+}

--- a/frontend/app/components/product/ProductAiReviewRequestDialog.vue
+++ b/frontend/app/components/product/ProductAiReviewRequestDialog.vue
@@ -99,18 +99,6 @@
         <v-btn variant="text" @click="dialogModel = false">
           {{ t('product.aiReview.request.cancel') }}
         </v-btn>
-        <v-spacer />
-        <v-btn
-          v-if="showSubmitButton"
-          color="primary"
-          size="large"
-          variant="flat"
-          :loading="requesting"
-          :disabled="submitDisabled"
-          @click="emit('submit')"
-        >
-          {{ t('product.aiReview.request.submit') }}
-        </v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -133,10 +121,6 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  agreementAccepted: {
-    type: Boolean,
-    default: true,
-  },
   requiresCaptcha: {
     type: Boolean,
     default: false,
@@ -152,14 +136,6 @@ const props = defineProps({
   captchaLocale: {
     type: String,
     default: 'en',
-  },
-  requesting: {
-    type: Boolean,
-    default: false,
-  },
-  submitDisabled: {
-    type: Boolean,
-    default: false,
   },
   errorMessage: {
     type: String,
@@ -184,11 +160,8 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
-  (
-    event: 'update:modelValue' | 'update:agreementAccepted',
-    value: boolean
-  ): void
-  (event: 'submit' | 'captcha-expired' | 'captcha-error'): void
+  (event: 'update:modelValue', value: boolean): void
+  (event: 'captcha-expired' | 'captcha-error'): void
   (event: 'captcha-verify', token: string): void
 }>()
 
@@ -201,11 +174,6 @@ const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 const dialogModel = computed({
   get: () => props.modelValue,
   set: value => emit('update:modelValue', value),
-})
-
-const agreementModel = computed({
-  get: () => props.agreementAccepted,
-  set: value => emit('update:agreementAccepted', value),
 })
 
 const hasSiteKey = computed(() => props.siteKey.length > 0)
@@ -226,34 +194,8 @@ watch(
   }
 )
 
-const submitDisabled = computed(() => {
-  if (!agreementModel.value || props.requesting) {
-    return true
-  }
-
-  if (props.requiresCaptcha) {
-    // If captcha is required, valid captcha token is needed
-    // But if we have a token, we should have auto-submitted.
-    // So the button is effectively only for non-captcha or retry?
-    // User requested "Removing Validate button".
-    // I will hide the button if captcha is required.
-    return true
-  }
-
-  return false
-})
-
-const showSubmitButton = computed(() => {
-  if (props.requiresCaptcha) {
-    // Show button only if captcha is verified (fallback for auto-submit)
-    return !submitDisabled.value
-  }
-  return true
-})
-
 const handleCaptchaVerify = (token: string) => {
   emit('captcha-verify', token)
-  emit('submit')
 }
 </script>
 

--- a/frontend/app/components/product/ProductAiReviewRequestPanel.vue
+++ b/frontend/app/components/product/ProductAiReviewRequestPanel.vue
@@ -81,23 +81,6 @@
         <p>{{ statusMessage }}</p>
       </div>
     </div>
-
-    <v-divider class="my-4" />
-
-    <div class="product-ai-review-request-panel__actions">
-      <v-spacer />
-      <v-btn
-        v-if="showSubmitButton"
-        color="primary"
-        size="large"
-        variant="flat"
-        :loading="requesting"
-        :disabled="submitDisabled"
-        @click="emit('submit')"
-      >
-        {{ t('product.aiReview.request.submit') }}
-      </v-btn>
-    </div>
   </div>
 </template>
 
@@ -114,10 +97,6 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  agreementAccepted: {
-    type: Boolean,
-    default: true,
-  },
   requiresCaptcha: {
     type: Boolean,
     default: false,
@@ -133,14 +112,6 @@ const props = defineProps({
   captchaLocale: {
     type: String,
     default: 'en',
-  },
-  requesting: {
-    type: Boolean,
-    default: false,
-  },
-  submitDisabled: {
-    type: Boolean,
-    default: false,
   },
   errorMessage: {
     type: String,
@@ -161,7 +132,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits<{
-  (event: 'update:agreementAccepted', value: boolean): void
   (event: 'submit' | 'captcha-expired' | 'captcha-error'): void
   (event: 'captcha-verify', token: string): void
 }>()
@@ -172,11 +142,6 @@ const VueHcaptcha = defineAsyncComponent(
 )
 const captchaRef = ref<InstanceType<typeof VueHcaptcha> | null>(null)
 
-const agreementModel = computed({
-  get: () => props.agreementAccepted,
-  set: value => emit('update:agreementAccepted', value),
-})
-
 const hasSiteKey = computed(() => props.siteKey.length > 0)
 const showCaptcha = computed(() => props.requiresCaptcha && hasSiteKey.value)
 
@@ -186,40 +151,8 @@ const productLabel = computed(() =>
     : t('product.aiReview.request.productFallback')
 )
 
-const submitDisabled = computed(() => {
-  if (!agreementModel.value || props.requesting) {
-    return true
-  }
-
-  if (props.requiresCaptcha) {
-    // If captcha is required, valid captcha token is needed
-    // The parent controls 'submitDisabled' based on token presence too,
-    // but here we double check or rely on parent.
-    // Actually prop `submitDisabled` should supervise everything.
-    return props.submitDisabled
-  }
-
-  return false
-})
-
-const showSubmitButton = computed(() => {
-  // Always show submit button, it will be disabled if captcha not verified
-  return true
-})
-
 const handleCaptchaVerify = (token: string) => {
   emit('captcha-verify', token)
-  // Auto submit can happen here if desired, or user clicks button.
-  // emit('submit') // Let's wait for user click or make it consistent with previous UX?
-  // Previous Code: emit('submit') immediately.
-  // Refactor request: "User requested: Removing Validate button" logic was confusing in previous file.
-  // Let's keep manual submit for better UX in a panel, or auto if preferred.
-  // If hCaptcha is the only barrier, auto-submit is nice.
-  // But let's stick to manual submit for stability unless requested.
-  // Wait, the previous code had:
-  // "User requested Removing Validate button... I will hide the button if captcha is required."
-  // effectively auto-submitting.
-  // Let's reproduce that behavior:
   emit('submit')
 }
 </script>
@@ -311,10 +244,5 @@ const handleCaptchaVerify = (token: string) => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.product-ai-review-request-panel__actions {
-  display: flex;
-  justify-content: flex-end;
 }
 </style>


### PR DESCRIPTION
### Motivation
- Submit product review URLs to the Google Indexing API after AI review generation so newly created reviews become discoverable.  
- Simplify the frontend AI review request UX and remove redundant agreement/submit state to make captcha flow predictable.  

### Description
- Introduce a new Google Indexing subsystem: `GoogleIndexingProperties`, `GoogleIndexingConfig`, `GoogleIndexingService`, `GoogleIndexingClient` (interface), `GoogleIndexingHttpClient`, a file-backed `GoogleIndexingQueueRepository`, and models `GoogleIndexingQueueItem` / `GoogleIndexingQueueState`.  
- Expose metrics & health: `GoogleIndexingMetricsDto`, `GoogleIndexingMetricsController`, and `GoogleIndexingHealthIndicator`, plus `additional-spring-configuration-metadata.json` and `application.yml` entries and defaults.  
- Wire indexing into product workflow: `ProductMappingService.getReviewStatus` now accepts `DomainLanguage` + `Locale` and enqueues the product review URL (`enqueueReviewIndexing`) when a generation `SUCCESS` status is observed; helper methods `resolveProductSlug` and `resolveFullSlug` added.  
- Frontend changes to AI review request flow: remove agreement binding and explicit submit-state props from `ProductAiReviewRequestPanel` / `ProductAiReviewRequestDialog`, adjust captcha handling (emit `captcha-verify` and rely on parent flow), and auto-trigger request when dialog opens if captcha is not required; update `ProductAiReviewSection` accordingly.  
- Add tests and docs: new unit/integration tests for indexing queue/service/controller, update `front-api` README, register configuration metadata, and add the Google Auth library dependency to `front-api/pom.xml`.  

### Testing
- Frontend unit tests: ran `pnpm test` (Vitest) and observed `399` tests passed across the test suite.  
- Frontend generation: ran `pnpm generate` and the Nuxt build/prerender completed successfully and produced `.output/public`.  
- Backend tests: ran `mvn --offline -pl front-api -am test` (Maven reactor for the front-api build) and executed module tests; the test run completed without failing tests.  
- Manual quick-run: started the frontend dev server (`pnpm dev`) and exercised the site (headless screenshot) to validate no immediate runtime regressions in the modified UI flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69741a6b389083228481620dee3668b1)