### PR TITLE
Improve impact subscore UI: center values, add method info & ranking badge, update i18n

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.vue
@@ -237,20 +237,23 @@ const coefficientValue = computed(() => {
 .impact-subscore__value {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.5rem;
+  text-align: center;
 }
 
 .impact-subscore__value-primary {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
+  justify-content: center;
   gap: 0.5rem 0.75rem;
 }
 
 .impact-subscore__value-default {
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 0.15rem;
 }
 
@@ -271,7 +274,7 @@ const coefficientValue = computed(() => {
 }
 
 .impact-subscore__coefficient {
-  align-self: flex-start;
+  align-self: center;
 }
 
 .impact-subscore__badge {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2704,11 +2704,13 @@
         "markerAverage": "Average for {scoreLabel} sits here.",
         "markerProduct": "{productName} sits here.",
         "title": "Criteria distribution",
-        "toggleAbsolute": "Values",
-        "toggleNormalized": "Scores",
+        "toggleAbsolute": "Absolute values",
+        "toggleNormalized": "Relative indexes",
         "unknownProduct": "This product"
       },
-      "importanceTitle": "Why it matters",
+      "importanceTitle": "{scoreName}: why it matters",
+      "rankingBadge": "Rank {ranking}/{count}",
+      "rankingBadgeSingle": "Rank {ranking}",
       "subscores": {
         "default": {
           "ranking": "Rank {ranking} out of {count}.",
@@ -2769,6 +2771,16 @@
             "constant": {
               "scoring": "The score is fixed at {constantValue} regardless of the value."
             }
+          },
+          "statisticalMethodInfo": {
+            "title": "Why this method?",
+            "sigma": "This method is set in the attribute configuration for continuous values. σ is the standard deviation and {sigmaK}σ represents the interval around the mean that contains most values.",
+            "percentile": "This method is used when values are sparse or highly discrete. The configuration favors a relative ranking within the distribution.",
+            "minmax_fixed": "This method applies when the attribute has stable bounds defined in configuration. It fits well for standardized ranges.",
+            "minmax_quantile": "This method is used to reduce the impact of extreme values. The configuration relies on quantiles to keep comparisons relative.",
+            "fixed_mapping": "This method is selected for categorical values with a fixed mapping defined in configuration.",
+            "binary": "This method applies when the attribute is evaluated against a threshold. The configuration defines the pass value.",
+            "constant": "This method is a configuration fallback when the attribute must remain stable."
           }
         },
         "repairability_index": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2461,11 +2461,13 @@
         "markerAverage": "La moyenne de {scoreLabel} se positionne ici.",
         "markerProduct": "{productName} se positionne ici.",
         "title": "Répartition des critères",
-        "toggleAbsolute": "Valeurs",
-        "toggleNormalized": "Scores",
+        "toggleAbsolute": "Valeures absolues",
+        "toggleNormalized": "Indices relatifs",
         "unknownProduct": "Ce produit"
       },
-      "importanceTitle": "Pourquoi c'est important ?",
+      "importanceTitle": "{scoreName} : pourquoi c'est important ?",
+      "rankingBadge": "Classement {ranking}/{count}",
+      "rankingBadgeSingle": "Classement {ranking}",
       "subscores": {
         "default": {
           "ranking": "Classe {ranking} sur {count}.",
@@ -2526,6 +2528,16 @@
             "constant": {
               "scoring": "La note est fixée à {constantValue} quelle que soit la valeur."
             }
+          },
+          "statisticalMethodInfo": {
+            "title": "Pourquoi cette méthode ?",
+            "sigma": "Cette méthode est définie dans la configuration de l'attribut pour comparer des valeurs continues. σ est l’écart-type et {sigmaK}σ décrit l’intervalle autour de la moyenne qui couvre la plupart des valeurs.",
+            "percentile": "Cette méthode est choisie quand les valeurs sont peu nombreuses ou très discrètes. La configuration privilégie alors un classement relatif dans la distribution.",
+            "minmax_fixed": "Cette méthode est appliquée quand l'attribut possède des bornes stables définies dans la configuration. Elle convient bien aux valeurs normées.",
+            "minmax_quantile": "Cette méthode est utilisée quand il faut limiter l'effet des valeurs extrêmes. La configuration s'appuie sur des quantiles pour conserver une comparaison relative.",
+            "fixed_mapping": "Cette méthode est choisie pour des valeurs catégorielles avec un barème fixe défini dans la configuration.",
+            "binary": "Cette méthode s'applique lorsque l'attribut est évalué par seuil. La configuration définit la valeur de passage.",
+            "constant": "Cette méthode est un fallback défini dans la configuration lorsque l'attribut doit rester stable."
           }
         },
         "repairability_index": {


### PR DESCRIPTION
### Motivation
- Improve the visual alignment of impact subscore values and their coefficient badge so numeric values are centered and easier to read.
- Provide clearer, score-specific explanatory text by using per-score importance headings and surfacing a short statistical-method info card to explain normalization choices.
- Show a compact ranking badge to give immediate context about the product position within the population.

### Description
- Centered value and coefficient layout by updating CSS in `ProductImpactSubscoreGenericCard.vue` to align the value, unit and coefficient badge (`align-items: center`, `justify-content: center`, `text-align: center`).
- Enhanced `ProductImpactSubscoreExplanation.vue` by replacing the generic importance heading with a computed `importanceTitle`, adding a `statisticalMethodInfo` resolver and tonal info card, introducing a `rankingBadgeText` computed property and chip, and updating `hasContent` logic and supporting CSS for the new UI elements.
- Extended i18n in `en-US.json` and `fr-FR.json` to update chart toggle labels (`toggleAbsolute`/`toggleNormalized`), make `importanceTitle` score-aware, add `rankingBadge`/`rankingBadgeSingle`, and add `statisticalMethodInfo` entries for the normalized scoring methods.
- No changes to scoring logic or backend behaviour were made; the changes are presentation and localization only.

### Testing
- A Playwright visual capture was attempted against `http://localhost:3000`, but it failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not running, so no screenshot was produced.
- No unit or integration tests were executed as part of this change (no automated test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69742fba3eac8322b8e9878ac5b2873c)