### PR TITLE
Disable ESG nudge tool score via config flag

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolScoreDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/category/NudgeToolScoreDto.java
@@ -12,6 +12,8 @@ public record NudgeToolScoreDto(
         Double scoreMinValue,
         @Schema(description = "Material Design icon representing the score.", example = "leaf")
         String mdiIcon,
+        @Schema(description = "Whether the score should be disabled in the UI.", example = "true")
+        Boolean disabled,
         @Schema(description = "Localised title of the nudge.")
         String title,
         @Schema(description = "Localised description for the nudge.")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/CategoryMappingService.java
@@ -543,6 +543,7 @@ public class CategoryMappingService {
                 score.getScoreName(),
                 score.getScoreMinValue(),
                 score.getMdiIcon(),
+                score.getDisabled(),
                 localise(score.getTitle(), domainLanguage),
                 localise(score.getDescription(), domainLanguage));
     }

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.spec.ts
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.spec.ts
@@ -110,4 +110,32 @@ describe('NudgeToolStepScores', () => {
 
     expect(wrapper.emitted('update:modelValue')).toEqual([[[]]])
   })
+
+  it('blocks toggling disabled scores', async () => {
+    const wrapper = mount(NudgeToolStepScores, {
+      props: {
+        modelValue: [],
+        scores: [
+          {
+            scoreName: 'esg',
+            title: 'ESG',
+            disabled: true,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          VRow: VRowStub,
+          VCol: VColStub,
+          VCard: VCardStub,
+          VIcon: VIconStub,
+          VTooltip: VTooltipStub,
+        },
+      },
+    })
+
+    await wrapper.find('.nudge-toggle-card').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
 })

--- a/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepScores.vue
@@ -17,17 +17,17 @@
               border="thin"
               :class="{
                 'nudge-toggle-card--selected': isSelected(score.scoreName),
-                'nudge-toggle-card--disabled': isDisabled(score.scoreName),
+                'nudge-toggle-card--disabled': isDisabled(score),
               }"
               rounded="lg"
               role="button"
               :aria-pressed="isSelected(score.scoreName).toString()"
-              :aria-disabled="isDisabled(score.scoreName).toString()"
+              :aria-disabled="isDisabled(score).toString()"
               :aria-label="score.title"
-              :tabindex="isDisabled(score.scoreName) ? -1 : 0"
-              @click="toggle(score.scoreName ?? '')"
-              @keydown.enter.prevent="toggle(score.scoreName ?? '')"
-              @keydown.space.prevent="toggle(score.scoreName ?? '')"
+              :tabindex="isDisabled(score) ? -1 : 0"
+              @click="toggle(score)"
+              @keydown.enter.prevent="toggle(score)"
+              @keydown.space.prevent="toggle(score)"
             >
               <div class="nudge-toggle-card__body">
                 <div class="nudge-toggle-card__icon-rail">
@@ -72,14 +72,19 @@ const getScoreIcon = (score: NudgeToolScoreDto) => score.mdiIcon ?? 'mdi-leaf'
 const isSelected = (scoreName?: string | null) =>
   scoreName ? selectedNames.value.includes(scoreName) : false
 
-const isDisabled = (scoreName?: string | null) =>
-  Boolean(props.isZeroResults) && !isSelected(scoreName)
+const isDisabled = (score: NudgeToolScoreDto) =>
+  Boolean(score.disabled) ||
+  (Boolean(props.isZeroResults) && !isSelected(score.scoreName))
 
-const toggle = (scoreName: string) => {
-  if (isDisabled(scoreName)) {
+const toggle = (score: NudgeToolScoreDto) => {
+  if (isDisabled(score)) {
     return
   }
 
+  const scoreName = score.scoreName ?? ''
+  if (!scoreName) {
+    return
+  }
   const next = new Set(selectedNames.value)
 
   if (next.has(scoreName)) {

--- a/frontend/app/utils/_nudge-tool-filters.spec.ts
+++ b/frontend/app/utils/_nudge-tool-filters.spec.ts
@@ -41,10 +41,10 @@ describe('nudge tool filters', () => {
   it('creates score filters using score min values', () => {
     const filters = buildScoreFilters(
       [
-        { scoreName: 'IMPACT_SCORE', scoreMinValue: 70 },
+        { scoreName: 'IMPACT_SCORE', scoreMinValue: 70, disabled: true },
         { scoreName: 'REPAIRABILITY', scoreMinValue: 6 },
       ],
-      ['REPAIRABILITY']
+      ['IMPACT_SCORE', 'REPAIRABILITY']
     )
 
     expect(filters).toEqual([

--- a/frontend/app/utils/_nudge-tool-filters.ts
+++ b/frontend/app/utils/_nudge-tool-filters.ts
@@ -43,7 +43,7 @@ export const buildScoreFilters = (
       const matchedScore = scores.find(
         candidate => candidate.scoreName === name
       )
-      if (!matchedScore?.scoreMinValue) {
+      if (!matchedScore?.scoreMinValue || matchedScore.disabled) {
         return null
       }
 

--- a/frontend/shared/api-client/models/NudgeToolScoreDto.ts
+++ b/frontend/shared/api-client/models/NudgeToolScoreDto.ts
@@ -38,6 +38,12 @@ export interface NudgeToolScoreDto {
      */
     mdiIcon?: string;
     /**
+     * Whether the score should be disabled in the UI.
+     * @type {boolean}
+     * @memberof NudgeToolScoreDto
+     */
+    disabled?: boolean;
+    /**
      * Localised title of the nudge.
      * @type {string}
      * @memberof NudgeToolScoreDto
@@ -71,6 +77,7 @@ export function NudgeToolScoreDtoFromJSONTyped(json: any, ignoreDiscriminator: b
         'scoreName': json['scoreName'] == null ? undefined : json['scoreName'],
         'scoreMinValue': json['scoreMinValue'] == null ? undefined : json['scoreMinValue'],
         'mdiIcon': json['mdiIcon'] == null ? undefined : json['mdiIcon'],
+        'disabled': json['disabled'] == null ? undefined : json['disabled'],
         'title': json['title'] == null ? undefined : json['title'],
         'description': json['description'] == null ? undefined : json['description'],
     };
@@ -90,8 +97,8 @@ export function NudgeToolScoreDtoToJSONTyped(value?: NudgeToolScoreDto | null, i
         'scoreName': value['scoreName'],
         'scoreMinValue': value['scoreMinValue'],
         'mdiIcon': value['mdiIcon'],
+        'disabled': value['disabled'],
         'title': value['title'],
         'description': value['description'],
     };
 }
-

--- a/model/src/main/java/org/open4goods/model/vertical/NudgeToolScore.java
+++ b/model/src/main/java/org/open4goods/model/vertical/NudgeToolScore.java
@@ -14,6 +14,10 @@ public class NudgeToolScore {
     private String mdiIcon;
     private Localisable<String, String> title = new Localisable<>();
     private Localisable<String, String> description = new Localisable<>();
+    /**
+     * Flag indicating the score should be disabled in the UI.
+     */
+    private Boolean disabled;
 
     public String getScoreName() {
         return scoreName;
@@ -55,6 +59,24 @@ public class NudgeToolScore {
         this.description = description;
     }
 
+    /**
+     * Returns whether this score is disabled in the UI.
+     *
+     * @return {@code true} when the score should be disabled, {@code false} otherwise.
+     */
+    public Boolean getDisabled() {
+        return disabled;
+    }
+
+    /**
+     * Defines whether this score is disabled in the UI.
+     *
+     * @param disabled the flag to apply
+     */
+    public void setDisabled(Boolean disabled) {
+        this.disabled = disabled;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -66,11 +88,11 @@ public class NudgeToolScore {
         NudgeToolScore that = (NudgeToolScore) o;
         return Objects.equals(scoreName, that.scoreName) && Objects.equals(scoreMinValue, that.scoreMinValue)
                 && Objects.equals(mdiIcon, that.mdiIcon) && Objects.equals(title, that.title)
-                && Objects.equals(description, that.description);
+                && Objects.equals(description, that.description) && Objects.equals(disabled, that.disabled);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(scoreName, scoreMinValue, mdiIcon, title, description);
+        return Objects.hash(scoreName, scoreMinValue, mdiIcon, title, description, disabled);
     }
 }

--- a/verticals/src/main/resources/verticals/dishwasher.yml
+++ b/verticals/src/main/resources/verticals/dishwasher.yml
@@ -182,6 +182,7 @@ nudgeToolConfig:
     - scoreName: "BRAND_SUSTAINALYTICS_SCORING"
       scoreMinValue: 4
       mdiIcon: "mdi-scale-balance"
+      disabled: true
       title:
         en: "ESG criterias"
         fr: "Critères ESG"

--- a/verticals/src/main/resources/verticals/oven.yml
+++ b/verticals/src/main/resources/verticals/oven.yml
@@ -155,6 +155,7 @@ nudgeToolConfig:
     - scoreName: "BRAND_SUSTAINALYTICS_SCORING"
       scoreMinValue: 4
       mdiIcon: "mdi-scale-balance"
+      disabled: true
       title:
         en: "ESG criterias"
         fr: "Critères ESG"

--- a/verticals/src/main/resources/verticals/refrigerator.yml
+++ b/verticals/src/main/resources/verticals/refrigerator.yml
@@ -158,6 +158,7 @@ nudgeToolConfig:
     - scoreName: "BRAND_SUSTAINALYTICS_SCORING"
       scoreMinValue: 3.0
       mdiIcon: "mdi-scale-balance"
+      disabled: true
       title:
         en: "ESG criteria"
         fr: "Critères ESG"


### PR DESCRIPTION
### Motivation

- Provide a simple, configurable way to hide/disable specific nudge tool scores from the UI and filter pipeline without removing their definitions from verticals.
- Immediately disable the BRAND_SUSTAINALYTICS_SCORING (ESG) score for affected verticals while keeping data and mapping stable.

### Description

- Add a `disabled` Boolean property to the domain model `NudgeToolScore` and include getters/setters, `equals` and `hashCode` updates. 
- Expose the flag through the front-api DTO `NudgeToolScoreDto` and populate it in the mapping in `CategoryMappingService`. 
- Propagate the field to the generated frontend API client model `frontend/shared/api-client/models/NudgeToolScoreDto.ts`. 
- Mark ESG scores as `disabled: true` in vertical YAML configs for `refrigerator`, `dishwasher`, and `oven`. 
- Update the frontend nudge tool: the scores step (`NudgeToolStepScores.vue`) now respects `disabled` (visual disabled state and prevented toggling) and `buildScoreFilters` ignores disabled scores, plus unit tests updated/added for both behaviors. 

### Testing

- Ran `mvn --offline -pl model,verticals,front-api -am test` and the Maven test run completed successfully with BUILD SUCCESS. 
- Ran frontend unit tests with `pnpm test` (Vitest) and all tests passed (`112` test files, `398` tests passed). 
- Ran the frontend generation step with `pnpm generate` which completed successfully and produced the static output without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754d3ec8dc83228ac6b7b136f68f2e)