### PR TITLE
Align impact score normalization with market-relative scoring

### DIFF
--- a/frontend/docs/impactscore/IMPACT_SCORE_CONFIGURATION_YAML.md
+++ b/frontend/docs/impactscore/IMPACT_SCORE_CONFIGURATION_YAML.md
@@ -83,7 +83,7 @@ scoring:
     method: SIGMA
     params:
       sigmaK: 2.0
-  missingValuePolicy: WORST
+  missingValuePolicy: NEUTRAL
 ```
 
 ### 4.2 Classe énergétique (bornes fixes via mapping numérique)
@@ -126,7 +126,7 @@ impactBetterIs: GREATER
 scoring:
   normalization:
     method: MINMAX_OBSERVED
-  missingValuePolicy: WORST
+  missingValuePolicy: NEUTRAL
 ```
 
 ## 5) Validation à implémenter

--- a/frontend/docs/impactscore/IMPACT_SCORE_METHODOLOGIE.md
+++ b/frontend/docs/impactscore/IMPACT_SCORE_METHODOLOGIE.md
@@ -82,8 +82,9 @@ Une politique explicite doit exister :
 - **NEUTRAL** (ex : 2.5/5)
 - **WORST** (0/5)
 
-Recommandation fréquente :
-- Utiliser **WORST** pour éviter qu’une donnée manquante améliore artificiellement le score, et compenser via un critère `DATA_QUALITY`.
+Décision actuelle :
+- Utiliser **NEUTRAL** partout pour ne pas sur- ou sous-pondérer un produit sur une donnée absente.
+- Reporter la pénalisation globale via le critère `DATA_QUALITY`.
 
 ## 4. Points de cohérence à vérifier (backend)
 

--- a/frontend/docs/impactscore/scoring_methods.md
+++ b/frontend/docs/impactscore/scoring_methods.md
@@ -94,6 +94,10 @@ La méthode est définie dans `scoring.normalization.method` :
 **À éviter quand**
 - Trop peu de valeurs ou distribution instable (risque d'effet “yoyo” dans le temps).
 - Présence d’outliers forts (préférer `MINMAX_QUANTILE`).
+ 
+**Paramétrage recommandé**
+- La méthode est définie par attribut : on ajuste par vertical si la distribution devient instable.
+- En cas de distribution dégénérée, activer un `degenerateDistributionPolicy` explicite pour basculer sur une méthode de secours.
 
 ---
 
@@ -166,53 +170,53 @@ Cela permet d'utiliser la même normalisation (ex: MINMAX_FIXED) tout en indiqua
 
 ### Durabilité / support / disponibilité
 
-- `MINAVAILABILITYSOFTWAREUPDATESYEARS` (SIGMA) : proposer `MINMAX_FIXED` avec bornes marché (ex: 0–10 ans) si ces bornes sont connues, ou `MINMAX_OBSERVED` si l’on veut un score relatif au marché actuel.
-- `MINAVAILABILITYSPAREPARTSYEARS` (SIGMA) : même recommandation.
-- `MINGUARANTEEDSUPPORTYEARS` (SIGMA) : même recommandation.
-- `WARRANTY` (SIGMA) : même recommandation.
+- `MINAVAILABILITYSOFTWAREUPDATESYEARS` : `MINMAX_OBSERVED`.
+- `MINAVAILABILITYSPAREPARTSYEARS` : `MINMAX_OBSERVED`.
+- `MINGUARANTEEDSUPPORTYEARS` : `MINMAX_OBSERVED`.
+- `WARRANTY` : `MINMAX_OBSERVED`.
 
-**Pourquoi** : les durées sont souvent discrètes et bornées. Une échelle fixe donne un score stable et lisible.
+**Pourquoi** : les durées sont discrètes et bornées ; on veut un score relatif au marché actuel.
 
 ### Consommations électriques (W)
 
-- `POWER_CONSUMPTION_TYPICAL` (SIGMA) : considérer `MINMAX_QUANTILE` (p5/p95) ou `MINMAX_FIXED` si bornes stables.
-- `POWER_CONSUMPTION_SDR` (SIGMA) : idem.
-- `POWER_CONSUMPTION_HDR` (SIGMA) : idem.
-- `POWER_CONSUMPTION_STANDBY` (SIGMA) : idem.
-- `POWER_CONSUMPTION_STANDBY_NETWORKD` (SIGMA) : idem.
-- `POWER_CONSUMPTION_OFF` (SIGMA) : idem.
+- `POWER_CONSUMPTION_TYPICAL` : `MINMAX_OBSERVED`.
+- `POWER_CONSUMPTION_SDR` : `MINMAX_OBSERVED`.
+- `POWER_CONSUMPTION_HDR` : `MINMAX_OBSERVED`.
+- `POWER_CONSUMPTION_STANDBY` : `MINMAX_OBSERVED`.
+- `POWER_CONSUMPTION_STANDBY_NETWORKD` : `MINMAX_OBSERVED`.
+- `POWER_CONSUMPTION_OFF` : `MINMAX_OBSERVED`.
 
-**Pourquoi** : distributions souvent très asymétriques / coverage faible → SIGMA peu robuste.
+**Pourquoi** : on cherche une sobriété relative à l’offre actuelle ; la méthode reste ajustable par attribut si la distribution devient instable.
 
 ### Classe énergétique (catégoriel)
 
-- `CLASSE_ENERGY` (MINMAX_FIXED + mapping numérique) : préférable en `FIXED_MAPPING` pour éviter une distance linéaire implicite entre classes.
-- `CLASSE_ENERGY_SDR` (MINMAX_FIXED + mapping numérique) : idem.
-- `CLASSE_ENERGY_HDR` (MINMAX_FIXED + mapping numérique) : idem.
+- `CLASSE_ENERGY` : `FIXED_MAPPING` avec barème A–G.
+- `CLASSE_ENERGY_SDR` : `FIXED_MAPPING` avec barème A–G.
+- `CLASSE_ENERGY_HDR` : `FIXED_MAPPING` avec barème A–G.
 
-**Pourquoi** : les classes énergétiques sont des paliers, pas une mesure continue.
+**Pourquoi** : les classes énergétiques sont des paliers réglementaires.
 
 ### Indice de réparabilité (0–10)
 
-- `REPAIRABILITY_INDEX` (MINMAX_FIXED 0–10) : méthode pertinente si la note officielle est 0–10. Alternative : `PERCENTILE` si on veut une relativisation purement marché.
+- `REPAIRABILITY_INDEX` : `MINMAX_OBSERVED` pour refléter le marché actuel.
 
 ### Taille / poids
 
-- `DIAGONALE_POUCES` (SIGMA) : alternative `MINMAX_QUANTILE` pour limiter l'effet des extrêmes.
-- `WEIGHT` (SIGMA) : alternative `MINMAX_QUANTILE` ou `MINMAX_FIXED` si bornes connues par segment.
+- `DIAGONALE_POUCES` : `MINMAX_OBSERVED`.
+- `WEIGHT` : `MINMAX_OBSERVED`.
 
 ### ESG / Sustainalytics
 
-- `ESG` (SIGMA) : recommandé `MINMAX_FIXED` avec `fixedMin: 0`, `fixedMax: 100`, et `impactBetterIs: LOWER`.
-- `BRAND_SUSTAINALYTICS_SCORING` (SIGMA) : recommandé `MINMAX_FIXED` avec `fixedMin: 0`, `fixedMax: 100`, et `impactBetterIs: LOWER`.
+- `ESG` : `MINMAX_OBSERVED` avec **plus haut = mieux**.
+- `BRAND_SUSTAINALYTICS_SCORING` : `MINMAX_OBSERVED` avec **plus haut = mieux**.
 
-**Pourquoi** : scores ESG et Sustainalytics sont sur 0–100 avec sens inversé (plus bas = meilleur). Un MINMAX_FIXED donne un score stable, tout en permettant l’inversion via `impactBetterIs`.
+**Pourquoi** : on conserve une lecture relative au marché actuel avec un sens « performance » (plus haut = mieux).
 
 ### Qualité de la donnée
 
-- `DATA_QUALITY` (SIGMA) : recommandé `MINMAX_FIXED` sur une borne marché (ex: 0–100), avec `impactBetterIs: GREATER` si plus de complétude = meilleur.
+- `DATA_QUALITY` : `MINMAX_OBSERVED`, et utilisé comme pénalisation globale quand les données sont incomplètes.
 
-**Pourquoi** : la qualité de donnée est souvent un taux ou une note bornée, donc une échelle fixe est plus claire.
+**Pourquoi** : on conserve une lecture relative, tout en faisant porter la pénalisation au niveau global.
 
 ## 5) Note sur la relativisation (Score.relativ)
 

--- a/verticals/src/main/resources/attributes/BRAND_SUSTAINALYTICS_SCORING.yml
+++ b/verticals/src/main/resources/attributes/BRAND_SUSTAINALYTICS_SCORING.yml
@@ -1,6 +1,6 @@
 key: "BRAND_SUSTAINALYTICS_SCORING"
-userBetterIs: "LOWER"
-impactBetterIs: "LOWER"
+userBetterIs: "GREATER"
+impactBetterIs: "GREATER"
 faIcon: "mdi-web"
 #    attributePath: attributes.features
 name:
@@ -12,10 +12,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreUtility:
   fr: "Reflète les engagements globaux de la marque qui influencent l’empreinte de ses produits."

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY.yml
@@ -12,11 +12,17 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "MINMAX_FIXED"
+    method: "FIXED_MAPPING"
     params:
-      fixedMin: 0.0
-      fixedMax: 18.0
-  missingValuePolicy: "WORST"
+      mapping:
+        "100": 5.0
+        "85": 4.25
+        "70": 3.5
+        "55": 2.75
+        "40": 2.0
+        "25": 1.25
+        "10": 0.5
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Classe énergétique"
@@ -54,23 +60,23 @@ parser:
   - "(ÉCHELLE A++ À E)"
   - "NOT AVAILABLE"
 numericMapping:
-  A+++: 18.0    
-  A++: 18.0
-  A+: 17.0
-  A: 16.0
-  B++: 15.0
-  B+: 14.0
-  B: 13.0
-  C++: 12.0
-  C+: 11.0
-  C: 10.0
-  D++: 9.0
-  D+: 8.0
-  D: 7.0
-  E++: 6.0
-  E+: 5.0
-  E: 4.0
-  F++: 3.0
-  F+: 2.0
-  F: 1.0
-  G: 0.0
+  A+++: 100.0
+  A++: 100.0
+  A+: 100.0
+  A: 100.0
+  B++: 85.0
+  B+: 85.0
+  B: 85.0
+  C++: 70.0
+  C+: 70.0
+  C: 70.0
+  D++: 55.0
+  D+: 55.0
+  D: 55.0
+  E++: 40.0
+  E+: 40.0
+  E: 40.0
+  F++: 25.0
+  F+: 25.0
+  F: 25.0
+  G: 10.0

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY_HDR.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY_HDR.yml
@@ -17,11 +17,17 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "MINMAX_FIXED"
+    method: "FIXED_MAPPING"
     params:
-      fixedMin: 0.0
-      fixedMax: 18.0
-  missingValuePolicy: "WORST"
+      mapping:
+        "100": 5.0
+        "85": 4.25
+        "70": 3.5
+        "55": 2.75
+        "40": 2.0
+        "25": 1.25
+        "10": 0.5
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Classe énergétique (HDR)"
@@ -50,23 +56,23 @@ parser:
     - "(ÉCHELLE A++ À E)"
     - "NOT AVAILABLE"
 numericMapping:
-  A+++: 18.0
-  A++: 18.0
-  A+: 17.0
-  A: 16.0
-  B++: 15.0
-  B+: 14.0
-  B: 13.0
-  C++: 12.0
-  C+: 11.0
-  C: 10.0
-  D++: 9.0
-  D+: 8.0
-  D: 7.0
-  E++: 6.0
-  E+: 5.0
-  E: 4.0
-  F++: 3.0
-  F+: 2.0
-  F: 1.0
-  G: 0.0
+  A+++: 100.0
+  A++: 100.0
+  A+: 100.0
+  A: 100.0
+  B++: 85.0
+  B+: 85.0
+  B: 85.0
+  C++: 70.0
+  C+: 70.0
+  C: 70.0
+  D++: 55.0
+  D+: 55.0
+  D: 55.0
+  E++: 40.0
+  E+: 40.0
+  E: 40.0
+  F++: 25.0
+  F+: 25.0
+  F: 25.0
+  G: 10.0

--- a/verticals/src/main/resources/attributes/CLASSE_ENERGY_SDR.yml
+++ b/verticals/src/main/resources/attributes/CLASSE_ENERGY_SDR.yml
@@ -17,11 +17,17 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "MINMAX_FIXED"
+    method: "FIXED_MAPPING"
     params:
-      fixedMin: 0.0
-      fixedMax: 18.0
-  missingValuePolicy: "WORST"
+      mapping:
+        "100": 5.0
+        "85": 4.25
+        "70": 3.5
+        "55": 2.75
+        "40": 2.0
+        "25": 1.25
+        "10": 0.5
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Classe énergétique (SDR)"
@@ -50,23 +56,23 @@ parser:
     - "(ÉCHELLE A++ À E)"
     - "NOT AVAILABLE"
 numericMapping:
-  A+++: 18.0
-  A++: 18.0
-  A+: 17.0
-  A: 16.0
-  B++: 15.0
-  B+: 14.0
-  B: 13.0
-  C++: 12.0
-  C+: 11.0
-  C: 10.0
-  D++: 9.0
-  D+: 8.0
-  D: 7.0
-  E++: 6.0
-  E+: 5.0
-  E: 4.0
-  F++: 3.0
-  F+: 2.0
-  F: 1.0
-  G: 0.0
+  A+++: 100.0
+  A++: 100.0
+  A+: 100.0
+  A: 100.0
+  B++: 85.0
+  B+: 85.0
+  B: 85.0
+  C++: 70.0
+  C+: 70.0
+  C: 70.0
+  D++: 55.0
+  D+: 55.0
+  D: 55.0
+  E++: 40.0
+  E+: 40.0
+  E: 40.0
+  F++: 25.0
+  F+: 25.0
+  F: 25.0
+  G: 10.0

--- a/verticals/src/main/resources/attributes/DATA_QUALITY.yml
+++ b/verticals/src/main/resources/attributes/DATA_QUALITY.yml
@@ -12,9 +12,7 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
+    method: "MINMAX_OBSERVED"
   missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreUtility:

--- a/verticals/src/main/resources/attributes/DIAGONALE_POUCES.yml
+++ b/verticals/src/main/resources/attributes/DIAGONALE_POUCES.yml
@@ -3,7 +3,7 @@
 ##################################
 key: "DIAGONALE_POUCES"
 userBetterIs: "GREATER"
-impactBetterIs: "LOWER"
+impactBetterIs: "GREATER"
 icecatFeaturesIds:
   - 944
 eprelFeatureNames:
@@ -22,10 +22,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreUtility:
   fr: "La diagonale influe sur matériaux et énergie : plus elle est grande, plus l’impact de fabrication, transport et usage augmente."

--- a/verticals/src/main/resources/attributes/ESG.yml
+++ b/verticals/src/main/resources/attributes/ESG.yml
@@ -11,10 +11,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   default: "ESG performance"

--- a/verticals/src/main/resources/attributes/MINAVAILABILITYSOFTWAREUPDATESYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINAVAILABILITYSOFTWAREUPDATESYEARS.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Mises à jour logicielles"

--- a/verticals/src/main/resources/attributes/MINAVAILABILITYSPAREPARTSYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINAVAILABILITYSPAREPARTSYEARS.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Disponibilité pièces détachées"

--- a/verticals/src/main/resources/attributes/MINGUARANTEEDSUPPORTYEARS.yml
+++ b/verticals/src/main/resources/attributes/MINGUARANTEEDSUPPORTYEARS.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Support garanti"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_HDR.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_HDR.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (HDR)"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_OFF.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_OFF.yml
@@ -9,10 +9,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (arret)"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_SDR.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_SDR.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (SDR)"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (mode veille)"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY_NETWORKD.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_STANDBY_NETWORKD.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (veille réseau)"

--- a/verticals/src/main/resources/attributes/POWER_CONSUMPTION_TYPICAL.yml
+++ b/verticals/src/main/resources/attributes/POWER_CONSUMPTION_TYPICAL.yml
@@ -9,10 +9,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Consommation électrique (en marche)"

--- a/verticals/src/main/resources/attributes/REPAIRABILITY_INDEX.yml
+++ b/verticals/src/main/resources/attributes/REPAIRABILITY_INDEX.yml
@@ -12,11 +12,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "MINMAX_FIXED"
-    params:
-      fixedMin: 0.0
-      fixedMax: 10.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Indice de réparabilité"

--- a/verticals/src/main/resources/attributes/WARRANTY.yml
+++ b/verticals/src/main/resources/attributes/WARRANTY.yml
@@ -20,10 +20,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Garantie"

--- a/verticals/src/main/resources/attributes/WEIGHT.yml
+++ b/verticals/src/main/resources/attributes/WEIGHT.yml
@@ -18,10 +18,8 @@ scoring:
     min: 0.0
     max: 5.0
   normalization:
-    method: "SIGMA"
-    params:
-      sigmaK: 2.0
-  missingValuePolicy: "WORST"
+    method: "MINMAX_OBSERVED"
+  missingValuePolicy: "NEUTRAL"
   degenerateDistributionPolicy: "FALLBACK"
 scoreTitle:
   fr: "Poids de l'objet"


### PR DESCRIPTION
### Motivation

- Standardise impact-score behaviour across verticals to a market-relative 0–5 subscore convention and ensure "higher = better" semantics where appropriate. 
- Avoid letting missing attribute values artificially advantage or penalise products by treating missing subscores as `NEUTRAL` and shifting penalisation to a global `DATA_QUALITY` criterion. 
- Use fixed mappings for categorical regulatory attributes (energy class) to avoid implicit linear distances between categories and keep UI/aggregation explanations consistent.

### Description

- Switched many attributes from `SIGMA` / `MINMAX_FIXED` to `MINMAX_OBSERVED` and set `missingValuePolicy: NEUTRAL` (examples include `POWER_CONSUMPTION_*`, `REPAIRABILITY_INDEX`, `WARRANTY`, durability attributes such as `MINAVAILABILITY*`, `WEIGHT`, `ESG`, `DATA_QUALITY`, etc.).
- Replaced the `CLASSE_ENERGY*` normalization with `FIXED_MAPPING` and provided a concrete mapping table into the 0–5 scale while remapping the old `numericMapping` values to a 0–100 base so the mapping is stable and explicit.
- Adjusted directional semantics for some attributes so the impact sense is consistent with the project decision (e.g. `DIAGONALE_POUCES` and `BRAND_SUSTAINALYTICS_SCORING` set to `impactBetterIs: GREATER`).
- Updated frontend documentation under `frontend/docs/impactscore/` (`IMPACT_SCORE_CONFIGURATION_YAML.md`, `IMPACT_SCORE_METHODOLOGIE.md`, `scoring_methods.md`) to record the `NEUTRAL` missing-value decision, recommend `MINMAX_OBSERVED` for market-relative scoring, describe `FIXED_MAPPING` usage, and document other alignment notes.

### Testing

- No automated tests were executed as part of this change.
- Please run the full backend build and tests with `mvn --offline clean install` and the frontend checks with `pnpm test` / `pnpm lint` before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975540e91e88322a3aeb8d9505911b9)