### PR TITLE
Expose ImpactScore & uncategorised counts and add AI summary to home hero

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
@@ -20,6 +20,12 @@ public record CategoriesStatsDto(
         @Schema(description = "Total number of ISBN items available in the OpenData exports.", example = "870000")
         long isbnOpenDataItemsCount,
 
+        @Schema(description = "Count of recent products with offers, a valid ImpactScore, and not excluded.", example = "5925")
+        long impactScoreProductsCount,
+
+        @Schema(description = "Count of recent products with offers that are not mapped to any vertical.", example = "81234")
+        long productsWithoutVerticalCount,
+
         @Schema(description = "Per-category product counts for recent products with offers, keyed by vertical id.", example = "{\"electronics\": 12000, \"appliances\": 8500}")
         Map<String, Long> productsCountByCategory,
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/mock/MockProductRepository.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/mock/MockProductRepository.java
@@ -53,6 +53,16 @@ public class MockProductRepository extends ProductRepository {
     }
 
     @Override
+    public Long countMainIndexHavingImpactScore() {
+        return 0L;
+    }
+
+    @Override
+    public Long countMainIndexWithoutVertical() {
+        return 0L;
+    }
+
+    @Override
     public Stream<Product> exportAll() {
         return Stream.empty();
     }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
@@ -42,6 +42,8 @@ class StatsServiceTest {
         given(openDataService.totalItemsGTIN()).willReturn(1_234L);
         given(openDataService.totalItemsISBN()).willReturn(567L);
         given(productRepository.countMainIndexHavingVertical("enabled")).willReturn(42L);
+        given(productRepository.countMainIndexHavingImpactScore()).willReturn(5_925L);
+        given(productRepository.countMainIndexWithoutVertical()).willReturn(3_210L);
         given(partnerService.getPartners()).willReturn(List.of(mock(AffiliationPartner.class), mock(AffiliationPartner.class)));
 
         StatsService service = new StatsService(serialisationService, resolver, partnerService, openDataService, productRepository);
@@ -52,6 +54,8 @@ class StatsServiceTest {
         assertThat(dto.affiliationPartnersCount()).isEqualTo(2);
         assertThat(dto.gtinOpenDataItemsCount()).isEqualTo(1_234L);
         assertThat(dto.isbnOpenDataItemsCount()).isEqualTo(567L);
+        assertThat(dto.impactScoreProductsCount()).isEqualTo(5_925L);
+        assertThat(dto.productsWithoutVerticalCount()).isEqualTo(3_210L);
         assertThat(dto.productsCountByCategory()).isEqualTo(Map.of("enabled", 42L));
         assertThat(dto.productsCountSum()).isEqualTo(42L);
     }

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -31,6 +31,9 @@ const props = defineProps<{
   openDataMillions?: number
   productsCount?: number
   categoriesCount?: number
+  impactScoreProductsCount?: number
+  productsWithoutVerticalCount?: number
+  aiSummaryRemainingCredits?: number
   heroBackgroundI18nKey?: string
   shouldReduceMotion?: boolean
 }>()
@@ -320,6 +323,9 @@ useHead({
                     :open-data-millions="openDataMillions"
                     :products-count="productsCount"
                     :categories-count="categoriesCount"
+                    :impact-score-products-count="impactScoreProductsCount"
+                    :products-without-vertical-count="productsWithoutVerticalCount"
+                    :ai-summary-remaining-credits="aiSummaryRemainingCredits"
                   />
                 </div>
               </div>

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -47,10 +47,24 @@ const messages: Record<string, unknown> = {
       title: '🌿 ImpactScore: guiding your purchases',
       segments: [
         {
-          text: 'An innovative ecological and environmental assessment for {products} products across',
+          text: 'Buy less harmful for the planet, thanks to our',
         },
         {
-          text: '{categories} categories',
+          text: 'environmental assessment',
+          to: '/impact-score',
+        },
+        {
+          text: 'covering',
+        },
+        {
+          text: '{impactScoreProducts}',
+          to: '/impact-score',
+        },
+        {
+          text: 'products across',
+        },
+        {
+          text: '{impactScoreCategories} categories',
           to: '/categories',
         },
       ],
@@ -59,15 +73,33 @@ const messages: Record<string, unknown> = {
       title: '🇫🇷 Open & ethical',
       segments: [
         {
-          text: '100% independent. Over {millions}M products in',
+          text: '100% independent. Made in France,',
+          icon: 'breton-flag',
+          iconPosition: 'after',
+        },
+        {
+          text: 'hosted in Europe. Over',
+        },
+        {
+          text: '{millions}M',
+          to: '/opendata',
+        },
+        {
+          text: 'products in',
         },
         {
           text: 'open data.',
           to: '/opendata',
         },
         {
-          text: 'Open-source software',
+          text: 'Nudger is also',
+        },
+        {
+          text: 'open source',
           to: '/opensource',
+        },
+        {
+          text: 'and collects no personal data.',
         },
       ],
     },
@@ -75,14 +107,21 @@ const messages: Record<string, unknown> = {
       title: 'Price comparison',
       segments: [
         {
-          text: 'Avoid price traps with',
+          text: 'Avoid price traps with the best offers from',
         },
         {
-          text: '{partnersLink}.',
+          text: '{partnersLink}',
           to: '/partners',
         },
         {
-          text: 'Best prices, new and used price history for {products} products',
+          text: 'merchants. Buy at the right time with new and used price history for',
+        },
+        {
+          text: '{priceHistoryProducts}',
+          to: '/categories',
+        },
+        {
+          text: 'products.',
         },
       ],
     },
@@ -143,10 +182,24 @@ const messages: Record<string, unknown> = {
       title: '🌿 ImpactScore: guiding your purchases',
       segments: [
         {
-          text: 'An innovative ecological and environmental assessment for {products} products across',
+          text: 'Buy less harmful for the planet, thanks to our',
         },
         {
-          text: '{categories} categories',
+          text: 'environmental assessment',
+          to: '/impact-score',
+        },
+        {
+          text: 'covering',
+        },
+        {
+          text: '{impactScoreProducts}',
+          to: '/impact-score',
+        },
+        {
+          text: 'products across',
+        },
+        {
+          text: '{impactScoreCategories} categories',
           to: '/categories',
         },
       ],
@@ -155,15 +208,33 @@ const messages: Record<string, unknown> = {
       title: '🇫🇷 Open & ethical',
       segments: [
         {
-          text: '100% independent. Over {millions}M products in',
+          text: '100% independent. Made in France,',
+          icon: 'breton-flag',
+          iconPosition: 'after',
+        },
+        {
+          text: 'hosted in Europe. Over',
+        },
+        {
+          text: '{millions}M',
+          to: '/opendata',
+        },
+        {
+          text: 'products in',
         },
         {
           text: 'open data.',
           to: '/opendata',
         },
         {
-          text: 'Open-source software',
+          text: 'Nudger is also',
+        },
+        {
+          text: 'open source',
           to: '/opensource',
+        },
+        {
+          text: 'and collects no personal data.',
         },
       ],
     },
@@ -171,18 +242,30 @@ const messages: Record<string, unknown> = {
       title: 'Price comparison',
       segments: [
         {
-          text: 'Avoid price traps with',
+          text: 'Avoid price traps with the best offers from',
         },
         {
-          text: '{partnersLink}.',
+          text: '{partnersLink}',
           to: '/partners',
         },
         {
-          text: 'Best prices, new and used price history for {products} products',
+          text: 'merchants. Buy at the right time with new and used price history for',
+        },
+        {
+          text: '{priceHistoryProducts}',
+          to: '/categories',
+        },
+        {
+          text: 'products.',
         },
       ],
     },
   ],
+  'home.hero.aiSummary.title': 'Community AI summary',
+  'home.hero.aiSummary.creditsLabel': 'Credits remaining: {count}',
+  'home.hero.aiSummary.creditsFallback': 'Credits remaining: unavailable',
+  'home.hero.aiSummary.description':
+    'A powerful tool with real AI inside, giving you a panoramic view of your product. Free and community-driven.',
   'home.hero.search.partnerLinkLabel':
     '{formattedCount} partner | {formattedCount} partners',
   'home.hero.search.partnerLinkFallback': 'our partners',

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -8,6 +8,7 @@ import type {
   AffiliationPartnerDto,
   BlogPostDto,
   CategoriesStatsDto,
+  IpQuotaStatusDto,
 } from '~~/shared/api-client'
 import HomeHeroSection from '~/components/home/sections/HomeHeroSection.vue'
 import HomeProblemsSection from '~/components/home/sections/HomeProblemsSection.vue'
@@ -91,6 +92,18 @@ const { data: affiliationPartners } = await useAsyncData<
   }
 )
 
+const { data: reviewQuotaStatus } = await useAsyncData<IpQuotaStatusDto | null>(
+  'home-review-quota',
+  () =>
+    $fetch<IpQuotaStatusDto>('/api/quotas/REVIEW_GENERATION', {
+      headers: requestHeaders,
+    }).catch(() => null),
+  {
+    default: () => null,
+    server: true,
+  }
+)
+
 const heroPartnersCount = computed(() => {
   const statsCount = categoriesStats.value?.affiliationPartnersCount
 
@@ -119,6 +132,26 @@ const openDataMillions = computed(() => {
   return roundedMillions > 0 ? roundedMillions : null
 })
 
+const impactScoreProductsCount = computed(() => {
+  const count = categoriesStats.value?.impactScoreProductsCount
+
+  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) {
+    return null
+  }
+
+  return count
+})
+
+const productsWithoutVerticalCount = computed(() => {
+  const count = categoriesStats.value?.productsWithoutVerticalCount
+
+  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) {
+    return null
+  }
+
+  return count
+})
+
 const productsCount = computed(() => {
   const count = categoriesStats.value?.productsCountSum
 
@@ -139,6 +172,16 @@ const categoriesCount = computed(() => {
   const fallbackCount = categoriesStats.value?.enabledVerticalConfigs ?? 0
 
   return fallbackCount > 0 ? fallbackCount : null
+})
+
+const aiSummaryRemainingCredits = computed(() => {
+  const remaining = reviewQuotaStatus.value?.remaining
+
+  if (typeof remaining !== 'number' || !Number.isFinite(remaining)) {
+    return null
+  }
+
+  return remaining
 })
 
 const seasonalEventPack = useSeasonalEventPack()
@@ -775,6 +818,9 @@ useHead(() => ({
         :open-data-millions="openDataMillions"
         :products-count="productsCount"
         :categories-count="categoriesCount"
+        :impact-score-products-count="impactScoreProductsCount"
+        :products-without-vertical-count="productsWithoutVerticalCount"
+        :ai-summary-remaining-credits="aiSummaryRemainingCredits"
         :should-reduce-motion="shouldReduceMotion"
         hero-background-i18n-key="hero.background"
         @submit="handleSearchSubmit"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -111,10 +111,24 @@
               "title": "🌿 ImpactScore: guiding your purchases",
               "segments": [
                 {
-                  "text": "An innovative ecological and environmental assessment for {products} products across"
+                  "text": "Buy less harmful for the planet, thanks to our"
                 },
                 {
-                  "text": "{categories} categories",
+                  "text": "environmental assessment",
+                  "to": "/impact-score"
+                },
+                {
+                  "text": "covering"
+                },
+                {
+                  "text": "{impactScoreProducts}",
+                  "to": "/impact-score"
+                },
+                {
+                  "text": "products across"
+                },
+                {
+                  "text": "{impactScoreCategories} categories",
                   "to": "/categories"
                 }
               ]
@@ -123,15 +137,33 @@
               "title": "🇫🇷 Open & ethical",
               "segments": [
                 {
-                  "text": "100% independent. Over {millions}M products in"
+                  "text": "100% independent. Made in France,",
+                  "icon": "breton-flag",
+                  "iconPosition": "after"
+                },
+                {
+                  "text": "hosted in Europe. Over"
+                },
+                {
+                  "text": "{millions}M",
+                  "to": "/opendata"
+                },
+                {
+                  "text": "products in"
                 },
                 {
                   "text": "open data.",
                   "to": "/opendata"
                 },
                 {
-                  "text": "Open-source software",
+                  "text": "Nudger is also"
+                },
+                {
+                  "text": "open source",
                   "to": "/opensource"
+                },
+                {
+                  "text": "and collects no personal data."
                 }
               ]
             },
@@ -139,14 +171,21 @@
               "title": "Price comparison",
               "segments": [
                 {
-                  "text": "Avoid price traps with"
+                  "text": "Avoid price traps with the best offers from"
                 },
                 {
-                  "text": "{partnersLink}.",
+                  "text": "{partnersLink}",
                   "to": "/partners"
                 },
                 {
-                  "text": "Best prices, new and used price history for {products} products"
+                  "text": "merchants. Buy at the right time with new and used price history for"
+                },
+                {
+                  "text": "{priceHistoryProducts}",
+                  "to": "/categories"
+                },
+                {
+                  "text": "products."
                 }
               ]
             }
@@ -328,10 +367,24 @@
           "title": "🌿 ImpactScore: guiding your purchases",
           "segments": [
             {
-              "text": "An innovative ecological and environmental assessment for {products} products across"
+              "text": "Buy less harmful for the planet, thanks to our"
             },
             {
-              "text": "{categories} categories",
+              "text": "environmental assessment",
+              "to": "/impact-score"
+            },
+            {
+              "text": "covering"
+            },
+            {
+              "text": "{impactScoreProducts}",
+              "to": "/impact-score"
+            },
+            {
+              "text": "products across"
+            },
+            {
+              "text": "{impactScoreCategories} categories",
               "to": "/categories"
             }
           ]
@@ -340,15 +393,33 @@
           "title": "🇫🇷 Open & ethical",
           "segments": [
             {
-              "text": "100% independent. Over {millions}M products in"
+              "text": "100% independent. Made in France,",
+              "icon": "breton-flag",
+              "iconPosition": "after"
+            },
+            {
+              "text": "hosted in Europe. Over"
+            },
+            {
+              "text": "{millions}M",
+              "to": "/opendata"
+            },
+            {
+              "text": "products in"
             },
             {
               "text": "open data.",
               "to": "/opendata"
             },
             {
-              "text": "Open-source software",
+              "text": "Nudger is also"
+            },
+            {
+              "text": "open source",
               "to": "/opensource"
+            },
+            {
+              "text": "and collects no personal data."
             }
           ]
         },
@@ -356,18 +427,31 @@
           "title": "Price comparison",
           "segments": [
             {
-              "text": "Avoid price traps with"
+              "text": "Avoid price traps with the best offers from"
             },
             {
-              "text": "{partnersLink}.",
+              "text": "{partnersLink}",
               "to": "/partners"
             },
             {
-              "text": "Best prices, new and used price history for {products} products"
+              "text": "merchants. Buy at the right time with new and used price history for"
+            },
+            {
+              "text": "{priceHistoryProducts}",
+              "to": "/categories"
+            },
+            {
+              "text": "products."
             }
           ]
         }
       ],
+      "aiSummary": {
+        "title": "Community AI summary",
+        "creditsLabel": "Credits remaining: {count}",
+        "creditsFallback": "Credits remaining: unavailable",
+        "description": "A powerful tool with real AI inside, giving you a panoramic view of your product. Free and community-driven."
+      },
       "agent": {
         "title": "Any questions?",
         "subtitle": "Ask your question to our expert AI agent Nudger."

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -76,10 +76,24 @@
           "title": "🌿 ImpactScore : Guider vos achats",
           "segments": [
             {
-              "text": "On va vous faire acheter moins pire pour la planète, grâce à notre évaluation environnementale innovante pour {products} produits dans"
+              "text": "Acheter moins pire pour la planète, grâce à notre"
             },
             {
-              "text": "{categories} catégories",
+              "text": "évaluation environnementale",
+              "to": "/impact-score"
+            },
+            {
+              "text": "innovante pour"
+            },
+            {
+              "text": "{impactScoreProducts}",
+              "to": "/impact-score"
+            },
+            {
+              "text": "produits dans"
+            },
+            {
+              "text": "{impactScoreCategories}",
               "to": "/categories"
             }
           ]
@@ -88,15 +102,33 @@
           "title": "🇫🇷 Ouvert & éthique",
           "segments": [
             {
-              "text": "100% indépendant. Fait en france, hébergé en europe. Plus de {millions}M de produits en"
+              "text": "100% indépendant. Fait en France,",
+              "icon": "breton-flag",
+              "iconPosition": "after"
             },
             {
-              "text": "données ouvertes.Nudger est un ",
+              "text": "hébergé en Europe. Plus de"
+            },
+            {
+              "text": "{millions}M",
               "to": "/opendata"
             },
             {
-              "text": "Logiciel libre",
+              "text": "de produits en"
+            },
+            {
+              "text": "données ouvertes.",
+              "to": "/opendata"
+            },
+            {
+              "text": "Nudger est aussi"
+            },
+            {
+              "text": "open source",
               "to": "/opensource"
+            },
+            {
+              "text": "et ne collecte aucune donnée personnelle."
             }
           ]
         },
@@ -104,18 +136,31 @@
           "title": "🫰 Comparateur de prix",
           "segments": [
             {
-              "text": "Sans se faire avoir sur les prix avec"
+              "text": "Sans se faire avoir sur les prix, avec les meilleures offres auprès de"
             },
             {
-              "text": "{partnersLink}.",
+              "text": "{partnersLink}",
               "to": "/partenaires"
             },
             {
-              "text": "Les meilleurs prix, l'historique neuf et occasion pour {products} produits"
+              "text": "commerçants. Achetez au meilleur moment avec l'historique neuf et occasion pour"
+            },
+            {
+              "text": "{priceHistoryProducts}",
+              "to": "/categories"
+            },
+            {
+              "text": "produits."
             }
           ]
         }
       ],
+      "aiSummary": {
+        "title": "Synthèse IA communautaire",
+        "creditsLabel": "Crédits restants : {count}",
+        "creditsFallback": "Crédits restants : indisponible",
+        "description": "Un outil puissant avec de la vraie IA dedans, qui vous offre un panoramique de votre produit. Gratuit, communautaire."
+      },
       "agent": {
         "title": "Une question ?",
         "subtitle": "Posez votre question à notre agent IA expert Nudger."

--- a/frontend/public/images/icons/breton-flag.svg
+++ b/frontend/public/images/icons/breton-flag.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 32" aria-hidden="true">
+  <rect width="48" height="32" fill="#fff"/>
+  <rect width="6" height="32" fill="#000"/>
+  <rect x="12" width="6" height="32" fill="#000"/>
+  <rect x="24" width="6" height="32" fill="#000"/>
+  <rect x="36" width="6" height="32" fill="#000"/>
+  <rect width="24" height="16" fill="#000"/>
+  <g fill="#fff">
+    <circle cx="4" cy="4" r="1.2"/>
+    <circle cx="10" cy="4" r="1.2"/>
+    <circle cx="16" cy="4" r="1.2"/>
+    <circle cx="22" cy="4" r="1.2"/>
+    <circle cx="4" cy="8" r="1.2"/>
+    <circle cx="10" cy="8" r="1.2"/>
+    <circle cx="16" cy="8" r="1.2"/>
+    <circle cx="22" cy="8" r="1.2"/>
+    <circle cx="4" cy="12" r="1.2"/>
+    <circle cx="10" cy="12" r="1.2"/>
+    <circle cx="16" cy="12" r="1.2"/>
+    <circle cx="22" cy="12" r="1.2"/>
+  </g>
+</svg>

--- a/frontend/shared/api-client/models/CategoriesStatsDto.ts
+++ b/frontend/shared/api-client/models/CategoriesStatsDto.ts
@@ -44,6 +44,18 @@ export interface CategoriesStatsDto {
      */
     isbnOpenDataItemsCount?: number;
     /**
+     * Count of recent products with offers, a valid ImpactScore, and not excluded.
+     * @type {number}
+     * @memberof CategoriesStatsDto
+     */
+    impactScoreProductsCount?: number;
+    /**
+     * Count of recent products with offers that are not mapped to any vertical.
+     * @type {number}
+     * @memberof CategoriesStatsDto
+     */
+    productsWithoutVerticalCount?: number;
+    /**
      * Per-category product counts for recent products with offers, keyed by vertical id.
      * @type {{ [key: string]: number; }}
      * @memberof CategoriesStatsDto
@@ -78,6 +90,8 @@ export function CategoriesStatsDtoFromJSONTyped(json: any, ignoreDiscriminator: 
         'affiliationPartnersCount': json['affiliationPartnersCount'] == null ? undefined : json['affiliationPartnersCount'],
         'gtinOpenDataItemsCount': json['gtinOpenDataItemsCount'] == null ? undefined : json['gtinOpenDataItemsCount'],
         'isbnOpenDataItemsCount': json['isbnOpenDataItemsCount'] == null ? undefined : json['isbnOpenDataItemsCount'],
+        'impactScoreProductsCount': json['impactScoreProductsCount'] == null ? undefined : json['impactScoreProductsCount'],
+        'productsWithoutVerticalCount': json['productsWithoutVerticalCount'] == null ? undefined : json['productsWithoutVerticalCount'],
         'productsCountByCategory': json['productsCountByCategory'] == null ? undefined : json['productsCountByCategory'],
         'productsCountSum': json['productsCountSum'] == null ? undefined : json['productsCountSum'],
     };
@@ -98,8 +112,9 @@ export function CategoriesStatsDtoToJSONTyped(value?: CategoriesStatsDto | null,
         'affiliationPartnersCount': value['affiliationPartnersCount'],
         'gtinOpenDataItemsCount': value['gtinOpenDataItemsCount'],
         'isbnOpenDataItemsCount': value['isbnOpenDataItemsCount'],
+        'impactScoreProductsCount': value['impactScoreProductsCount'],
+        'productsWithoutVerticalCount': value['productsWithoutVerticalCount'],
         'productsCountByCategory': value['productsCountByCategory'],
         'productsCountSum': value['productsCountSum'],
     };
 }
-

--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -914,6 +914,33 @@ public class ProductRepository {
         }
 
         /**
+         * Count recent products with offers, a registered impact score, and not excluded from the catalogue.
+         *
+         * @return count of recent products with an ImpactScore
+         */
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexHavingImpactScore() {
+                Criteria criteria = getRecentPriceQuery()
+                        .and(new Criteria("excluded").is(false))
+                        .and(new Criteria("scores.IMPACTSCORE.value").exists());
+                CriteriaQuery query = new CriteriaQuery(criteria);
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
+        /**
+         * Count recent products with offers that are missing a vertical assignment.
+         *
+         * @return count of recent products without a vertical
+         */
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexWithoutVertical() {
+                Criteria criteria = getRecentPriceQuery()
+                        .and(new Criteria("vertical").exists().not());
+                CriteriaQuery query = new CriteriaQuery(criteria);
+                return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
+        /**
          * Count recent products for a specific vertical.
          *
          * @param vertical vertical identifier


### PR DESCRIPTION
### Motivation
- Surface richer homepage hero metrics by exposing counts for recent products that have an `IMPACTSCORE` and for recent products missing a `vertical`, and show AI summary credit info. 
- Refresh hero highlight copy to include ImpactScore placeholders and a small visual cue (Breton flag) for the “Made in France” messaging. 

### Description
- Add `countMainIndexHavingImpactScore()` and `countMainIndexWithoutVertical()` to `ProductRepository` to count recent products with offers filtered by impact score and missing vertical respectively. 
- Extend backend DTO `CategoriesStatsDto` and `StatsService` to include `impactScoreProductsCount` and `productsWithoutVerticalCount`, add `safeCount()` helper and update `MockProductRepository` and unit test expectations. 
- Update frontend types and API model (`CategoriesStatsDto.ts`), fetch the `REVIEW_GENERATION` quota (`/api/quotas/REVIEW_GENERATION`) and wire the new counts into the homepage (`index.vue`, `HomeHeroSection.vue`), plus update `HomeHeroHighlights.vue` to support new placeholders, icons and an AI summary banner. 
- Add i18n copy updates for EN/FR, add a small Breton flag SVG asset, and adjust hero highlight plumbing and text placeholders. 

### Testing
- Ran the frontend lint with `pnpm lint` which succeeded. 
- Ran the full frontend unit suite with `pnpm test` which completed successfully (`400 tests` across the suite passed). 
- Ran `pnpm generate` / Nuxt build which succeeded (produced `.output/public`) with unrelated warnings about duplicate keys in other components. 
- Attempted `mvn --offline -pl front-api -am test` but it failed in offline mode due to missing cached Spring Boot BOM artifacts; backend unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697560a35ab0832291419c6a3b5829c7)