### PR TITLE
Align global search with semantic filters and sorting payloads

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchRequestDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/search/GlobalSearchRequestDto.java
@@ -6,9 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * Request payload for global product search.
  *
  * @param query free-text query supplied by the caller
+ * @param filters optional filters scoped to the global search
+ * @param sort optional sort definition applied to the global search results
  */
 public record GlobalSearchRequestDto(
         @Schema(description = "Free-text query used to search across products.",
                 example = "Fairphone 4")
-        String query) {
+        String query,
+        @Schema(description = "Optional filters applied to global search results.")
+        FilterRequestDto filters,
+        @Schema(description = "Optional sort definition applied to global search results.")
+        SortRequestDto sort) {
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/share/ShareResolutionService.java
@@ -34,6 +34,7 @@ import org.open4goods.nudgerfrontapi.service.exception.InvalidAffiliationTokenEx
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -218,7 +219,7 @@ public class ShareResolutionService {
      * @return ordered list of candidates
      */
     private List<ShareCandidateDto> searchByQuery(String query, DomainLanguage domainLanguage) {
-        GlobalSearchResult searchResult = searchService.globalSearch(query, domainLanguage);
+        GlobalSearchResult searchResult = searchService.globalSearch(query, domainLanguage, null, Sort.unsorted());
         List<ShareCandidateDto> mapped = new ArrayList<>();
 
         searchResult.verticalGroups().forEach(group -> group.results().stream()

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/SearchServiceTest.java
@@ -58,7 +58,7 @@ class SearchServiceTest {
     void setUp() {
         searchProperties = new SearchProperties();
         searchService = new SearchService(repository, verticalsConfigService, productMappingService, apiProperties,
-                textEmbeddingService, embeddingProperties);
+                searchProperties, textEmbeddingService, embeddingProperties);
     }
 
     @Test
@@ -85,7 +85,8 @@ class SearchServiceTest {
         // WHEN
         when(textEmbeddingService.embed(any())).thenReturn(new float[]{0.1f});
 
-        GlobalSearchResult result = searchService.globalSearch("téléviseurs", DomainLanguage.fr);
+        GlobalSearchResult result = searchService.globalSearch("téléviseurs", DomainLanguage.fr, null,
+                org.springframework.data.domain.Sort.unsorted());
 
         // THEN
         assertThat(result).isNotNull();
@@ -111,7 +112,8 @@ class SearchServiceTest {
         // WHEN
         when(textEmbeddingService.embed(any())).thenReturn(new float[]{0.1f});
 
-        GlobalSearchResult result = searchService.globalSearch("something else", DomainLanguage.fr);
+        GlobalSearchResult result = searchService.globalSearch("something else", DomainLanguage.fr, null,
+                org.springframework.data.domain.Sort.unsorted());
 
         // THEN
         assertThat(result.verticalCta()).isNull();
@@ -133,7 +135,8 @@ class SearchServiceTest {
 
 
         // WHEN
-        GlobalSearchResult result = searchService.globalSearch("iphone", DomainLanguage.fr);
+        GlobalSearchResult result = searchService.globalSearch("iphone", DomainLanguage.fr, null,
+                org.springframework.data.domain.Sort.unsorted());
 
         // THEN
         // We verify that semantic embeddings were requested once.
@@ -174,11 +177,25 @@ class SearchServiceTest {
         when(productMappingService.mapProduct(any(), any(), any(), any(), eq(false)))
                 .thenReturn(new ProductDto(0L, null, null, null, null, null, null, null, null, null, null, null, null, null));
 
-        GlobalSearchResult result = searchService.globalSearch("bras articule", DomainLanguage.fr);
+        GlobalSearchResult result = searchService.globalSearch("bras articule", DomainLanguage.fr, null,
+                org.springframework.data.domain.Sort.unsorted());
 
         assertThat(result).isNotNull();
         assertThat(result.diagnostics()).isNotNull();
         assertThat(result.diagnostics().resultCount()).isEqualTo(1);
         assertThat(result.diagnostics().topScore()).isCloseTo(1.2d, org.assertj.core.data.Offset.offset(0.0001d));
+    }
+
+    @Test
+    void suggest_shouldSkipSemanticFallback_whenDisabled() {
+        searchProperties.getSuggest().setSemanticFallbackEnabled(false);
+        SearchHits<Product> emptyHits = new SearchHitsImpl<Product>(0L, TotalHitsRelation.EQUAL_TO, 0.0f,
+                java.time.Duration.ZERO, null, null, java.util.Collections.emptyList(), null, null, null);
+
+        when(repository.search(any(), eq(ProductRepository.MAIN_INDEX_NAME))).thenReturn(emptyHits);
+
+        searchService.suggest("iphone", DomainLanguage.fr);
+
+        verify(textEmbeddingService, times(0)).embed(any());
     }
 }

--- a/frontend/app/pages/search/index.vue
+++ b/frontend/app/pages/search/index.vue
@@ -395,6 +395,7 @@ const { data, pending, error, refresh } =
         headers: requestHeaders,
         body: {
           query: normalizedQuery.value,
+          ...(isFiltered.value ? { filters: filterRequest.value } : {}),
         },
       })
     },

--- a/frontend/server/api/products/search.post.ts
+++ b/frontend/server/api/products/search.post.ts
@@ -28,6 +28,8 @@ interface ProductsSearchPayload {
 
 interface GlobalSearchPayload {
   query?: string
+  filters?: FilterRequestDto
+  sort?: SortRequestDto
 }
 
 const isGlobalSearchPayload = (
@@ -40,9 +42,7 @@ const isGlobalSearchPayload = (
     'verticalId' in payload ||
     'pageNumber' in payload ||
     'pageSize' in payload ||
-    'sort' in payload ||
     'aggs' in payload ||
-    'filters' in payload ||
     'semanticSearch' in payload ||
     'include' in payload
   )
@@ -68,7 +68,11 @@ export default defineEventHandler(
 
     if (isGlobalSearchPayload(payload)) {
       try {
-        return await productService.searchGlobalProducts(payload.query ?? '')
+        return await productService.searchGlobalProducts({
+          query: payload.query ?? '',
+          filters: payload.filters,
+          sort: payload.sort,
+        })
       } catch (error) {
         const backendError = await extractBackendErrorDetails(error)
         console.error(

--- a/frontend/shared/api-client/models/GlobalSearchRequestDto.ts
+++ b/frontend/shared/api-client/models/GlobalSearchRequestDto.ts
@@ -13,6 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
+import type { FilterRequestDto } from './FilterRequestDto';
+import type { SortRequestDto } from './SortRequestDto';
 /**
  * 
  * @export
@@ -25,6 +27,18 @@ export interface GlobalSearchRequestDto {
      * @memberof GlobalSearchRequestDto
      */
     query?: string;
+    /**
+     * Optional filters applied to global search results.
+     * @type {FilterRequestDto}
+     * @memberof GlobalSearchRequestDto
+     */
+    filters?: FilterRequestDto;
+    /**
+     * Optional sort definition applied to global search results.
+     * @type {SortRequestDto}
+     * @memberof GlobalSearchRequestDto
+     */
+    sort?: SortRequestDto;
 }
 
 /**
@@ -45,6 +59,8 @@ export function GlobalSearchRequestDtoFromJSONTyped(json: any, ignoreDiscriminat
     return {
         
         'query': json['query'] == null ? undefined : json['query'],
+        'filters': json['filters'] == null ? undefined : json['filters'],
+        'sort': json['sort'] == null ? undefined : json['sort'],
     };
 }
 
@@ -60,6 +76,7 @@ export function GlobalSearchRequestDtoToJSONTyped(value?: GlobalSearchRequestDto
     return {
         
         'query': value['query'],
+        'filters': value['filters'],
+        'sort': value['sort'],
     };
 }
-

--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -3,6 +3,7 @@ import { ProductApi } from '..'
 import type {
   AggregationRequestDto,
   FilterRequestDto,
+  GlobalSearchRequestDto,
   GlobalSearchResponseDto,
   ProductDto,
   ProductFieldOptionsResponse,
@@ -154,9 +155,9 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
   }
 
   const searchGlobalProducts = async (
-    query: string
+    payload: GlobalSearchRequestDto
   ): Promise<GlobalSearchResponseDto> => {
-    const normalizedQuery = query?.trim()
+    const normalizedQuery = payload?.query?.trim()
 
     if (!normalizedQuery) {
       throw new TypeError('Query is required to execute a global search.')
@@ -177,6 +178,8 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
         },
         body: {
           query: normalizedQuery,
+          filters: payload.filters,
+          sort: payload.sort,
         },
       })
     } catch (error) {


### PR DESCRIPTION
### Motivation

- Allow global (embeddings-driven) search to accept client-supplied filters and optional sort rules so the frontend can request scoped semantic results.  
- Unify suggest behavior with configuration-driven semantic fallback and ensure share resolution reuses the new global search contract.  
- Keep the global search contract consistent across backend, server middleware and frontend API clients to avoid duplicated client-side workarounds.

### Description

- Extend the global search payload with `filters` and `sort` by adding fields to `GlobalSearchRequestDto` and updating the frontend server route and API client to forward those fields.  
- Refactor `SearchService` to accept `SearchProperties`, add a `VerticalScope` enum, and implement embeddings-only semantic filtering with vertical scoping, plus an internal mechanism to sort semantic hits using a comparator that resolves values from `Product` (price, brand, model, ecoscore, creation/lastChange).  
- Update `ProductController` to validate incoming global `filters` and `sort` against allowed mappings and forward a validated `Sort` to the service, and adjust `ShareResolutionService` to call the new `globalSearch` signature.  
- Update tests and wiring: adapt `SearchServiceTest` to the new constructor and `globalSearch` signature and add a suggest test that checks the semantic suggest fallback toggle; update frontend pages to include filters when calling global search.

### Testing

- Ran `mvn --offline -pl front-api -am test`, which failed due to missing Spring Boot BOM in offline mode (environment constraint).  
- Ran `pnpm lint` in the frontend, which passed.  
- Ran `pnpm test` in the frontend; most tests passed but one test failed: `ProductAiReviewSection.spec.ts` assertion mismatch.  
- Ran `pnpm generate` (Nuxt build/generate) which completed successfully with non-blocking warnings about duplicate keys in some Vue files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975732f208c832298f4033d8907e71c)