### PR TITLE
Make search filters always visible and add lexical fallback for missing-vertical results

### DIFF
--- a/frontend/app/components/category/CategoryFiltersPanel.vue
+++ b/frontend/app/components/category/CategoryFiltersPanel.vue
@@ -1,139 +1,122 @@
 <template>
   <div class="category-filters" data-testid="category-filters">
-    <v-expansion-panels multiple class="category-filters__panels">
-      <v-expansion-panel value="global" expand-icon="mdi-chevron-down">
-        <template #title>
-          <h2 class="category-filters__title">
-            <v-icon
-              icon="mdi-tune-variant"
-              size="20"
-              class="category-filters__title-icon"
-            />
-            <span>{{ t('category.filters.globalTitle') }}</span>
-          </h2>
-        </template>
-        <template #text>
-          <div class="category-filters__section">
-            <CategoryFilterList
-              :fields="filterOptions?.global ?? []"
-              :aggregations="aggregationMap"
-              :baseline-aggregations="baselineAggregationMap"
-              :active-filters="activeFilters"
-              @update-range="updateRangeFilter"
-              @update-terms="updateTermsFilter"
-            />
-          </div>
-        </template>
-      </v-expansion-panel>
+    <section class="category-filters__section">
+      <h2 class="category-filters__title">
+        <v-icon
+          icon="mdi-tune-variant"
+          size="20"
+          class="category-filters__title-icon"
+        />
+        <span>{{ t('category.filters.globalTitle') }}</span>
+      </h2>
+      <div class="category-filters__section-body">
+        <CategoryFilterList
+          :fields="filterOptions?.global ?? []"
+          :aggregations="aggregationMap"
+          :baseline-aggregations="baselineAggregationMap"
+          :active-filters="activeFilters"
+          @update-range="updateRangeFilter"
+          @update-terms="updateTermsFilter"
+        />
+      </div>
+    </section>
 
-      <v-expansion-panel value="impact" expand-icon="mdi-chevron-down">
-        <template #title>
-          <h2 class="category-filters__title">
-            <v-icon
-              icon="mdi-leaf"
-              size="20"
-              class="category-filters__title-icon"
-            />
-            <span>{{ t('category.filters.impactTitle') }}</span>
-          </h2>
-        </template>
-        <template #text>
-          <div class="category-filters__section">
-            <CategoryFilterList
-              :fields="impactPrimary"
-              :aggregations="aggregationMap"
-              :baseline-aggregations="baselineAggregationMap"
-              :active-filters="activeFilters"
-              @update-range="updateRangeFilter"
-              @update-terms="updateTermsFilter"
-            />
+    <section class="category-filters__section">
+      <h2 class="category-filters__title">
+        <v-icon
+          icon="mdi-leaf"
+          size="20"
+          class="category-filters__title-icon"
+        />
+        <span>{{ t('category.filters.impactTitle') }}</span>
+      </h2>
+      <div class="category-filters__section-body">
+        <CategoryFilterList
+          :fields="impactPrimary"
+          :aggregations="aggregationMap"
+          :baseline-aggregations="baselineAggregationMap"
+          :active-filters="activeFilters"
+          @update-range="updateRangeFilter"
+          @update-terms="updateTermsFilter"
+        />
 
-            <div
-              v-if="impactRemaining.length"
-              class="category-filters__see-more"
-            >
-              <v-btn
-                variant="text"
-                density="comfortable"
-                color="primary"
-                @click="toggleImpactExpansion"
-              >
-                {{
-                  impactExpanded
-                    ? t('category.filters.hideImpact')
-                    : t('category.filters.showMoreImpact')
-                }}
-              </v-btn>
+        <div v-if="impactRemaining.length" class="category-filters__see-more">
+          <v-btn
+            variant="text"
+            density="comfortable"
+            color="primary"
+            @click="toggleImpactExpansion"
+          >
+            {{
+              impactExpanded
+                ? t('category.filters.hideImpact')
+                : t('category.filters.showMoreImpact')
+            }}
+          </v-btn>
 
-              <CategoryFilterList
-                v-if="impactExpanded"
-                :fields="impactRemaining"
-                :aggregations="aggregationMap"
-                :baseline-aggregations="baselineAggregationMap"
-                :active-filters="activeFilters"
-                class="mt-3"
-                @update-range="updateRangeFilter"
-                @update-terms="updateTermsFilter"
-              />
-            </div>
-          </div>
-        </template>
-      </v-expansion-panel>
+          <CategoryFilterList
+            v-if="impactExpanded"
+            :fields="impactRemaining"
+            :aggregations="aggregationMap"
+            :baseline-aggregations="baselineAggregationMap"
+            :active-filters="activeFilters"
+            class="mt-3"
+            @update-range="updateRangeFilter"
+            @update-terms="updateTermsFilter"
+          />
+        </div>
+      </div>
+    </section>
 
-      <v-expansion-panel value="technical" expand-icon="mdi-chevron-down">
-        <template #title>
-          <h2 class="category-filters__title">
-            <v-icon
-              icon="mdi-cog"
-              size="20"
-              class="category-filters__title-icon"
-            />
-            <span>{{ t('category.filters.technicalTitle') }}</span>
-          </h2>
-        </template>
-        <template #text>
-          <div class="category-filters__section">
-            <CategoryFilterList
-              :fields="technicalPrimary"
-              :aggregations="aggregationMap"
-              :baseline-aggregations="baselineAggregationMap"
-              :active-filters="activeFilters"
-              @update-range="updateRangeFilter"
-              @update-terms="updateTermsFilter"
-            />
+    <section class="category-filters__section">
+      <h2 class="category-filters__title">
+        <v-icon
+          icon="mdi-cog"
+          size="20"
+          class="category-filters__title-icon"
+        />
+        <span>{{ t('category.filters.technicalTitle') }}</span>
+      </h2>
+      <div class="category-filters__section-body">
+        <CategoryFilterList
+          :fields="technicalPrimary"
+          :aggregations="aggregationMap"
+          :baseline-aggregations="baselineAggregationMap"
+          :active-filters="activeFilters"
+          @update-range="updateRangeFilter"
+          @update-terms="updateTermsFilter"
+        />
 
-            <div
-              v-if="technicalRemaining.length"
-              class="category-filters__see-more"
-            >
-              <v-btn
-                variant="text"
-                density="comfortable"
-                color="primary"
-                @click="toggleTechnicalExpansion"
-              >
-                {{
-                  technicalExpanded
-                    ? t('category.filters.hideTechnical')
-                    : t('category.filters.showMoreTechnical')
-                }}
-              </v-btn>
+        <div
+          v-if="technicalRemaining.length"
+          class="category-filters__see-more"
+        >
+          <v-btn
+            variant="text"
+            density="comfortable"
+            color="primary"
+            @click="toggleTechnicalExpansion"
+          >
+            {{
+              technicalExpanded
+                ? t('category.filters.hideTechnical')
+                : t('category.filters.showMoreTechnical')
+            }}
+          </v-btn>
 
-              <CategoryFilterList
-                v-if="technicalExpanded"
-                :fields="technicalRemaining"
-                :aggregations="aggregationMap"
-                :baseline-aggregations="baselineAggregationMap"
-                :active-filters="activeFilters"
-                class="mt-3"
-                @update-range="updateRangeFilter"
-                @update-terms="updateTermsFilter"
-              />
-            </div>
-          </div>
-        </template>
-      </v-expansion-panel>
-    </v-expansion-panels>
+          <CategoryFilterList
+            v-if="technicalExpanded"
+            :fields="technicalRemaining"
+            :aggregations="aggregationMap"
+            :baseline-aggregations="baselineAggregationMap"
+            :active-filters="activeFilters"
+            class="mt-3"
+            @update-range="updateRangeFilter"
+            @update-terms="updateTermsFilter"
+          />
+        </div>
+      </div>
+    </section>
   </div>
 </template>
 
@@ -283,15 +266,19 @@ const toggleTechnicalExpansion = () => {
   flex-direction: column
   gap: 1rem
 
-  &__panels
-    background: transparent
-    :deep(.v-expansion-panel)
-      background: rgb(var(--v-theme-surface-default))
-      border-radius: 0.75rem
-      margin-bottom: 0.75rem
-
   &__section
     padding: 1rem
+    border-radius: 0.75rem
+    background: rgb(var(--v-theme-surface-default))
+    border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.3)
+    display: flex
+    flex-direction: column
+    gap: 1rem
+
+  &__section-body
+    display: flex
+    flex-direction: column
+    gap: 1rem
 
   &__see-more
     margin-top: 1rem

--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -15,46 +15,19 @@
     </template>
 
     <template v-else>
-      <v-menu
-        v-for="field in fields"
-        :key="field.mapping ?? field.title"
-        :close-on-content-click="false"
-        location="bottom start"
-        offset="8"
-      >
-        <template #activator="{ props: menuProps }">
-          <v-btn
-            v-bind="menuProps"
-            :color="isActive(field) ? 'primary' : undefined"
-            :variant="isActive(field) ? 'flat' : 'outlined'"
-            append-icon="mdi-chevron-down"
-            class="text-none"
-          >
-            {{ resolveTitle(field) }}
-
-            <v-avatar
-              v-if="getFilterCount(field) > 0"
-              color="white"
-              size="20"
-              class="ms-2 text-primary font-weight-bold"
-              style="font-size: 12px"
-            >
-              {{ getFilterCount(field) }}
-            </v-avatar>
-          </v-btn>
-        </template>
-
-        <v-sheet min-width="320" class="pa-4 rounded-lg elevation-4 border">
-          <component
-            :is="resolveComponent(field)"
-            :field="field"
-            :aggregation="aggregations[field.mapping ?? '']"
-            :baseline-aggregation="baselineAggregations[field.mapping ?? '']"
-            :model-value="findActiveFilter(field.mapping)"
-            @update:model-value="onFilterChange(field, $event)"
-          />
-        </v-sheet>
-      </v-menu>
+      <div class="category-filter-list__row">
+        <component
+          :is="resolveComponent(field)"
+          v-for="field in fields"
+          :key="field.mapping ?? field.title"
+          :field="field"
+          :aggregation="aggregations[field.mapping ?? '']"
+          :baseline-aggregation="baselineAggregations[field.mapping ?? '']"
+          :model-value="findActiveFilter(field.mapping)"
+          class="category-filter-list__row-item"
+          @update:model-value="onFilterChange(field, $event)"
+        />
+      </div>
     </template>
   </div>
 </template>
@@ -65,8 +38,6 @@ import type {
   FieldMetadataDto,
   Filter,
 } from '~~/shared/api-client'
-import { resolveFilterFieldTitle } from '~/utils/_field-localization'
-
 import CategoryFilterNumeric from './CategoryFilterNumeric.vue'
 import CategoryFilterCondition from './CategoryFilterCondition.vue'
 import CategoryFilterTerms from './CategoryFilterTerms.vue'
@@ -90,8 +61,6 @@ const emit = defineEmits<{
   'update-terms': [field: string, terms: string[]]
 }>()
 
-const { t } = useI18n()
-
 const resolveComponent = (field: FieldMetadataDto) => {
   if (field.mapping === 'price.conditions') {
     return CategoryFilterCondition
@@ -104,30 +73,6 @@ const resolveComponent = (field: FieldMetadataDto) => {
 
 const findActiveFilter = (field?: string | null) => {
   return props.activeFilters.find(filter => filter.field === field) ?? null
-}
-
-const isActive = (field: FieldMetadataDto) => {
-  return !!findActiveFilter(field.mapping)
-}
-
-const getFilterCount = (field: FieldMetadataDto) => {
-  const filter = findActiveFilter(field.mapping)
-  if (!filter) return 0
-
-  if (filter.operator === 'term') {
-    return filter.terms?.length ?? 0
-  }
-
-  if (filter.operator === 'range') {
-    // If range is active, count as 1
-    return filter.min !== undefined || filter.max !== undefined ? 1 : 0
-  }
-
-  return 0
-}
-
-const resolveTitle = (field: FieldMetadataDto) => {
-  return resolveFilterFieldTitle(field, t)
 }
 
 const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
@@ -165,14 +110,23 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
     align-items: stretch
 
   &--row
-    display: flex
-    flex-direction: row
-    flex-wrap: wrap
-    gap: 0.75rem
-    align-items: center
+    display: block
 
   &__item
     display: flex
     flex-direction: column
     min-width: 0
+
+  &__row
+    display: flex
+    flex-direction: row
+    flex-wrap: wrap
+    gap: 1rem
+    align-items: stretch
+
+  &__row-item
+    display: flex
+    flex-direction: column
+    flex: 1 1 280px
+    min-width: min(280px, 100%)
 </style>

--- a/frontend/app/pages/search/index.vue
+++ b/frontend/app/pages/search/index.vue
@@ -175,9 +175,17 @@
           <v-col cols="12" lg="5">
             <section class="search-page__column">
               <div class="search-page__column-header">
-                <h2 class="text-h5 font-weight-bold mb-0">
-                  {{ t('search.columns.verticals.title') }}
-                </h2>
+                <div class="search-page__column-heading">
+                  <v-icon
+                    icon="mdi-star-check-outline"
+                    size="22"
+                    class="search-page__column-heading-icon"
+                    aria-hidden="true"
+                  />
+                  <h2 class="text-h5 font-weight-bold mb-0">
+                    {{ t('search.columns.verticals.title') }}
+                  </h2>
+                </div>
               </div>
 
               <div
@@ -255,9 +263,17 @@
                 class="search-page__column-header search-page__column-header--with-actions"
               >
                 <div class="search-page__column-title">
-                  <h2 class="text-h5 font-weight-bold mb-0">
-                    {{ t('search.columns.products.title') }}
-                  </h2>
+                  <div class="search-page__column-heading">
+                    <v-icon
+                      icon="mdi-star-off-outline"
+                      size="22"
+                      class="search-page__column-heading-icon"
+                      aria-hidden="true"
+                    />
+                    <h2 class="text-h5 font-weight-bold mb-0">
+                      {{ t('search.columns.products.title') }}
+                    </h2>
+                  </div>
                   <p class="search-page__column-subtitle">
                     {{ t('search.columns.products.subtitle') }}
                   </p>
@@ -347,7 +363,7 @@ const routeQuery = computed(() =>
 const searchInput = ref(routeQuery.value)
 const filtersOpen = ref(false)
 const filterRequest = ref<FilterRequestDto>({ filters: [], filterGroups: [] })
-const openPanels = ref<number[]>([0])
+const openPanels = ref<number[]>([])
 
 watch(
   routeQuery,
@@ -702,8 +718,8 @@ const limitedGroups = computed(() => {
 
 watch(
   limitedGroups,
-  groups => {
-    openPanels.value = groups.length ? [0] : []
+  () => {
+    openPanels.value = []
   },
   { immediate: true }
 )
@@ -932,6 +948,17 @@ function formatFallbackVerticalTitle(verticalId: string): string {
     display: flex
     flex-direction: column
     gap: 0.35rem
+
+  &__column-heading
+    display: inline-flex
+    align-items: center
+    justify-content: center
+    gap: 0.5rem
+    text-align: center
+    width: 100%
+
+  &__column-heading-icon
+    color: rgba(var(--v-theme-primary), 0.85)
 
   &__column-subtitle
     margin: 0


### PR DESCRIPTION
### Motivation

- Improve the search UX by keeping category filters visible (remove nested menus/accordions) and centre column headings with icons for clarity. 
- Improve search recall for uncategorised products by falling back to a lexical query when semantic (embedding) missing-vertical results are empty. 
- Make range aggregation bounds more robust when stats are missing, so front-end filters get sensible `min`/`max` values.

### Description

- UI: replaced expansion/menu-based filter controls with always-visible sections and inline row-mode filters, and centred the vertical/products column headings with icons; changes in `frontend/app/components/category/CategoryFiltersPanel.vue`, `frontend/app/components/category/filters/CategoryFilterList.vue` and `frontend/app/pages/search/index.vue`.
- Search service: added a lexical fallback query scoped to products without a `vertical` and invoked it when semantic missing-vertical results are empty; new helper `buildMissingVerticalSearchQuery(...)` and `executeMissingVerticalLexicalSearch(...)` in `front-api/src/main/java/org/open4goods/nudgerfrontapi/service/SearchService.java`.
- Aggregations: when stats are missing, compute `min`/`max` from request defaults or from first/last histogram buckets to ensure range responses include sensible bounds; changes in `extractRangeAggregation(...)` in `SearchService.java`.
- Small behavioural change: keep vertical result panels collapsed by default (`openPanels` initialised to empty) and reset them when groups change.

### Testing

- Ran `pnpm lint` in `frontend` and the linter passed successfully. 
- Ran `pnpm test` in `frontend`: overall `392` tests passed, but there were 2 failing suites and 1 unhandled error (failures reported: missing `#components` specifier in Nuxt config for one suite, a missing `en-US.json` import in a spec, plus an unhandled manifest fetch error in Vitest output). 
- Built the site with `pnpm generate` and static generation completed successfully. 
- Attempted end-to-end screenshot via Playwright against `pnpm dev` but the Playwright script timed out (no screenshot captured).

If you want, I can split the UI changes into a dedicated PR, or iterate on the failing tests (Nuxt/Vite test environment issues and missing test fixture imports) to get `pnpm test` green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697586f550bc83228da9c7ed07676e4e)