### PR TITLE
Fix stats: expose ECOSCORE-rated totals and align reviewed counts

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/CategoriesStatsDto.java
@@ -38,6 +38,9 @@ public record CategoriesStatsDto(
         @Schema(description = "Total excluded products count.", example = "5000")
         long excludedProductsCount,
 
+        @Schema(description = "Total products with a valid ECOSCORE and offers.", example = "25000")
+        long ratedProductsCount,
+
         @Schema(description = "Total products with AI reviews.", example = "10000")
         long reviewedProductsCount,
 

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/VerticalStatsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/stats/VerticalStatsDto.java
@@ -15,9 +15,9 @@ public record VerticalStatsDto(
         @Schema(description = "Number of valid products (active, with offers) in this vertical.", example = "800")
         long validProducts,
 
-        @Schema(description = "Number of rated products (having an impact score) in this vertical.", example = "700")
+        @Schema(description = "Number of rated products (having an ECOSCORE) in this vertical.", example = "700")
         long ratedProducts,
 
-        @Schema(description = "Number of reviewed products (having an AI description) in this vertical.", example = "600")
+        @Schema(description = "Number of reviewed products (having AI reviews) in this vertical.", example = "600")
         long reviewedProducts
 ) { }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
@@ -72,7 +72,7 @@ public class StatsService {
      *
      * @param domainLanguage currently unused but retained for future localisation of statistics labels
      * @return DTO describing the category statistics used by the frontend including affiliation partners,
-     * OpenData counts, ImpactScore products count, and per-category product counts for recent products with offers.
+     * OpenData counts, rated/reviewed product counts, and per-category product counts for recent products with offers.
      */
     @Cacheable(cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME, keyGenerator = CacheConstants.KEY_GENERATOR)
     public CategoriesStatsDto categories(DomainLanguage domainLanguage) {
@@ -84,6 +84,7 @@ public class StatsService {
         long productsWithoutVerticalCount = safeCount(productRepository.countMainIndexWithoutVertical());
         long totalProductsCount = safeCount(productRepository.countMainIndex());
         long excludedProductsCount = safeCount(productRepository.countMainIndexExcluded());
+        long ratedProductsCount = safeCount(productRepository.countMainIndexValidAndRated());
         long reviewedProductsCount = safeCount(productRepository.countMainIndexValidAndReviewed());
 
         Map<String, Long> productsCountByCategory = new LinkedHashMap<>();
@@ -118,6 +119,7 @@ public class StatsService {
                 productsCountSum,
                 totalProductsCount,
                 excludedProductsCount,
+                ratedProductsCount,
                 reviewedProductsCount,
                 detailedStats
         );

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
@@ -45,6 +45,8 @@ class StatsServiceTest {
         given(productRepository.countMainIndexHavingVertical("enabled")).willReturn(42L);
         given(productRepository.countMainIndexHavingImpactScore()).willReturn(5_925L);
         given(productRepository.countMainIndexWithoutVertical()).willReturn(3_210L);
+        given(productRepository.countMainIndexValidAndRated()).willReturn(9_876L);
+        given(productRepository.countMainIndexValidAndReviewed()).willReturn(4_321L);
         given(partnerService.getPartners()).willReturn(List.of(mock(AffiliationPartner.class), mock(AffiliationPartner.class)));
 
         StatsService service = new StatsService(serialisationService, resolver, partnerService, openDataService, productRepository, productMappingService);
@@ -59,6 +61,8 @@ class StatsServiceTest {
         assertThat(dto.productsWithoutVerticalCount()).isEqualTo(3_210L);
         assertThat(dto.productsCountByCategory()).isEqualTo(Map.of("enabled", 42L));
         assertThat(dto.productsCountSum()).isEqualTo(42L);
+        assertThat(dto.ratedProductsCount()).isEqualTo(9_876L);
+        assertThat(dto.reviewedProductsCount()).isEqualTo(4_321L);
     }
 
     private Resource resource(String filename, String yaml) {

--- a/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
+++ b/services/product-repository/src/main/java/org/open4goods/services/productrepository/services/ProductRepository.java
@@ -998,9 +998,29 @@ public class ProductRepository {
             return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 
+        /**
+         * Count recent products with offers, AI reviews, and not excluded from the catalogue.
+         *
+         * @return count of recent products with AI reviews
+         */
         @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
         public Long countMainIndexValidAndReviewed() {
-            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery().and(new Criteria("excluded").is(false)).and(new Criteria("aiDescriptions").exists()));
+            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery()
+                    .and(new Criteria("excluded").is(false))
+                    .and(new Criteria("reviews").exists()));
+            return elasticsearchOperations.count(query, CURRENT_INDEX);
+        }
+
+        /**
+         * Count recent products with offers, a valid ECOSCORE, and not excluded from the catalogue.
+         *
+         * @return count of recent products with an ECOSCORE
+         */
+        @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
+        public Long countMainIndexValidAndRated() {
+            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery()
+                    .and(new Criteria("excluded").is(false))
+                    .and(new Criteria("scores.ECOSCORE.value").exists()));
             return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 
@@ -1016,15 +1036,27 @@ public class ProductRepository {
             return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 
+        /**
+         * Count recent products with offers, AI reviews, and not excluded for a specific vertical.
+         *
+         * @param vertical vertical identifier
+         * @return count of recent products with AI reviews for the vertical
+         */
         @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
         public Long countMainIndexValidAndReviewed(String vertical) {
-            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery().and(new Criteria("vertical").is(vertical)).and(new Criteria("excluded").is(false)).and(new Criteria("aiDescriptions").exists()));
+            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery()
+                    .and(new Criteria("vertical").is(vertical))
+                    .and(new Criteria("excluded").is(false))
+                    .and(new Criteria("reviews").exists()));
             return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 
         @Cacheable(keyGenerator = CacheConstants.KEY_GENERATOR, cacheNames = CacheConstants.ONE_HOUR_LOCAL_CACHE_NAME)
         public Long countMainIndexValidAndRated(String vertical) {
-            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery().and(new Criteria("vertical").is(vertical)).and(new Criteria("excluded").is(false)).and(new Criteria("scores.IMPACTSCORE.value").exists()));
+            CriteriaQuery query = new CriteriaQuery(getRecentPriceQuery()
+                    .and(new Criteria("vertical").is(vertical))
+                    .and(new Criteria("excluded").is(false))
+                    .and(new Criteria("scores.ECOSCORE.value").exists()));
             return elasticsearchOperations.count(query, CURRENT_INDEX);
         }
 


### PR DESCRIPTION
### Motivation
- Clarify and expose the count of products that are rated by ECOSCORE in category statistics so the frontend can show rated totals separately from other scores. 
- Align reviewed-product counting with the actual `reviews` field (instead of the old `aiDescriptions` field) to ensure reviewed counts reflect stored AI reviews. 

### Description
- Added `countMainIndexValidAndRated()` and updated queries to use `scores.ECOSCORE.value` in `ProductRepository` to count ECOSCORE-rated recent products and per-vertical rated totals. 
- Replaced `aiDescriptions` checks with `reviews` in `countMainIndexValidAndReviewed()` queries to correctly identify reviewed products. 
- Exposed a new `ratedProductsCount` field in `CategoriesStatsDto` and updated `VerticalStatsDto` descriptions to reference ECOSCORE and AI reviews. 
- Wired the new rated counts into `StatsService.categories()` and updated `StatsServiceTest` to assert the new `ratedProductsCount` and `reviewedProductsCount`. 

### Testing
- Updated unit test `front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java` to include mocked returns for `countMainIndexValidAndRated()` and `countMainIndexValidAndReviewed()` and corresponding assertions. 
- No automated test suite was executed as part of this change in the workspace (unit tests were modified but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a16c12608322a9e5c43ac2681c2e)