### PR TITLE
Home hero: add reviewed products count, compact counts and AI summary layout

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -34,6 +34,7 @@ const props = defineProps<{
   impactScoreProductsCount?: number
   impactScoreCategoriesCount?: number
   productsWithoutVerticalCount?: number
+  reviewedProductsCount?: number
   aiSummaryRemainingCredits?: number
   heroBackgroundI18nKey?: string
   shouldReduceMotion?: boolean
@@ -329,6 +330,7 @@ useHead({
                     :products-without-vertical-count="
                       productsWithoutVerticalCount
                     "
+                    :reviewed-products-count="reviewedProductsCount"
                     :ai-summary-remaining-credits="aiSummaryRemainingCredits"
                   />
                 </div>

--- a/frontend/app/components/shared/ui/SectionReveal.vue
+++ b/frontend/app/components/shared/ui/SectionReveal.vue
@@ -99,7 +99,7 @@ const handleIntersect = (
       :is="transitionComponent || 'div'"
       :disabled="shouldReduceMotion || !transitionComponent"
     >
-      <div v-show="isVisible">
+      <div v-show="isVisible" class="section-reveal__content text-center">
         <slot :reveal="isVisible" />
       </div>
     </component>

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -166,6 +166,16 @@ const productsWithoutVerticalCount = computed(() => {
   return count
 })
 
+const reviewedProductsCount = computed(() => {
+  const count = categoriesStats.value?.reviewedProductsCount
+
+  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) {
+    return null
+  }
+
+  return count
+})
+
 const productsCount = computed(() => {
   const count = categoriesStats.value?.productsCountSum
 
@@ -835,6 +845,7 @@ useHead(() => ({
         :impact-score-products-count="impactScoreProductsCount"
         :impact-score-categories-count="impactScoreCategoriesCount"
         :products-without-vertical-count="productsWithoutVerticalCount"
+        :reviewed-products-count="reviewedProductsCount"
         :ai-summary-remaining-credits="aiSummaryRemainingCredits"
         :should-reduce-motion="shouldReduceMotion"
         hero-background-i18n-key="hero.background"

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -450,7 +450,8 @@
         "title": "Community AI summary",
         "creditsLabel": "Credits remaining: {count}",
         "creditsFallback": "Credits remaining: unavailable",
-        "description": "A powerful tool with real AI inside, giving you a panoramic view of your product. Free and community-driven."
+        "description": "A powerful tool with real AI inside, giving you a panoramic view of your product. Free and community-driven.",
+        "reviewedProductsSuffix": "{reviewedProductsCount} product pages generated so far."
       },
       "agent": {
         "title": "Any questions?",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -159,7 +159,8 @@
         "title": "Synthèse IA communautaire",
         "creditsLabel": "Crédits restants : {count}",
         "creditsFallback": "Crédits restants : indisponible",
-        "description": "Un outil puissant avec de la vraie IA dedans, qui vous offre un panoramique de votre produit. Gratuit, communautaire."
+        "description": "Un outil puissant avec de la vraie IA dedans, qui vous offre un panoramique de votre produit. Gratuit, communautaire.",
+        "reviewedProductsSuffix": "{reviewedProductsCount} fiches produits générées jusqu'à présent."
       },
       "agent": {
         "title": "Une question ?",


### PR DESCRIPTION
### Motivation
- Surface the number of AI-reviewed product pages in the home hero AI summary to give users context about coverage. 
- Display large counts more compactly in hero highlights to keep the UI concise and readable. 
- Improve the AI summary card visual layout to show an icon on the left and center the content for better prominence. 

### Description
- Added a new `reviewedProductsCount` prop and propagated it from `pages/index.vue` to `HomeHeroSection.vue` and `HomeHeroHighlights.vue`. 
- Introduced `formatCompactCount` and used it to abbreviate `productsWithoutVerticalCount` (k-format), and added `formattedReviewedProductsCount` for the AI suffix logic. 
- Updated `aiSummaryDescription` to append `home.hero.aiSummary.reviewedProductsSuffix` when a reviewed count is available and added the new i18n keys in `frontend/i18n/locales/en-US.json` and `fr-FR.json`. 
- Reworked the AI summary card markup and styles in `HomeHeroHighlights.vue` and `SectionReveal.vue` to use a left-side icon and centered content, with small CSS adjustments to spacing. 

### Testing
- Ran `pnpm --offline lint` in `frontend` and it completed successfully. 
- Ran `pnpm --offline test` (Vitest) and all tests passed (`112 files`, `401 tests` succeeded). 
- Ran `pnpm --offline generate` (Nuxt generate) which completed successfully but emitted a Workbox glob warning about `**/_payload.json` not matching any files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975b888efb48322a71087ecab1396f0)