### PR TITLE
Add SVG variant to ImpactScore and render it on Product Hero

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -48,6 +48,7 @@
             <ProductHero
               :product="product"
               :breadcrumbs="productBreadcrumbs"
+              :impact-score="impactScoreOutOf20"
               :popular-attributes="heroPopularAttributes"
             />
             <div class="product-page__hero-corner" role="presentation">
@@ -2127,6 +2128,16 @@ const impactScoreValue = computed(() => {
     return null
   }
   return resolvePrimaryImpactScore(product.value)
+})
+
+const impactScoreOutOf20 = computed(() => {
+  const score = impactScoreValue.value
+
+  if (typeof score !== 'number') {
+    return null
+  }
+
+  return Number((score * 4).toFixed(1))
 })
 
 const reviewStructuredData = computed(() => {

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -19,6 +19,15 @@
           title-class="product-hero__title text-center"
           description-class="product-hero__short-description text-center"
         />
+        <div v-if="impactScore != null" class="product-hero__impact-score">
+          <ImpactScore
+            mode="svg"
+            :score="impactScore"
+            :min="0"
+            :max="20"
+            svg-size="lg"
+          />
+        </div>
         <CategoryNavigationBreadcrumbs
           v-if="heroBreadcrumbs.length"
           v-bind="heroBreadcrumbProps"
@@ -248,6 +257,7 @@ import { useI18n } from 'vue-i18n'
 import CategoryNavigationBreadcrumbs from '~/components/category/navigation/CategoryNavigationBreadcrumbs.vue'
 import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
 import ProductDesignation from '~/components/product/ProductDesignation.vue'
+import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import {
   MAX_COMPARE_ITEMS,
   useProductCompareStore,
@@ -291,6 +301,10 @@ const props = defineProps({
   popularAttributes: {
     type: Array as PropType<AttributeConfigDto[]>,
     default: () => [],
+  },
+  impactScore: {
+    type: Number,
+    default: null,
   },
   image: {
     type: String,
@@ -744,6 +758,12 @@ const gtinCountry = computed(() => {
   font-size: 1.05rem;
   color: rgb(var(--v-theme-text-neutral-secondary));
   text-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.product-hero__impact-score {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
 }
 
 .product-hero__breadcrumbs {

--- a/frontend/app/components/shared/ui/ImpactScore.spec.ts
+++ b/frontend/app/components/shared/ui/ImpactScore.spec.ts
@@ -12,6 +12,8 @@ const i18n = createI18n({
       'components.impactScore.tooltip': 'Score: {value} / {max}',
       'components.impactScore.tooltipBadge': 'Score: {value} / 20',
       'components.impactScore.outOf20': '/20',
+      'components.impactScore.scale': 'Scale: {min}-{max}',
+      'components.impactScore.svgAriaLabel': 'Score {score} out of 20',
     },
   },
 })
@@ -188,5 +190,70 @@ describe('ImpactScore', () => {
     expect(badge.classes()).toContain('impact-score-badge--corner')
     expect(wrapper.text()).toContain('16.0')
     expect(wrapper.text()).toContain('/20')
+  })
+
+  it('renders the svg variant with a scaled bar', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 13,
+        min: 0,
+        max: 20,
+        mode: 'svg',
+        svgSize: 'md',
+      },
+      global: globalOptions,
+    })
+
+    const svg = wrapper.find('svg.scoreSvg')
+    expect(svg.exists()).toBe(true)
+    expect(svg.attributes('aria-label')).toBe('Score 13 out of 20')
+
+    const progressRect = wrapper
+      .findAll('rect')
+      .find(
+        rect =>
+          rect.attributes('x') === '34' &&
+          rect.attributes('y') === '96' &&
+          rect.attributes('width') !== '300'
+      )
+
+    expect(progressRect?.attributes('width')).toBe('195')
+  })
+
+  it('generates unique clipPath ids for multiple svg instances', () => {
+    const wrapper = mount(
+      defineComponent({
+        components: { ImpactScore },
+        template: `
+          <div>
+            <ImpactScore mode="svg" :score="10" :min="0" :max="20" />
+            <ImpactScore mode="svg" :score="15" :min="0" :max="20" />
+          </div>
+        `,
+      }),
+      {
+        global: globalOptions,
+      }
+    )
+
+    const clipIds = wrapper
+      .findAll('clipPath')
+      .map(node => node.attributes('id'))
+    expect(new Set(clipIds).size).toBe(clipIds.length)
+  })
+
+  it('hides the scale label when showScale is false', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 8,
+        min: 0,
+        max: 20,
+        mode: 'svg',
+        showScale: false,
+      },
+      global: globalOptions,
+    })
+
+    expect(wrapper.text()).not.toContain('Scale:')
   })
 })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1148,7 +1148,9 @@
     "impactScore": {
       "tooltip": "Impact quality rated at {value} out of {max}",
       "tooltipBadge": "Impact quality rated at {value} out of 20",
-      "outOf20": "/20"
+      "outOf20": "/20",
+      "scale": "Scale: {min}–{max}",
+      "svgAriaLabel": "Score {score} out of 20"
     },
     "pageLoadingOverlay": {
       "label": "Loading page content"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -862,7 +862,9 @@
     "impactScore": {
       "tooltip": "Qualité de l'impact évalué à {value} sur {max}",
       "tooltipBadge": "Qualité de l'impact évalué à {value} sur 20",
-      "outOf20": "/20"
+      "outOf20": "/20",
+      "scale": "Échelle : {min}–{max}",
+      "svgAriaLabel": "Score {score} sur 20"
     },
     "pageLoadingOverlay": {
       "label": "Chargement du contenu"


### PR DESCRIPTION
### Motivation
- Provide an attractive, accessible SVG visualization for impact scores with flexible sizing and a readable scale to better showcase product impact under the hero title.
- Reuse the existing ImpactScore component surface while offering a vector-based, theme-aware variant suitable for large hero placements.

### Description
- Add a new `svg` mode to `ImpactScore.vue` that renders a responsive SVG bar, numeric label and optional scale text, using HSL interpolation between theme colors for an active gradient; new props include `min`, `svgSize`, and `showScale` and the existing `mode` now accepts `'svg'`.
- Wire the product page to calculate an out-of-20 score and pass it to the `ProductHero` as `impactScore`, and render the new SVG `ImpactScore` beneath the product title in `ProductHero.vue`.
- Add i18n strings for the SVG scale label and aria text in `en-US.json` and `fr-FR.json` and update `ImpactScore.spec.ts` with tests covering SVG rendering, clipPath uniqueness, progress width and toggling of the scale label.
- Minor styling and helper functions added to `ImpactScore.vue` for color conversion/interpolation, clip-id generation via `useId`, sizing and computed dimensions.

### Testing
- Ran lint with `pnpm --offline lint` and it passed successfully.
- Ran the test suite with `pnpm --offline test` and all tests passed (`112 files, 404 tests` reported as passed).
- Built a static site with `pnpm --offline generate` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d02736b0832286b45d640a82e7ea)