### PR TITLE
Search: segmented search-mode toggle and baseline aggregations for empty-query filters

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterList.vue
+++ b/frontend/app/components/category/filters/CategoryFilterList.vue
@@ -1,16 +1,26 @@
 <template>
   <div :class="['category-filter-list', `category-filter-list--${mode}`]">
-    <div
-      class="category-filter-list__header d-flex align-center justify-end mb-2"
-    >
-      <v-switch
-        :model-value="searchType === 'TEXT'"
-        color="primary"
-        label="Recherche textuelle"
-        hide-details
-        density="compact"
-        @update:model-value="$emit('update:searchType', $event ? 'TEXT' : null)"
-      />
+    <div class="category-filter-list__header d-flex align-center">
+      <v-btn-toggle
+        class="category-filter-list__search-toggle"
+        :model-value="resolvedSearchType"
+        mandatory
+        rounded="pill"
+        density="comfortable"
+        @update:model-value="emit('update:searchType', $event)"
+      >
+        <v-btn
+          size="large"
+          value="SEMANTIC"
+          color="primary"
+          variant="outlined"
+        >
+          {{ t('category.filters.searchMode.semantic') }}
+        </v-btn>
+        <v-btn size="large" value="TEXT" color="primary" variant="outlined">
+          {{ t('category.filters.searchMode.text') }}
+        </v-btn>
+      </v-btn-toggle>
     </div>
     <template v-if="mode === 'grid'">
       <component
@@ -54,6 +64,8 @@ import CategoryFilterNumeric from './CategoryFilterNumeric.vue'
 import CategoryFilterCondition from './CategoryFilterCondition.vue'
 import CategoryFilterTerms from './CategoryFilterTerms.vue'
 
+const { t } = useI18n()
+
 const props = withDefaults(
   defineProps<{
     fields: FieldMetadataDto[]
@@ -75,6 +87,8 @@ const emit = defineEmits<{
   'update-terms': [field: string, terms: string[]]
   'update:searchType': [value: string | null]
 }>()
+
+const resolvedSearchType = computed(() => props.searchType ?? 'SEMANTIC')
 
 const resolveComponent = (field: FieldMetadataDto) => {
   if (field.mapping === 'price.conditions') {
@@ -115,7 +129,6 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
 </script>
 
 <style scoped lang="sass">
-
 .category-filter-list
   display: grid
   gap: 1.5rem
@@ -125,7 +138,10 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
     align-items: stretch
 
   &--row
-    display: block
+    display: flex
+    align-items: center
+    gap: 1.5rem
+    flex-wrap: wrap
 
   &__item
     display: flex
@@ -138,10 +154,21 @@ const onFilterChange = (field: FieldMetadataDto, filter: Filter | null) => {
     flex-wrap: wrap
     gap: 1rem
     align-items: stretch
+    flex: 1 1 auto
 
   &__row-item
     display: flex
     flex-direction: column
     flex: 1 1 200px
     min-width: min(200px, 100%)
+
+  &__header
+    justify-content: flex-start
+
+  &__search-toggle
+    align-items: center
+    :deep(.v-btn)
+      text-transform: none
+      font-weight: 600
+      padding-inline: 1.25rem
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -993,6 +993,10 @@
         "new": "New",
         "used": "Used"
       },
+      "searchMode": {
+        "semantic": "Semantic search",
+        "text": "Text search"
+      },
       "showMoreImpact": "Show more impact filters",
       "showMoreTechnical": "Show more technical filters",
       "technicalTitle": "Technical filters",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -716,6 +716,10 @@
         "new": "Neuf",
         "used": "Occasion"
       },
+      "searchMode": {
+        "semantic": "Recherche sémantique",
+        "text": "Recherche textuelle"
+      },
       "showMoreImpact": "Plus de filtres",
       "showMoreTechnical": "Plus de filtres",
       "technicalTitle": "Filtres techniques",


### PR DESCRIPTION
### Motivation
- Improve the search filters UX by replacing the cramped switch with a clear, accessible segmented control and i18n labels. 
- Ensure filter metrics shown for the empty-query / "latest products" state use a full aggregation set instead of a partial/latest slice.

### Description
- Replace the small `v-switch` with a larger `v-btn-toggle` segmented control in `frontend/app/components/category/filters/CategoryFilterList.vue` and add i18n labels (`category.filters.searchMode`) for semantic/text modes. 
- Default `searchType` to `SEMANTIC`, compute a `resolvedSearchType` and `semanticSearchEnabled`, and wire those into global/product/baseline search request bodies in `frontend/app/pages/search/index.vue`. 
- Add a dedicated aggregation fetch (`search-baseline-aggregations`) to retrieve baseline aggregations for the empty-query state and reuse that response for filter metrics, plus expose `aggsPending`/`aggsError` in the loader/error UI and add a `handleRetry` helper to refresh the correct sources. 
- Adjust filter row layout/styles so the row mode behaves as a horizontal header and keep the header left-aligned when in row mode. 
- Update localized strings in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` for the new toggle labels.

### Testing
- Ran `pnpm install` successfully to update the local workspace and dependencies. 
- Ran `pnpm lint` which failed due to existing test issues reported in `app/components/product/ProductImpactSection.spec.ts` (unused vars / explicit `any`).
- Ran `pnpm test` (Vitest) which produced mostly green suites but ended with 2 failing test files and 1 error (see Vitest output in the rollout for details). 
- Ran `pnpm generate` which completed successfully and produced a working production build output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d8e661c88322b884bbee996b48d9)