### PR TITLE
Center home hero highlights and make reviewed-products counts locale-aware

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/StatsService.java
@@ -85,7 +85,8 @@ public class StatsService {
         long totalProductsCount = safeCount(productRepository.countMainIndex());
         long excludedProductsCount = safeCount(productRepository.countMainIndexExcluded());
         long ratedProductsCount = safeCount(productRepository.countMainIndexValidAndRated());
-        long reviewedProductsCount = safeCount(productRepository.countMainIndexValidAndReviewed());
+        String reviewLocale = domainLanguage != null ? domainLanguage.languageTag() : null;
+        long reviewedProductsCount = safeCount(productRepository.countMainIndexValidAndReviewed(reviewLocale));
 
         Map<String, Long> productsCountByCategory = new LinkedHashMap<>();
         Map<String, VerticalStatsDto> detailedStats = new LinkedHashMap<>();
@@ -103,7 +104,7 @@ public class StatsService {
             long vTotal = safeCount(productRepository.countMainIndexTotal(verticalId));
             long vExcluded = safeCount(productRepository.countMainIndexExcluded(verticalId));
             long vRated = safeCount(productRepository.countMainIndexValidAndRated(verticalId));
-            long vReviewed = safeCount(productRepository.countMainIndexValidAndReviewed(verticalId));
+            long vReviewed = safeCount(productRepository.countMainIndexValidAndReviewed(verticalId, reviewLocale));
 
             detailedStats.put(verticalId, new VerticalStatsDto(vTotal, vExcluded, safeCount, vRated, vReviewed));
         }

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/StatsServiceTest.java
@@ -47,7 +47,7 @@ class StatsServiceTest {
         given(productRepository.countMainIndexHavingImpactScore()).willReturn(5_925L);
         given(productRepository.countMainIndexWithoutVertical()).willReturn(3_210L);
         given(productRepository.countMainIndexValidAndRated()).willReturn(9_876L);
-        given(productRepository.countMainIndexValidAndReviewed()).willReturn(4_321L);
+        given(productRepository.countMainIndexValidAndReviewed("fr")).willReturn(4_321L);
         given(partnerService.getPartners()).willReturn(List.of(mock(AffiliationPartner.class), mock(AffiliationPartner.class)));
 
         StatsService service = new StatsService(serialisationService, resolver, partnerService, openDataService, productRepository, productMappingService);

--- a/frontend/app/components/home/sections/HomeHeroHighlights.vue
+++ b/frontend/app/components/home/sections/HomeHeroHighlights.vue
@@ -612,7 +612,7 @@ const aiSummaryDescription = computed(() => {
   const baseDescription = t('home.hero.aiSummary.description')
   const reviewedProductsCount = formattedReviewedProductsCount.value
 
-  if (!reviewedProductsCount) {
+  if (reviewedProductsCount == null) {
     return baseDescription
   }
 
@@ -756,7 +756,7 @@ const isCreditsDialogActive = ref(false)
           <v-col cols="12" md="2" class="home-hero-highlights__ai-summary-icon">
             <v-icon size="56" color="secondary">mdi-robot</v-icon>
           </v-col>
-          <v-col cols="12" md="10">
+          <v-col cols="12" md="10" class="home-hero-highlights__ai-summary-text">
             <div class="home-hero-highlights__ai-summary-header">
               <span class="home-hero-highlights__ai-summary-title">
                 <v-icon color="secondary" class="mr-2"
@@ -851,6 +851,8 @@ const isCreditsDialogActive = ref(false)
   display: flex
   flex-direction: column
   gap: 0.6rem
+  align-items: center
+  text-align: center
 
 .home-hero-highlights__title
   margin: 0
@@ -901,7 +903,7 @@ const isCreditsDialogActive = ref(false)
 .home-hero-highlights__ai-summary-header
   display: flex
   flex-wrap: wrap
-  justify-content: space-between
+  justify-content: center
   gap: 0.5rem
   font-weight: 600
   color: rgb(var(--v-theme-text-neutral-strong))
@@ -909,6 +911,11 @@ const isCreditsDialogActive = ref(false)
 .home-hero-highlights__ai-summary-title
   font-size: 0.95rem
 
+.home-hero-highlights__ai-summary-text
+  text-align: center
+  display: flex
+  flex-direction: column
+  gap: 0.25rem
 
 .home-hero-highlights__ai-summary-description
   margin: 0

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -169,7 +169,7 @@ const productsWithoutVerticalCount = computed(() => {
 const reviewedProductsCount = computed(() => {
   const count = categoriesStats.value?.reviewedProductsCount
 
-  if (typeof count !== 'number' || !Number.isFinite(count) || count <= 0) {
+  if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) {
     return null
   }
 

--- a/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
+++ b/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch._types.KnnSearch;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,19 +116,19 @@ class ProductRepositoryTest
     {
         when(elasticsearchOperations.count(any(org.springframework.data.elasticsearch.core.query.Query.class), eq(ProductRepository.CURRENT_INDEX))).thenReturn(10L);
 
-        repository.countMainIndexValidAndReviewed();
+        repository.countMainIndexValidAndReviewed("fr");
 
         ArgumentCaptor<CriteriaQuery> queryCaptor = ArgumentCaptor.forClass(CriteriaQuery.class);
         verify(elasticsearchOperations).count(queryCaptor.capture(), eq(ProductRepository.CURRENT_INDEX));
 
         CriteriaQuery submittedQuery = queryCaptor.getValue();
-        // Just verify that we are indeed checking for reviews existence
-        // In the legacy code it was "reviews" (which is the object). 
-        // We want to verify usage of "reviews" or something more specific if we change it.
-        // For reproduction, checking it contains "reviews" logic.
-        
-        // Note: The criteria chain is complex to inspect deeply with simple asserts on the object graph without helpers,
-        // but we can at least capture it to debug or assert basics.
         assertThat(submittedQuery).isNotNull();
+
+        boolean hasReviewCriteria = submittedQuery.getCriteria().getCriteriaChain().stream()
+                .map(Criteria::getField)
+                .filter(Objects::nonNull)
+                .anyMatch(field -> "reviews.fr.review".equals(field.getName()));
+
+        assertThat(hasReviewCriteria).isTrue();
     }
 }


### PR DESCRIPTION
### Motivation

- Align the home hero highlights visually and ensure the AI summary always shows the reviewed-products suffix when a count is available (including zero).  
- Ensure reviewed-products statistics are computed per-locale so frontend statistics match localized review fields in the product index.

### Description

- Centered hero highlight card content and AI summary text by updating `HomeHeroHighlights.vue` layout and styles and by wrapping the AI summary column with `home-hero-highlights__ai-summary-text`.  
- Always append the reviewed-products suffix only when the formatted reviewed count is present by changing the check to `reviewedProductsCount == null` in `HomeHeroHighlights.vue`.  
- Allow zero reviewed counts to be shown by relaxing the guard in `frontend/app/pages/index.vue` to treat `count < 0` as invalid instead of `<= 0`.  
- Make review count queries locale-aware by adding locale-aware overloads to `ProductRepository`: `countMainIndexValidAndReviewed(String locale)` and `countMainIndexValidAndReviewed(String vertical, String locale)` and a helper `resolveReviewField(String locale)` that resolves to `reviews.<locale>.review` (falling back to `default`).  
- Propagate the domain language from `StatsService.categories` into the repository calls and update `StatsServiceTest` and `ProductRepositoryTest` to use the locale-aware methods and to assert the review field is targeted in the generated criteria query.

### Testing

- Ran frontend lint with `pnpm lint` which reported a parsing error in `app/composables/categories/useCategoryNavigation.spec.ts` (lint failed).  
- Ran frontend unit tests with `pnpm test` / Vitest; the test suite mostly passed but `app/components/product/impact/ProductAlternatives.spec.ts` had one failing expectation (test run reported one failed test).  
- Ran `pnpm generate` (Nuxt generate) which completed successfully (with a PWA glob warning) and produced a previewable static build.  
- Ran backend module tests with `mvn --offline -pl front-api -am test`; after adjusting repository code and tests the Maven test run completed successfully for the reactor including `front-api` (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975ecbe21708322a12678e903d89569)