### PR TITLE
feat(frontend): replace end-of-life alert with support card

### DIFF
--- a/frontend/app/components/product/ProductImpactSection.spec.ts
+++ b/frontend/app/components/product/ProductImpactSection.spec.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createI18n } from 'vue-i18n'
 import ProductImpactSection from './ProductImpactSection.vue'
 
@@ -7,22 +7,50 @@ const i18nMessages = {
   'fr-FR': {
     product: {
       impact: {
-        endOfLife: 'Produit plus commercialisé par {brand} !',
+        endOfLifeTitle: 'Produit plus commercialisé',
+        endOfLifeDescription:
+          "Le produit n'est plus officiellement commercialisé par {brand}. La durée de support légal a démarré le {onMarketEndDate}.",
+        endOfLifeDescriptionFallback:
+          "Le produit n'est plus officiellement commercialisé par {brand}.",
+        endOfLifeSupportEnd: 'Fin du support légal',
+        endOfLifeSupportDuration: 'Durée de support légal',
+        endOfLifeSupportRemaining: 'Support légal restant',
+        endOfLifeSupportExpired: 'Support légal terminé',
         alternatives: {
           title: 'Alternatives',
         },
         explanationTitle: 'Explication',
       },
     },
+    common: {
+      count: {
+        years: '1 an | {count} ans',
+        months: '1 mois | {count} mois',
+      },
+    },
   },
   'en-US': {
     product: {
       impact: {
-        endOfLife: 'Product no longer marketed by {brand}!',
+        endOfLifeTitle: 'Product no longer marketed',
+        endOfLifeDescription:
+          'This product is no longer officially marketed by {brand}. Legal support started on {onMarketEndDate}.',
+        endOfLifeDescriptionFallback:
+          'This product is no longer officially marketed by {brand}.',
+        endOfLifeSupportEnd: 'Legal support ends',
+        endOfLifeSupportDuration: 'Legal support duration',
+        endOfLifeSupportRemaining: 'Legal support remaining',
+        endOfLifeSupportExpired: 'Legal support ended',
         alternatives: {
           title: 'Alternatives',
         },
         explanationTitle: 'Explanation',
+      },
+    },
+    common: {
+      count: {
+        years: '1 year | {count} years',
+        months: '1 month | {count} months',
       },
     },
   },
@@ -57,19 +85,46 @@ describe('ProductImpactSection', () => {
   }
 
   it('renders end of life alert when onMarketEndDate is in the past', async () => {
-    const pastDate = new Date('2020-01-01')
-    const wrapper = await mountComponent({ onMarketEndDate: pastDate })
-    expect(wrapper.text()).toContain('Produit plus commercialisé par Brand A !')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    try {
+      const pastDate = new Date('2020-01-01T00:00:00Z')
+      const wrapper = await mountComponent({
+        onMarketEndDate: pastDate,
+        eprelData: {
+          eprelDatas: {
+            categorySpecificAttributes: {
+              minGuaranteedSupportYears: 10,
+            },
+          },
+        },
+      })
+
+      expect(wrapper.find('[data-testid="end-of-life-card"]').exists()).toBe(
+        true
+      )
+      expect(wrapper.text()).toContain('Produit plus commercialisé')
+      expect(wrapper.text()).toContain('Durée de support légal')
+      expect(wrapper.text()).toContain('10 ans')
+      expect(wrapper.text()).toContain('Support légal restant')
+      expect(wrapper.text()).toContain('4 ans')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not render end of life alert when onMarketEndDate is in the future', async () => {
     const futureDate = new Date('2030-01-01')
     const wrapper = await mountComponent({ onMarketEndDate: futureDate })
-    expect(wrapper.text()).not.toContain('Produit plus commercialisé')
+    expect(wrapper.find('[data-testid="end-of-life-card"]').exists()).toBe(
+      false
+    )
   })
 
   it('does not render end of life alert when onMarketEndDate is null', async () => {
     const wrapper = await mountComponent({ onMarketEndDate: null })
-    expect(wrapper.text()).not.toContain('Produit plus commercialisé')
+    expect(wrapper.find('[data-testid="end-of-life-card"]').exists()).toBe(
+      false
+    )
   })
 })

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2852,7 +2852,13 @@
       "supportGuaranteedUntil": "Guaranteed support until"
     },
     "impact": {
-      "endOfLife": "This product is no longer marketed by {brand}. Legal support durations started from {onMarketEndDate}.",
+      "endOfLifeTitle": "Product no longer marketed",
+      "endOfLifeDescription": "This product is no longer officially marketed by {brand}. Legal support started on {onMarketEndDate}.",
+      "endOfLifeDescriptionFallback": "This product is no longer officially marketed by {brand}.",
+      "endOfLifeSupportEnd": "Legal support ends",
+      "endOfLifeSupportDuration": "Legal support duration",
+      "endOfLifeSupportRemaining": "Legal support remaining",
+      "endOfLifeSupportExpired": "Legal support ended",
       "alternatives": {
         "title": "Greener alternatives",
         "subtitle": "Discover similar products with a better impact score or price.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2569,7 +2569,13 @@
       "viewSingleOffer": "Voir l'offre"
     },
     "impact": {
-      "endOfLife": "Produit plus officiellement commercialisé par {brand} ! Les durées de supports légales démarrent à partir du {onMarketEndDate}",
+      "endOfLifeTitle": "Produit plus commercialisé",
+      "endOfLifeDescription": "Le produit n'est plus officiellement commercialisé par {brand}. La durée de support légal a démarré le {onMarketEndDate}.",
+      "endOfLifeDescriptionFallback": "Le produit n'est plus officiellement commercialisé par {brand}.",
+      "endOfLifeSupportEnd": "Fin du support légal",
+      "endOfLifeSupportDuration": "Durée de support légal",
+      "endOfLifeSupportRemaining": "Support légal restant",
+      "endOfLifeSupportExpired": "Support légal terminé",
       "alternatives": {
         "title": "Moins cher, et meilleur pour la planète ?",
         "subtitle": "Découvrez des produits similaires avec un meilleur score d'impact, un prix égal ou plus accessible et des caracteristiques techniques similaires.",


### PR DESCRIPTION
### Motivation

- Improve the end-of-life UX by replacing a single-line alert with a richer, clearer support card that surfaces support dates and durations.  
- Compute legal support windows from EPREL data so the UI displays concrete support-start/end dates and remaining time.  
- Provide localized, accessible copy and chips to better communicate support status to users.

### Description

- Replace the old `v-alert` with a styled Vuetify `v-card` in `ProductImpactSection.vue` that shows a title, descriptive text, support end date, support duration and remaining support chips.  
- Add date parsing and support calculations: import `normalizeTimestamp` and compute `supportStartDate`, `supportEndDate`, `supportDuration`, `supportRemaining` and chip color logic in `ProductImpactSection.vue`.  
- Add i18n keys and localized messages for FR/EN in `frontend/i18n/locales/fr-FR.json` and `frontend/i18n/locales/en-US.json` to support the new card copy and labels.  
- Update unit tests in `ProductImpactSection.spec.ts` to assert card rendering, formatted durations and remaining-support logic using a fixed system time.

### Testing

- Ran linter with `pnpm --dir frontend lint` and it reported a remaining lint failure (unused variable) unrelated to these changes.  
- Ran unit tests with `pnpm --dir frontend test` (Vitest); the test run executed ~414 specs where 413 passed and 1 test failed (`app/components/impact-score/ImpactScoreMethodology.spec.ts`), see failing assertion in that spec.  
- Attempted a production build with `pnpm --dir frontend generate` and it failed during SSR build with a JavaScript heap out-of-memory error; this is an environment/memory issue rather than feature logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978af678610832b88268844922befe7)