### PR TITLE
Redesign product competition card with tiered visuals and i18n updates

### DIFF
--- a/frontend/app/components/product/ProductPriceSection.spec.ts
+++ b/frontend/app/components/product/ProductPriceSection.spec.ts
@@ -57,9 +57,17 @@ const i18nMessages = {
         noHistory:
           "L'historique des prix n'est pas encore disponible pour ce produit.",
         competition: {
+          title: 'Niveau de concurrence',
+          count: '{count} offres',
           low: 'Concurrence faible !',
+          lowDescription:
+            'Peu d’offres disponibles, la comparaison est limitée.',
           correct: 'Concurrence correcte !',
-          good: 'Bonne Concurrence !',
+          correctDescription:
+            'Assez d’offres pour comparer en toute sérénité.',
+          super: 'Super concurrence !',
+          superDescription:
+            'Beaucoup d’offres pour décrocher le meilleur prix.',
         },
         headers: {
           source: 'Source',
@@ -109,9 +117,14 @@ const i18nMessages = {
           untitled: 'Commercial event',
         },
         competition: {
+          title: 'Competition level',
+          count: '{count} offers',
           low: 'Low competition!',
-          correct: 'Correct competition!',
-          good: 'Good competition!',
+          lowDescription: 'Few offers available, limited comparison.',
+          correct: 'Healthy competition!',
+          correctDescription: 'Enough offers to compare with confidence.',
+          super: 'Super competition!',
+          superDescription: 'Plenty of offers to secure the best price.',
         },
         headers: {
           source: 'Source',
@@ -393,9 +406,9 @@ describe('ProductPriceSection', () => {
     const card = wrapper.find('.product-price__competition-card')
     expect(card.exists()).toBe(true)
     expect(card.text()).toContain('Concurrence faible !')
-    expect(card.classes()).toContain('text-warning') // Depending on how color is applied, wait, mapped to v-card color
-    // v-card color prop doesn't add text-color class directly usually but background/theme color.
-    // We can check attributes or just existence.
+    expect(card.text()).toContain(
+      'Peu d’offres disponibles, la comparaison est limitée.'
+    )
     await wrapper.unmount()
   })
 
@@ -429,11 +442,14 @@ describe('ProductPriceSection', () => {
     const card = wrapper.find('.product-price__competition-card')
     expect(card.exists()).toBe(true)
     expect(card.text()).toContain('Concurrence correcte !')
+    expect(card.text()).toContain(
+      'Assez d’offres pour comparer en toute sérénité.'
+    )
 
     await wrapper.unmount()
   })
 
-  it('renders a good competition card for > 4 offers', async () => {
+  it('renders a super competition card for > 4 offers', async () => {
     const wrapper = await mountComponent({
       offersByCondition: {
         NEW: Array(5).fill({
@@ -448,7 +464,10 @@ describe('ProductPriceSection', () => {
 
     const card = wrapper.find('.product-price__competition-card')
     expect(card.exists()).toBe(true)
-    expect(card.text()).toContain('Bonne Concurrence !')
+    expect(card.text()).toContain('Super concurrence !')
+    expect(card.text()).toContain(
+      'Beaucoup d’offres pour décrocher le meilleur prix.'
+    )
 
     await wrapper.unmount()
   })

--- a/frontend/app/components/product/ProductPriceSection.vue
+++ b/frontend/app/components/product/ProductPriceSection.vue
@@ -181,15 +181,55 @@
 
         <v-card
           v-if="allOffers.length > 0"
-          class="mt-6 border product-price__competition-card"
-          variant="tonal"
-          :color="competitionLevel.color"
+          class="mt-6 product-price__competition-card"
+          :class="`product-price__competition-card--${competitionLevel.tone}`"
+          variant="flat"
         >
-          <div class="d-flex align-center pa-4">
-            <v-icon :icon="competitionLevel.icon" size="28" class="mr-4" />
-            <span class="text-h6 font-weight-medium">
-              {{ $t(competitionLevel.labelKey) }}
-            </span>
+          <div class="product-price__competition-content">
+            <div
+              class="product-price__competition-icon"
+              :class="`product-price__competition-icon--${competitionLevel.tone}`"
+            >
+              <v-icon :icon="competitionLevel.icon" size="28" />
+            </div>
+            <div class="product-price__competition-text">
+              <p class="product-price__competition-eyebrow">
+                {{
+                  $t(
+                    'product.price.competition.title',
+                    'Niveau de concurrence'
+                  )
+                }}
+              </p>
+              <h4 class="product-price__competition-title">
+                {{
+                  $t(
+                    competitionLevel.labelKey,
+                    competitionLevel.labelFallback
+                  )
+                }}
+              </h4>
+              <p class="product-price__competition-subtitle">
+                {{
+                  $t(
+                    competitionLevel.descriptionKey,
+                    competitionLevel.descriptionFallback
+                  )
+                }}
+              </p>
+            </div>
+            <v-chip
+              class="product-price__competition-count"
+              variant="tonal"
+              :color="competitionLevel.color"
+              size="small"
+            >
+              {{
+                $t('product.price.competition.count', '{count} offres', {
+                  count: allOffers.length,
+                })
+              }}
+            </v-chip>
           </div>
         </v-card>
       </div>
@@ -867,24 +907,39 @@ const competitionLevel = computed(() => {
 
   if (count < 2) {
     return {
-      icon: 'mdi-account-alert-outline',
+      tone: 'low',
+      icon: 'mdi-alert-outline',
       labelKey: 'product.price.competition.low',
+      labelFallback: 'Concurrence faible !',
+      descriptionKey: 'product.price.competition.lowDescription',
+      descriptionFallback:
+        'Peu d’offres disponibles, la comparaison est limitée.',
       color: 'warning',
     }
   }
 
   if (count > 4) {
     return {
-      icon: 'mdi-store-check-outline',
-      labelKey: 'product.price.competition.good',
+      tone: 'super',
+      icon: 'mdi-trophy-outline',
+      labelKey: 'product.price.competition.super',
+      labelFallback: 'Super concurrence !',
+      descriptionKey: 'product.price.competition.superDescription',
+      descriptionFallback:
+        'Beaucoup d’offres pour décrocher le meilleur prix.',
       color: 'success',
     }
   }
 
   // 2-4 offers
   return {
-    icon: 'mdi-store-outline',
+    tone: 'correct',
+    icon: 'mdi-account-multiple-check-outline',
     labelKey: 'product.price.competition.correct',
+    labelFallback: 'Concurrence correcte !',
+    descriptionKey: 'product.price.competition.correctDescription',
+    descriptionFallback:
+      'Assez d’offres pour comparer en toute sérénité.',
     color: 'info',
   }
 })
@@ -1384,6 +1439,104 @@ onBeforeUnmount(() => {
   border-radius: 16px;
 }
 
+.product-price__competition-card {
+  border-radius: 24px;
+  padding: 1.5rem;
+  background: rgba(var(--v-theme-surface-glass), 0.96);
+  border: 1px solid rgba(var(--v-theme-border-primary-strong), 0.12);
+  box-shadow:
+    0 12px 28px rgba(var(--v-theme-shadow-primary-600), 0.08),
+    inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.04);
+}
+
+.product-price__competition-card--low {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-surface-primary-050), 0.95),
+    rgba(var(--v-theme-surface-muted), 0.9)
+  );
+}
+
+.product-price__competition-card--correct {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-surface-primary-080), 0.95),
+    rgba(var(--v-theme-surface-glass), 0.9)
+  );
+}
+
+.product-price__competition-card--super {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-surface-primary-100), 0.95),
+    rgba(var(--v-theme-surface-glass-strong), 0.92)
+  );
+}
+
+.product-price__competition-content {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.product-price__competition-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--v-theme-surface-primary-120), 0.85);
+  color: rgb(var(--v-theme-text-on-accent));
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-border-primary-strong), 0.1);
+}
+
+.product-price__competition-icon--low {
+  background: rgba(var(--v-theme-surface-primary-080), 0.9);
+}
+
+.product-price__competition-icon--correct {
+  background: rgba(var(--v-theme-surface-primary-100), 0.9);
+}
+
+.product-price__competition-icon--super {
+  background: rgba(var(--v-theme-surface-primary-120), 0.95);
+}
+
+.product-price__competition-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.product-price__competition-eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.85);
+}
+
+.product-price__competition-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-text-neutral-strong));
+}
+
+.product-price__competition-subtitle {
+  margin: 0;
+  color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
+  font-size: 0.95rem;
+}
+
+.product-price__competition-count {
+  font-weight: 600;
+  border-radius: 999px;
+}
+
 .product-price__single-offer {
   border-radius: 24px;
 }
@@ -1521,6 +1674,16 @@ onBeforeUnmount(() => {
 @media (max-width: 768px) {
   .product-price__chart-header {
     align-items: stretch;
+  }
+
+  .product-price__competition-content {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    text-align: left;
+  }
+
+  .product-price__competition-count {
+    justify-self: flex-start;
   }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Improve the product page competition indicator to provide clearer, tiered visuals and more helpful copy when there are few/medium/many offers.
- Make the card visually consistent with design system tones and responsive on small screens.

### Description
- Replace the simple tonal `v-card` markup with a structured competition card including an eyebrow, title, subtitle, icon, and a count chip, and add new CSS utility classes for `--low`, `--correct`, and `--super` tones (file: `frontend/app/components/product/ProductPriceSection.vue`).
- Introduce `competitionLevel.tone`, `labelFallback`, and `descriptionKey`/`descriptionFallback` to surface richer fallback i18n strings and change the icons/thresholds for low/correct/super tiers (file: `frontend/app/components/product/ProductPriceSection.vue`).
- Update unit test fixtures and assertions to include the new i18n keys and descriptions and to expect the renamed `super` tier (file: `frontend/app/components/product/ProductPriceSection.spec.ts`).

### Testing
- Ran `pnpm lint --offline` in `frontend` and it passed successfully (lint-forbidden checks passed).
- Ran `pnpm test` (Vitest) where the frontend test suite mostly passed but one unrelated test failed: `ImpactScoreMethodology > renders clickable capsules for each vertical` (1 failing test, 412 passing); this failure appears unrelated to the competition card changes.
- Ran `pnpm generate --offline` (production generate) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978b1fb3c54832bb497eae2f83e4f72)