### PR TITLE
Add compact corner variant to ImpactScore and normalize small size

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -69,11 +69,8 @@
                 v-if="impactScoreValue(product) != null"
                 :score="impactScoreValue(product) ?? 0"
                 :max="5"
-                :size="normalizedSize === 'big' ? 'default' : 'small'"
-                mode="badge"
-                badge-layout="stacked"
-                badge-variant="corner"
-                flat
+                size="small"
+                variant="corner"
               />
               <span v-else class="category-product-card-grid__corner-fallback">
                 {{ $t('category.products.notRated') }}

--- a/frontend/app/components/category/products/ProductTileCard.vue
+++ b/frontend/app/components/category/products/ProductTileCard.vue
@@ -185,10 +185,7 @@
                 :score="impactScore"
                 :max="scoreMax"
                 size="small"
-                mode="badge"
-                badge-layout="stacked"
-                badge-variant="corner"
-                flat
+                variant="corner"
               />
 
               <span v-else class="product-tile-card__corner-fallback">

--- a/frontend/app/components/shared/ui/ImpactScore.spec.ts
+++ b/frontend/app/components/shared/ui/ImpactScore.spec.ts
@@ -69,6 +69,34 @@ describe('ImpactScore', () => {
     expect(wrapper.find('.impact-score-panel__bar').exists()).toBe(true)
   })
 
+  it('maps the small size alias to the compact xs layout', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 12,
+        size: 'small',
+      },
+      global: globalOptions,
+    })
+
+    const panel = wrapper.find('.impact-score-panel')
+    expect(panel.classes()).toContain('impact-score-panel--xs')
+  })
+
+  it('hides meta and progress bar in corner variant', () => {
+    const wrapper = mount(ImpactScore, {
+      props: {
+        score: 10,
+        variant: 'corner',
+        showMethodology: true,
+        showRange: true,
+      },
+      global: globalOptions,
+    })
+
+    expect(wrapper.find('.impact-score-panel__col-right').exists()).toBe(false)
+    expect(wrapper.find('.impact-score-panel__bar').exists()).toBe(false)
+  })
+
   it('hides/shows meta information', () => {
     const wrapper = mount(ImpactScore, {
       props: {

--- a/frontend/app/components/shared/ui/ImpactScore.vue
+++ b/frontend/app/components/shared/ui/ImpactScore.vue
@@ -2,7 +2,8 @@
   <div
     class="impact-score-panel"
     :class="[
-      `impact-score-panel--${size}`,
+      `impact-score-panel--${normalizedSize}`,
+      `impact-score-panel--${normalizedVariant}`,
       `impact-score-panel--${accentStep}`,
     ]"
     role="img"
@@ -18,7 +19,7 @@
         </div>
       </div>
 
-      <div v-if="hasMeta" class="impact-score-panel__col-right">
+      <div v-if="shouldShowMeta" class="impact-score-panel__col-right">
         <v-btn
           v-if="showMethodology"
           class="impact-score-panel__cta"
@@ -53,7 +54,7 @@
       </div>
     </div>
 
-    <div class="impact-score-panel__bar" aria-hidden="true">
+    <div v-if="shouldShowBar" class="impact-score-panel__bar" aria-hidden="true">
       <div class="impact-score-panel__track">
         <div
           class="impact-score-panel__fill"
@@ -83,8 +84,14 @@ const props = defineProps({
     default: 20,
   },
   size: {
-    type: String as PropType<'xs' | 'sm' | 'md' | 'lg'>,
+    type: String as PropType<
+      'xs' | 'sm' | 'md' | 'lg' | 'small' | 'medium' | 'default'
+    >,
     default: 'md',
+  },
+  variant: {
+    type: String as PropType<'default' | 'corner'>,
+    default: 'default',
   },
   showMethodology: {
     type: Boolean,
@@ -124,6 +131,18 @@ const accentStep = computed(() => {
   return 'high'
 })
 
+const normalizedSize = computed(() => {
+  const size = props.size
+
+  if (size === 'small') return 'xs'
+  if (size === 'medium' || size === 'default') return 'md'
+  return size
+})
+
+const normalizedVariant = computed(() =>
+  props.variant === 'corner' ? 'corner' : 'default'
+)
+
 const formattedScoreValue = computed(() =>
   n(displayScore.value, {
     maximumFractionDigits: 1,
@@ -136,6 +155,14 @@ const ariaLabel = computed(() =>
 )
 
 const hasMeta = computed(() => props.showMethodology || props.showRange)
+
+const shouldShowMeta = computed(
+  () => normalizedVariant.value === 'default' && hasMeta.value
+)
+
+const shouldShowBar = computed(
+  () => normalizedVariant.value === 'default'
+)
 </script>
 
 <style scoped>
@@ -209,6 +236,32 @@ const hasMeta = computed(() => props.showMethodology || props.showRange)
 
 .impact-score-panel--lg .impact-score-panel__score-value {
   font-size: 3.4rem;
+}
+
+/* Variant styles */
+.impact-score-panel--corner {
+  padding: 6px 8px;
+  border-radius: 12px;
+  gap: 6px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+  background: rgba(var(--v-theme-surface), 0.7);
+}
+
+.impact-score-panel--corner::before {
+  opacity: 0.6;
+}
+
+.impact-score-panel--corner .impact-score-panel__score {
+  gap: 4px;
+}
+
+.impact-score-panel--corner .impact-score-panel__score-value {
+  font-size: 1.35rem;
+  line-height: 1.1;
+}
+
+.impact-score-panel--corner .impact-score-panel__score-out {
+  font-size: 0.75rem;
 }
 
 /* Top layout */


### PR DESCRIPTION
### Motivation
- Provide a compact, corner-friendly rendering for impact score badges so they fit neatly in the top corner of product cards. 
- Keep a single shared `ImpactScore` component as the source of truth and avoid duplicating corner-specific markup across cards. 
- Support a `small` size alias so callers can request a truly compact variant without changing every call site.

### Description
- Extended `ImpactScore.vue` with a new `variant` prop (`'default' | 'corner'`) and size alias handling by normalising `size` to `normalizedSize` and `normalizedVariant`, and added `shouldShowMeta` / `shouldShowBar` computed flags to hide meta and progress bar for the corner variant.
- Added dedicated compact CSS for the corner variant (`.impact-score-panel--corner`) to reduce padding, font sizes and remove the progress bar, while keeping color accent logic intact in `frontend/app/components/shared/ui/ImpactScore.vue`.
- Updated product card usages to use the new API: replaced previous badge-related props with `size="small" variant="corner"` in `ProductTileCard.vue` and `CategoryProductCardGrid.vue` to render the compact corner badge.
- Extended `ImpactScore` unit tests (`ImpactScore.spec.ts`) to cover the `small` size alias and the `corner` variant behaviour, and removed the now-unused badge props from component calls.

### Testing
- Ran `pnpm --offline lint` and the lint checks passed.
- Ran `pnpm --offline test`; the test suite executed and reported 415 tests with 1 failure: `app/components/impact-score/ImpactScoreMethodology.spec.ts > renders clickable capsules for each vertical` (expected route `/lave-linge` but received `undefined`), which appears unrelated to the ImpactScore changes; all ImpactScore-related tests passed.
- Ran `pnpm --offline generate` and the production build/generate completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c10846a0832b92f287ce522778ec)