### PR TITLE
Improve commercial event overlays in price chart

### DIFF
--- a/frontend/app/components/product/ProductPriceSection.spec.ts
+++ b/frontend/app/components/product/ProductPriceSection.spec.ts
@@ -47,6 +47,7 @@ const i18nMessages = {
           viewOffer: "Ouvrir l'offre chez {source}",
         },
         events: {
+          toggleLabel: 'Afficher les offres commerciales',
           detailsTitle: 'Événement commercial',
           clearSelection: 'Effacer la sélection',
           dateLabel: 'Dates :',
@@ -109,6 +110,7 @@ const i18nMessages = {
           viewOffer: 'Open offer from {source}',
         },
         events: {
+          toggleLabel: 'Show commercial offers',
           detailsTitle: 'Commercial event',
           clearSelection: 'Clear selection',
           dateLabel: 'Dates:',

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -3126,6 +3126,7 @@
         "unknownSource": "Unknown source"
       },
       "events": {
+        "toggleLabel": "Show commercial offers",
         "detailsTitle": "Commercial event",
         "clearSelection": "Clear selection",
         "dateLabel": "Dates:",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2847,6 +2847,7 @@
         "unknownSource": "Source inconnue"
       },
       "events": {
+        "toggleLabel": "Afficher les offres commerciales",
         "detailsTitle": "Événement commercial",
         "clearSelection": "Effacer la sélection",
         "dateLabel": "Dates :",


### PR DESCRIPTION
### Motivation
- Make commercial events in the price history match the requested UI: show only the event label + date range, use a 16px/18px label style, and provide a top-right checkbox to show/hide commercial offers.
- Keep the selected-event details card consistent with the toggle so selection is hidden when events are disabled.

### Description
- Added a visibility toggle (`showCommercialEvents`) and computed guards (`hasCommercialEvents`, `displayCommercialEvents`, `displaySelectedCommercialEvent`) and wired a compact `v-checkbox` into the price history header to show/hide commercial offers; the selected-event card is now gated by the same toggle (file: `frontend/app/components/product/ProductPriceSection.vue`).
- Split event rendering into two ECharts custom series: a label band (larger row, 16px font / 18px line-height) and a translucent range overlay with tooltip support, and tuned sizing constants (`EVENT_LABEL_ROW_HEIGHT`, `EVENT_RANGE_HEIGHT`, `EVENT_LABEL_FONT_SIZE`, etc.) and opacities for better legibility (file: `frontend/app/components/product/ProductPriceSection.vue`).
- Guarded chart input so events are omitted when toggled off and clear event selection when hiding events (file: `frontend/app/components/product/ProductPriceSection.vue`).
- Added styles for the header/toggle layout and checkbox label, and added i18n keys for the toggle label in `fr-FR.json` and `en-US.json` plus updated the component test messages fixture (`frontend/app/components/product/ProductPriceSection.spec.ts`).

### Testing
- Ran lint with `pnpm lint` and the checks passed (including the `lint-forbidden` scan). 
- Executed unit tests with `pnpm test` (Vitest) and all tests passed: 115 test files / 415 tests (green).
- Built the static site with `pnpm generate` and the Nuxt build/prerender completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ca734e34832b96e163db8c648af3)