### PR TITLE
Add EPREL support timeline events and latest-version handling

### DIFF
--- a/api/src/test/java/org/open4goods/api/services/completion/EprelCompletionServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/completion/EprelCompletionServiceTest.java
@@ -1,0 +1,79 @@
+package org.open4goods.api.services.completion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.services.AggregationFacadeService;
+import org.open4goods.api.services.aggregation.aggregator.StandardAggregator;
+import org.open4goods.model.attribute.ReferentielKey;
+import org.open4goods.model.eprel.EprelProduct;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.services.eprelservice.service.EprelSearchService;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+
+import ch.qos.logback.classic.Level;
+
+class EprelCompletionServiceTest {
+
+    private EprelCompletionService service;
+    private EprelSearchService eprelSearchService;
+    private VerticalConfig vertical;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        VerticalsConfigService verticalConfigService = Mockito.mock(VerticalsConfigService.class);
+        ProductRepository productRepository = Mockito.mock(ProductRepository.class);
+        ApiProperties apiProperties = Mockito.mock(ApiProperties.class);
+        eprelSearchService = Mockito.mock(EprelSearchService.class);
+        AggregationFacadeService aggregationFacadeService = Mockito.mock(AggregationFacadeService.class);
+        StandardAggregator aggregator = Mockito.mock(StandardAggregator.class);
+
+        when(apiProperties.logsFolder()).thenReturn("/tmp/logs");
+        when(apiProperties.aggLogLevel()).thenReturn(Level.INFO);
+        when(aggregationFacadeService.getStandardAggregator("eprel-aggregation")).thenReturn(aggregator);
+
+        service = new EprelCompletionService(verticalConfigService, productRepository, apiProperties,
+                eprelSearchService, aggregationFacadeService);
+        vertical = new VerticalConfig();
+        vertical.setEprelGroupNames(List.of("TELEVISION"));
+        product = new Product(123L);
+        product.getAttributes().addReferentielAttribute(ReferentielKey.MODEL, "MODEL-A");
+    }
+
+    @Test
+    void processProductUsesLatestEprelVersionWhenAvailable() {
+        EprelProduct current = new EprelProduct();
+        current.setEprelRegistrationNumber("old");
+        current.setLastVersion(false);
+        current.setProductModelCoreId(10L);
+        current.setVersionId(1L);
+
+        EprelProduct latest = new EprelProduct();
+        latest.setEprelRegistrationNumber("new");
+        latest.setLastVersion(true);
+        latest.setProductModelCoreId(10L);
+        latest.setVersionId(2L);
+
+        when(eprelSearchService.search(anyString(), anyList(), anyCollection()))
+                .thenReturn(List.of(current));
+        when(eprelSearchService.searchByProductModelCoreId(Mockito.eq(10L), anyCollection()))
+                .thenReturn(List.of(current, latest));
+
+        service.processProduct(vertical, product);
+
+        assertThat(product.getEprelDatas()).isEqualTo(latest);
+        assertThat(product.getExternalIds().getEprel()).isEqualTo("new");
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductTimelineEventType.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductTimelineEventType.java
@@ -37,6 +37,15 @@ public enum ProductTimelineEventType {
     /** EPREL export timestamp. */
     @Schema(description = "EPREL export timestamp")
     EPREL_EXPORT,
+    /** EPREL spare parts availability end. */
+    @Schema(description = "EPREL calculated end date for spare parts availability")
+    EPREL_SPARE_PARTS_END,
+    /** EPREL software updates support end. */
+    @Schema(description = "EPREL calculated end date for software updates availability")
+    EPREL_SOFTWARE_SUPPORT_END,
+    /** EPREL guaranteed support end. */
+    @Schema(description = "EPREL calculated end date for overall technical support")
+    EPREL_SUPPORT_END,
     /** Internal import timestamp. */
     @Schema(description = "Date when the EPREL entry was imported")
     EPREL_IMPORTED,

--- a/services/eprel-service/src/main/java/org/open4goods/services/eprelservice/service/EprelSearchService.java
+++ b/services/eprel-service/src/main/java/org/open4goods/services/eprelservice/service/EprelSearchService.java
@@ -71,6 +71,23 @@ public class EprelSearchService
     }
 
     /**
+     * Finds all EPREL products for a shared model core identifier.
+     *
+     * @param modelCoreId model core identifier
+     * @param eprelCategories optional EPREL categories to restrict the search
+     * @return matching products
+     */
+    public List<EprelProduct> searchByProductModelCoreId(Long modelCoreId, Collection<String> eprelCategories)
+    {
+        if (modelCoreId == null)
+        {
+            return List.of();
+        }
+        Query query = Query.of(q -> q.term(t -> t.field("productModelCoreId").value(modelCoreId)));
+        return execute(query, eprelCategories);
+    }
+
+    /**
      * Finds products whose model identifier matches the provided value exactly (case insensitive).
      *
      * @param model model identifier to search for


### PR DESCRIPTION
### Motivation
- Compute and expose EPREL-derived after-sales dates (spare parts, software, support) in product timelines so the frontend can show estimated support end milestones.
- Ensure product completion uses the most recent EPREL record when a catalog entry is flagged as non-latest to avoid populating products with stale EPREL data.
- Add unit tests to cover the new timeline calculations and the completion path that resolves to the latest EPREL version.

### Description
- Add three new timeline event types: `EPREL_SPARE_PARTS_END`, `EPREL_SOFTWARE_SUPPORT_END` and `EPREL_SUPPORT_END` in `ProductTimelineEventType`.
- Compute support end events in `ProductTimelineService` by reading category-specific EPREL duration attributes, validating and parsing values, applying them to the on-market end baseline and guarding against absurd future dates.
- Add `searchByProductModelCoreId` to `EprelSearchService` and implement `resolveLatestVersion` + `compareVersionId` in `EprelCompletionService` to fetch and prefer the latest EPREL version when available.
- Add and update unit tests: `ProductTimelineServiceTest` (new assertions for EPREL support events) and `EprelCompletionServiceTest` (new test ensuring completion chooses latest EPREL version).

### Testing
- Ran `mvn --offline clean install` across the reactor and verified a full build with tests completed successfully (`BUILD SUCCESS`).
- New and updated unit tests executed as part of the build: `ProductTimelineServiceTest` and `EprelCompletionServiceTest` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c50e9dc4832bb1bb2d5295ab6894)