### PR TITLE
Refactor home hero highlights and add promises section

### DIFF
--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -256,16 +256,16 @@ useHead({
             </p>
           </v-col>
         </v-row>
-        <v-row justify="center">
-          <v-col cols="12" lg="10" xl="8">
+        <v-row justify="center" class="home-hero__panel-row">
+          <v-col cols="12" lg="10" xl="8" class="home-hero__panel-col">
             <v-sheet
               class="home-hero__panel home-reveal-item home-reveal-item--scale"
               color="transparent"
               elevation="0"
               :style="{ '--reveal-delay': '180ms' }"
             >
-              <div class="d-flex flex-column ga-6">
-                <div class="d-flex flex-column ga-4">
+              <div class="home-hero__panel-content">
+                <div class="home-hero__panel-top d-flex flex-column ga-4">
                   <form
                     class="home-hero__search"
                     role="search"
@@ -325,7 +325,9 @@ useHead({
                   <div class="d-flex flex-column ga-4">
                     <NudgeToolWizard :verticals="wizardVerticals" />
                   </div>
+                </div>
 
+                <div class="home-hero__panel-bottom">
                   <HomeHeroHighlights
                     :partners-count="partnersCount"
                     :open-data-millions="openDataMillions"
@@ -338,6 +340,12 @@ useHead({
                     "
                     :reviewed-products-count="reviewedProductsCount"
                     :ai-summary-remaining-credits="aiSummaryRemainingCredits"
+                    highlights-i18n-key="hero.highlightsCompact"
+                    :highlights-fallback-keys="['home.hero.highlightsCompact']"
+                    ai-summary-i18n-key="home.hero.aiSummaryCompact"
+                    :enable-links="false"
+                    scroll-target-id="home-promises"
+                    variant="hero"
                   />
                 </div>
               </div>
@@ -475,11 +483,34 @@ useHead({
   width: 100%
   max-width: clamp(56rem, 82vw, 72rem)
   margin-inline: auto
+  height: 100%
+  display: flex
+  flex-direction: column
 
 // .home-hero__panel-grid and .home-hero__panel-block styles now handled by utility classes: d-flex flex-column ga-6, ga-4
 
 .home-hero__wizard
   width: 100%
+
+.home-hero__panel-row
+  flex: 1
+  align-items: stretch
+
+.home-hero__panel-col
+  display: flex
+
+.home-hero__panel-content
+  display: flex
+  flex-direction: column
+  gap: clamp(1.5rem, 4vw, 2.5rem)
+  height: 100%
+  width: 100%
+
+.home-hero__panel-top
+  width: 100%
+
+.home-hero__panel-bottom
+  margin-top: auto
 
 @media (max-width: 959px)
   .home-hero
@@ -488,6 +519,7 @@ useHead({
 
   .home-hero__panel
     padding: clamp(1.25rem, 5vw, 2rem)
+    height: auto
 
   .home-hero__panel-grid
     gap: clamp(1rem, 3vw, 1.5rem)
@@ -507,6 +539,9 @@ useHead({
 
   .home-hero__helpers
     margin-inline-start: 1.5rem
+
+  .home-hero__inner
+    height: 100%
 
 @media (min-width: 1280px)
   .home-hero__panel-grid

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -840,6 +840,34 @@ useHead(() => ({
           </section>
         </ParallaxWidget>
 
+        <section
+          id="home-promises"
+          class="home-page__section-wrapper home-page__stack home-page__promises"
+          :aria-label="t('home.promises.ariaLabel')"
+        >
+          <SectionReveal class="home-page__section" transition="slide-y">
+            <template #default="{ reveal }">
+              <div
+                class="home-page__promises-content"
+                :class="{ 'home-page__promises-content--visible': reveal }"
+              >
+                <HomeHeroHighlights
+                  :partners-count="heroPartnersCount"
+                  :open-data-millions="openDataMillions"
+                  :products-count="productsCount"
+                  :categories-count="categoriesCount"
+                  :impact-score-products-count="impactScoreProductsCount"
+                  :impact-score-categories-count="impactScoreCategoriesCount"
+                  :products-without-vertical-count="productsWithoutVerticalCount"
+                  :reviewed-products-count="reviewedProductsCount"
+                  :ai-summary-remaining-credits="aiSummaryRemainingCredits"
+                  variant="section"
+                />
+              </div>
+            </template>
+          </SectionReveal>
+        </section>
+
         <ParallaxWidget
           class="home-page__parallax"
           reverse
@@ -952,6 +980,26 @@ useHead(() => ({
 
 .home-page__section
   width: 100%
+
+.home-page__promises
+  padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 6vw, 4rem)
+  background: linear-gradient(
+    160deg,
+    rgba(var(--v-theme-surface-ice-050), 0.85) 0%,
+    rgba(var(--v-theme-surface-default), 0.95) 60%,
+    rgba(var(--v-theme-surface-ice-100), 0.95) 100%
+  )
+
+.home-page__promises-content
+  max-width: 1100px
+  margin: 0 auto
+  opacity: 0
+  transform: translateY(20px)
+  transition: opacity 300ms ease, transform 300ms ease
+
+.home-page__promises-content--visible
+  opacity: 1
+  transform: translateY(0)
 
 .home-contact-redirect__card
   border: 1px solid rgb(var(--v-theme-surface-primary-080))

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -470,11 +470,48 @@
           ]
         }
       ],
+      "highlightsCompact": [
+        {
+          "title": "🌿 ImpactScore",
+          "segments": [
+            {
+              "text": "A clear score to buy more responsibly."
+            }
+          ]
+        },
+        {
+          "title": "🫰 Fair prices",
+          "segments": [
+            {
+              "text": "Best offers and price history at the right time."
+            }
+          ]
+        },
+        {
+          "title": "🇫🇷 Open & ethical",
+          "segments": [
+            {
+              "text": "Independent, open source, open data."
+            }
+          ]
+        }
+      ],
       "aiSummary": {
         "title": "Community AI summary",
         "creditsLabel": "Credits remaining: {count}",
         "creditsFallback": "Credits remaining: unavailable",
         "description": "A powerful tool with real AI inside, giving you a panoramic view of your product. Free and community-driven.",
+        "reviewedProductsSuffix": "{reviewedProductsCount} product pages generated so far.",
+        "dialog": {
+          "description": "Visit product pages that have not been summarised yet to use your generations!",
+          "confirm": "Got it!"
+        }
+      },
+      "aiSummaryCompact": {
+        "title": "Community AI summary",
+        "creditsLabel": "Credits remaining: {count}",
+        "creditsFallback": "Credits remaining: unavailable",
+        "description": "A one-glance AI summary, free and community-driven.",
         "reviewedProductsSuffix": "{reviewedProductsCount} product pages generated so far."
       },
       "example": {
@@ -491,7 +528,11 @@
         "cornerTooltip": "Key highlights from Nudger’s methodology",
         "ariaLabel": "Hero context card summarising Nudger’s promise"
       },
+      "highlightsScrollCta": "Scroll to the promises: {title}",
       "background": "hero-background.webp"
+    },
+    "promises": {
+      "ariaLabel": "Our promises and commitments to compare responsibly"
     },
     "parallax": {
       "essentials": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -191,11 +191,48 @@
           ]
         }
       ],
+      "highlightsCompact": [
+        {
+          "title": "🌿 ImpactScore",
+          "segments": [
+            {
+              "text": "Un score clair pour acheter plus responsable."
+            }
+          ]
+        },
+        {
+          "title": "🫰 Prix justes",
+          "segments": [
+            {
+              "text": "Les meilleures offres et l'historique au bon moment."
+            }
+          ]
+        },
+        {
+          "title": "🇫🇷 Ouvert & éthique",
+          "segments": [
+            {
+              "text": "Indépendant, open source et données ouvertes."
+            }
+          ]
+        }
+      ],
       "aiSummary": {
         "title": "Fiches produits sur-puissantes 💪",
         "creditsLabel": "synthèses restantes : {count}",
         "creditsFallback": "Crédits restants : indisponible",
         "description": "Un outil puissant avec de la vraie IA dedans, qui vous offre un panoramique de votre produit. Dans une optique de sobriété -et parceque le partage est dans notre ADN-, ces synthèses sont aussi mises à disposition des autres utilisateurs. Gratuit, sans inscription.",
+        "reviewedProductsSuffix": "{reviewedProductsCount} fiches produits générées jusqu'à présent.",
+        "dialog": {
+          "description": "Rendez vous sur les pages produits non encore synthétisées pour activer vos générations !",
+          "confirm": "Compris !"
+        }
+      },
+      "aiSummaryCompact": {
+        "title": "Fiches produits sur-puissantes 💪",
+        "creditsLabel": "synthèses restantes : {count}",
+        "creditsFallback": "Crédits restants : indisponible",
+        "description": "Une synthèse IA claire en un coup d'œil, gratuite et sans inscription.",
         "reviewedProductsSuffix": "{reviewedProductsCount} fiches produits générées jusqu'à présent."
       },
       "example": {
@@ -212,7 +249,11 @@
         "cornerTooltip": "Les points forts de la méthodologie Nudger",
         "ariaLabel": "Carte contexte du héros présentant la promesse Nudger"
       },
+      "highlightsScrollCta": "Faire défiler vers les promesses : {title}",
       "background": "hero-background.webp"
+    },
+    "promises": {
+      "ariaLabel": "Nos promesses et engagements pour comparer responsablement"
     },
     "parallax": {
       "essentials": {


### PR DESCRIPTION
### Motivation
- Make hero highlights reusable in a compact hero presentation and in a full "promises" section, and enable smooth-scroll interactions from hero cards to the promises section. 
- Improve accessibility and i18n coverage for hero highlights and the AI summary dialog so the content is usable in multiple contexts. 

### Description
- Reworked the hero panel layout in `HomeHeroSection.vue` to separate top controls and a bottom highlights area and added structural utility classes (`home-hero__panel-top`, `home-hero__panel-bottom`, etc.).
- Extended `HomeHeroHighlights.vue` to accept new props (`highlightsI18nKey`, `highlightsFallbackKeys`, `aiSummaryI18nKey`, `enableLinks`, `scrollTargetId`, `variant`) and added behavior for compact/hero variants, scroll CTA, conditional link rendering and per-card styles; also replaced `process.client` with `import.meta.client` and provided default prop values with `withDefaults`.
- Added a new `home-promises` section to `frontend/app/pages/index.vue` that reuses `HomeHeroHighlights` in the full-section (`variant="section"`) form with reveal animation and styling.
- Added compact highlight copies and AI dialog strings to `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` and a scroll CTA i18n key.
- Fixed SASS syntax for transitions and adjusted styles to support the new compact/hero variants.

### Testing
- Ran `pnpm lint` in `frontend`; the run completed but lint currently fails due to pre-existing errors in `app/middleware/record.global.spec.ts` (errors unrelated to these changes).
- Ran `pnpm test` (Vitest) in `frontend`; the test run completed with most specs passing but 3 failing tests (`useAiReviewGenerationStore.spec.ts`, `ProductAiReviewSection.spec.ts`, `ProductSummaryNavigation.spec.ts`).
- Ran `pnpm generate` (Nuxt build) during verification; initial CSS syntax error was fixed, but the server bundle failed later due to an unresolved import (`./shared/utils/hotjar-recording.ts`) unrelated to these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3e2ae1dc832ba4aa0f2f6f39da45)