### PR TITLE
Impact subscore: rich read‑indicator, unit pluralisation and i18n updates

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2922,21 +2922,35 @@
           "readIndicator": {
             "title": "How to read this indicator",
             "higher": {
-              "worst": "The lowest {scoreLabelLower} recorded is {worst}{unit}.",
-              "best": "The highest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}{unit}.",
-              "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}{unit}.",
+              "worst": "The lowest {scoreLabelLower} recorded is {worstValue}.",
+              "best": "The highest {scoreLabelLower} observed among the {count} {verticalTitle} is {bestValue}.",
+              "average": "Across the {count} {verticalTitle} with available data, the average reaches {averageValue}.",
               "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}{unit}, which converts to {productOn20}/20.",
               "sigmaBounds": "Normalization spans [{sigmaLower}{unit} ; {sigmaUpper}{unit}] based on {sigmaK}σ around the mean.",
               "percentile": "This product sits around the {percentile}th percentile of the distribution.",
+              "minmax_observed": "Observed values range from {worstValue} to {bestValue}.",
+              "minmax_fixed": "Fixed bounds run from {fixedMinValue} to {fixedMaxValue}.",
+              "minmax_quantile": "Quantile bounds run from {quantileLowValue} to {quantileHighValue}.",
+              "fixed_mapping": "The score follows a fixed mapping with {mappingCount} possible values.",
+              "binary_greater": "The score passes when the value is ≥ {thresholdValue}.",
+              "binary_lower": "The score passes when the value is ≤ {thresholdValue}.",
+              "constant": "The score is fixed at {constantValueLabel}.",
               "distribution": "The scoring uses standard deviation ({sigma}{unit}) to ensure extreme values do not overshadow differences between common products."
             },
             "lower": {
-              "worst": "The highest {scoreLabelLower} recorded is {worst}{unit}.",
-              "best": "The lowest {scoreLabelLower} observed among the {count} {verticalTitle} is {best}{unit}.",
-              "average": "Across the {count} {verticalTitle} with available data, the average reaches {average}{unit}.",
+              "worst": "The highest {scoreLabelLower} recorded is {worstValue}.",
+              "best": "The lowest {scoreLabelLower} observed among the {count} {verticalTitle} is {bestValue}.",
+              "average": "Across the {count} {verticalTitle} with available data, the average reaches {averageValue}.",
               "product": "{productName} posts a {scoreLabelLower} of {productAbsolute}{unit}, which converts to {productOn20}/20.",
               "sigmaBounds": "Normalization spans [{sigmaLower}{unit} ; {sigmaUpper}{unit}] based on {sigmaK}σ around the mean.",
               "percentile": "This product sits around the {percentile}th percentile of the distribution.",
+              "minmax_observed": "Observed values range from {worstValue} to {bestValue}.",
+              "minmax_fixed": "Fixed bounds run from {fixedMinValue} to {fixedMaxValue}.",
+              "minmax_quantile": "Quantile bounds run from {quantileLowValue} to {quantileHighValue}.",
+              "fixed_mapping": "The score follows a fixed mapping with {mappingCount} possible values.",
+              "binary_greater": "The score passes when the value is ≥ {thresholdValue}.",
+              "binary_lower": "The score passes when the value is ≤ {thresholdValue}.",
+              "constant": "The score is fixed at {constantValueLabel}.",
               "distribution": "The scoring uses standard deviation ({sigma}{unit}) to ensure extreme values do not overshadow differences between common products."
             },
             "method": {
@@ -3000,6 +3014,20 @@
             "fixed_mapping": "This method is selected for categorical values with a fixed mapping defined in configuration.",
             "binary": "This method applies when the attribute is evaluated against a threshold. The configuration defines the pass value.",
             "constant": "This method is a configuration fallback when the attribute must remain stable."
+          }
+        },
+        "warranty": {
+          "readIndicator": {
+            "higher": {
+              "worst": "Warranty <b>minimum</b> observed is <b>{worstValue}</b>.",
+              "best": "Warranty <b>maximum</b> observed reaches <b>{bestValue}</b>.",
+              "average": "The <b>average</b> across the {count} {verticalTitle} with data is <b>{averageValue}</b>."
+            },
+            "lower": {
+              "worst": "Warranty <b>minimum</b> observed is <b>{worstValue}</b>.",
+              "best": "Warranty <b>maximum</b> observed reaches <b>{bestValue}</b>.",
+              "average": "The <b>average</b> across the {count} {verticalTitle} with data is <b>{averageValue}</b>."
+            }
           }
         },
         "repairability_index": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2640,21 +2640,35 @@
           "readIndicator": {
             "title": "Comment lire cet indicateur",
             "higher": {
-              "worst": "Le plus faible {scoreLabelLower} observé est de {worst}{unit}.",
-              "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {best}{unit}.",
-              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}{unit}.",
+              "worst": "Le plus faible {scoreLabelLower} observé est de {worstValue}.",
+              "best": "Le meilleur {scoreLabelLower} constaté parmi les {count} {verticalTitle} atteint {bestValue}.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {averageValue}.",
               "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}{unit}, obtient la note de {productOn20}/20.",
               "sigmaBounds": "La normalisation couvre l’intervalle [{sigmaLower}{unit} ; {sigmaUpper}{unit}] basé sur {sigmaK}σ autour de la moyenne.",
               "percentile": "Ce produit se situe autour du {percentile}ᵉ percentile de la distribution.",
+              "minmax_observed": "Les valeurs observées vont de {worstValue} à {bestValue}.",
+              "minmax_fixed": "Les bornes fixes sont {fixedMinValue} et {fixedMaxValue}.",
+              "minmax_quantile": "Les bornes par quantiles sont {quantileLowValue} et {quantileHighValue}.",
+              "fixed_mapping": "La note suit un barème de {mappingCount} valeurs possibles.",
+              "binary_greater": "La note passe quand la valeur est ≥ {thresholdValue}.",
+              "binary_lower": "La note passe quand la valeur est ≤ {thresholdValue}.",
+              "constant": "La note est fixée à {constantValueLabel}.",
               "distribution": "La notation utilise l'écart-type ({sigma}{unit}) pour s'assurer que les valeurs extrêmes n'écrasent pas les différences entre produits courants."
             },
             "lower": {
-              "worst": "Le {scoreLabelLower} le plus élevé observé est de {worst}{unit}.",
-              "best": "Le {scoreLabelLower} le plus faible constaté parmi les {count} {verticalTitle} atteint {best}{unit}.",
-              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {average}{unit}.",
+              "worst": "Le {scoreLabelLower} le plus élevé observé est de {worstValue}.",
+              "best": "Le {scoreLabelLower} le plus faible constaté parmi les {count} {verticalTitle} atteint {bestValue}.",
+              "average": "La moyenne pour les {count} {verticalTitle} disposant de données est de {averageValue}.",
               "product": "{productName}, avec un {scoreLabelLower} de {productAbsolute}{unit}, obtient la note de {productOn20}/20.",
               "sigmaBounds": "La normalisation couvre l’intervalle [{sigmaLower}{unit} ; {sigmaUpper}{unit}] basé sur {sigmaK}σ autour de la moyenne.",
               "percentile": "Ce produit se situe autour du {percentile}ᵉ percentile de la distribution.",
+              "minmax_observed": "Les valeurs observées vont de {worstValue} à {bestValue}.",
+              "minmax_fixed": "Les bornes fixes sont {fixedMinValue} et {fixedMaxValue}.",
+              "minmax_quantile": "Les bornes par quantiles sont {quantileLowValue} et {quantileHighValue}.",
+              "fixed_mapping": "La note suit un barème de {mappingCount} valeurs possibles.",
+              "binary_greater": "La note passe quand la valeur est ≥ {thresholdValue}.",
+              "binary_lower": "La note passe quand la valeur est ≤ {thresholdValue}.",
+              "constant": "La note est fixée à {constantValueLabel}.",
               "distribution": "La notation utilise l'écart-type ({sigma}{unit}) pour s'assurer que les valeurs extrêmes n'écrasent pas les différences entre produits courants."
             },
             "method": {
@@ -2718,6 +2732,20 @@
             "fixed_mapping": "Idéale pour les critères qualitatifs (ex: classe énergétique). Elle permet d'attribuer une note précise à chaque valeur possible, sans calcul statistique.",
             "binary": "La méthode la plus simple : ça passe ou ça casse. Utilisée pour les critères binaires (présence/absence) où aucune nuance n'est nécessaire.",
             "constant": "Méthode de repli utilisée rarement, pour attribuer une note fixe indépendamment des caractéristiques du produit."
+          }
+        },
+        "warranty": {
+          "readIndicator": {
+            "higher": {
+              "worst": "garantie <b>minimum</b> observé est de <b>{worstValue}</b>.",
+              "best": "garantie <b>maximum</b> constaté atteint <b>{bestValue}</b>.",
+              "average": "La <b>moyenne</b> pour les {count} {verticalTitle} disposant de données est de <b>{averageValue}</b>."
+            },
+            "lower": {
+              "worst": "garantie <b>minimum</b> observé est de <b>{worstValue}</b>.",
+              "best": "garantie <b>maximum</b> constaté atteint <b>{bestValue}</b>.",
+              "average": "La <b>moyenne</b> pour les {count} {verticalTitle} disposant de données est de <b>{averageValue}</b>."
+            }
           }
         },
         "repairability_index": {


### PR DESCRIPTION
### Motivation
- Improve how the impact subscore explanation communicates values by allowing rich-text highlights and showing units correctly (including plural forms) so displayed lines read naturally across languages. 
- Surface method-specific explanation lines depending on the normalization method to make the reader guidance more informative and context-aware. 
- Add dedicated warranty wording for a clearer user-facing message when the criterion is warranty duration.

### Description
- Render read-indicator bullets as HTML and add plural-aware unit handling in `ProductImpactSubscoreExplanation.vue` (compute plural forms, resolve unit labels, and format value+unit strings). 
- Add computed values for unit-aware variants (`worstValueWithUnit`, `bestValueWithUnit`, `averageValueWithUnit`, plus fixed/quantile/threshold/constant variants) and include them in the translation parameter object. 
- Select a method-specific highlight line according to the normalization method (`SIGMA`, `PERCENTILE`, `MINMAX_OBSERVED`, `MINMAX_FIXED`, `MINMAX_QUANTILE`, `FIXED_MAPPING`, `BINARY`, `CONSTANT`) and push it into `readIndicatorHighlights`. 
- Update locale files to use new placeholders and to add warranty-specific and method-specific copy in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`. 
- Files changed: `frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue`, `frontend/i18n/locales/en-US.json`, `frontend/i18n/locales/fr-FR.json`.

### Testing
- Ran linter: `pnpm lint` (frontend) — failed due to unrelated issues in tests: unused vars and `@typescript-eslint/no-explicit-any` warnings in `app/middleware/record.global.spec.ts`. 
- Ran unit tests: `pnpm test` (frontend) — majority passed but 3 specs failed: `app/stores/useAiReviewGenerationStore.spec.ts` (one assertion on progress percent), `app/components/product/ProductAiReviewSection.spec.ts` (store API mismatch: `getDisplayedMessage` missing), and `app/components/product/ProductSummaryNavigation.spec.ts` (CSS class expectation). 
- Attempted production build: `pnpm generate` — failed in Nitro build step due to a missing import (`./shared/utils/hotjar-recording.ts`) unrelated to these changes. 
- Summary: functional changes implemented and covered by component logic; automated checks surfaced pre-existing unrelated failures that need addressing separately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3c836140832bb5d61543ef6c0ed2)