### PR TITLE
Add nudge-tool threshold computation and ECOSCORE-based impact subsets

### DIFF
--- a/api/src/main/java/org/open4goods/api/controller/api/VerticalsGenerationController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/VerticalsGenerationController.java
@@ -240,5 +240,14 @@ public class VerticalsGenerationController {
 
 	}
 
+	@GetMapping(path="/update/{vertical}/nudgetool/")
+	@Operation(summary="Update the nudge tool score thresholds and impact score subsets for a given vertical")
+	@PreAuthorize("hasAuthority('"+RolesConstants.ROLE_ADMIN+"')")
+	public String updateVerticalWithNudgeTool(
+			@PathVariable String vertical) throws ResourceNotFoundException, IOException {
+
+		return verticalsGenService.updateVerticalFileWithNudgeToolConfig("/home/goulven/git/open4goods/verticals/src/main/resources/verticals/" + vertical + ".yml");
+	}
+
 
 }

--- a/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
+++ b/services/product-repository/src/test/java/org/open4goods/services/productrepository/services/ProductRepositoryTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.SubsetCriteriaOperator;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -110,5 +111,25 @@ class ProductRepositoryTest
         // If possible we could check if the verticalId is in the toString of the criteria if exposed
         // But for now, ensuring the method was called and query object formed is enough for this unit level verification
         // given the internal implementation is straightforward.
+    }
+
+    @Test
+    void countMainIndexHavingScoreWithFiltersReturnsCount()
+    {
+        when(elasticsearchOperations.count(any(CriteriaQuery.class), eq(ProductRepository.CURRENT_INDEX))).thenReturn(17L);
+
+        Long count = repository.countMainIndexHavingScoreWithFilters("ECOSCORE", "tv");
+
+        assertThat(count).isEqualTo(17L);
+    }
+
+    @Test
+    void countMainIndexHavingScoreThresholdReturnsCount()
+    {
+        when(elasticsearchOperations.count(any(CriteriaQuery.class), eq(ProductRepository.CURRENT_INDEX))).thenReturn(9L);
+
+        Long count = repository.countMainIndexHavingScoreThreshold("ECOSCORE", "tv", SubsetCriteriaOperator.GREATER_THAN, 2.5);
+
+        assertThat(count).isEqualTo(9L);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to compute and enforce nudge-tool score thresholds per vertical using the actual `scores.ECOSCORE.value` field. 
- Automate updating vertical YAML files (nudge-tool `scoreMinValue` and impact `subsets`) so front-end nudges reflect real product distribution. 

### Description
- Add admin endpoint `GET /update/{vertical}/nudgetool/` in `VerticalsGenerationController` to trigger vertical file updates. 
- Implement heuristic threshold computation and YAML rewriting in `VerticalsGenerationService`, including iterative threshold search, formatting helpers, and YAML block replacement for ECOSCORE subsets. 
- Add product-repository helpers `countMainIndexHavingScoreWithFilters` and `countMainIndexHavingScoreThreshold` plus internal `applyScoreThreshold` to query `scores.<NAME>.value` with `Criteria` for filtered/threshold counts. 
- Add unit tests: `ProductRepositoryTest` verifies the new counting helpers and `VerticalsGenerationServiceTest` validates the nudge-tool YAML updates and ECOSCORE subset values. 

### Testing
- Ran the full test suite with `mvn --offline test` and the reactor completed successfully (`BUILD SUCCESS`). 
- The new unit tests (`ProductRepositoryTest` and `VerticalsGenerationServiceTest`) executed as part of the build and passed. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7500e588832ba5d8f0701ae5cf74)