### PR TITLE
Add reusable AI review action button and integrate into product cards/hero

### DIFF
--- a/frontend/app/components/category/products/CategoryProductCardGrid.vue
+++ b/frontend/app/components/category/products/CategoryProductCardGrid.vue
@@ -68,8 +68,13 @@
                 </span>
               </div>
 
-              <!-- Compare Button (Right) -->
-              <div class="category-product-card-grid__compare">
+              <!-- Actions (Right) -->
+              <div class="category-product-card-grid__actions">
+                <AiReviewActionButton
+                  :is-reviewed="isReviewed(product)"
+                  :review-created-at="reviewCreatedAt(product)"
+                  size="compact"
+                />
                 <CompareToggleButton :product="product" size="compact" />
               </div>
             </div>
@@ -151,6 +156,7 @@ import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import ProductTileCard from '~/components/category/products/ProductTileCard.vue'
 import CompareToggleButton from '~/components/shared/ui/CompareToggleButton.vue'
+import AiReviewActionButton from '~/components/shared/ai/AiReviewActionButton.vue'
 import ProductDesignation from '~/components/product/ProductDesignation.vue'
 import ProductPriceRows from '~/components/product/ProductPriceRows.vue'
 import {
@@ -211,6 +217,11 @@ const impactScoreValue = (product: ProductDto) =>
 
 const offersCountLabel = (product: ProductDto) =>
   formatOffersCount(product, translatePlural)
+
+const isReviewed = (product: ProductDto) => !!product.aiReview
+
+const reviewCreatedAt = (product: ProductDto) =>
+  product.aiReview?.createdMs ?? undefined
 
 type OfferBadge = {
   key: string
@@ -385,9 +396,12 @@ const popularAttributesByProduct = (
     margin-top: -4px /* visual tweak */
     margin-left: -4px
 
-  &__compare
+  &__actions
     pointer-events: auto
     margin: 0.5rem 0.5rem 0 0 /* top right spacing */
+    display: inline-flex
+    align-items: center
+    gap: 0.4rem
 
   &__body
     display: flex

--- a/frontend/app/components/category/products/CategoryProductListView.vue
+++ b/frontend/app/components/category/products/CategoryProductListView.vue
@@ -44,10 +44,6 @@
                 <span class="category-product-list__status-text">
                   {{ resolveBaseLine(product) }}
                 </span>
-                <AiReviewAvailabilityIcon
-                  :is-reviewed="isReviewed(product)"
-                  size="20"
-                />
               </template>
               <span v-else class="category-product-list__offers">
                 <v-icon icon="mdi-store" size="18" class="me-1" />
@@ -102,7 +98,17 @@
 
         <div class="category-product-list__actions">
           <!-- Removed best price button as it is now in micro prices -->
-          <CompareToggleButton :product="product" />
+          <AiReviewActionButton
+            :is-reviewed="isReviewed(product)"
+            :review-created-at="reviewCreatedAt(product)"
+            size="compact"
+            appearance="plain"
+          />
+          <CompareToggleButton
+            :product="product"
+            size="compact"
+            appearance="plain"
+          />
         </div>
       </div>
     </v-list-item>
@@ -114,7 +120,7 @@ import { computed } from 'vue'
 import type { AttributeConfigDto, ProductDto } from '~~/shared/api-client'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
 import CompareToggleButton from '~/components/shared/ui/CompareToggleButton.vue'
-import AiReviewAvailabilityIcon from '~/components/shared/ai/AiReviewAvailabilityIcon.vue'
+import AiReviewActionButton from '~/components/shared/ai/AiReviewActionButton.vue'
 import ProductPriceRows from '~/components/product/ProductPriceRows.vue'
 import {
   formatAttributeValue,
@@ -159,6 +165,9 @@ const resolveBaseLine = (product: ProductDto) =>
   product.aiReview?.baseLine ?? null
 
 const isReviewed = (product: ProductDto) => !!product.aiReview
+
+const reviewCreatedAt = (product: ProductDto) =>
+  product.aiReview?.createdMs ?? undefined
 
 type DisplayedAttribute = {
   key: string
@@ -267,6 +276,7 @@ const popularAttributesByProduct = (
     display: flex
     align-items: center
     justify-content: flex-end
+    gap: 0.5rem
     flex: 0 0 auto
 
   &__score-fallback

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -283,15 +283,14 @@
               </ul>
 
               <div class="product-hero__actions">
-                <v-btn
+                <AiReviewActionButton
                   v-if="!hasAiReview"
-                  class="product-hero__ai-button"
-                  prepend-icon="mdi-robot"
-                  variant="flat"
+                  :is-reviewed="hasAiReview"
+                  variant="button"
+                  :label="t('product.hero.aiReview.label')"
+                  button-class="product-hero__ai-button"
                   @click="handleAiReviewClick"
-                >
-                  {{ t('product.hero.aiReview.label', 'Synthèse IA') }}
-                </v-btn>
+                />
 
                 <v-btn
                   class="product-hero__compare-button"
@@ -344,6 +343,7 @@ import CategoryNavigationBreadcrumbs from '~/components/category/navigation/Cate
 import ProductHeroPricing from '~/components/product/ProductHeroPricing.vue'
 import ProductDesignation from '~/components/product/ProductDesignation.vue'
 import ImpactScore from '~/components/shared/ui/ImpactScore.vue'
+import AiReviewActionButton from '~/components/shared/ai/AiReviewActionButton.vue'
 import { useAccessibilityStore } from '~/stores/useAccessibilityStore'
 import {
   MAX_COMPARE_ITEMS,

--- a/frontend/app/components/shared/ai/AiReviewActionButton.vue
+++ b/frontend/app/components/shared/ai/AiReviewActionButton.vue
@@ -1,0 +1,242 @@
+<template>
+  <v-tooltip location="bottom" open-delay="150">
+    <template #activator="{ props: tooltipProps }">
+      <span
+        v-bind="tooltipProps"
+        class="ai-review-action-button__wrapper"
+      >
+        <v-btn
+          class="ai-review-action-button"
+          :class="[
+            `ai-review-action-button--variant-${variant}`,
+            `ai-review-action-button--size-${size}`,
+            `ai-review-action-button--appearance-${appearance}`,
+            {
+              'ai-review-action-button--active': isReviewed,
+              'ai-review-action-button--disabled': isDisabled,
+            },
+            buttonClass,
+          ]"
+          :variant="buttonVariant"
+          :color="buttonColor"
+          :disabled="isDisabled"
+          :aria-label="ariaLabel"
+          :title="tooltipText"
+          @click.stop.prevent="handleClick"
+        >
+          <span class="ai-review-action-button__icon-wrapper">
+            <v-icon icon="mdi-robot" :size="iconSize" />
+            <v-icon
+              v-if="isReviewed"
+              icon="mdi-check-circle"
+              size="10"
+              class="ai-review-action-button__badge"
+              color="success"
+            />
+          </span>
+          <span
+            v-if="variant === 'button'"
+            class="ai-review-action-button__label"
+          >
+            {{ buttonLabel }}
+          </span>
+        </v-btn>
+      </span>
+    </template>
+    <span>{{ tooltipText }}</span>
+  </v-tooltip>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { format } from 'date-fns'
+import { fr, enUS } from 'date-fns/locale'
+import { IpQuotaCategory } from '~~/shared/api-client'
+import { useIpQuota } from '~/composables/useIpQuota'
+
+const props = withDefaults(
+  defineProps<{
+    isReviewed: boolean
+    reviewCreatedAt?: number
+    variant?: 'icon-only' | 'button'
+    size?: 'compact' | 'comfortable' | 'large'
+    appearance?: 'default' | 'plain'
+    label?: string
+    buttonClass?: string
+  }>(),
+  {
+    variant: 'icon-only',
+    size: 'comfortable',
+    appearance: 'default',
+    label: undefined,
+    buttonClass: undefined,
+    reviewCreatedAt: undefined,
+  }
+)
+
+const emit = defineEmits<{
+  (event: 'click'): void
+}>()
+
+const { t, locale } = useI18n()
+const { getRemaining } = useIpQuota()
+
+const quotaCategory = IpQuotaCategory.ReviewGeneration
+
+const remaining = computed(() => getRemaining(quotaCategory) ?? 0)
+const hasQuota = computed(() => remaining.value > 0)
+const isDisabled = computed(() => !props.isReviewed && !hasQuota.value)
+
+const iconSize = computed(() => {
+  switch (props.size) {
+    case 'compact':
+      return 18
+    case 'large':
+      return 26
+    default:
+      return 22
+  }
+})
+
+const buttonVariant = computed(() => {
+  if (props.appearance === 'plain') {
+    return 'plain'
+  }
+
+  return props.variant === 'icon-only' ? 'flat' : 'flat'
+})
+
+const buttonColor = computed(() => {
+  if (props.variant === 'button') {
+    return 'primary'
+  }
+
+  if (props.isReviewed) {
+    return 'primary'
+  }
+
+  return props.appearance === 'plain' ? undefined : 'surface'
+})
+
+const buttonLabel = computed(() => {
+  return props.label ?? t('product.hero.aiReview.label')
+})
+
+const createdDate = computed(() => {
+  if (!props.reviewCreatedAt) {
+    return null
+  }
+
+  return format(props.reviewCreatedAt, 'PPP', {
+    locale: locale.value.startsWith('fr') ? fr : enUS,
+  })
+})
+
+const tooltipText = computed(() => {
+  if (props.isReviewed) {
+    if (createdDate.value) {
+      return t('product.aiReview.tooltip.generatedAt', {
+        date: createdDate.value,
+      })
+    }
+
+    return t('product.aiReview.tooltip.available')
+  }
+
+  if (hasQuota.value) {
+    return t('product.aiReview.tooltip.remaining', {
+      count: remaining.value,
+    })
+  }
+
+  return t('product.aiReview.tooltip.quotaExceeded')
+})
+
+const ariaLabel = computed(() => {
+  return props.variant === 'button' ? buttonLabel.value : tooltipText.value
+})
+
+const handleClick = () => {
+  if (isDisabled.value) {
+    return
+  }
+
+  emit('click')
+}
+</script>
+
+<style scoped lang="sass">
+.ai-review-action-button
+  text-transform: none
+  letter-spacing: 0
+  font-weight: 600
+  transition: all 0.2s ease
+
+  &__wrapper
+    display: inline-flex
+    align-items: center
+
+  &__icon-wrapper
+    position: relative
+    display: inline-flex
+    align-items: center
+    justify-content: center
+
+  &__badge
+    position: absolute
+    bottom: -4px
+    right: -4px
+    background: white
+    border-radius: 50%
+    border: 1px solid white
+
+  &__label
+    margin-left: 0.5rem
+
+  &--variant-icon-only
+    border-radius: 50%
+    min-width: 0
+    padding: 0
+    box-shadow: 0 4px 12px rgba(21, 46, 73, 0.12)
+    background-color: rgba(var(--v-theme-surface-default), 0.92)
+    color: rgb(var(--v-theme-text-neutral-strong))
+
+    &:hover
+      transform: translateY(-2px)
+      box-shadow: 0 8px 16px rgba(21, 46, 73, 0.16)
+
+    &.ai-review-action-button--active
+      background-color: rgba(var(--v-theme-primary), 0.16)
+      color: rgb(var(--v-theme-primary))
+      box-shadow: none
+
+    &.ai-review-action-button--size-compact
+      width: 2.25rem
+      height: 2.25rem
+
+    &.ai-review-action-button--size-comfortable
+      width: 2.75rem
+      height: 2.75rem
+
+    &.ai-review-action-button--size-large
+      width: 3.25rem
+      height: 3.25rem
+
+  &--variant-button
+    border-radius: 999px
+    padding-inline: 1.25rem
+
+  &--appearance-plain
+    box-shadow: none
+    background-color: transparent !important
+
+    &:hover
+      background-color: rgba(var(--v-theme-surface-default), 0.08)
+
+  &--disabled
+    opacity: 0.5
+    box-shadow: none
+
+    &:hover
+      transform: none
+</style>

--- a/frontend/app/components/shared/ai/AiReviewAvailabilityIcon.vue
+++ b/frontend/app/components/shared/ai/AiReviewAvailabilityIcon.vue
@@ -46,12 +46,12 @@ const hasQuota = computed(() => remaining.value > 0)
 
 const tooltipText = computed(() => {
   if (props.isReviewed) {
-    return t('product.ai_review.available')
+    return t('product.aiReview.tooltip.available')
   }
   if (hasQuota.value) {
-    return t('product.ai_review.generate_available', { count: remaining.value })
+    return t('product.aiReview.tooltip.remaining', { count: remaining.value })
   }
-  return t('product.ai_review.quota_exceeded')
+  return t('product.aiReview.tooltip.quotaExceeded')
 })
 </script>
 

--- a/frontend/app/components/shared/ui/CompareToggleButton.vue
+++ b/frontend/app/components/shared/ui/CompareToggleButton.vue
@@ -7,12 +7,13 @@
         :class="[
           `compare-toggle-button--variant-${variant}`,
           `compare-toggle-button--size-${size}`,
+          `compare-toggle-button--appearance-${appearance}`,
           {
             'compare-toggle-button--active': isSelected,
             'compare-toggle-button--inactive': !isSelected,
           },
         ]"
-        :variant="variant === 'icon-only' ? 'flat' : 'elevated'"
+        :variant="buttonVariant"
         :color="buttonColor"
         :aria-pressed="isSelected"
         :aria-label="ariaLabel"
@@ -57,11 +58,13 @@ const props = withDefaults(
     variant?: 'icon-only' | 'button-icon' | 'button-text'
     size?: 'compact' | 'comfortable' | 'large'
     icon?: string
+    appearance?: 'default' | 'plain'
   }>(),
   {
     variant: 'icon-only',
     size: 'comfortable',
     icon: 'mdi-plus',
+    appearance: 'default',
   }
 )
 
@@ -89,6 +92,14 @@ const iconSize = computed(() => {
 const currentIcon = computed(() => {
   if (isSelected.value) return 'mdi-minus'
   return props.icon
+})
+
+const buttonVariant = computed(() => {
+  if (props.appearance === 'plain') {
+    return 'plain'
+  }
+
+  return props.variant === 'icon-only' ? 'flat' : 'elevated'
 })
 
 const buttonColor = computed(() => {
@@ -200,6 +211,13 @@ const toggle = async () => {
       background-color: rgba(var(--v-theme-primary), 0.16)
       color: rgb(var(--v-theme-primary))
       box-shadow: none
+
+  &--appearance-plain
+    box-shadow: none
+    background-color: transparent !important
+
+    &:hover
+      background-color: rgba(var(--v-theme-surface-default), 0.08)
 
   /* Size adjustments for Icon Only */
   &--variant-icon-only.compare-toggle-button--size-compact

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2608,6 +2608,11 @@
       "ariaLabel": "Sticky banner promoting responsible shopping",
       "offersCount": "{count} offer | {count} offers"
     },
+    "hero": {
+      "aiReview": {
+        "label": "AI summary"
+      }
+    },
     "start_impact_text": "Enjoying this?",
     "start_impact_subtext": "Support an independent, open, and impactful web by shopping through Nudger! It also works via our partner merchants",
     "partners_link": "our partners",
@@ -2624,6 +2629,12 @@
         "notEnoughData": "Not enough reliable data was found to generate a summary."
       },
       "generatedAt": "Summary generated on {date}",
+      "tooltip": {
+        "generatedAt": "Generated on {date}",
+        "available": "AI summary available",
+        "remaining": "{count} generation remaining | {count} generations remaining",
+        "quotaExceeded": "Quota exceeded"
+      },
       "dataQuality": {
         "title": "Data quality",
         "description": "Assessment of the reliability and completeness of the sources used for this AI summary."

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2258,6 +2258,11 @@
       "ariaLabel": "Bannière fixe pour promouvoir un achat responsable",
       "offersCount": "{count} offre | {count} offres"
     },
+    "hero": {
+      "aiReview": {
+        "label": "Synthèse IA"
+      }
+    },
     "start_impact_text": "Vous aimez ?",
     "start_impact_subtext": "Soutenez un projet à impact, ouvert et éthique en faisant vos achats par Nudger ! Ca marche aussi en passant directement via nos ",
     "partners_link": "nos partenaires",
@@ -2274,6 +2279,12 @@
         "notEnoughData": "Pas assez de données fiables pour générer une synthèse."
       },
       "generatedAt": "Synthèse générée le {date}",
+      "tooltip": {
+        "generatedAt": "Génération le {date}",
+        "available": "Synthèse IA disponible",
+        "remaining": "{count} génération restante | {count} générations restantes",
+        "quotaExceeded": "Quota épuisé"
+      },
       "dataQuality": {
         "title": "Qualité des données",
         "description": "Évaluation de la fiabilité et de la complétude des sources utilisées pour cette synthèse IA."


### PR DESCRIPTION
### Motivation
- Provide a single, reusable UI action for requesting / showing AI product summaries and surface it in product lists and the product hero. 
- Show availability/remaining-quota state in the button tooltip and visually mark reviewed products for a consistent UX. 
- Allow the compare toggle to render a `plain` appearance so the new AI action and compare button can be displayed side-by-side without visual clashes. 

### Description
- Add a new component `frontend/app/components/shared/ai/AiReviewActionButton.vue` implementing tooltip text, quota checks (`useIpQuota` + `IpQuotaCategory.ReviewGeneration`), created-date formatting (`date-fns`), variants (`icon-only` / `button`), sizes and `appearance` options, and scoped SASS styles. 
- Replace ad-hoc AI action UI with the new component in `frontend/app/components/product/ProductHero.vue`, `frontend/app/components/category/products/CategoryProductCardGrid.vue` and `frontend/app/components/category/products/CategoryProductListView.vue`, and wire helper functions (`isReviewed`, `reviewCreatedAt`) where needed. 
- Extend `CompareToggleButton` to accept an `appearance` prop and compute `buttonVariant` so it can render `plain` appearance; add corresponding SASS rules to keep styling consistent. 
- Update `AiReviewAvailabilityIcon.vue` to use the new i18n tooltip keys, and add new i18n keys in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` for hero label and tooltip variants. 
- Fix SASS selector issues in the new component (use class combinators instead of invalid `&` usage) and minor layout updates to category card/list actions (spacing / display). 

### Testing
- Ran lint with `pnpm --offline lint`, which failed due to unrelated issues: `ProductHeroPricing.spec.ts` (three `@typescript-eslint/no-explicit-any` occurrences) and `ProductHeroPricing.vue` (`ProductTrend` defined but never used). (lint: failed) 
- Ran unit tests with `pnpm --offline test` which completed successfully: `118` test files and `428` tests passed. (tests: passed) 
- Built the static site with `pnpm --offline generate` which completed successfully and produced `.output/public`. (generate: succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b89ebf3d4832b8de1a5eec4478836)