### PR TITLE
Add EPREL support-end timeline labels, icons and i18n

### DIFF
--- a/frontend/app/components/product/ProductLifeTimeline.vue
+++ b/frontend/app/components/product/ProductLifeTimeline.vue
@@ -179,6 +179,10 @@ const eventLabelKeys: Record<string, string> = {
   EPREL_LAST_PUBLICATION:
     'product.attributes.timeline.events.eprelLastPublication',
   EPREL_EXPORT: 'product.attributes.timeline.events.eprelExport',
+  EPREL_SPARE_PARTS_END: 'product.attributes.timeline.events.eprelSparePartsEnd',
+  EPREL_SOFTWARE_SUPPORT_END:
+    'product.attributes.timeline.events.eprelSoftwareSupportEnd',
+  EPREL_SUPPORT_END: 'product.attributes.timeline.events.eprelSupportEnd',
   EPREL_IMPORTED: 'product.attributes.timeline.events.eprelImported',
   EPREL_ORGANISATION_CLOSED:
     'product.attributes.timeline.events.eprelOrganisationClosed',
@@ -200,6 +204,9 @@ const eventIcons: Record<string, string> = {
   EPREL_FIRST_PUBLICATION: 'mdi-newspaper-variant-outline',
   EPREL_LAST_PUBLICATION: 'mdi-newspaper-check',
   EPREL_EXPORT: 'mdi-cloud-upload-outline',
+  EPREL_SPARE_PARTS_END: 'mdi-cog-off-outline',
+  EPREL_SOFTWARE_SUPPORT_END: 'mdi-update',
+  EPREL_SUPPORT_END: 'mdi-shield-off-outline',
   EPREL_IMPORTED: 'mdi-database-import-outline',
   EPREL_ORGANISATION_CLOSED: 'mdi-domain-off',
 }
@@ -244,6 +251,11 @@ const eventDescriptionKeys: Record<string, string> = {
   EPREL_LAST_PUBLICATION:
     'product.attributes.timeline.descriptions.eprelLastPublication',
   EPREL_EXPORT: 'product.attributes.timeline.descriptions.eprelExport',
+  EPREL_SPARE_PARTS_END:
+    'product.attributes.timeline.descriptions.eprelSparePartsEnd',
+  EPREL_SOFTWARE_SUPPORT_END:
+    'product.attributes.timeline.descriptions.eprelSoftwareSupportEnd',
+  EPREL_SUPPORT_END: 'product.attributes.timeline.descriptions.eprelSupportEnd',
   EPREL_IMPORTED: 'product.attributes.timeline.descriptions.eprelImported',
   EPREL_ORGANISATION_CLOSED:
     'product.attributes.timeline.descriptions.eprelOrganisationClosed',

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2766,6 +2766,9 @@
           "eprelFirstPublication": "First EPREL publication",
           "eprelLastPublication": "Latest EPREL publication",
           "eprelExport": "EPREL export",
+          "eprelSparePartsEnd": "Spare parts availability end",
+          "eprelSoftwareSupportEnd": "Software support end",
+          "eprelSupportEnd": "Guaranteed support end",
           "eprelImported": "Imported into Nudger",
           "eprelOrganisationClosed": "Organisation closed",
           "generic": "Lifecycle event"
@@ -2781,6 +2784,9 @@
           "eprelFirstPublication": "EPREL first publication date.",
           "eprelLastPublication": "EPREL most recent publication date.",
           "eprelExport": "EPREL export timestamp.",
+          "eprelSparePartsEnd": "EPREL calculated end date for spare parts availability.",
+          "eprelSoftwareSupportEnd": "EPREL calculated end date for software updates availability.",
+          "eprelSupportEnd": "EPREL calculated end date for overall technical support.",
           "eprelImported": "Date when the EPREL entry was imported.",
           "eprelOrganisationClosed": "EPREL organisation close date.",
           "generic": "Lifecycle event"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2419,6 +2419,9 @@
           "eprelFirstPublication": "Première publication EPREL",
           "eprelLastPublication": "Dernière publication EPREL",
           "eprelExport": "Export EPREL",
+          "eprelSparePartsEnd": "Fin disponibilité pièces détachées",
+          "eprelSoftwareSupportEnd": "Fin support logiciel",
+          "eprelSupportEnd": "Fin support garanti",
           "eprelImported": "Importé dans Nudger",
           "eprelOrganisationClosed": "Organisation fermée",
           "generic": "Événement du cycle de vie"
@@ -2434,6 +2437,9 @@
           "eprelFirstPublication": "Date de première publication EPREL.",
           "eprelLastPublication": "Date de dernière publication EPREL.",
           "eprelExport": "Horodatage d'export EPREL.",
+          "eprelSparePartsEnd": "Date de fin de disponibilité des pièces détachées calculée via EPREL.",
+          "eprelSoftwareSupportEnd": "Date de fin des mises à jour logicielles calculée via EPREL.",
+          "eprelSupportEnd": "Date de fin du support technique global calculée via EPREL.",
           "eprelImported": "Date d'import de l'entrée EPREL.",
           "eprelOrganisationClosed": "Date de fermeture de l'organisation EPREL.",
           "generic": "Événement du cycle de vie"


### PR DESCRIPTION
### Motivation
- EPREL-derived lifecycle events for support (spare parts, software updates, and overall support) were missing explicit labels/icons/descriptions and fell back to a generic lifecycle label in the product timeline.
- Providing dedicated labels, icons and localized descriptions improves UX and accessibility for timeline entries originating from EPREL.

### Description
- Added `EPREL_SPARE_PARTS_END`, `EPREL_SOFTWARE_SUPPORT_END`, and `EPREL_SUPPORT_END` keys to `eventLabelKeys`, `eventIcons`, and `eventDescriptionKeys` in `frontend/app/components/product/ProductLifeTimeline.vue` so these event types have explicit labels, icons and descriptions.
- Added corresponding English strings in `frontend/i18n/locales/en-US.json` for event labels and descriptions.
- Added corresponding French strings in `frontend/i18n/locales/fr-FR.json` for event labels and descriptions.

### Testing
- No unit or integration tests were executed for this change (none were requested).
- An automated UI capture attempt using Playwright via the `mcp__browser_tools__run_playwright_script` helper was performed and failed due to a Chromium crash (SIGSEGV), so no screenshot artifact was produced.
- Repository operations such as `git status` and `git commit` were executed successfully to stage and record the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bd6283310832b8ab4222ff676c714)