### PR TITLE
Fix Hotjar record badge activation

### DIFF
--- a/frontend/app/components/shared/footers/TheMainFooterContent.vue
+++ b/frontend/app/components/shared/footers/TheMainFooterContent.vue
@@ -112,7 +112,9 @@ const feedbackLinks = computed<FooterLink[]>(() => [
 
 const footerLogo = useFooterLogoAsset()
 
-const hotjarCookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME)
+const hotjarCookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME, {
+  watch: true,
+})
 const isRecording = computed(() =>
   isHotjarRecordingCookieEnabled(hotjarCookie.value)
 )

--- a/frontend/app/middleware/record.global.ts
+++ b/frontend/app/middleware/record.global.ts
@@ -9,6 +9,7 @@ export default defineNuxtRouteMiddleware(to => {
     return
   }
 
+  const { record, ...restQuery } = to.query
   const cookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME, {
     maxAge: HOTJAR_RECORDING_COOKIE_MAX_AGE,
     sameSite: 'lax',
@@ -22,8 +23,7 @@ export default defineNuxtRouteMiddleware(to => {
     {
       path: to.path,
       query: {
-        ...to.query,
-        record: undefined,
+        ...restQuery,
       },
     },
     { redirectCode: 302 }


### PR DESCRIPTION
### Motivation
- Ensure the Hotjar opt-in flow does not leave a lingering `record` query parameter in the URL after setting the cookie.
- Make the footer badge reactive so the Hotjar recording indicator updates immediately after the opt-in redirect.

### Description
- Update `frontend/app/middleware/record.global.ts` to destructure `to.query` (`const { record, ...restQuery } = to.query`) and redirect using `restQuery` to remove the `record` parameter from the URL.
- Update `frontend/app/components/shared/footers/TheMainFooterContent.vue` to call `useCookie(HOTJAR_RECORDING_COOKIE_NAME, { watch: true })` so the footer reacts to cookie changes and updates the recording badge.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697be81e1884832bb07194781f414fe4)