### PR TITLE
Map description attributes into datasource descriptions

### DIFF
--- a/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
+++ b/api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.open4goods.model.attribute.Attribute;
 import org.open4goods.brand.service.BrandService;
 import org.open4goods.icecat.services.IcecatService;
 import org.open4goods.model.attribute.ProductAttribute;
@@ -190,5 +191,25 @@ class AttributeRealtimeAggregationServiceTest {
 		String result = service.parseValue("0.5 W", attrConfig, verticalConfig);
 		// Assert
 		assertThat(result).isEqualTo("0.5");
+	}
+
+	@Test
+	void onDataFragmentMovesDescriptionAttributesToDatasourceDescriptions() throws Exception {
+		// Arrange
+		Product product = new Product(123L);
+		DataFragment fragment = new DataFragment();
+		fragment.setDatasourceName("source-a");
+		fragment.getAttributes().add(new Attribute("DESCRIPTION", "Long description"));
+		fragment.getAttributes().add(new Attribute("required_attr", "value"));
+		verticalConfig.setDescriptionAttributes(Set.of("DESCRIPTION"));
+
+		// Act
+		service.onDataFragment(fragment, product, verticalConfig);
+
+		// Assert
+		assertThat(product.getDescriptionsByDatasource())
+				.containsEntry("source-a", "Long description");
+		assertThat(product.getAttributes().getAll()).containsKey("required_attr");
+		assertThat(product.getAttributes().getAll()).doesNotContainKey("DESCRIPTION");
 	}
 }

--- a/verticals/src/main/resources/verticals/_default.yml
+++ b/verticals/src/main/resources/verticals/_default.yml
@@ -45,16 +45,10 @@ generationExcludedFromAttributesMatching:
 
 # Attributes that should be treated as product descriptions
 descriptionAttributes:
-  - DESCRIPTION
   - DESCRIPTIF
+  - DESCRIPTION
   - PRODUCT_DESCRIPTION
-  - PRODUCT_LONG_DESCRIPTION
   - PRODUCT_SHORT_DESCRIPTION
-  - SHORT_DESCRIPTION
-  - LONG_DESCRIPTION
-  - DESCRIPTION_LONGUE
-  - DESCRIPTION_COURTE
-  - DETAILS
 
 # If product categories contains one of this token, this will be unmatched
 excludingTokensFromCategoriesMatching:


### PR DESCRIPTION
### Motivation
- Description-like attributes configured in `VerticalConfig` should be treated as product descriptions and stored per datasource instead of staying as regular attributes.
- When multiple sources provide descriptions, the system should merge them and prefer the longest content for a given datasource.

### Description
- Added `handleDescriptions` and `mergeDescription` to `AttributeRealtimeAggregationService` and call them from `onDataFragment` to extract and merge description attributes into `Product.getDescriptionsByDatasource()` using normalized attribute name matching via `VerticalConfig.getDescriptionAttributes()`.
- The extraction removes matched description attributes from `DataFragment.getAttributes()` and also folds `DataFragment.getDescriptionsByDatasource()` into the product descriptions, preferring longer values when merging.
- Updated the default vertical config file `verticals/_default.yml` to the requested baseline description keys: `DESCRIPTIF`, `DESCRIPTION`, `PRODUCT_DESCRIPTION`, `PRODUCT_SHORT_DESCRIPTION`.
- Added a unit test `onDataFragmentMovesDescriptionAttributesToDatasourceDescriptions` in `AttributeRealtimeAggregationServiceTest` and imported `Attribute` to cover the new behavior.

### Testing
- Added unit test `onDataFragmentMovesDescriptionAttributesToDatasourceDescriptions` in `api/src/test/java/org/open4goods/api/services/aggregation/services/realtime/AttributeRealtimeAggregationServiceTest.java`; tests were not executed as part of this change.
- No automated build or test run (`mvn`) was performed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bfdea7984832bbaf349771fe9b906)