### PR TITLE
Add CategoryResultsToolbar and integrate into category & global search views

### DIFF
--- a/frontend/app/components/category/CategoryResultsToolbar.spec.ts
+++ b/frontend/app/components/category/CategoryResultsToolbar.spec.ts
@@ -1,0 +1,214 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import CategoryResultsToolbar from './CategoryResultsToolbar.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const resolveClassList = (value: unknown): string => {
+  if (!value) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(entry => resolveClassList(entry))
+      .filter(Boolean)
+      .join(' ')
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, active]) => Boolean(active))
+      .map(([name]) => name)
+      .join(' ')
+  }
+
+  return String(value)
+}
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  emits: ['click'],
+  setup(_, { attrs, slots, emit }) {
+    return () =>
+      h(
+        'button',
+        {
+          ...attrs,
+          class: [
+            'v-btn-stub',
+            resolveClassList((attrs as Record<string, unknown>).class),
+          ].join(' '),
+          type: 'button',
+          onClick: () => emit('click'),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VBtnToggleStub = defineComponent({
+  name: 'VBtnToggle',
+  emits: ['update:modelValue'],
+  setup(_, { attrs, slots }) {
+    return () =>
+      h(
+        'div',
+        {
+          ...attrs,
+          class: [
+            'v-btn-toggle-stub',
+            resolveClassList((attrs as Record<string, unknown>).class),
+          ].join(' '),
+        },
+        slots.default?.()
+      )
+  },
+})
+
+const VSelectStub = defineComponent({
+  name: 'VSelect',
+  props: {
+    modelValue: { type: String, default: null },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { attrs, emit }) {
+    return () =>
+      h('div', {
+        ...attrs,
+        class: [
+          'v-select-stub',
+          resolveClassList((attrs as Record<string, unknown>).class),
+        ].join(' '),
+        'data-model': props.modelValue ?? '',
+        onClick: () => emit('update:modelValue', 'offersCount'),
+      })
+  },
+})
+
+const VTextFieldStub = defineComponent({
+  name: 'VTextField',
+  props: {
+    modelValue: { type: String, default: '' },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { attrs, emit }) {
+    return () =>
+      h('input', {
+        ...attrs,
+        class: [
+          'v-text-field-stub',
+          resolveClassList((attrs as Record<string, unknown>).class),
+        ].join(' '),
+        value: props.modelValue,
+        onInput: () => emit('update:modelValue', 'query'),
+      })
+  },
+})
+
+const VTooltipStub = defineComponent({
+  name: 'VTooltip',
+  setup(_, { slots }) {
+    return () => h('div', { class: 'v-tooltip-stub' }, slots.activator?.({ props: {} }))
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  setup(_, { attrs }) {
+    return () => h('span', { ...attrs, class: 'v-icon-stub' })
+  },
+})
+
+const VBadgeStub = defineComponent({
+  name: 'VBadge',
+  setup(_, { attrs, slots }) {
+    return () =>
+      h('span', { ...attrs, class: 'v-badge-stub' }, slots.default?.())
+  },
+})
+
+const CategoryResultsCountStub = defineComponent({
+  name: 'CategoryResultsCount',
+  props: {
+    count: { type: Number, default: 0 },
+  },
+  setup(props) {
+    return () => h('span', { class: 'category-results-count-stub' }, `${props.count}`)
+  },
+})
+
+describe('CategoryResultsToolbar', () => {
+  const mountComponent = () =>
+    mount(CategoryResultsToolbar, {
+      props: {
+        isDesktop: false,
+        resultsCount: 12,
+        viewMode: 'cards',
+        sortItems: [
+          { title: 'Price', value: 'price.minPrice.price' },
+          { title: 'Offers', value: 'offersCount' },
+        ],
+        sortField: 'price.minPrice.price',
+        sortOrder: 'desc',
+        searchTerm: 'phone',
+        showFiltersButton: true,
+        filtersCount: 2,
+      },
+      global: {
+        stubs: {
+          VBtn: VBtnStub,
+          VBtnToggle: VBtnToggleStub,
+          VSelect: VSelectStub,
+          VTextField: VTextFieldStub,
+          VTooltip: VTooltipStub,
+          VIcon: VIconStub,
+          VBadge: VBadgeStub,
+          CategoryResultsCount: CategoryResultsCountStub,
+        },
+      },
+    })
+
+  it('emits filter toggle when the mobile filters button is clicked', async () => {
+    const wrapper = mountComponent()
+
+    await wrapper
+      .find('[data-testid="results-toolbar-filter-button"]')
+      .trigger('click')
+
+    expect(wrapper.emitted('toggle-filters')).toHaveLength(1)
+  })
+
+  it('emits search, sort, and view updates', async () => {
+    const wrapper = mountComponent()
+
+    await wrapper.find('.v-text-field-stub').trigger('input')
+    expect(wrapper.emitted('update:searchTerm')?.[0]).toEqual(['query'])
+
+    await wrapper.find('.v-select-stub').trigger('click')
+    expect(wrapper.emitted('update:sortField')?.[0]).toEqual(['offersCount'])
+
+    const toggleButtons = wrapper.findAllComponents(VBtnToggleStub)
+    const viewToggle = toggleButtons.find(
+      toggle => toggle.attributes()['data-testid'] === 'results-toolbar-view-toggle'
+    )
+    viewToggle?.vm.$emit('update:modelValue', 'table')
+    expect(wrapper.emitted('update:viewMode')?.[0]).toEqual(['table'])
+
+    const sortToggle = toggleButtons.find(
+      toggle => toggle.attributes()['data-testid'] === 'results-toolbar-sort-order'
+    )
+    sortToggle?.vm.$emit('update:modelValue', 'asc')
+    expect(wrapper.emitted('update:sortOrder')?.[0]).toEqual(['asc'])
+  })
+})

--- a/frontend/app/components/category/CategoryResultsToolbar.vue
+++ b/frontend/app/components/category/CategoryResultsToolbar.vue
@@ -1,0 +1,276 @@
+<template>
+  <div class="category-results-toolbar">
+    <div
+      class="category-results-toolbar__section category-results-toolbar__section--left"
+    >
+      <v-btn
+        v-if="showFiltersButton && !isDesktop"
+        color="primary"
+        variant="flat"
+        prepend-icon="mdi-filter-variant"
+        data-testid="results-toolbar-filter-button"
+        @click="emit('toggle-filters')"
+      >
+        {{ t('category.products.openFilters') }}
+        <v-badge
+          v-if="filtersCount"
+          :content="filtersCount"
+          color="primary"
+          inline
+          class="ms-2"
+        />
+      </v-btn>
+
+      <CategoryResultsCount v-if="showResultsCount" :count="resultsCount" />
+
+      <div v-if="showSort" class="category-results-toolbar__sort">
+        <div class="category-results-toolbar__sort-select">
+          <v-tooltip
+            location="bottom"
+            :text="t('category.products.tooltips.sortField')"
+          >
+            <template #activator="{ props: sortSelectProps }">
+              <v-select
+                v-bind="sortSelectProps"
+                :model-value="sortField"
+                :items="sortItems"
+                :label="t('category.products.sortLabel')"
+                item-title="title"
+                item-value="value"
+                clearable
+                :disabled="sortItems.length === 0"
+                hide-details
+                density="comfortable"
+                data-testid="results-toolbar-sort-select"
+                @update:model-value="emit('update:sortField', $event)"
+              />
+            </template>
+          </v-tooltip>
+        </div>
+        <v-btn-toggle
+          v-model="internalSortOrder"
+          class="category-results-toolbar__sort-order"
+          density="comfortable"
+          data-testid="results-toolbar-sort-order"
+        >
+          <v-btn
+            value="asc"
+            :aria-label="t('category.products.sortOrderAsc')"
+          >
+            <v-icon icon="mdi-sort-ascending" />
+            <v-tooltip
+              activator="parent"
+              location="bottom"
+              :text="t('category.products.tooltips.sortAscending')"
+            />
+          </v-btn>
+          <v-btn
+            value="desc"
+            :aria-label="t('category.products.sortOrderDesc')"
+          >
+            <v-icon icon="mdi-sort-descending" />
+            <v-tooltip
+              activator="parent"
+              location="bottom"
+              :text="t('category.products.tooltips.sortDescending')"
+            />
+          </v-btn>
+        </v-btn-toggle>
+      </div>
+    </div>
+
+    <div
+      v-if="showSearch"
+      class="category-results-toolbar__section category-results-toolbar__section--center"
+    >
+      <div class="category-results-toolbar__search">
+        <v-tooltip
+          location="bottom"
+          :text="t('category.products.tooltips.search')"
+        >
+          <template #activator="{ props: searchProps }">
+            <v-text-field
+              v-bind="searchProps"
+              :model-value="searchTerm"
+              :label="t('category.products.searchPlaceholder')"
+              prepend-inner-icon="mdi-magnify"
+              clearable
+              hide-details
+              density="comfortable"
+              class="category-results-toolbar__search-input"
+              data-testid="results-toolbar-search-input"
+              @update:model-value="emit('update:searchTerm', $event)"
+            />
+          </template>
+        </v-tooltip>
+      </div>
+    </div>
+
+    <div
+      v-if="showViewToggle"
+      class="category-results-toolbar__section category-results-toolbar__section--right"
+    >
+      <v-btn-toggle
+        v-model="internalViewMode"
+        mandatory
+        class="category-results-toolbar__view-toggle"
+        data-testid="results-toolbar-view-toggle"
+      >
+        <v-btn value="cards" :aria-label="t('category.products.viewCards')">
+          <v-icon icon="mdi-view-grid" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :text="t('category.products.tooltips.viewCards')"
+          />
+        </v-btn>
+        <v-btn value="list" :aria-label="t('category.products.viewList')">
+          <v-icon icon="mdi-view-list" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :text="t('category.products.tooltips.viewList')"
+          />
+        </v-btn>
+        <v-btn value="table" :aria-label="t('category.products.viewTable')">
+          <v-icon icon="mdi-table" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :text="t('category.products.tooltips.viewTable')"
+          />
+        </v-btn>
+      </v-btn-toggle>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { CategoryViewMode } from '~/utils/_category-filter-state'
+import CategoryResultsCount from '~/components/category/CategoryResultsCount.vue'
+
+type SortItem = {
+  title: string
+  value: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    isDesktop: boolean
+    resultsCount: number
+    viewMode: CategoryViewMode
+    sortItems: SortItem[]
+    sortField: string | null
+    sortOrder: 'asc' | 'desc'
+    searchTerm: string
+    showSearch?: boolean
+    showSort?: boolean
+    showViewToggle?: boolean
+    showResultsCount?: boolean
+    showFiltersButton?: boolean
+    filtersCount?: number
+  }>(),
+  {
+    showSearch: true,
+    showSort: true,
+    showViewToggle: true,
+    showResultsCount: true,
+    showFiltersButton: false,
+    filtersCount: 0,
+  }
+)
+
+const emit = defineEmits<{
+  'toggle-filters': []
+  'update:searchTerm': [string]
+  'update:sortField': [string | null]
+  'update:sortOrder': ['asc' | 'desc']
+  'update:viewMode': [CategoryViewMode]
+}>()
+
+const { t } = useI18n()
+
+const internalViewMode = computed({
+  get: () => props.viewMode,
+  set: value => emit('update:viewMode', value),
+})
+
+const internalSortOrder = computed({
+  get: () => props.sortOrder,
+  set: value => emit('update:sortOrder', value),
+})
+</script>
+
+<style scoped lang="sass">
+.category-results-toolbar
+  display: flex
+  flex-direction: column
+  gap: 1rem
+  margin-bottom: 1.5rem
+  width: 100%
+
+  &__section
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    gap: 1rem
+
+  &__section--left
+    justify-content: flex-start
+
+  &__section--center
+    justify-content: center
+
+  &__section--right
+    justify-content: flex-end
+
+  &__sort
+    display: flex
+    flex-wrap: wrap
+    align-items: center
+    gap: 0.75rem
+
+  &__sort-select
+    flex: 1 1 220px
+
+  &__search
+    flex: 1 1 100%
+    min-width: 0
+
+  &__search-input
+    width: 100%
+
+@media (min-width: 960px)
+  .category-results-toolbar
+    display: grid
+    grid-template-columns: auto minmax(260px, 1fr) auto
+    align-items: center
+    gap: 1.5rem
+
+  .category-results-toolbar__section
+    flex-wrap: nowrap
+
+  .category-results-toolbar__section--center
+    justify-content: center
+
+  .category-results-toolbar__section--right
+    justify-content: flex-end
+
+  .category-results-toolbar__search
+    flex: 0 1 420px
+
+@media (max-width: 959px)
+  .category-results-toolbar__section--center
+    justify-content: center
+
+  .category-results-toolbar__section--right
+    justify-content: flex-end
+
+  .category-results-toolbar__sort
+    width: 100%
+
+  .category-results-toolbar__sort-select
+    flex: 1 1 100%
+</style>

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -217,143 +217,21 @@
           <meta itemprop="name" :content="seoTitle" />
           <meta itemprop="numberOfItems" :content="String(resultsCount)" />
 
-          <div class="category-page__toolbar">
-            <div
-              class="category-page__toolbar-section category-page__toolbar-section--left"
-            >
-              <v-btn
-                v-if="!isDesktop"
-                color="primary"
-                variant="flat"
-                prepend-icon="mdi-filter-variant"
-                @click="filtersDrawer = true"
-              >
-                {{ $t('category.products.openFilters') }}
-              </v-btn>
-
-              <CategoryResultsCount :count="resultsCount" />
-
-              <div class="category-page__sort">
-                <div class="category-page__sort-select">
-                  <v-tooltip
-                    location="bottom"
-                    :text="$t('category.products.tooltips.sortField')"
-                  >
-                    <template #activator="{ props: sortSelectProps }">
-                      <v-select
-                        v-bind="sortSelectProps"
-                        v-model="sortField"
-                        :items="sortItems"
-                        :label="$t('category.products.sortLabel')"
-                        item-title="title"
-                        item-value="value"
-                        clearable
-                        :disabled="sortItems.length === 0"
-                        hide-details
-                        density="comfortable"
-                      />
-                    </template>
-                  </v-tooltip>
-                </div>
-                <v-btn-toggle
-                  v-model="sortOrder"
-                  class="category-page__sort-order"
-                  density="comfortable"
-                >
-                  <v-btn
-                    value="asc"
-                    :aria-label="$t('category.products.sortOrderAsc')"
-                  >
-                    <v-icon icon="mdi-sort-ascending" />
-                    <v-tooltip
-                      activator="parent"
-                      location="bottom"
-                      :text="$t('category.products.tooltips.sortAscending')"
-                    />
-                  </v-btn>
-                  <v-btn
-                    value="desc"
-                    :aria-label="$t('category.products.sortOrderDesc')"
-                  >
-                    <v-icon icon="mdi-sort-descending" />
-                    <v-tooltip
-                      activator="parent"
-                      location="bottom"
-                      :text="$t('category.products.tooltips.sortDescending')"
-                    />
-                  </v-btn>
-                </v-btn-toggle>
-              </div>
-            </div>
-
-            <div
-              class="category-page__toolbar-section category-page__toolbar-section--center"
-            >
-              <div class="category-page__search">
-                <v-tooltip
-                  location="bottom"
-                  :text="$t('category.products.tooltips.search')"
-                >
-                  <template #activator="{ props: searchProps }">
-                    <v-text-field
-                      v-bind="searchProps"
-                      v-model="searchTerm"
-                      :label="$t('category.products.searchPlaceholder')"
-                      prepend-inner-icon="mdi-magnify"
-                      clearable
-                      hide-details
-                      density="comfortable"
-                      class="category-page__search-input"
-                    />
-                  </template>
-                </v-tooltip>
-              </div>
-            </div>
-
-            <div
-              class="category-page__toolbar-section category-page__toolbar-section--right"
-            >
-              <v-btn-toggle
-                v-model="viewMode"
-                mandatory
-                class="category-page__view-toggle"
-              >
-                <v-btn
-                  value="cards"
-                  :aria-label="$t('category.products.viewCards')"
-                >
-                  <v-icon icon="mdi-view-grid" />
-                  <v-tooltip
-                    activator="parent"
-                    location="bottom"
-                    :text="$t('category.products.tooltips.viewCards')"
-                  />
-                </v-btn>
-                <v-btn
-                  value="list"
-                  :aria-label="$t('category.products.viewList')"
-                >
-                  <v-icon icon="mdi-view-list" />
-                  <v-tooltip
-                    activator="parent"
-                    location="bottom"
-                    :text="$t('category.products.tooltips.viewList')"
-                  />
-                </v-btn>
-                <v-btn
-                  value="table"
-                  :aria-label="$t('category.products.viewTable')"
-                >
-                  <v-icon icon="mdi-table" />
-                  <v-tooltip
-                    activator="parent"
-                    location="bottom"
-                    :text="$t('category.products.tooltips.viewTable')"
-                  />
-                </v-btn>
-              </v-btn-toggle>
-            </div>
-          </div>
+          <CategoryResultsToolbar
+            :is-desktop="isDesktop"
+            :results-count="resultsCount"
+            :view-mode="viewMode"
+            :sort-items="sortItems"
+            :sort-field="sortField"
+            :sort-order="sortOrder"
+            :search-term="searchTerm"
+            :show-filters-button="true"
+            @toggle-filters="filtersDrawer = true"
+            @update:search-term="searchTerm = $event"
+            @update:sort-field="sortField = $event"
+            @update:sort-order="sortOrder = $event"
+            @update:view-mode="viewMode = $event"
+          />
 
           <v-alert
             v-if="productError"
@@ -462,7 +340,7 @@ import CategoryFastFilters from '~/components/category/CategoryFastFilters.vue'
 import CategoryHero from '~/components/category/CategoryHero.vue'
 import CategoryEcoscoreCard from '~/components/category/CategoryEcoscoreCard.vue'
 import CategoryFiltersSidebar from '~/components/category/CategoryFiltersSidebar.vue'
-import CategoryResultsCount from '~/components/category/CategoryResultsCount.vue'
+import CategoryResultsToolbar from '~/components/category/CategoryResultsToolbar.vue'
 import CategoryProductCardGrid from '~/components/category/products/CategoryProductCardGrid.vue'
 import CategoryProductListView from '~/components/category/products/CategoryProductListView.vue'
 import CategoryProductTable from '~/components/category/products/CategoryProductTable.vue'
@@ -2259,29 +2137,6 @@ const clearAllFilters = () => {
   &__container
     max-width: 1560px
 
-  &__toolbar
-    display: flex
-    flex-direction: column
-    gap: 1rem
-    margin-bottom: 1.5rem
-    width: 100%
-
-  &__toolbar-section
-    display: flex
-    align-items: center
-    gap: 1rem
-    width: 100%
-    flex-wrap: wrap
-
-  &__toolbar-section--left
-    justify-content: flex-start
-
-  &__toolbar-section--center
-    justify-content: center
-
-  &__toolbar-section--right
-    justify-content: flex-end
-
   &__fast-filters
     display: flex
     flex-direction: column
@@ -2500,28 +2355,6 @@ const clearAllFilters = () => {
     flex-direction: column
     gap: 1.5rem
 
-@media (min-width: 960px)
-  .category-page__toolbar
-    display: grid
-    grid-template-columns: auto minmax(260px, 1fr) auto
-    align-items: center
-    gap: 1.5rem
-
-  .category-page__toolbar-section
-    flex-wrap: nowrap
-
-  .category-page__toolbar-section--left
-    justify-content: flex-start
-
-  .category-page__toolbar-section--center
-    justify-content: center
-
-  .category-page__toolbar-section--right
-    justify-content: flex-end
-
-  .category-page__search
-    flex: 0 1 420px
-
 @media (min-width: 1280px)
   .category-page__layout
     grid-template-columns: minmax(260px, 300px) minmax(0, 1fr)
@@ -2534,29 +2367,9 @@ const clearAllFilters = () => {
     display: flex
 
 @media (max-width: 959px)
-  .category-page__toolbar
-    align-items: stretch
-
   .category-page__fast-filters
     flex-direction: column
     align-items: stretch
-
-  .category-page__search
-    flex: 1 1 100%
-    min-width: 0
-    max-width: 100%
-
-  .category-page__toolbar-section--center
-    justify-content: center
-
-  .category-page__toolbar-section--right
-    justify-content: flex-end
-
-  .category-page__sort
-    width: 100%
-
-  .category-page__sort-select
-    flex: 1 1 100%
 
   .category-page__layout
     grid-template-columns: minmax(0, 1fr)


### PR DESCRIPTION
### Motivation
- Provide a single reusable results toolbar with search/sort/view controls so category and global search share consistent UX and behaviour.
- Expose view toggles (cards/list/table), sort controls and optional mobile filters button to align global search with category listing logic.

### Description
- Added a new component `CategoryResultsToolbar.vue` that implements search input, sort select, sort order toggle, view toggle and optional filters badge. (new file: `frontend/app/components/category/CategoryResultsToolbar.vue`).
- Added unit tests for the toolbar component (`frontend/app/components/category/CategoryResultsToolbar.spec.ts`) and lightweight stubs to validate emits and interactions.
- Replaced the inline toolbar on the category page with the new `CategoryResultsToolbar` and wired props/emits (`frontend/app/components/pages/CategoryPage.vue`).
- Integrated the shared toolbar into the global search right column and implemented card/list/table views, sorting, filter fields and pagination for the right column, plus a small refactor to reuse `SortRequestDto` and consistent `pageNumber`/`pageSize` handling (`frontend/app/pages/search/index.vue`).
- Added default filter field definitions to the global search right column: `price.minPrice.price`, `offersCount`, `gtinInfos.country`, and `price.conditions`, and added `sortItems` / `sortRequest` plumbing to drive server queries.

### Testing
- Ran `pnpm lint` in the frontend and it passed successfully.
- Ran `pnpm test` (Vitest): most tests passed, but the suite failed with 1 failing test: `ProductAttributesSection.spec.ts > displays localized GTIN label and supports copy to clipboard` (assertion failure), overall run finished with 431 passed / 1 failed.
- Attempted a production build via `pnpm generate`, which started but failed with a JavaScript heap out-of-memory error during SSR build (Node OOM).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d335d0a2083228255253d672a5003)