### PR TITLE
Add tilt unlock effect for home visuals

### DIFF
--- a/frontend/app/assets/sass/components/home-animations.sass
+++ b/frontend/app/assets/sass/components/home-animations.sass
@@ -26,6 +26,20 @@
   transition: transform 0.25s ease, box-shadow 0.25s ease
   will-change: transform
 
+.home-tilt-lock
+  --tilt-angle: var(--tilt-default-angle, 0deg)
+  --tilt-translate-y: var(--tilt-default-offset, 0)
+  transform: translateY(var(--tilt-translate-y)) rotate(var(--tilt-angle))
+  transition: transform 0.18s ease
+  will-change: transform
+
+.home-tilt-lock--unlocked
+  --tilt-angle: 0deg
+
+@media (hover: none)
+  .home-tilt-lock
+    --tilt-angle: 0deg
+
 @media (hover: hover)
   .home-hover-card:hover
     transform: translateY(-6px) scale(1.01)
@@ -45,6 +59,10 @@
   .home-hover-card:hover
     transform: none !important
 
+  .home-tilt-lock
+    transition: none !important
+    transform: translateY(var(--tilt-translate-y)) rotate(0deg) !important
+
 :root.accessibility-reduced-motion
   .home-reveal-group
     .home-reveal-item
@@ -58,3 +76,7 @@
 
   .home-hover-card:hover
     transform: none !important
+
+  .home-tilt-lock
+    transition: none !important
+    transform: translateY(var(--tilt-translate-y)) rotate(0deg) !important

--- a/frontend/app/components/home/sections/HomeHeroHighlights.vue
+++ b/frontend/app/components/home/sections/HomeHeroHighlights.vue
@@ -235,10 +235,25 @@ const resolveHighlightStyle = (index: number) => {
   const offset = index % 2 === 0 ? '-10px' : '10px'
 
   return {
-    '--highlight-tilt': tilt,
-    '--highlight-offset': offset,
+    '--tilt-default-angle': tilt,
+    '--tilt-default-offset': offset,
   } as Record<string, string>
 }
+
+const unlockedHighlightIndexes = ref(new Set<number>())
+
+const unlockHighlight = (index: number) => {
+  if (unlockedHighlightIndexes.value.has(index)) {
+    return
+  }
+
+  const next = new Set(unlockedHighlightIndexes.value)
+  next.add(index)
+  unlockedHighlightIndexes.value = next
+}
+
+const isHighlightUnlocked = (index: number) =>
+  unlockedHighlightIndexes.value.has(index)
 </script>
 
 <template>
@@ -265,6 +280,11 @@ const resolveHighlightStyle = (index: number) => {
         >
           <RoundedCornerCard
             class="home-hero-highlights__card"
+            :class="{
+              'home-tilt-lock': isHeroVariant,
+              'home-tilt-lock--unlocked':
+                isHeroVariant && isHighlightUnlocked(index),
+            }"
             surface="strong"
             accent-corner="bottom-right"
             corner-variant="none"
@@ -278,6 +298,8 @@ const resolveHighlightStyle = (index: number) => {
             "
             :style="resolveHighlightStyle(index)"
             @click="handleHighlightClick"
+            @pointerenter="unlockHighlight(index)"
+            @focusin="unlockHighlight(index)"
           >
             <div
               class="home-hero-highlights__card-content d-flex flex-column align-center text-center ga-2"
@@ -506,8 +528,6 @@ const resolveHighlightStyle = (index: number) => {
 .home-hero-highlights__card
   height: 100%
   width: 100%
-  transform: translateY(var(--highlight-offset, 0)) rotate(var(--highlight-tilt, 0deg))
-  transition: transform 180ms ease, box-shadow 180ms ease
 
   :deep(.rounded-card__content)
     min-height: auto
@@ -562,10 +582,10 @@ const resolveHighlightStyle = (index: number) => {
 @media (min-width: 960px)
   .home-hero-highlights--hero
     .home-hero-highlights__col:nth-child(odd) .home-hero-highlights__card
-      --highlight-offset: -12px
+      --tilt-default-offset: -12px
 
     .home-hero-highlights__col:nth-child(even) .home-hero-highlights__card
-      --highlight-offset: 12px
+      --tilt-default-offset: 12px
 
 .home-hero-highlights__ai-summary-cards-container
   width: 100%

--- a/frontend/app/components/home/sections/HomeSolutionSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeSolutionSection.spec.ts
@@ -1,0 +1,60 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import HomeSolutionSection from './HomeSolutionSection.vue'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const createStub = (tag: string, className = '') =>
+  defineComponent({
+    name: `${tag}-stub`,
+    setup(_, { slots, attrs }) {
+      return () =>
+        h(
+          tag,
+          { class: [className, attrs.class], ...attrs },
+          slots.default ? slots.default() : []
+        )
+    },
+  })
+
+const mountComponent = () =>
+  mountSuspended(HomeSolutionSection, {
+    props: {
+      benefits: [
+        {
+          emoji: '🌿',
+          label: 'label',
+          description: 'description',
+        },
+      ],
+    },
+    global: {
+      stubs: {
+        VRow: createStub('div'),
+        VCol: createStub('div'),
+        VAvatar: createStub('div'),
+        NudgerCard: createStub('div', 'nudger-card-stub'),
+      },
+    },
+  })
+
+describe('HomeSolutionSection', () => {
+  it('unlocks the tilted image after pointer entry', async () => {
+    const wrapper = await mountComponent()
+    const image = wrapper.find('.home-solution__image')
+
+    expect(image.classes()).toContain('home-tilt-lock')
+    expect(image.classes()).not.toContain('home-tilt-lock--unlocked')
+
+    await wrapper.find('.home-solution__image-wrapper').trigger('pointerenter')
+
+    expect(image.classes()).toContain('home-tilt-lock--unlocked')
+
+    await wrapper.unmount()
+  })
+})

--- a/frontend/app/components/home/sections/HomeSolutionSection.vue
+++ b/frontend/app/components/home/sections/HomeSolutionSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import NudgerCard from '~/components/shared/cards/NudgerCard.vue'
 
 const solutionImageSrc = '/homepage/gain/nudger-screaming.webp'
@@ -20,6 +20,15 @@ const { t } = useI18n()
 const sectionTitle = computed(() => t('home.solution.title'))
 const sectionDescription = computed(() => t('home.solution.description'))
 const isVisible = computed(() => Boolean(props.reveal))
+const isImageTiltUnlocked = ref(false)
+
+const unlockImageTilt = () => {
+  if (isImageTiltUnlocked.value) {
+    return
+  }
+
+  isImageTiltUnlocked.value = true
+}
 </script>
 
 <template>
@@ -75,11 +84,15 @@ const isVisible = computed(() => Boolean(props.reveal))
           </v-row>
         </v-col>
         <v-col cols="12" md="6" class="home-solution__visual">
-          <div class="home-solution__image-wrapper">
+          <div
+            class="home-solution__image-wrapper"
+            @pointerenter="unlockImageTilt"
+          >
             <img
               :src="solutionImageSrc"
               :alt="sectionTitle"
-              class="home-solution__image"
+              class="home-solution__image home-tilt-lock"
+              :class="{ 'home-tilt-lock--unlocked': isImageTiltUnlocked }"
               loading="lazy"
               decoding="async"
             />
@@ -143,7 +156,7 @@ const isVisible = computed(() => Boolean(props.reveal))
   height: auto
   display: block
   margin-inline: auto
-  transform: rotate(7deg)
+  --tilt-default-angle: 7deg
 
 @media (max-width: 599px)
   .home-solution__item


### PR DESCRIPTION
### Motivation

- Improve the home hero/solution visuals by introducing a stable "tilt lock" animation that can be unlocked on first user interaction so elements stop in a horizontal position once hovered/focused. 
- Respect reduced-motion accessibility preferences and make the tilt behavior predictable across hero highlight cards and the solution image.

### Description

- Added a reusable tilt-lock utility in `frontend/app/assets/sass/components/home-animations.sass` with CSS custom properties and reduced-motion handling (`.home-tilt-lock`, `.home-tilt-lock--unlocked`).
- Wired tilt variables and unlock behaviour into the hero highlights component by emitting per-item tilt defaults and tracking unlocked indexes in `frontend/app/components/home/sections/HomeHeroHighlights.vue`.
- Added pointer/focus unlock to the solution image and toggled the tilt class in `frontend/app/components/home/sections/HomeSolutionSection.vue` and replaced the static rotate with the new CSS variable approach.
- Added a unit test `frontend/app/components/home/sections/HomeSolutionSection.spec.ts` that validates the image tilt unlock on `pointerenter`.

### Testing

- Ran linter with `pnpm lint` which passed successfully.
- Ran unit tests with `pnpm test` (Vitest): 431 tests passed and 1 test failed, specifically `app/components/product/ProductAttributesSection.spec.ts > ProductAttributesSection > displays localized GTIN label and supports copy to clipboard` (assertion failure).
- The change set includes the new `HomeSolutionSection` test which passed in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d40e4be8c8322895b046409bc8141)