### PR TITLE
Add feed indexation by datasource/provider name

### DIFF
--- a/api/src/main/java/org/open4goods/api/controller/api/FeedController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/FeedController.java
@@ -72,6 +72,14 @@ public class FeedController {
 		batchService.fetchFeedsByKey(feedKey);
 	}
 
+    @PatchMapping(path = "/feedsByDatasourceName")
+    @Operation(summary="Manually run the indexation of feeds matching the datasource/provider name")
+    @PreAuthorize("hasAuthority('"+RolesConstants.ROLE_ADMIN+"')")
+    public void feedByDatasourceName(@RequestParam @NotBlank final String datasourceName)
+    {
+        batchService.fetchFeedsByDatasourceName(datasourceName);
+    }
+
 	@PatchMapping(path = "/feedsByUrl")
 	@Operation(summary="List all feeds from catalogs corresponding the given url")
 	@PreAuthorize("hasAuthority('"+RolesConstants.ROLE_ADMIN+"')")

--- a/api/src/main/java/org/open4goods/api/services/BatchService.java
+++ b/api/src/main/java/org/open4goods/api/services/BatchService.java
@@ -256,6 +256,26 @@ public class BatchService {
         }
     }
 
+    /**
+     * Fetches feeds that match the specified datasource/provider name.
+     *
+     * @param datasourceName the datasource/provider name to match
+     */
+    public void fetchFeedsByDatasourceName(String datasourceName)
+    {
+        logger.info("Fetching feeds with datasource name: {}", datasourceName);
+        Set<DataSourceProperties> datasources = feedService.getFeedsByDatasourceName(datasourceName);
+        logger.info("Found {} feeds for datasource name matching.", datasources.size());
+        for (DataSourceProperties ds : datasources) {
+            try {
+                logger.info("Fetching feed {}: {}", ds.getDatasourceConfigName(), ds);
+                csvDatasourceFetchingService.start(ds, ds.getDatasourceConfigName());
+            } catch (Exception e) {
+                logger.error("Error fetching feed {}: ", ds.getDatasourceConfigName(), e);
+            }
+        }
+    }
+
 
 
     /**

--- a/services/feedservice/src/main/java/org/open4goods/services/feedservice/service/FeedService.java
+++ b/services/feedservice/src/main/java/org/open4goods/services/feedservice/service/FeedService.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.open4goods.commons.config.yml.datasource.DataSourceProperties;
 import org.open4goods.commons.services.DataSourceConfigService;
 import org.open4goods.model.affiliation.AffiliationPartner;
+import org.open4goods.model.helper.IdHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,7 +17,8 @@ import org.slf4j.LoggerFactory;
  * This class maintains the original external contract:
  * - {@code fetchFeeds()} to load and fetch all feeds,
  * - {@code fetchFeedsByUrl(String)} to fetch feeds by URL,
- * - {@code fetchFeedsByKey(String)} to fetch feeds by key, and
+ * - {@code fetchFeedsByKey(String)} to fetch feeds by key,
+ * - {@code getFeedsByDatasourceName(String)} to fetch feeds by datasource name, and
  * - {@code getFeedsUrl()} to aggregate datasource properties.
  * </p>
  * <p>
@@ -98,6 +100,39 @@ public class FeedService {
         });
 
         return result;
+    }
+
+    /**
+     * Returns datasources matching the provided datasource or provider name.
+     *
+     * @param datasourceName datasource/provider name to match
+     * @return matching datasource properties
+     */
+    public Set<DataSourceProperties> getFeedsByDatasourceName(String datasourceName)
+    {
+        String cleanedName = normalizeDatasourceName(datasourceName);
+        Set<DataSourceProperties> result = new HashSet<>();
+        for (DataSourceProperties ds : getFeedsUrl()) {
+            try {
+                String configName = normalizeDatasourceName(ds.getDatasourceConfigName());
+                String dsName = normalizeDatasourceName(ds.getName());
+                if (cleanedName.equals(configName) || cleanedName.equals(dsName)) {
+                    result.add(ds);
+                    logger.info("Matched feed: {}", ds);
+                }
+            } catch (Exception e) {
+                logger.error("Error matching feed {}: ", ds, e);
+            }
+        }
+        return result;
+    }
+
+    private String normalizeDatasourceName(String datasourceName)
+    {
+        if (datasourceName == null) {
+            return "";
+        }
+        return IdHelper.azCharAndDigits(datasourceName).toLowerCase();
     }
 
 

--- a/services/feedservice/src/test/java/org/open4goods/services/feedservice/service/FeedServiceTest.java
+++ b/services/feedservice/src/test/java/org/open4goods/services/feedservice/service/FeedServiceTest.java
@@ -1,0 +1,59 @@
+package org.open4goods.services.feedservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.commons.config.yml.datasource.DataSourceProperties;
+import org.open4goods.commons.services.DataSourceConfigService;
+
+/**
+ * Tests for FeedService datasource matching.
+ */
+class FeedServiceTest
+{
+
+    @Test
+    void getFeedsByDatasourceNameMatchesDatasourceConfigName()
+    {
+        DataSourceProperties datasource = datasource("Partner", "provider-42");
+        FeedService feedService = buildFeedService(Set.of(datasource));
+
+        Set<DataSourceProperties> result = feedService.getFeedsByDatasourceName("provider 42");
+
+        assertThat(result).containsExactly(datasource);
+    }
+
+    @Test
+    void getFeedsByDatasourceNameMatchesDatasourceName()
+    {
+        DataSourceProperties datasource = datasource("Acme Partner", "acme-partner");
+        FeedService feedService = buildFeedService(Set.of(datasource));
+
+        Set<DataSourceProperties> result = feedService.getFeedsByDatasourceName("acme partner");
+
+        assertThat(result).containsExactly(datasource);
+    }
+
+    private FeedService buildFeedService(Set<DataSourceProperties> datasources)
+    {
+        AbstractFeedService feedProvider = mock(AbstractFeedService.class);
+        DataSourceConfigService dataSourceConfigService = mock(DataSourceConfigService.class);
+        when(feedProvider.getDatasources()).thenReturn(datasources);
+        when(dataSourceConfigService.datasourceConfigs()).thenReturn(Map.of());
+        return new FeedService(List.of(feedProvider), dataSourceConfigService);
+    }
+
+    private DataSourceProperties datasource(String name, String configName)
+    {
+        DataSourceProperties properties = new DataSourceProperties();
+        properties.setName(name);
+        properties.setDatasourceConfigName(configName);
+        return properties;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a way to trigger feed indexation when an operator knows the datasource/provider name instead of the feed key or URL.

### Description

- Added `FeedService#getFeedsByDatasourceName(String)` which normalises names using `IdHelper.azCharAndDigits(...)` and returns matching `DataSourceProperties` entries.
- Added a helper `normalizeDatasourceName` and logging for matched and error cases inside `FeedService`.
- Exposed an admin endpoint `PATCH /feedsByDatasourceName` in `FeedController` which calls `BatchService.fetchFeedsByDatasourceName(String)`.
- Implemented `BatchService.fetchFeedsByDatasourceName(String)` to retrieve matches and invoke `csvDatasourceFetchingService.start(...)` for each matching datasource, and added unit tests in `services/feedservice/src/test/java/.../FeedServiceTest.java` covering matching by config name and datasource name.

### Testing

- Executed `mvn --offline -pl services/feedservice test` and the module tests completed successfully with `BUILD SUCCESS` (3 tests run, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d47046d2c8322bbbcc5b4aabeaf13)