### PR TITLE
Add Google Indexation service and front‑API dispatch

### DIFF
--- a/front-api/README.md
+++ b/front-api/README.md
@@ -42,6 +42,35 @@ Requests are limited using an in-memory token bucket. Defaults can be changed in
 
 When limits are exceeded the API responds with HTTP `429 Too Many Requests`.
 
+## Google Indexation
+
+The front API can notify the Google Indexing API after AI review generation
+succeeds. The integration is disabled by default and must be enabled explicitly.
+
+Front API dispatch configuration:
+
+- `front.google-indexation.enabled` – master toggle (default `false`).
+- `front.google-indexation.realtime-enabled` – dispatch immediately on success.
+- `front.google-indexation.batch-enabled` – dispatch queued URLs on schedule.
+- `front.google-indexation.batch-interval` – schedule delay (default `30m`).
+- `front.google-indexation.batch-size` – maximum URLs per batch.
+- `front.google-indexation.max-attempts` – retry limit for failed URLs.
+- `front.google-indexation.site-base-url` – public base URL used to build product URLs.
+
+Google Indexing API credentials:
+
+- `google-indexation.service-account-json` – raw service account JSON.
+- `google-indexation.service-account-path` – file path to the service account JSON.
+
+Credentials are required when `front.google-indexation.enabled=true`. You can
+provide them via environment variables:
+
+```bash
+export FRONT_GOOGLE_INDEXATION_ENABLED=true
+export FRONT_GOOGLE_INDEXATION_SITE_BASE_URL=https://nudger.fr
+export GOOGLE_INDEXATION_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
+```
+
 ## API documentation
 
 Access to the Swagger UI (`/swagger-ui.html`) and the raw OpenAPI specification

--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -98,6 +98,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>google-indexation</artifactId>
+      <version>${global.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.ibm.icu</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GoogleIndexationProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GoogleIndexationProperties.java
@@ -1,0 +1,173 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration settings controlling Google Indexation dispatch in the front API.
+ */
+@ConfigurationProperties(prefix = "front.google-indexation")
+public class GoogleIndexationProperties {
+
+    /**
+     * Enable Google Indexation dispatch from the front API.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Enable real-time dispatch when a review generation succeeds.
+     */
+    private boolean realtimeEnabled = true;
+
+    /**
+     * Enable scheduled batch dispatch of queued URLs.
+     */
+    private boolean batchEnabled = true;
+
+    /**
+     * Fixed delay between batch dispatches.
+     */
+    private Duration batchInterval = Duration.ofMinutes(30);
+
+    /**
+     * Maximum number of URLs to send per batch.
+     */
+    private int batchSize = 50;
+
+    /**
+     * Maximum number of attempts before giving up on a URL.
+     */
+    private int maxAttempts = 5;
+
+    /**
+     * Base URL of the public frontend used to build canonical product URLs.
+     */
+    private String siteBaseUrl;
+
+    /**
+     * Return whether Google indexation is enabled.
+     *
+     * @return {@code true} when enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enable or disable Google indexation.
+     *
+     * @param enabled whether indexation is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Return whether realtime dispatch is enabled.
+     *
+     * @return {@code true} when realtime dispatch is enabled
+     */
+    public boolean isRealtimeEnabled() {
+        return realtimeEnabled;
+    }
+
+    /**
+     * Enable or disable realtime dispatch.
+     *
+     * @param realtimeEnabled whether realtime dispatch is enabled
+     */
+    public void setRealtimeEnabled(boolean realtimeEnabled) {
+        this.realtimeEnabled = realtimeEnabled;
+    }
+
+    /**
+     * Return whether batch dispatch is enabled.
+     *
+     * @return {@code true} when batch dispatch is enabled
+     */
+    public boolean isBatchEnabled() {
+        return batchEnabled;
+    }
+
+    /**
+     * Enable or disable batch dispatch.
+     *
+     * @param batchEnabled whether batch dispatch is enabled
+     */
+    public void setBatchEnabled(boolean batchEnabled) {
+        this.batchEnabled = batchEnabled;
+    }
+
+    /**
+     * Return the batch interval.
+     *
+     * @return batch interval
+     */
+    public Duration getBatchInterval() {
+        return batchInterval;
+    }
+
+    /**
+     * Set the batch interval.
+     *
+     * @param batchInterval batch interval
+     */
+    public void setBatchInterval(Duration batchInterval) {
+        this.batchInterval = batchInterval;
+    }
+
+    /**
+     * Return the batch size.
+     *
+     * @return batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Set the batch size.
+     *
+     * @param batchSize batch size
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Return the maximum number of attempts.
+     *
+     * @return max attempts
+     */
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    /**
+     * Set the maximum number of attempts.
+     *
+     * @param maxAttempts max attempts
+     */
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    /**
+     * Return the site base URL.
+     *
+     * @return site base URL
+     */
+    public String getSiteBaseUrl() {
+        return siteBaseUrl;
+    }
+
+    /**
+     * Set the site base URL.
+     *
+     * @param siteBaseUrl site base URL
+     */
+    public void setSiteBaseUrl(String siteBaseUrl) {
+        this.siteBaseUrl = siteBaseUrl;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexationController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexationController.java
@@ -1,0 +1,77 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.indexation.GoogleIndexationMetricsDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleIndexationQueueService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST endpoints exposing Google Indexation metrics.
+ */
+@RestController
+@RequestMapping("/api/indexation")
+@Tag(name = "Indexation", description = "Google Indexation queue metrics and status.")
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+public class GoogleIndexationController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexationController.class);
+
+    private final GoogleIndexationQueueService queueService;
+
+    /**
+     * Create the controller.
+     *
+     * @param queueService queue service for metrics
+     */
+    public GoogleIndexationController(GoogleIndexationQueueService queueService) {
+        this.queueService = queueService;
+    }
+
+    /**
+     * Return the current Google Indexation queue metrics.
+     *
+     * @param domainLanguage requested domain language
+     * @return metrics snapshot
+     */
+    @GetMapping("/metrics")
+    @Operation(
+            summary = "Get Google Indexation metrics",
+            description = "Expose queue metrics and recent dispatch status for Google Indexation.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Metrics returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string")))
+            }
+    )
+    public ResponseEntity<GoogleIndexationMetricsDto> metrics(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Entering GoogleIndexationController.metrics(domainLanguage={})", domainLanguage);
+        GoogleIndexationMetricsDto metrics = queueService.metricsSnapshot(domainLanguage);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(metrics);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/indexation/GoogleIndexationMetricsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/indexation/GoogleIndexationMetricsDto.java
@@ -1,0 +1,26 @@
+package org.open4goods.nudgerfrontapi.dto.indexation;
+
+import java.time.Instant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing Google Indexation queue metrics.
+ */
+public record GoogleIndexationMetricsDto(
+        @Schema(description = "Whether Google indexation dispatch is enabled", example = "false")
+        boolean enabled,
+        @Schema(description = "Number of URLs currently stored in the queue", example = "12")
+        int queuedCount,
+        @Schema(description = "Number of URLs pending processing", example = "5")
+        int pendingCount,
+        @Schema(description = "Number of URLs that failed during the last attempts", example = "2")
+        int failedCount,
+        @Schema(description = "Timestamp of the last successful dispatch", example = "2024-01-01T12:00:00Z")
+        Instant lastSuccessAt,
+        @Schema(description = "Timestamp of the last failed dispatch", example = "2024-01-01T12:05:00Z")
+        Instant lastFailureAt,
+        @Schema(description = "Last failure message, if any", example = "HTTP 429: quota exceeded")
+        String lastFailureMessage
+) {
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexationQueueEntry.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexationQueueEntry.java
@@ -1,0 +1,159 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import java.time.Instant;
+
+/**
+ * In-memory entry representing a pending Google Indexation notification.
+ */
+public class GoogleIndexationQueueEntry {
+
+    /**
+     * Status of the indexation entry.
+     */
+    public enum Status {
+        PENDING,
+        IN_PROGRESS,
+        SUCCESS,
+        FAILED
+    }
+
+    private final String url;
+    private final long gtin;
+    private final Instant createdAt;
+    private Status status;
+    private int attempts;
+    private Instant lastAttemptAt;
+    private Instant lastSuccessAt;
+    private String lastError;
+
+    /**
+     * Create a new queue entry.
+     *
+     * @param url product URL to index
+     * @param gtin product identifier
+     * @param createdAt creation timestamp
+     */
+    public GoogleIndexationQueueEntry(String url, long gtin, Instant createdAt) {
+        this.url = url;
+        this.gtin = gtin;
+        this.createdAt = createdAt;
+        this.status = Status.PENDING;
+    }
+
+    /**
+     * Return the URL to index.
+     *
+     * @return product URL
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Return the product identifier.
+     *
+     * @return GTIN
+     */
+    public long getGtin() {
+        return gtin;
+    }
+
+    /**
+     * Return the creation timestamp.
+     *
+     * @return creation time
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Return the current status.
+     *
+     * @return status
+     */
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Update the status.
+     *
+     * @param status new status
+     */
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    /**
+     * Return the number of attempts.
+     *
+     * @return attempt count
+     */
+    public int getAttempts() {
+        return attempts;
+    }
+
+    /**
+     * Set the number of attempts.
+     *
+     * @param attempts attempt count
+     */
+    public void setAttempts(int attempts) {
+        this.attempts = attempts;
+    }
+
+    /**
+     * Return the last attempt timestamp.
+     *
+     * @return last attempt time
+     */
+    public Instant getLastAttemptAt() {
+        return lastAttemptAt;
+    }
+
+    /**
+     * Set the last attempt timestamp.
+     *
+     * @param lastAttemptAt last attempt time
+     */
+    public void setLastAttemptAt(Instant lastAttemptAt) {
+        this.lastAttemptAt = lastAttemptAt;
+    }
+
+    /**
+     * Return the last success timestamp.
+     *
+     * @return last success time
+     */
+    public Instant getLastSuccessAt() {
+        return lastSuccessAt;
+    }
+
+    /**
+     * Set the last success timestamp.
+     *
+     * @param lastSuccessAt last success time
+     */
+    public void setLastSuccessAt(Instant lastSuccessAt) {
+        this.lastSuccessAt = lastSuccessAt;
+    }
+
+    /**
+     * Return the last error message.
+     *
+     * @return last error message
+     */
+    public String getLastError() {
+        return lastError;
+    }
+
+    /**
+     * Set the last error message.
+     *
+     * @param lastError last error message
+     */
+    public void setLastError(String lastError) {
+        this.lastError = lastError;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexationQueueRepository.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/repository/GoogleIndexationQueueRepository.java
@@ -1,0 +1,87 @@
+package org.open4goods.nudgerfrontapi.repository;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry.Status;
+import org.springframework.stereotype.Repository;
+
+/**
+ * In-memory repository storing URLs pending for Google Indexation.
+ */
+@Repository
+public class GoogleIndexationQueueRepository {
+
+    private final Map<String, GoogleIndexationQueueEntry> entries = new ConcurrentHashMap<>();
+
+    /**
+     * Insert or reuse an entry for the provided URL.
+     *
+     * @param url product URL
+     * @param gtin product identifier
+     * @return stored queue entry
+     */
+    public GoogleIndexationQueueEntry upsert(String url, long gtin) {
+        return entries.compute(url, (key, existing) -> {
+            if (existing == null) {
+                return new GoogleIndexationQueueEntry(url, gtin, Instant.now());
+            }
+            return existing;
+        });
+    }
+
+    /**
+     * Return the queue entry for a URL, if present.
+     *
+     * @param url product URL
+     * @return optional queue entry
+     */
+    public Optional<GoogleIndexationQueueEntry> find(String url) {
+        return Optional.ofNullable(entries.get(url));
+    }
+
+    /**
+     * Retrieve a snapshot of all entries sorted by creation time.
+     *
+     * @return list of entries
+     */
+    public List<GoogleIndexationQueueEntry> findAll() {
+        return entries.values().stream()
+                .sorted(Comparator.comparing(GoogleIndexationQueueEntry::getCreatedAt))
+                .toList();
+    }
+
+    /**
+     * Fetch a batch of entries that are pending or failed.
+     *
+     * @param max batch size
+     * @param maxAttempts maximum allowed attempts
+     * @return list of entries to process
+     */
+    public List<GoogleIndexationQueueEntry> findPending(int max, int maxAttempts) {
+        List<GoogleIndexationQueueEntry> candidates = new ArrayList<>();
+        for (GoogleIndexationQueueEntry entry : entries.values()) {
+            if (entry.getStatus() == Status.PENDING || entry.getStatus() == Status.FAILED) {
+                if (entry.getAttempts() < maxAttempts) {
+                    candidates.add(entry);
+                }
+            }
+        }
+        candidates.sort(Comparator.comparing(GoogleIndexationQueueEntry::getCreatedAt));
+        return candidates.stream().limit(max).toList();
+    }
+
+    /**
+     * Return the current number of entries stored.
+     *
+     * @return entry count
+     */
+    public int size() {
+        return entries.size();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationDispatchService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationDispatchService.java
@@ -1,0 +1,141 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResult;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResultItem;
+import org.open4goods.services.googleindexation.service.GoogleIndexationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Service orchestrating real-time and batch Google Indexation dispatches.
+ */
+@Service
+public class GoogleIndexationDispatchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexationDispatchService.class);
+
+    private final GoogleIndexationProperties properties;
+    private final GoogleIndexationQueueService queueService;
+    private final GoogleIndexationService googleIndexationService;
+    private final ProductUrlService productUrlService;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Create the dispatch service.
+     *
+     * @param properties indexation configuration
+     * @param queueService queue service
+     * @param googleIndexationService Google Indexing API client
+     * @param productUrlService product URL resolver
+     * @param meterRegistry meter registry for metrics
+     */
+    public GoogleIndexationDispatchService(GoogleIndexationProperties properties,
+            GoogleIndexationQueueService queueService,
+            GoogleIndexationService googleIndexationService,
+            ProductUrlService productUrlService,
+            MeterRegistry meterRegistry) {
+        this.properties = properties;
+        this.queueService = queueService;
+        this.googleIndexationService = googleIndexationService;
+        this.productUrlService = productUrlService;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Handle a successful review generation event.
+     *
+     * @param gtin product identifier
+     * @param domainLanguage domain language
+     */
+    public void handleReviewSuccess(long gtin, DomainLanguage domainLanguage) {
+        if (!properties.isEnabled() || !googleIndexationService.isEnabled()) {
+            return;
+        }
+        String url = productUrlService.resolveProductUrl(gtin, domainLanguage);
+        if (!StringUtils.hasText(url)) {
+            LOGGER.warn("Unable to enqueue Google indexation for GTIN {} due to missing URL.", gtin);
+            return;
+        }
+        GoogleIndexationQueueEntry entry = queueService.enqueue(url, gtin);
+        if (entry == null) {
+            return;
+        }
+        meterRegistry.counter("google.indexation.queue.enqueued").increment();
+        if (properties.isRealtimeEnabled()) {
+            dispatchEntry(entry);
+        }
+    }
+
+    /**
+     * Dispatch queued URLs on a fixed schedule.
+     */
+    @Scheduled(fixedDelayString = "${front.google-indexation.batch-interval:PT30M}")
+    public void dispatchBatch() {
+        if (!properties.isEnabled() || !properties.isBatchEnabled() || !googleIndexationService.isEnabled()) {
+            return;
+        }
+        List<GoogleIndexationQueueEntry> entries = queueService.claimPending(properties.getBatchSize());
+        if (entries.isEmpty()) {
+            return;
+        }
+        List<String> urls = entries.stream().map(GoogleIndexationQueueEntry::getUrl).toList();
+        GoogleIndexationResult result = googleIndexationService.publishUrls(urls);
+        handleBatchResult(entries, result);
+    }
+
+    /**
+     * Dispatch a single entry immediately.
+     *
+     * @param entry queue entry
+     */
+    private void dispatchEntry(GoogleIndexationQueueEntry entry) {
+        GoogleIndexationResultItem resultItem = googleIndexationService.publishUrl(entry.getUrl());
+        if (resultItem.success()) {
+            queueService.markSuccess(entry);
+        } else {
+            queueService.markFailure(entry, resultItem.message());
+        }
+    }
+
+    /**
+     * Apply a batch result to the queue entries.
+     *
+     * @param entries entries dispatched
+     * @param result batch result
+     */
+    private void handleBatchResult(List<GoogleIndexationQueueEntry> entries, GoogleIndexationResult result) {
+        if (result == null || result.items() == null) {
+            for (GoogleIndexationQueueEntry entry : entries) {
+                queueService.markFailure(entry, "Missing result from Google Indexing API");
+            }
+            return;
+        }
+        for (GoogleIndexationResultItem item : result.items()) {
+            GoogleIndexationQueueEntry entry = entries.stream()
+                    .filter(candidate -> candidate.getUrl().equals(item.url()))
+                    .findFirst()
+                    .orElse(null);
+            if (entry == null) {
+                continue;
+            }
+            if (item.success()) {
+                queueService.markSuccess(entry);
+            } else {
+                queueService.markFailure(entry, item.message());
+            }
+        }
+        LOGGER.info("Google indexation batch completed at {} with {} successes and {} failures.",
+                Instant.now(), result.successCount(), result.failureCount());
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationHealthIndicator.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationHealthIndicator.java
@@ -1,0 +1,59 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.services.googleindexation.service.GoogleIndexationService;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator for the Google Indexation pipeline in the front API.
+ */
+@Component
+public class GoogleIndexationHealthIndicator implements HealthIndicator {
+
+    private final GoogleIndexationProperties properties;
+    private final GoogleIndexationQueueService queueService;
+    private final GoogleIndexationService googleIndexationService;
+
+    /**
+     * Create the health indicator.
+     *
+     * @param properties indexation configuration
+     * @param queueService queue service
+     * @param googleIndexationService Google Indexing API client
+     */
+    public GoogleIndexationHealthIndicator(GoogleIndexationProperties properties,
+            GoogleIndexationQueueService queueService,
+            GoogleIndexationService googleIndexationService) {
+        this.properties = properties;
+        this.queueService = queueService;
+        this.googleIndexationService = googleIndexationService;
+    }
+
+    /**
+     * Report health for the queue and downstream client.
+     *
+     * @return health status
+     */
+    @Override
+    public Health health() {
+        if (!properties.isEnabled()) {
+            return Health.up()
+                    .withDetail("enabled", false)
+                    .withDetail("queueSize", queueService.getQueueSize())
+                    .build();
+        }
+        Health serviceHealth = googleIndexationService.health();
+        Health.Builder builder = serviceHealth.getStatus().equals(Status.UP)
+                ? Health.up()
+                : Health.down();
+        builder.withDetail("enabled", true)
+                .withDetail("queueSize", queueService.getQueueSize());
+        if (queueService.getLastFailureMessage() != null) {
+            builder.withDetail("lastQueueFailure", queueService.getLastFailureMessage());
+        }
+        return builder.build();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationQueueService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationQueueService.java
@@ -1,0 +1,187 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.dto.indexation.GoogleIndexationMetricsDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry.Status;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Service responsible for managing the Google Indexation queue.
+ */
+@Service
+public class GoogleIndexationQueueService {
+
+    private final GoogleIndexationQueueRepository repository;
+    private final GoogleIndexationProperties properties;
+    private final MeterRegistry meterRegistry;
+
+    private volatile Instant lastSuccessAt;
+    private volatile Instant lastFailureAt;
+    private volatile String lastFailureMessage;
+
+    /**
+     * Create the queue service.
+     *
+     * @param repository queue repository
+     * @param properties indexation configuration
+     * @param meterRegistry meter registry for metrics
+     */
+    public GoogleIndexationQueueService(GoogleIndexationQueueRepository repository,
+            GoogleIndexationProperties properties,
+            MeterRegistry meterRegistry) {
+        this.repository = repository;
+        this.properties = properties;
+        this.meterRegistry = meterRegistry;
+        this.meterRegistry.gauge("google.indexation.queue.size", repository, GoogleIndexationQueueRepository::size);
+    }
+
+    /**
+     * Enqueue a URL for indexation.
+     *
+     * @param url product URL
+     * @param gtin product identifier
+     * @return stored queue entry or {@code null} when input is invalid
+     */
+    public GoogleIndexationQueueEntry enqueue(String url, long gtin) {
+        if (!StringUtils.hasText(url)) {
+            return null;
+        }
+        GoogleIndexationQueueEntry entry = repository.upsert(url, gtin);
+        if (entry.getStatus() == Status.SUCCESS) {
+            return entry;
+        }
+        entry.setStatus(Status.PENDING);
+        return entry;
+    }
+
+    /**
+     * Claim a batch of pending entries for processing.
+     *
+     * @param max batch size
+     * @return list of claimed entries
+     */
+    public List<GoogleIndexationQueueEntry> claimPending(int max) {
+        List<GoogleIndexationQueueEntry> entries = repository.findPending(max, properties.getMaxAttempts());
+        for (GoogleIndexationQueueEntry entry : entries) {
+            entry.setStatus(Status.IN_PROGRESS);
+            entry.setLastAttemptAt(Instant.now());
+            entry.setAttempts(entry.getAttempts() + 1);
+        }
+        return entries;
+    }
+
+    /**
+     * Mark a queued URL as successfully processed.
+     *
+     * @param entry queue entry
+     */
+    public void markSuccess(GoogleIndexationQueueEntry entry) {
+        if (entry == null) {
+            return;
+        }
+        entry.setStatus(Status.SUCCESS);
+        entry.setLastSuccessAt(Instant.now());
+        entry.setLastError(null);
+        lastSuccessAt = entry.getLastSuccessAt();
+        meterRegistry.counter("google.indexation.queue.success").increment();
+    }
+
+    /**
+     * Mark a queued URL as failed.
+     *
+     * @param entry queue entry
+     * @param errorMessage error message to record
+     */
+    public void markFailure(GoogleIndexationQueueEntry entry, String errorMessage) {
+        if (entry == null) {
+            return;
+        }
+        entry.setStatus(Status.FAILED);
+        entry.setLastError(errorMessage);
+        lastFailureAt = Instant.now();
+        lastFailureMessage = errorMessage;
+        meterRegistry.counter("google.indexation.queue.failure").increment();
+    }
+
+    /**
+     * Build the current queue metrics snapshot.
+     *
+     * @param domainLanguage requested domain language (reserved for future use)
+     * @return metrics DTO
+     */
+    public GoogleIndexationMetricsDto metricsSnapshot(DomainLanguage domainLanguage) {
+        List<GoogleIndexationQueueEntry> entries = repository.findAll();
+        int pendingCount = (int) entries.stream()
+                .filter(entry -> entry.getStatus() == Status.PENDING || entry.getStatus() == Status.IN_PROGRESS)
+                .count();
+        int failedCount = (int) entries.stream()
+                .filter(entry -> entry.getStatus() == Status.FAILED)
+                .count();
+
+        return new GoogleIndexationMetricsDto(
+                properties.isEnabled(),
+                entries.size(),
+                pendingCount,
+                failedCount,
+                lastSuccessAt,
+                lastFailureAt,
+                lastFailureMessage);
+    }
+
+    /**
+     * Return the most recent failure message.
+     *
+     * @return last failure message
+     */
+    public String getLastFailureMessage() {
+        return lastFailureMessage;
+    }
+
+    /**
+     * Return the most recent success timestamp.
+     *
+     * @return last success timestamp
+     */
+    public Instant getLastSuccessAt() {
+        return lastSuccessAt;
+    }
+
+    /**
+     * Return the most recent failure timestamp.
+     *
+     * @return last failure timestamp
+     */
+    public Instant getLastFailureAt() {
+        return lastFailureAt;
+    }
+
+    /**
+     * Check whether an entry is eligible for retry.
+     *
+     * @param entry queue entry
+     * @return {@code true} when the entry can be retried
+     */
+    public boolean canRetry(GoogleIndexationQueueEntry entry) {
+        return entry != null
+                && entry.getStatus() == Status.FAILED
+                && entry.getAttempts() < properties.getMaxAttempts();
+    }
+
+    /**
+     * Return the current queue size.
+     *
+     * @return size of the queue
+     */
+    public int getQueueSize() {
+        return repository.size();
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductUrlService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductUrlService.java
@@ -1,0 +1,151 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.model.Localisable;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.vertical.VerticalConfig;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Service responsible for resolving public product URLs.
+ */
+@Service
+public class ProductUrlService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProductUrlService.class);
+
+    private final ProductRepository productRepository;
+    private final VerticalsConfigService verticalsConfigService;
+    private final CategoryMappingService categoryMappingService;
+    private final GoogleIndexationProperties indexationProperties;
+
+    /**
+     * Create the product URL service.
+     *
+     * @param productRepository product repository
+     * @param verticalsConfigService vertical configuration service
+     * @param categoryMappingService category mapping service
+     * @param indexationProperties indexation properties
+     */
+    public ProductUrlService(ProductRepository productRepository,
+            VerticalsConfigService verticalsConfigService,
+            CategoryMappingService categoryMappingService,
+            GoogleIndexationProperties indexationProperties) {
+        this.productRepository = productRepository;
+        this.verticalsConfigService = verticalsConfigService;
+        this.categoryMappingService = categoryMappingService;
+        this.indexationProperties = indexationProperties;
+    }
+
+    /**
+     * Resolve the canonical product URL for a given GTIN.
+     *
+     * @param gtin product identifier
+     * @param domainLanguage requested domain language
+     * @return resolved URL or {@code null} when unavailable
+     */
+    public String resolveProductUrl(long gtin, DomainLanguage domainLanguage) {
+        if (!StringUtils.hasText(indexationProperties.getSiteBaseUrl())) {
+            LOGGER.warn("Google indexation site base URL is not configured.");
+            return null;
+        }
+        try {
+            Product product = productRepository.getById(gtin);
+            String slug = resolveLocalisedString(product.getNames() != null ? product.getNames().getUrl() : null, domainLanguage);
+            String verticalHomeUrl = resolveVerticalHomeUrl(product.getVertical(), domainLanguage);
+            String path = buildPath(gtin, slug, verticalHomeUrl);
+            return normalizeBaseUrl(indexationProperties.getSiteBaseUrl()) + path;
+        } catch (Exception exception) {
+            LOGGER.warn("Unable to resolve product URL for GTIN {}: {}", gtin, exception.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolve the vertical home URL using localisation rules.
+     *
+     * @param verticalId vertical identifier
+     * @param domainLanguage domain language
+     * @return resolved vertical home URL or {@code null}
+     */
+    private String resolveVerticalHomeUrl(String verticalId, DomainLanguage domainLanguage) {
+        if (!StringUtils.hasText(verticalId)) {
+            return null;
+        }
+        VerticalConfig config = verticalsConfigService.getConfigById(verticalId);
+        if (config == null) {
+            config = verticalsConfigService.getConfigByIdOrDefault(verticalId);
+        }
+        VerticalConfigDto dto = categoryMappingService.toVerticalConfigDto(config, domainLanguage);
+        return dto != null ? dto.verticalHomeUrl() : null;
+    }
+
+    /**
+     * Resolve a string from a localisable structure using the requested language.
+     *
+     * @param localisable localised values container
+     * @param domainLanguage requested language
+     * @return resolved value or {@code null}
+     */
+    private String resolveLocalisedString(Localisable<String, String> localisable, DomainLanguage domainLanguage) {
+        if (localisable == null) {
+            return null;
+        }
+        return localisable.i18n(domainLanguage != null ? domainLanguage.languageTag() : null);
+    }
+
+    /**
+     * Build the product path from slug and vertical data.
+     *
+     * @param gtin product identifier
+     * @param slug localised slug
+     * @param verticalHomeUrl vertical home URL
+     * @return path starting with a slash
+     */
+    private String buildPath(long gtin, String slug, String verticalHomeUrl) {
+        if (StringUtils.hasText(slug) && StringUtils.hasText(verticalHomeUrl)) {
+            return "/" + trimSlashes(verticalHomeUrl) + "/" + trimSlashes(slug);
+        }
+        if (StringUtils.hasText(slug)) {
+            return "/" + trimSlashes(slug);
+        }
+        return "/products/" + gtin;
+    }
+
+    /**
+     * Normalize the base URL by removing any trailing slash.
+     *
+     * @param baseUrl configured base URL
+     * @return normalized base URL
+     */
+    private String normalizeBaseUrl(String baseUrl) {
+        if (baseUrl.endsWith("/")) {
+            return baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        return baseUrl;
+    }
+
+    /**
+     * Trim leading and trailing slashes from a path fragment.
+     *
+     * @param value path fragment
+     * @return trimmed fragment
+     */
+    private String trimSlashes(String value) {
+        String trimmed = value;
+        while (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -48,6 +48,47 @@
       "defaultValue": true
     },
     {
+      "name": "front.google-indexation.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Google Indexation dispatch in the front API.",
+      "defaultValue": false
+    },
+    {
+      "name": "front.google-indexation.realtime-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable real-time Indexing API dispatch when a review generation succeeds.",
+      "defaultValue": true
+    },
+    {
+      "name": "front.google-indexation.batch-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable scheduled batch dispatch of queued URLs.",
+      "defaultValue": true
+    },
+    {
+      "name": "front.google-indexation.batch-interval",
+      "type": "java.time.Duration",
+      "description": "Fixed delay between batch dispatches.",
+      "defaultValue": "30m"
+    },
+    {
+      "name": "front.google-indexation.batch-size",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of URLs to send per batch.",
+      "defaultValue": 50
+    },
+    {
+      "name": "front.google-indexation.max-attempts",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of attempts before giving up on a URL.",
+      "defaultValue": 5
+    },
+    {
+      "name": "front.google-indexation.site-base-url",
+      "type": "java.lang.String",
+      "description": "Base URL of the public frontend used to build canonical product URLs."
+    },
+    {
       "name": "front.semantic-diagnostics-enabled",
       "type": "java.lang.Boolean",
       "description": "Enable semantic score diagnostics in global search responses.",

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -67,6 +67,14 @@ front:
     quota:
       max-per-ip: ${FRONT_REVIEW_GENERATION_MAX_PER_IP:3}
       window: ${FRONT_REVIEW_GENERATION_WINDOW:24h}
+  google-indexation:
+    enabled: ${FRONT_GOOGLE_INDEXATION_ENABLED:false}
+    realtime-enabled: ${FRONT_GOOGLE_INDEXATION_REALTIME_ENABLED:true}
+    batch-enabled: ${FRONT_GOOGLE_INDEXATION_BATCH_ENABLED:true}
+    batch-interval: ${FRONT_GOOGLE_INDEXATION_BATCH_INTERVAL:30m}
+    batch-size: ${FRONT_GOOGLE_INDEXATION_BATCH_SIZE:50}
+    max-attempts: ${FRONT_GOOGLE_INDEXATION_MAX_ATTEMPTS:5}
+    site-base-url: ${FRONT_GOOGLE_INDEXATION_SITE_BASE_URL:https://nudger.fr}
   search:
     suggest:
       semantic-fallback-enabled: true
@@ -145,6 +153,14 @@ management:
 
 open-data-config:
   generation-enabled: false
+
+google-indexation:
+  enabled: ${GOOGLE_INDEXATION_ENABLED:false}
+  service-account-json: ${GOOGLE_INDEXATION_SERVICE_ACCOUNT_JSON:}
+  service-account-path: ${GOOGLE_INDEXATION_SERVICE_ACCOUNT_PATH:}
+  api-url: ${GOOGLE_INDEXATION_API_URL:https://indexing.googleapis.com/v3/urlNotifications:publish}
+  request-timeout: ${GOOGLE_INDEXATION_REQUEST_TIMEOUT:10s}
+  batch-size: ${GOOGLE_INDEXATION_BATCH_SIZE:50}
 
 team-config:
   cores:

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexationControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/GoogleIndexationControllerTest.java
@@ -1,0 +1,41 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.indexation.GoogleIndexationMetricsDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleIndexationQueueService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Unit tests for {@link GoogleIndexationController}.
+ */
+class GoogleIndexationControllerTest {
+
+    @Test
+    void metricsReturnsSnapshot() {
+        GoogleIndexationQueueService queueService = mock(GoogleIndexationQueueService.class);
+        GoogleIndexationMetricsDto metrics = new GoogleIndexationMetricsDto(
+                true,
+                3,
+                2,
+                1,
+                Instant.now(),
+                Instant.now(),
+                "error");
+        when(queueService.metricsSnapshot(DomainLanguage.fr)).thenReturn(metrics);
+
+        GoogleIndexationController controller = new GoogleIndexationController(queueService);
+
+        ResponseEntity<GoogleIndexationMetricsDto> response = controller.metrics(DomainLanguage.fr);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(metrics);
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ProductControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/ProductControllerTest.java
@@ -31,6 +31,7 @@ import org.open4goods.nudgerfrontapi.dto.search.FilterRequestDto.FilterOperator;
 import org.open4goods.nudgerfrontapi.dto.search.ProductSearchRequestDto;
 import org.open4goods.nudgerfrontapi.dto.search.ProductSearchResponseDto;
 import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.GoogleIndexationDispatchService;
 import org.open4goods.nudgerfrontapi.service.ProductMappingService;
 import org.open4goods.nudgerfrontapi.service.SearchService;
 import org.open4goods.verticals.VerticalsConfigService;
@@ -54,11 +55,14 @@ class ProductControllerTest {
     @Mock
     private SearchService searchService;
 
+    @Mock
+    private GoogleIndexationDispatchService googleIndexationDispatchService;
+
     private ProductController controller;
 
     @BeforeEach
     void setUp() {
-        controller = new ProductController(productMappingService, verticalsConfigService, searchService);
+        controller = new ProductController(productMappingService, verticalsConfigService, searchService, googleIndexationDispatchService);
     }
 
     @Test

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationDispatchServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationDispatchServiceTest.java
@@ -1,0 +1,85 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResult;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResultItem;
+import org.open4goods.services.googleindexation.service.GoogleIndexationService;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Unit tests for {@link GoogleIndexationDispatchService}.
+ */
+class GoogleIndexationDispatchServiceTest {
+
+    @Test
+    void handleReviewSuccessDispatchesImmediatelyWhenEnabled() {
+        GoogleIndexationProperties properties = new GoogleIndexationProperties();
+        properties.setEnabled(true);
+        properties.setRealtimeEnabled(true);
+
+        GoogleIndexationQueueService queueService = mock(GoogleIndexationQueueService.class);
+        GoogleIndexationService googleIndexationService = mock(GoogleIndexationService.class);
+        ProductUrlService productUrlService = mock(ProductUrlService.class);
+
+        when(googleIndexationService.isEnabled()).thenReturn(true);
+        GoogleIndexationQueueEntry entry = new GoogleIndexationQueueEntry("https://example.org/product/1", 1L, java.time.Instant.now());
+        when(productUrlService.resolveProductUrl(1L, DomainLanguage.fr)).thenReturn(entry.getUrl());
+        when(queueService.enqueue(entry.getUrl(), 1L)).thenReturn(entry);
+        when(googleIndexationService.publishUrl(entry.getUrl()))
+                .thenReturn(new GoogleIndexationResultItem(entry.getUrl(), true, "ok", java.time.Instant.now()));
+
+        GoogleIndexationDispatchService service = new GoogleIndexationDispatchService(
+                properties,
+                queueService,
+                googleIndexationService,
+                productUrlService,
+                new SimpleMeterRegistry());
+
+        service.handleReviewSuccess(1L, DomainLanguage.fr);
+
+        verify(queueService).markSuccess(entry);
+    }
+
+    @Test
+    void dispatchBatchMarksFailures() {
+        GoogleIndexationProperties properties = new GoogleIndexationProperties();
+        properties.setEnabled(true);
+        properties.setBatchEnabled(true);
+        properties.setBatchSize(2);
+
+        GoogleIndexationQueueService queueService = mock(GoogleIndexationQueueService.class);
+        GoogleIndexationService googleIndexationService = mock(GoogleIndexationService.class);
+        ProductUrlService productUrlService = mock(ProductUrlService.class);
+
+        when(googleIndexationService.isEnabled()).thenReturn(true);
+        GoogleIndexationQueueEntry entry = new GoogleIndexationQueueEntry("https://example.org/product/2", 2L, java.time.Instant.now());
+        when(queueService.claimPending(anyInt())).thenReturn(List.of(entry));
+        GoogleIndexationResult result = new GoogleIndexationResult(1, 0, 1, java.time.Instant.now(),
+                List.of(new GoogleIndexationResultItem(entry.getUrl(), false, "error", java.time.Instant.now())));
+        when(googleIndexationService.publishUrls(List.of(entry.getUrl()))).thenReturn(result);
+
+        GoogleIndexationDispatchService service = new GoogleIndexationDispatchService(
+                properties,
+                queueService,
+                googleIndexationService,
+                productUrlService,
+                new SimpleMeterRegistry());
+
+        service.dispatchBatch();
+
+        verify(queueService).markFailure(eq(entry), eq("error"));
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationQueueServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/GoogleIndexationQueueServiceTest.java
@@ -1,0 +1,50 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueEntry.Status;
+import org.open4goods.nudgerfrontapi.repository.GoogleIndexationQueueRepository;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Unit tests for {@link GoogleIndexationQueueService}.
+ */
+class GoogleIndexationQueueServiceTest {
+
+    @Test
+    void claimPendingMarksEntriesInProgress() {
+        GoogleIndexationQueueRepository repository = new GoogleIndexationQueueRepository();
+        GoogleIndexationProperties properties = new GoogleIndexationProperties();
+        properties.setMaxAttempts(2);
+        GoogleIndexationQueueService service = new GoogleIndexationQueueService(repository, properties, new SimpleMeterRegistry());
+
+        GoogleIndexationQueueEntry entry = service.enqueue("https://example.org/product/1", 1L);
+
+        List<GoogleIndexationQueueEntry> pending = service.claimPending(1);
+
+        assertThat(pending).hasSize(1);
+        assertThat(entry.getStatus()).isEqualTo(Status.IN_PROGRESS);
+        assertThat(entry.getAttempts()).isEqualTo(1);
+    }
+
+    @Test
+    void markSuccessUpdatesStatusAndMetricsSnapshot() {
+        GoogleIndexationQueueRepository repository = new GoogleIndexationQueueRepository();
+        GoogleIndexationProperties properties = new GoogleIndexationProperties();
+        GoogleIndexationQueueService service = new GoogleIndexationQueueService(repository, properties, new SimpleMeterRegistry());
+
+        GoogleIndexationQueueEntry entry = service.enqueue("https://example.org/product/2", 2L);
+        service.markSuccess(entry);
+
+        assertThat(entry.getStatus()).isEqualTo(Status.SUCCESS);
+        assertThat(service.metricsSnapshot(DomainLanguage.fr).queuedCount()).isEqualTo(1);
+        assertThat(service.metricsSnapshot(DomainLanguage.fr).failedCount()).isZero();
+    }
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductUrlServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductUrlServiceTest.java
@@ -1,0 +1,51 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.open4goods.model.Localisable;
+import org.open4goods.model.product.Product;
+import org.open4goods.model.product.ProductTexts;
+import org.open4goods.nudgerfrontapi.config.properties.GoogleIndexationProperties;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalConfigDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.services.productrepository.services.ProductRepository;
+import org.open4goods.verticals.VerticalsConfigService;
+
+/**
+ * Unit tests for {@link ProductUrlService}.
+ */
+class ProductUrlServiceTest {
+
+    @Test
+    void resolveProductUrlBuildsFromVerticalAndSlug() throws Exception {
+        ProductRepository productRepository = Mockito.mock(ProductRepository.class);
+        VerticalsConfigService verticalsConfigService = Mockito.mock(VerticalsConfigService.class);
+        CategoryMappingService categoryMappingService = Mockito.mock(CategoryMappingService.class);
+
+        GoogleIndexationProperties properties = new GoogleIndexationProperties();
+        properties.setSiteBaseUrl("https://nudger.fr");
+
+        Product product = new Product();
+        product.setId(42L);
+        product.setVertical("tv");
+        ProductTexts texts = new ProductTexts();
+        Localisable<String, String> url = new Localisable<>();
+        url.put("fr", "smart-tv");
+        texts.setUrl(url);
+        product.setNames(texts);
+
+        when(productRepository.getById(42L)).thenReturn(product);
+        when(categoryMappingService.toVerticalConfigDto(Mockito.any(), Mockito.eq(DomainLanguage.fr)))
+                .thenReturn(new VerticalConfigDto("tv", true, true, null, null, 1, null, null, null, null,
+                        null, null, "televiseurs", null, null, null));
+
+        ProductUrlService service = new ProductUrlService(productRepository, verticalsConfigService, categoryMappingService, properties);
+
+        String result = service.resolveProductUrl(42L, DomainLanguage.fr);
+
+        assertThat(result).isEqualTo("https://nudger.fr/televiseurs/smart-tv");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>front-api</module>
         <module>services/urlfetching</module>
         <module>services/googlesearch</module>
+        <module>services/google-indexation</module>
         <module>services/evaluation</module>
         <module>services/serialisation</module>
         <module>services/prompt</module>

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -185,6 +185,22 @@ Each service has unique responsibilities and may have specific conventions beyon
 
 ---
 
+### google-indexation
+
+**Purpose**: Publishes product URLs to the Google Indexing API after AI review generation.
+
+**Key Responsibilities**:
+- Authenticate with Google service accounts
+- Publish URL_UPDATED notifications
+- Expose actuator metrics and health checks
+- Support batch submissions and retries
+
+**Configuration**:
+- Requires Google Indexing API service account credentials
+- Configure API URL, batch sizes, and request timeouts
+
+---
+
 ### gtinservice
 
 **Purpose**: GTIN (Global Trade Item Number) validation and lookup.

--- a/services/google-indexation/README.md
+++ b/services/google-indexation/README.md
@@ -1,0 +1,31 @@
+# Google Indexation Service
+
+This module provides a reusable client for the Google Indexing API. It supports
+service-account authentication, Micrometer metrics, and Actuator health checks.
+
+## Configuration
+
+```yaml
+google-indexation:
+  enabled: false
+  api-url: "https://indexing.googleapis.com/v3/urlNotifications:publish"
+  request-timeout: 10s
+  batch-size: 50
+  # Provide credentials using either inline JSON or a file path
+  service-account-json: ${GOOGLE_INDEXATION_SERVICE_ACCOUNT_JSON:}
+  service-account-path: ${GOOGLE_INDEXATION_SERVICE_ACCOUNT_PATH:}
+```
+
+## Metrics
+
+The service records:
+
+- `google.indexation.publish.attempt`
+- `google.indexation.publish.success`
+- `google.indexation.publish.failure`
+
+## Health
+
+A health indicator is exposed through Spring Boot Actuator. When disabled, the
+indicator reports `UP` with `enabled=false`. When enabled, it reports `DOWN` if
+credentials are missing or the last request failed.

--- a/services/google-indexation/pom.xml
+++ b/services/google-indexation/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.open4goods</groupId>
+    <artifactId>org.open4goods</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>google-indexation</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.30.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/config/GoogleIndexationConfig.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/config/GoogleIndexationConfig.java
@@ -1,0 +1,150 @@
+package org.open4goods.services.googleindexation.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Google Indexing API access.
+ */
+@ConfigurationProperties(prefix = "google-indexation")
+public class GoogleIndexationConfig {
+
+    /**
+     * Toggle the Google Indexation client on or off.
+     */
+    private boolean enabled = false;
+
+    /**
+     * Raw service account JSON content used to authenticate with the Indexing API.
+     */
+    private String serviceAccountJson;
+
+    /**
+     * Path to the service account JSON file used to authenticate with the Indexing API.
+     */
+    private String serviceAccountPath;
+
+    /**
+     * Google Indexing API endpoint.
+     */
+    private String apiUrl = "https://indexing.googleapis.com/v3/urlNotifications:publish";
+
+    /**
+     * Timeout applied to outbound HTTP requests.
+     */
+    private Duration requestTimeout = Duration.ofSeconds(10);
+
+    /**
+     * Default batch size used when publishing multiple URLs.
+     */
+    private int batchSize = 50;
+
+    /**
+     * Return whether the indexation client is enabled.
+     *
+     * @return {@code true} when enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enable or disable the indexation client.
+     *
+     * @param enabled whether the client is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Return the raw service account JSON payload.
+     *
+     * @return service account JSON
+     */
+    public String getServiceAccountJson() {
+        return serviceAccountJson;
+    }
+
+    /**
+     * Set the raw service account JSON payload.
+     *
+     * @param serviceAccountJson service account JSON
+     */
+    public void setServiceAccountJson(String serviceAccountJson) {
+        this.serviceAccountJson = serviceAccountJson;
+    }
+
+    /**
+     * Return the configured service account JSON file path.
+     *
+     * @return service account JSON file path
+     */
+    public String getServiceAccountPath() {
+        return serviceAccountPath;
+    }
+
+    /**
+     * Set the service account JSON file path.
+     *
+     * @param serviceAccountPath service account JSON file path
+     */
+    public void setServiceAccountPath(String serviceAccountPath) {
+        this.serviceAccountPath = serviceAccountPath;
+    }
+
+    /**
+     * Return the Google Indexing API endpoint URL.
+     *
+     * @return API URL
+     */
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    /**
+     * Set the Google Indexing API endpoint URL.
+     *
+     * @param apiUrl API URL
+     */
+    public void setApiUrl(String apiUrl) {
+        this.apiUrl = apiUrl;
+    }
+
+    /**
+     * Return the request timeout.
+     *
+     * @return request timeout
+     */
+    public Duration getRequestTimeout() {
+        return requestTimeout;
+    }
+
+    /**
+     * Set the request timeout.
+     *
+     * @param requestTimeout request timeout
+     */
+    public void setRequestTimeout(Duration requestTimeout) {
+        this.requestTimeout = requestTimeout;
+    }
+
+    /**
+     * Return the batch size.
+     *
+     * @return batch size
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Set the batch size.
+     *
+     * @param batchSize batch size
+     */
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+}

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/dto/GoogleIndexationResult.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/dto/GoogleIndexationResult.java
@@ -1,0 +1,22 @@
+package org.open4goods.services.googleindexation.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Result returned after attempting to publish URLs to the Google Indexing API.
+ *
+ * @param totalCount total number of URLs submitted
+ * @param successCount number of URLs successfully published
+ * @param failureCount number of URLs that failed to publish
+ * @param finishedAt timestamp of the batch completion
+ * @param items per-url details for the batch
+ */
+public record GoogleIndexationResult(
+        int totalCount,
+        int successCount,
+        int failureCount,
+        Instant finishedAt,
+        List<GoogleIndexationResultItem> items
+) {
+}

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/dto/GoogleIndexationResultItem.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/dto/GoogleIndexationResultItem.java
@@ -1,0 +1,19 @@
+package org.open4goods.services.googleindexation.dto;
+
+import java.time.Instant;
+
+/**
+ * Per-URL result details for a Google Indexing API request.
+ *
+ * @param url URL submitted to the Indexing API
+ * @param success whether the publish call succeeded
+ * @param message optional error or response message
+ * @param finishedAt timestamp when the URL was processed
+ */
+public record GoogleIndexationResultItem(
+        String url,
+        boolean success,
+        String message,
+        Instant finishedAt
+) {
+}

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/GoogleIndexationService.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/GoogleIndexationService.java
@@ -1,0 +1,283 @@
+package org.open4goods.services.googleindexation.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.open4goods.services.googleindexation.config.GoogleIndexationConfig;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResult;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResultItem;
+import org.open4goods.services.googleindexation.service.exception.GoogleIndexationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Service responsible for publishing URLs to the Google Indexing API.
+ */
+@Service
+public class GoogleIndexationService implements HealthIndicator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexationService.class);
+    private static final String INDEXING_SCOPE = "https://www.googleapis.com/auth/indexing";
+
+    private final GoogleIndexationConfig config;
+    private final MeterRegistry meterRegistry;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient;
+
+    private final AtomicReference<GoogleCredentials> credentials = new AtomicReference<>();
+    private final CredentialsProvider credentialsProvider;
+    private volatile String lastErrorMessage;
+    private volatile Instant lastSuccessAt;
+
+    /**
+     * Create the service with the default HTTP client.
+     *
+     * @param config configuration properties
+     * @param meterRegistry meter registry for metrics
+     */
+    @Autowired
+    public GoogleIndexationService(GoogleIndexationConfig config, MeterRegistry meterRegistry) {
+        this(config, meterRegistry, HttpClient.newHttpClient(), null);
+    }
+
+    /**
+     * Create the service with a custom HTTP client.
+     *
+     * @param config configuration properties
+     * @param meterRegistry meter registry for metrics
+     * @param httpClient HTTP client used for outbound calls
+     * @param credentialsProvider credentials provider override
+     */
+    GoogleIndexationService(GoogleIndexationConfig config, MeterRegistry meterRegistry, HttpClient httpClient,
+            CredentialsProvider credentialsProvider) {
+        this.config = config;
+        this.meterRegistry = meterRegistry;
+        this.httpClient = httpClient;
+        this.credentialsProvider = credentialsProvider != null ? credentialsProvider : this::loadCredentials;
+    }
+
+    /**
+     * Publish a list of URLs to the Google Indexing API.
+     *
+     * @param urls URLs to notify
+     * @return summary result for the batch
+     */
+    public GoogleIndexationResult publishUrls(List<String> urls) {
+        if (!config.isEnabled()) {
+            LOGGER.debug("Google indexation is disabled; skipping {} URLs.", urls == null ? 0 : urls.size());
+            return new GoogleIndexationResult(0, 0, 0, Instant.now(), List.of());
+        }
+        if (urls == null || urls.isEmpty()) {
+            return new GoogleIndexationResult(0, 0, 0, Instant.now(), List.of());
+        }
+
+        List<GoogleIndexationResultItem> items = new ArrayList<>();
+        int successCount = 0;
+        int failureCount = 0;
+
+        for (String url : urls) {
+            GoogleIndexationResultItem item = publishUrl(url);
+            items.add(item);
+            if (item.success()) {
+                successCount++;
+            } else {
+                failureCount++;
+            }
+        }
+
+        return new GoogleIndexationResult(urls.size(), successCount, failureCount, Instant.now(), items);
+    }
+
+    /**
+     * Publish a single URL to the Google Indexing API.
+     *
+     * @param url URL to notify
+     * @return per-URL result details
+     */
+    public GoogleIndexationResultItem publishUrl(String url) {
+        if (!config.isEnabled()) {
+            return new GoogleIndexationResultItem(url, false, "Google indexation is disabled", Instant.now());
+        }
+        if (!StringUtils.hasText(url)) {
+            return new GoogleIndexationResultItem(url, false, "URL is blank", Instant.now());
+        }
+
+        meterRegistry.counter("google.indexation.publish.attempt").increment();
+
+        try {
+            AccessToken token = accessToken();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(config.getApiUrl()))
+                    .timeout(config.getRequestTimeout())
+                    .header("Authorization", "Bearer " + token.getTokenValue())
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(buildPayload(url)))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            int status = response.statusCode();
+            if (status >= 200 && status < 300) {
+                lastSuccessAt = Instant.now();
+                lastErrorMessage = null;
+                meterRegistry.counter("google.indexation.publish.success").increment();
+                return new GoogleIndexationResultItem(url, true, response.body(), Instant.now());
+            }
+
+            String message = String.format("HTTP %d: %s", status, response.body());
+            lastErrorMessage = message;
+            meterRegistry.counter("google.indexation.publish.failure").increment();
+            return new GoogleIndexationResultItem(url, false, message, Instant.now());
+        } catch (Exception ex) {
+            String message = ex.getMessage();
+            lastErrorMessage = message;
+            meterRegistry.counter("google.indexation.publish.failure").increment();
+            return new GoogleIndexationResultItem(url, false, message, Instant.now());
+        }
+    }
+
+    /**
+     * Resolve a valid OAuth access token for the Indexing API.
+     *
+     * @return access token
+     */
+    private AccessToken accessToken() {
+        GoogleCredentials resolved = credentials.updateAndGet(existing -> existing != null ? existing : credentialsProvider.get());
+        try {
+            resolved.refreshIfExpired();
+        } catch (IOException exception) {
+            throw new GoogleIndexationException("Failed to refresh Google credentials", exception);
+        }
+        return Optional.ofNullable(resolved.getAccessToken())
+                .orElseThrow(() -> new GoogleIndexationException("Google credentials did not return an access token"));
+    }
+
+    /**
+     * Load Google credentials from the configured JSON payload or file path.
+     *
+     * @return resolved credentials
+     */
+    private GoogleCredentials loadCredentials() {
+        try {
+            if (StringUtils.hasText(config.getServiceAccountJson())) {
+                return GoogleCredentials.fromStream(new ByteArrayInputStream(
+                        config.getServiceAccountJson().getBytes(StandardCharsets.UTF_8)))
+                        .createScoped(List.of(INDEXING_SCOPE));
+            }
+            if (StringUtils.hasText(config.getServiceAccountPath())) {
+                byte[] content = Files.readAllBytes(Path.of(config.getServiceAccountPath()));
+                return GoogleCredentials.fromStream(new ByteArrayInputStream(content))
+                        .createScoped(List.of(INDEXING_SCOPE));
+            }
+        } catch (IOException exception) {
+            throw new GoogleIndexationException("Unable to load Google credentials", exception);
+        }
+        throw new GoogleIndexationException("Missing Google Indexation credentials");
+    }
+
+    /**
+     * Build the JSON payload sent to the Indexing API.
+     *
+     * @param url URL to publish
+     * @return JSON payload
+     */
+    private String buildPayload(String url) throws IOException {
+        return objectMapper.writeValueAsString(new Payload(url, "URL_UPDATED"));
+    }
+
+    /**
+     * Return the last error message captured by the client.
+     *
+     * @return last error or {@code null}
+     */
+    public String getLastErrorMessage() {
+        return lastErrorMessage;
+    }
+
+    /**
+     * Return whether the Google Indexation client is enabled.
+     *
+     * @return {@code true} when enabled
+     */
+    public boolean isEnabled() {
+        return config.isEnabled();
+    }
+
+    /**
+     * Return the last success timestamp captured by the client.
+     *
+     * @return last success timestamp or {@code null}
+     */
+    public Instant getLastSuccessAt() {
+        return lastSuccessAt;
+    }
+
+    /**
+     * Report health information for the indexation client.
+     *
+     * @return health status
+     */
+    @Override
+    public Health health() {
+        if (!config.isEnabled()) {
+            return Health.up().withDetail("enabled", false).build();
+        }
+        if (!StringUtils.hasText(config.getServiceAccountJson()) && !StringUtils.hasText(config.getServiceAccountPath())) {
+            return Health.down().withDetail("reason", "Missing service account credentials").build();
+        }
+        Health.Builder builder = lastErrorMessage == null ? Health.up() : Health.down();
+        builder.withDetail("enabled", true);
+        if (lastSuccessAt != null) {
+            builder.withDetail("lastSuccessAt", lastSuccessAt.toString());
+        }
+        if (lastErrorMessage != null) {
+            builder.withDetail("lastError", lastErrorMessage);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Payload type sent to the Indexing API.
+     *
+     * @param url URL to notify
+     * @param type notification type
+     */
+    private record Payload(String url, String type) {
+    }
+
+    /**
+     * Provider used to resolve Google credentials, mainly for testing.
+     */
+    @FunctionalInterface
+    interface CredentialsProvider {
+
+        /**
+         * Return resolved Google credentials.
+         *
+         * @return Google credentials instance
+         */
+        GoogleCredentials get();
+    }
+}

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/exception/GoogleIndexationException.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/exception/GoogleIndexationException.java
@@ -1,0 +1,26 @@
+package org.open4goods.services.googleindexation.service.exception;
+
+/**
+ * Exception raised when the Google Indexing API cannot be invoked.
+ */
+public class GoogleIndexationException extends RuntimeException {
+
+    /**
+     * Create a new exception with a message.
+     *
+     * @param message error message
+     */
+    public GoogleIndexationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create a new exception with a message and cause.
+     *
+     * @param message error message
+     * @param cause root cause
+     */
+    public GoogleIndexationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/services/google-indexation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/google-indexation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,38 @@
+{
+  "properties": [
+    {
+      "name": "google-indexation.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable or disable the Google Indexation client.",
+      "defaultValue": false
+    },
+    {
+      "name": "google-indexation.service-account-json",
+      "type": "java.lang.String",
+      "description": "Raw service account JSON used to authenticate with the Google Indexing API."
+    },
+    {
+      "name": "google-indexation.service-account-path",
+      "type": "java.lang.String",
+      "description": "Filesystem path to the service account JSON used to authenticate with the Google Indexing API."
+    },
+    {
+      "name": "google-indexation.api-url",
+      "type": "java.lang.String",
+      "description": "Google Indexing API endpoint.",
+      "defaultValue": "https://indexing.googleapis.com/v3/urlNotifications:publish"
+    },
+    {
+      "name": "google-indexation.request-timeout",
+      "type": "java.time.Duration",
+      "description": "Timeout applied to Indexing API requests.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "google-indexation.batch-size",
+      "type": "java.lang.Integer",
+      "description": "Default batch size used when publishing multiple URLs.",
+      "defaultValue": 50
+    }
+  ]
+}

--- a/services/google-indexation/src/test/java/org/open4goods/services/googleindexation/service/GoogleIndexationServiceTest.java
+++ b/services/google-indexation/src/test/java/org/open4goods/services/googleindexation/service/GoogleIndexationServiceTest.java
@@ -1,0 +1,85 @@
+package org.open4goods.services.googleindexation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.services.googleindexation.config.GoogleIndexationConfig;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResult;
+import org.open4goods.services.googleindexation.dto.GoogleIndexationResultItem;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Unit tests for {@link GoogleIndexationService}.
+ */
+class GoogleIndexationServiceTest {
+
+    @Test
+    void publishUrlsReturnsEmptyResultWhenDisabled() {
+        GoogleIndexationConfig config = new GoogleIndexationConfig();
+        config.setEnabled(false);
+        GoogleIndexationService service = new GoogleIndexationService(config, new SimpleMeterRegistry(), HttpClient.newHttpClient(),
+                () -> GoogleCredentials.create(new AccessToken("token", Date.from(Instant.now()))));
+
+        GoogleIndexationResult result = service.publishUrls(List.of("https://example.org/product/1"));
+
+        assertThat(result.totalCount()).isZero();
+        assertThat(result.successCount()).isZero();
+    }
+
+    @Test
+    void publishUrlMarksSuccessOn2xxResponse() throws Exception {
+        GoogleIndexationConfig config = new GoogleIndexationConfig();
+        config.setEnabled(true);
+        config.setServiceAccountJson("dummy");
+
+        HttpClient httpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("ok");
+        when(httpClient.send(any(), any())).thenReturn((HttpResponse) response);
+
+        GoogleCredentials credentials = GoogleCredentials.create(new AccessToken("token", Date.from(Instant.now().plusSeconds(3600))));
+        GoogleIndexationService service = new GoogleIndexationService(config, new SimpleMeterRegistry(), httpClient, () -> credentials);
+
+        GoogleIndexationResultItem result = service.publishUrl("https://example.org/product/2");
+
+        assertThat(result.success()).isTrue();
+        assertThat(service.getLastSuccessAt()).isNotNull();
+    }
+
+    @Test
+    void publishUrlMarksFailureOnNon2xxResponse() throws Exception {
+        GoogleIndexationConfig config = new GoogleIndexationConfig();
+        config.setEnabled(true);
+        config.setServiceAccountJson("dummy");
+
+        HttpClient httpClient = mock(HttpClient.class);
+        @SuppressWarnings("unchecked")
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(500);
+        when(response.body()).thenReturn("error");
+        when(httpClient.send(any(), any())).thenReturn((HttpResponse) response);
+
+        GoogleCredentials credentials = GoogleCredentials.create(new AccessToken("token", Date.from(Instant.now().plusSeconds(3600))));
+        GoogleIndexationService service = new GoogleIndexationService(config, new SimpleMeterRegistry(), httpClient, () -> credentials);
+
+        GoogleIndexationResultItem result = service.publishUrl("https://example.org/product/3");
+
+        assertThat(result.success()).isFalse();
+        assertThat(service.getLastErrorMessage()).contains("HTTP 500");
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable client to publish product URLs to the Google Indexing API and a front‑API pipeline to enqueue and dispatch notifications after AI review generation completes.
- Expose queue metrics and health information so operations can monitor indexation activity and failures.

### Description

- Added a new service module `services/google-indexation` implementing `GoogleIndexationService` with `GoogleIndexationConfig`, DTOs (`GoogleIndexationResult`, `GoogleIndexationResultItem`), a health indicator and unit tests for the client behaviour and credential handling.
- Wired the front API: added `front.google-indexation` configuration (`GoogleIndexationProperties`), an in-memory queue (`GoogleIndexationQueueEntry` / `GoogleIndexationQueueRepository`), a queue manager (`GoogleIndexationQueueService`), a dispatch orchestrator (`GoogleIndexationDispatchService`) and a `GoogleIndexationController` exposing `/api/indexation/metrics`.
- Implemented `ProductUrlService` to resolve canonical product URLs used for indexation and updated `ProductController` to trigger dispatch when review generation status is `SUCCESS`.
- Updated parent and `front-api` poms to include the new module and dependency, added `application.yml` config entries and `additional-spring-configuration-metadata.json` entries for the new properties, and documented the integration in `front-api/README.md` and `services/AGENTS.md`.

### Testing

- Ran unit tests for the new client with `mvn -pl services/google-indexation -am test` and all tests passed (3 tests, 0 failures).
- Ran the front API module tests with `mvn -pl front-api -am test` after wiring; the test run completed successfully (76 tests, 0 failures) and the module build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d4af22c60832285eb4d366dd08f38)