### PR TITLE
Update homepage headings and redirect /search to /rechercher

### DIFF
--- a/frontend/app/components/domains/home/hero/The-hero-title.vue
+++ b/frontend/app/components/domains/home/hero/The-hero-title.vue
@@ -6,12 +6,12 @@ const { t } = useI18n()
 
 <template>
   <div class="hero-title-container">
+    <span class="hero-title-eyebrow">
+      {{ t('siteIdentity.hero.mainSubtitle') }}
+    </span>
     <h1 class="hero-title-text">
       {{ t('siteIdentity.hero.mainTitle') }}
     </h1>
-    <h2 class="hero-subtitle-text">
-      {{ t('siteIdentity.hero.mainSubtitle') }}
-    </h2>
     <div class="pt-2">
       <TheSearchBar />
     </div>
@@ -30,14 +30,18 @@ const { t } = useI18n()
   text-align: left
 
 
-.hero-title-text, .hero-subtitle-text
+.hero-title-text
     color: white
+
+.hero-title-eyebrow
+    display: block
+    font-size: 1.125rem
+    font-weight: 600
+    letter-spacing: 0.08em
+    text-transform: uppercase
+    color: rgba(255, 255, 255, 0.82)
 
 .hero-title-text
     font-size: clamp(1.5rem, 6vw, 4rem)
     font-weight: 700
-
-.hero-subtitle-text
-    font-size: 2rem
-    font-weight: 600
 </style>

--- a/frontend/app/components/home/sections/HomeBlogSection.vue
+++ b/frontend/app/components/home/sections/HomeBlogSection.vue
@@ -58,12 +58,12 @@ const resolveCardStyle = (index: number) => {
         style="max-width: 1180px"
         :class="{ 'is-ready': true, 'is-visible': isVisible }"
       >
-        <p
+        <h2
           id="home-blog-title"
           class="home-hero__subtitle home-reveal-item ma-0"
         >
           {{ t('home.blog.title') }}
-        </p>
+        </h2>
         <p class="home-section__subtitle text-center home-reveal-item ma-0">
           {{ t('home.blog.subtitle') }}
         </p>

--- a/frontend/app/components/home/sections/HomeHeroHighlights.vue
+++ b/frontend/app/components/home/sections/HomeHeroHighlights.vue
@@ -57,6 +57,7 @@ const props = withDefaults(
 )
 
 const { t, locale } = useI18n()
+const localePath = useLocalePath()
 
 const shouldRenderLinks = computed(() => props.enableLinks)
 const scrollTargetId = computed(() => props.scrollTargetId?.trim() ?? '')
@@ -102,7 +103,7 @@ const heroHighlightItems = computed<HeroHighlightItem[]>(() => {
         { text: 'Acheter moins pire pour la planète. ' },
         { text: 'évaluation environnementale', to: '/impact-score' },
         { text: ' innovante pour ' },
-        { text: impactProducts, to: '/search' },
+        { text: impactProducts, to: localePath({ name: 'search' }) },
         { text: ' produits dans ' },
         { text: impactCategories, to: '/categories' },
         { text: ' catégories' },
@@ -324,9 +325,9 @@ const resolveAiSummaryStyle = () => {
               <v-icon v-if="item.icon" size="56" color="secondary" class="mb-4">
                 {{ item.icon }}
               </v-icon>
-              <p class="home-hero-highlights__title ma-0 font-weight-bold">
+              <h2 class="home-hero-highlights__title ma-0 font-weight-bold">
                 {{ item.title }}
-              </p>
+              </h2>
               <p class="home-hero-highlights__description ma-0">
                 <template
                   v-for="(segment, segmentIndex) in item.segments"

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -419,18 +419,22 @@ const faqPanels = computed(() =>
   }))
 )
 
-const faqJsonLd = computed(() => ({
-  '@context': 'https://schema.org',
-  '@type': 'FAQPage',
-  mainEntity: faqItems.value.map(item => ({
-    '@type': 'Question',
-    name: item.question,
-    acceptedAnswer: {
-      '@type': 'Answer',
-      text: item.answer,
-    },
-  })),
-}))
+const faqJsonLd = computed(() => {
+  const validItems = faqItems.value.filter(item => item.answer?.trim())
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: validItems.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  }
+})
 
 const canonicalUrl = computed(() =>
   new URL(

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -3343,8 +3343,8 @@
       "defaultCtaText": "Call to Action",
       "defaultSubtitle": "Video demo hero to show a clean integration in a Vue 3 application.",
       "defaultTitle": "Default Title",
-      "mainSubtitle": "Your Free and Independent Shopping Assistant",
-      "mainTitle": "The Comparator That Thinks About Tomorrow"
+      "mainSubtitle": "Buy better without spending more",
+      "mainTitle": "Nudger: The eco-friendly comparator"
     },
     "links": {
       "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -3008,8 +3008,8 @@
       "defaultCtaText": "Appel à l'action",
       "defaultSubtitle": "Démo vidéo hero pour montrer une intégration propre dans une application Vue 3.",
       "defaultTitle": "Titre par défaut",
-      "mainSubtitle": "Ton assistant achat, Libre et Indépendant",
-      "mainTitle": "Le comparateur qui pense à demain"
+      "mainSubtitle": "Acheter Mieux sans dépenser plus",
+      "mainTitle": "Nudger : Le comparateur écologique"
     },
     "links": {
       "linkedin": "https://www.linkedin.com/company/comparateur-nudger/"

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -296,6 +296,7 @@ export default defineNuxtConfig({
     '/offline': { prerender: true },
     '/ecoscore': { redirect: { to: '/impact-score', statusCode: 301 } },
     '/eco-score': { redirect: { to: '/impact-score', statusCode: 301 } },
+    '/search': { redirect: { to: '/rechercher', statusCode: 301 } },
   },
   modules: [
     'vuetify-nuxt-module',


### PR DESCRIPTION
### Motivation
- Improve homepage semantics and SEO by promoting important strings to proper headings and adding an eyebrow line for the hero. 
- Ensure internal links use localized routes and avoid indexing empty FAQ answers in structured data. 
- Provide a consistent user-facing route for search by redirecting the generic `/search` path to the localized `/rechercher`.

### Description
- Reworked hero title markup in `The-hero-title.vue` to use an eyebrow `span` plus an `h1`, removed the old `h2` subtitle and added eyebrow styles. 
- Updated French and English locale strings in `frontend/i18n/locales/fr-FR.json` and `frontend/i18n/locales/en-US.json` to refresh hero copy (`siteIdentity.hero.mainTitle` / `mainSubtitle`).
- Promoted the blog section title and hero highlight item titles from `p` to semantic `h2` in `HomeBlogSection.vue` and `HomeHeroHighlights.vue`. 
- Localized hero highlight search links by adding `useLocalePath()` and using `localePath({ name: 'search' })` for the segment link. 
- Filtered FAQ structured data in `index.vue` by having `faqJsonLd` ignore items with empty answers (`faqItems.value.filter(item => item.answer?.trim())`). 
- Added a route rule redirect in `nuxt.config.ts` to redirect `'/search'` to `'/rechercher'` (`routeRules`).

### Testing
- Ran `pnpm lint` (frontend); it failed due to missing `node_modules` and local ESLint config resolution, producing parsing errors in many files. (failure)
- Ran `pnpm test` (frontend); it failed because `vitest` was not found (missing `node_modules`). (failure)
- Ran `pnpm generate`; it failed because `nuxt` was not found (missing `node_modules`). (failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f1e7992908322b918537248d65aea)