### PR TITLE
Add HOTJAR_MODE (always|query|never) and remove enabled-only gating for Hotjar

### DIFF
--- a/frontend/app/middleware/record.global.ts
+++ b/frontend/app/middleware/record.global.ts
@@ -5,6 +5,15 @@ import {
 } from '~~/shared/utils/hotjar-recording'
 
 export default defineNuxtRouteMiddleware(to => {
+  const runtimeConfig = useRuntimeConfig()
+  const hotjarConfig = runtimeConfig.public.hotjar as
+    | { mode?: 'always' | 'never' | 'query' }
+    | undefined
+
+  if (hotjarConfig?.mode === 'always' || hotjarConfig?.mode === 'never') {
+    return
+  }
+
   if (to.query.record === undefined) {
     return
   }

--- a/frontend/app/plugins/hotjar.client.ts
+++ b/frontend/app/plugins/hotjar.client.ts
@@ -10,6 +10,7 @@ import { isDoNotTrackEnabled } from '~/utils/do-not-track'
 
 type HotjarPublicConfig = {
   enabled: boolean
+  mode?: 'always' | 'never' | 'query'
   siteId: number
   snippetVersion: number
 }
@@ -29,7 +30,11 @@ export default defineNuxtPlugin({
       | HotjarPublicConfig
       | undefined
 
-    if (!hotjarConfig?.enabled) {
+    if (!hotjarConfig) {
+      return
+    }
+
+    if (hotjarConfig.mode === 'never') {
       return
     }
 
@@ -37,15 +42,17 @@ export default defineNuxtPlugin({
       return
     }
 
-    const hotjarCookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME)
+    if (hotjarConfig.mode !== 'always') {
+      const hotjarCookie = useCookie(HOTJAR_RECORDING_COOKIE_NAME)
 
-    if (!isHotjarRecordingCookieEnabled(hotjarCookie.value)) {
-      return
+      if (!isHotjarRecordingCookieEnabled(hotjarCookie.value)) {
+        return
+      }
     }
 
     nuxtApp.vueApp.use(Hotjar as Plugin, {
       id: hotjarConfig.siteId,
-      isProduction: hotjarConfig.enabled,
+      isProduction: hotjarConfig.mode !== 'never',
       snippetVersion: hotjarConfig.snippetVersion,
     })
   },

--- a/frontend/docs/hotjar-recording.md
+++ b/frontend/docs/hotjar-recording.md
@@ -10,9 +10,9 @@ users explicitly land on the homepage with `/?record`.
    - redirects the request to the canonical `/` URL to avoid indexing the query
      string.
 2. On the client, the Hotjar plugin runs only when:
-   - the `hotjar_record` cookie is present,
+   - the `hotjar_record` cookie is present (when mode is `query`),
    - Do Not Track is **not** enabled,
-   - `public.hotjar.enabled` is true and a valid `public.hotjar.siteId` is set.
+   - a valid `public.hotjar.siteId` is set.
 
 If the `record` parameter is absent, no cookie is set and Hotjar is not
 initialized.
@@ -22,6 +22,7 @@ initialized.
 Hotjar is configured via runtime config values exposed to the client:
 
 - `HOTJAR_ENABLED` (defaults to `true` in production, otherwise `false`)
+- `HOTJAR_MODE` (`query`, `always`, or `never`; defaults to `query`)
 - `HOTJAR_SITE_ID` (Hotjar site ID, required to enable recordings)
 - `HOTJAR_SNIPPET_VERSION` (defaults to `6`)
 

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -65,6 +65,10 @@ const HOTJAR_ENABLED =
   process.env.HOTJAR_ENABLED !== undefined
     ? process.env.HOTJAR_ENABLED === 'true'
     : process.env.NODE_ENV === 'production'
+const HOTJAR_MODE_ENV = process.env.HOTJAR_MODE ?? 'query'
+const HOTJAR_MODE = ['always', 'never', 'query'].includes(HOTJAR_MODE_ENV)
+  ? HOTJAR_MODE_ENV
+  : 'query'
 const HOTJAR_SITE_ID = Number(process.env.HOTJAR_SITE_ID ?? 0)
 const HOTJAR_SNIPPET_VERSION = Number(process.env.HOTJAR_SNIPPET_VERSION ?? 6)
 const navigationOfflineFallbackPlugin = {
@@ -527,6 +531,7 @@ export default defineNuxtConfig({
       },
       hotjar: {
         enabled: HOTJAR_ENABLED,
+        mode: HOTJAR_MODE,
         siteId: HOTJAR_SITE_ID,
         snippetVersion: HOTJAR_SNIPPET_VERSION,
       },


### PR DESCRIPTION
### Motivation
- Make Hotjar initialization more flexible by supporting explicit modes (`query`, `always`, `never`) instead of relying on `public.hotjar.enabled` alone.
- Allow server-side opt-in (`/?record`) behavior to coexist with an explicit `always` or `never` mode.
- Simplify client plugin gating so site owners can control behavior via runtime env/config.

### Description
- Add `HOTJAR_MODE` env parsing in `frontend/nuxt.config.ts` and expose `runtimeConfig.public.hotjar.mode` with allowed values `always | never | query` and default `query`.
- Update `frontend/app/plugins/hotjar.client.ts` to remove the `public.hotjar.enabled` gating, add `mode` handling, skip initialization when `mode === 'never'`, always initialize when `mode === 'always'`, and use the recording cookie only for `mode === 'query'`.
- Update `frontend/app/middleware/record.global.ts` to ignore the `record` query param when `mode` is `always` or `never` (only set cookie when `mode === 'query'`).
- Update documentation `frontend/docs/hotjar-recording.md` to document the new `HOTJAR_MODE` option and clarify cookie behavior.
- Extend and adapt tests in `frontend/app/tests/hotjar.client.spec.ts` to cover `query`, `always`, and `never` modes.

### Testing
- Ran unit tests with `pnpm test` (Vitest) and all tests passed: `435 passed` (includes updated Hotjar tests).
- Ran production generation with `pnpm generate` and the site build completed successfully; prerender/generate finished with sitemap warnings about missing locale-specific sitemap entries (non-blocking warnings).
- Ran linter with `pnpm lint` which failed due to `lint-forbidden` reporting forbidden characters already present in repository files (these failures are unrelated to the Hotjar changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f2f7528e0832291531fd64b4677c5)