### PR TITLE
fix(frontend): align hero heading and category links

### DIFF
--- a/frontend/app/components/category/navigation/CategoryNavigationGrid.vue
+++ b/frontend/app/components/category/navigation/CategoryNavigationGrid.vue
@@ -96,8 +96,8 @@
 
               <div class="category-navigation-grid__actions">
                 <NuxtLink
-                  v-if="category.path"
-                  :to="`/categories/${category.path}`"
+                  v-if="normalizedCategoryPath(category.path)"
+                  :to="`/categories/${normalizedCategoryPath(category.path)}`"
                   class="category-navigation-grid__link"
                   :aria-label="
                     t('categories.navigation.grid.openSubcategory', {
@@ -138,6 +138,7 @@
 <script setup lang="ts">
 import type { CategoryNavigationDtoChildCategoriesInner } from '~~/shared/api-client'
 import { useI18n } from 'vue-i18n'
+import { normalizeCategoryPath } from '~/utils/normalizeCategoryPath'
 
 const { categories } = defineProps<{
   categories: CategoryNavigationDtoChildCategoriesInner[]
@@ -149,6 +150,9 @@ const ariaLabel = (title?: string) =>
   t('categories.navigation.grid.cardAriaLabel', {
     category: title ?? '',
   })
+
+const normalizedCategoryPath = (path?: string | null) =>
+  normalizeCategoryPath(path)
 
 const childrenPreview = (category: CategoryNavigationDtoChildCategoriesInner) =>
   (

--- a/frontend/app/components/home/sections/HomeHeroSection.spec.ts
+++ b/frontend/app/components/home/sections/HomeHeroSection.spec.ts
@@ -6,7 +6,7 @@ import HomeHeroSection from './HomeHeroSection.vue'
 import type { EventPackName } from '~~/config/theme/event-packs'
 
 const messages: Record<string, unknown> = {
-  'packs.default.hero.title': "Réconcilier écologie et pouvoir d'achat",
+  'packs.default.hero.title': 'Nudger : Le comparateur écologique',
   'packs.default.hero.titleSubtitle': ['Acheter mieux. Sans dépenser plus.'],
   'packs.default.hero.background': 'hero-background.webp',
 }

--- a/frontend/app/components/home/sections/HomeHeroSection.vue
+++ b/frontend/app/components/home/sections/HomeHeroSection.vue
@@ -250,7 +250,7 @@ useHead({
           >
             <h1
               id="home-hero-title"
-              class=" home-hero__title home-reveal-item"
+              class="home-hero__title home-reveal-item"
               :style="{ '--reveal-delay': '0ms' }"
             >
               {{ heroTitle }}
@@ -262,13 +262,13 @@ useHead({
             >
               {{ animatedSubtitle }}
             </p>
-            <p
+            <span
               v-if="heroTitleSubtitle"
               class="home-hero__title-subtitle home-reveal-item"
               :style="{ '--reveal-delay': '90ms' }"
             >
               {{ heroTitleSubtitle }}
-            </p>
+            </span>
           </v-col>
         </v-row>
         <v-row justify="center" class="mt-0 home-hero__panel-row">
@@ -479,6 +479,7 @@ useHead({
   color: rgba(var(--v-theme-surface-default), 0.94)
   font-size: clamp(1rem, 2.4vw, 1.4rem)
   line-height: 1.4
+  display: block
 
 .home-hero__title-animated-subtitle
   font-size: clamp(0.95rem, 2.2vw, 1.2rem)

--- a/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
+++ b/frontend/app/components/product/impact/ProductImpactDetailsTable.vue
@@ -1,9 +1,9 @@
 <template>
   <article class="impact-details">
     <header class="impact-details__header">
-      <h4 class="impact-details__title">
+      <h3 class="impact-details__title">
         {{ $t('product.impact.detailsTitle') }}
-      </h4>
+      </h3>
       <v-btn
         v-if="hasVirtualScores"
         variant="text"

--- a/frontend/app/pages/categories/[...slug].vue
+++ b/frontend/app/pages/categories/[...slug].vue
@@ -59,6 +59,7 @@ import type { CategoryNavigationDto } from '~~/shared/api-client'
 import CategoryNavigationGrid from '~/components/category/navigation/CategoryNavigationGrid.vue'
 import CategoryNavigationHero from '~/components/category/navigation/CategoryNavigationHero.vue'
 import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
+import { normalizeCategoryPath } from '~/utils/normalizeCategoryPath'
 
 const { t, locale } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
@@ -127,13 +128,17 @@ const heroDescription = computed(() => {
 const breadcrumbs = computed(() => {
   const items = navigationData.value?.breadcrumbs ?? []
   const normalized = items
-    .map((breadcrumb, index) => ({
-      title: breadcrumb.title ?? '',
-      link:
-        index < items.length - 1 && breadcrumb.link
-          ? `/categories/${breadcrumb.link}`
-          : undefined,
-    }))
+    .map((breadcrumb, index) => {
+      const normalizedPath = normalizeCategoryPath(breadcrumb.link)
+
+      return {
+        title: breadcrumb.title ?? '',
+        link:
+          index < items.length - 1 && normalizedPath
+            ? `/categories/${normalizedPath}`
+            : undefined,
+      }
+    })
     .filter(breadcrumb => breadcrumb.title.trim().length)
 
   const trail: { title: string; link?: string }[] = [
@@ -238,14 +243,18 @@ const breadcrumbJsonLd = computed(() => ({
 const itemListJsonLd = computed(() => ({
   '@context': 'https://schema.org',
   '@type': 'ItemList',
-  itemListElement: filteredCategories.value.map((category, index) => ({
-    '@type': 'ListItem',
-    position: index + 1,
-    name: category.title ?? '',
-    url: buildAbsoluteUrl(
-      category.path ? `/categories/${category.path}` : undefined
-    ),
-  })),
+  itemListElement: filteredCategories.value.map((category, index) => {
+    const normalizedPath = normalizeCategoryPath(category.path)
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      name: category.title ?? '',
+      url: buildAbsoluteUrl(
+        normalizedPath ? `/categories/${normalizedPath}` : undefined
+      ),
+    }
+  }),
 }))
 const ogImageUrl = computed(() =>
   new URL('/nudger-icon-512x512.png', requestURL.origin).toString()

--- a/frontend/app/pages/categories/index.vue
+++ b/frontend/app/pages/categories/index.vue
@@ -58,6 +58,7 @@ import type { CategoryNavigationDto } from '~~/shared/api-client'
 import CategoryNavigationGrid from '~/components/category/navigation/CategoryNavigationGrid.vue'
 import CategoryNavigationHero from '~/components/category/navigation/CategoryNavigationHero.vue'
 import CategoryNavigationVerticalHighlights from '~/components/category/navigation/CategoryNavigationVerticalHighlights.vue'
+import { normalizeCategoryPath } from '~/utils/normalizeCategoryPath'
 
 const { t } = useI18n()
 const { translatePlural } = usePluralizedTranslation()
@@ -105,13 +106,17 @@ const heroDescription = computed(
 
 const breadcrumbs = computed(() => {
   const items = navigationData.value?.breadcrumbs ?? []
-  const normalized = items.map((breadcrumb, index) => ({
-    title: breadcrumb.title ?? '',
-    link:
-      index < items.length - 1 && breadcrumb.link
-        ? `/categories/${breadcrumb.link}`
-        : undefined,
-  }))
+  const normalized = items.map((breadcrumb, index) => {
+    const normalizedPath = normalizeCategoryPath(breadcrumb.link)
+
+    return {
+      title: breadcrumb.title ?? '',
+      link:
+        index < items.length - 1 && normalizedPath
+          ? `/categories/${normalizedPath}`
+          : undefined,
+    }
+  })
 
   const trail = [
     {
@@ -205,14 +210,18 @@ const breadcrumbJsonLd = computed(() => ({
 const itemListJsonLd = computed(() => ({
   '@context': 'https://schema.org',
   '@type': 'ItemList',
-  itemListElement: filteredCategories.value.map((category, index) => ({
-    '@type': 'ListItem',
-    position: index + 1,
-    name: category.title ?? '',
-    url: buildAbsoluteUrl(
-      category.path ? `/categories/${category.path}` : undefined
-    ),
-  })),
+  itemListElement: filteredCategories.value.map((category, index) => {
+    const normalizedPath = normalizeCategoryPath(category.path)
+
+    return {
+      '@type': 'ListItem',
+      position: index + 1,
+      name: category.title ?? '',
+      url: buildAbsoluteUrl(
+        normalizedPath ? `/categories/${normalizedPath}` : undefined
+      ),
+    }
+  }),
 }))
 const ogImageUrl = computed(() =>
   new URL('/nudger-icon-512x512.png', requestURL.origin).toString()

--- a/frontend/app/pages/index.spec.ts
+++ b/frontend/app/pages/index.spec.ts
@@ -130,7 +130,7 @@ const messages: Record<string, unknown> = {
     '{formattedCount} partner | {formattedCount} partners',
   'packs.default.hero.search.partnerLinkFallback': 'our partners',
   'packs.default.hero.eyebrow': 'Responsible shopping',
-  'packs.default.hero.title': 'Responsible choices are not a luxury',
+  'packs.default.hero.title': 'Nudger: The eco-friendly comparator',
   'packs.default.hero.subtitles': [
     'Save time, stay true to your values.',
     'Shop smarter without compromise.',
@@ -270,7 +270,7 @@ const messages: Record<string, unknown> = {
     '{formattedCount} partner | {formattedCount} partners',
   'home.hero.search.partnerLinkFallback': 'our partners',
   'home.hero.eyebrow': 'Responsible shopping',
-  'home.hero.title': 'Responsible choices are not a luxury',
+  'home.hero.title': 'Nudger: The eco-friendly comparator',
 
   'home.hero.imageAlt': 'Hero illustration',
   'home.problems.title': 'Too many labels, not enough clarity?',

--- a/frontend/app/utils/normalizeCategoryPath.ts
+++ b/frontend/app/utils/normalizeCategoryPath.ts
@@ -1,0 +1,23 @@
+export const normalizeCategoryPath = (
+  path?: string | null
+): string | null => {
+  if (!path) {
+    return null
+  }
+
+  const trimmed = path.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  let normalized = trimmed.replace(/^\/+/u, '')
+
+  if (normalized.startsWith('categories/')) {
+    normalized = normalized.slice('categories/'.length)
+  }
+
+  normalized = normalized.replace(/^\/+/u, '').replace(/\/+$/u, '')
+
+  return normalized || null
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -295,7 +295,8 @@
     },
     "hero": {
       "eyebrow": "Responsible shopping",
-      "title": "Responsible choices aren't a luxury",
+      "title": "Nudger: The eco-friendly comparator",
+      "animatedSubtitle": "",
       "titleSubtitle": {
         "default": ["Buy better. Spend smarter."],
         "events": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -62,8 +62,8 @@
     },
     "hero": {
       "eyebrow": "Comparateur responsable",
-      "title": "Acheter mieux. Sans dépenser plus.",
-      "animatedSubtitle": "Le comparateur écologique",
+      "title": "Nudger : Le comparateur écologique",
+      "animatedSubtitle": "",
       "titleSubtitle": {
         "default": ["Acheter mieux. Sans dépenser plus."],
         "events": {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -297,7 +297,6 @@ export default defineNuxtConfig({
     '/offline': { prerender: true },
     '/ecoscore': { redirect: { to: '/impact-score', statusCode: 301 } },
     '/eco-score': { redirect: { to: '/impact-score', statusCode: 301 } },
-    '/search': { redirect: { to: '/rechercher', statusCode: 301 } },
   },
   modules: [
     'vuetify-nuxt-module',


### PR DESCRIPTION
### Motivation
- Remove an incorrect 301 redirect from `/search` to `/rechercher` so localized routes render their localized paths instead of being forcibly redirected. 
- Ensure the homepage hero uses the intended SEO H1 and renders subtitle text in the correct element and order. 
- Prevent duplicated `/categories/` segments in category links and JSON-LD by normalizing incoming category paths. 
- Make the product impact details title the correct heading level (H3) per design/SEO note.

### Description
- Removed the `/search` → `/rechercher` redirect rule from `frontend/nuxt.config.ts`. 
- Added `frontend/app/utils/normalizeCategoryPath.ts` and used it in `CategoryNavigationGrid.vue`, `pages/categories/index.vue` and `pages/categories/[...slug].vue` to normalize category `path` values before building links and JSON-LD. 
- Updated homepage hero markup in `HomeHeroSection.vue` to ensure the H1 and subtitle render in the intended order and element (`<h1>` + subtitle `<span>`), adjusted related CSS, and updated localized copy in `frontend/i18n/locales/fr-FR.json` and `frontend/i18n/locales/en-US.json`. 
- Bumped the impact details heading from `<h4>` to `<h3>` in `ProductImpactDetailsTable.vue`. 
- Updated unit/spec expectations to reflect text changes (`HomeHeroSection.spec.ts`, `index.spec.ts`).

### Testing
- Ran lint: `pnpm lint` — passed. 
- Ran unit tests: `pnpm test` (Vitest) — all tests passed (`435` tests passing across the suite). 
- Built static output: `pnpm generate` — generation completed successfully and produced static output; the run reported sitemap warnings about missing `fr-FR` / `en-US` sitemap entries (these are warnings only and unrelated to the functional changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f4c01cdec8322bc72b883a73aa86d)