### PR TITLE
Add product index copy support

### DIFF
--- a/api/src/main/java/org/open4goods/api/config/ApiConfigBeta.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfigBeta.java
@@ -1,6 +1,6 @@
 package org.open4goods.api.config;
 
-import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.BackupConfig;
 import org.open4goods.api.services.AggregationFacadeService;
 import org.open4goods.api.services.backup.BackupService;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -14,15 +14,9 @@ import org.springframework.context.annotation.Profile;
 @Profile({ "beta" })
 public class ApiConfigBeta {
 
-	private ApiProperties apiProperties;
-
-	public ApiConfigBeta(ApiProperties apiProperties) {
-		this.apiProperties = apiProperties;
-	}
-	
 	@Bean
-	BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
-		return new BackupService(xwikiService, productRepository, apiProperties.getBackupConfig(), serialisationService, aggregationService);
+	BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, BackupConfig backupConfig, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
+		return new BackupService(xwikiService, productRepository, backupConfig, serialisationService, aggregationService);
 	}
 
 }

--- a/api/src/main/java/org/open4goods/api/config/ApiConfigDev.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfigDev.java
@@ -1,6 +1,6 @@
 package org.open4goods.api.config;
 
-import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.BackupConfig;
 import org.open4goods.api.services.AggregationFacadeService;
 import org.open4goods.api.services.backup.BackupService;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -14,15 +14,9 @@ import org.springframework.context.annotation.Profile;
 @Profile({ "dev", "devsec" })
 public class ApiConfigDev {
 
-	private ApiProperties apiProperties;
-
-	public ApiConfigDev(ApiProperties apiProperties) {
-		this.apiProperties = apiProperties;
-	}
-
 	@Bean
-	BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
-		return new BackupService(xwikiService, productRepository, apiProperties.getBackupConfig(), serialisationService, aggregationService);
+	BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, BackupConfig backupConfig, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
+		return new BackupService(xwikiService, productRepository, backupConfig, serialisationService, aggregationService);
 	}
 
 }

--- a/api/src/main/java/org/open4goods/api/config/ApiConfigProd.java
+++ b/api/src/main/java/org/open4goods/api/config/ApiConfigProd.java
@@ -1,6 +1,6 @@
 package org.open4goods.api.config;
 
-import org.open4goods.api.config.yml.ApiProperties;
+import org.open4goods.api.config.yml.BackupConfig;
 import org.open4goods.api.services.AggregationFacadeService;
 import org.open4goods.api.services.backup.BackupService;
 import org.open4goods.services.productrepository.services.ProductRepository;
@@ -14,15 +14,9 @@ import org.springframework.context.annotation.Profile;
 @Profile({"prod"})
 public class ApiConfigProd {
 
-	private final ApiProperties apiProperties;
-
-	public ApiConfigProd(ApiProperties apiProperties) {
-		this.apiProperties = apiProperties;
-	}
-	
     @Bean
-    BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
-    	return new BackupService(xwikiService, productRepository, apiProperties.getBackupConfig(), serialisationService, aggregationService);
+    BackupService backupService(XWikiReadService xwikiService, ProductRepository productRepository, BackupConfig backupConfig, SerialisationService serialisationService, AggregationFacadeService aggregationService) {
+    	return new BackupService(xwikiService, productRepository, backupConfig, serialisationService, aggregationService);
     }
 	
 

--- a/api/src/main/java/org/open4goods/api/config/LocalDevConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/LocalDevConfig.java
@@ -100,8 +100,8 @@ public class LocalDevConfig {
 	
 	@Bean
 	@Primary
-	BackupService backupService() {
-		return new BackupService(null, null, new BackupConfig(), null, null);
+	BackupService backupService(BackupConfig backupConfig) {
+		return new BackupService(null, null, backupConfig, null, null);
 	}
 	
 	@Bean

--- a/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/ApiProperties.java
@@ -193,11 +193,6 @@ public class ApiProperties {
 	private long genAiPauseDurationMs = 0L;
 
 	/**
-	 * Options for Wiki backup
-	 */
-	private BackupConfig backupConfig = new BackupConfig();
-
-	/**
 	 * Config for verticals generation service
 	 *
 	 * @return
@@ -483,14 +478,6 @@ public class ApiProperties {
 
 	public void setCorsAllowedHosts(List<String> corsAllowedHosts) {
 		this.corsAllowedHosts = corsAllowedHosts;
-	}
-
-	public BackupConfig getBackupConfig() {
-		return backupConfig;
-	}
-
-	public void setBackupConfig(BackupConfig backupConfig) {
-		this.backupConfig = backupConfig;
 	}
 
 	public long getGenAiPauseDurationMs() {

--- a/api/src/main/java/org/open4goods/api/config/yml/BackupConfig.java
+++ b/api/src/main/java/org/open4goods/api/config/yml/BackupConfig.java
@@ -1,9 +1,13 @@
 package org.open4goods.api.config.yml;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotEmpty;
 
+@Configuration
+@ConfigurationProperties(prefix = "api.backup")
 @Validated
 public class BackupConfig {
 
@@ -40,6 +44,26 @@ public class BackupConfig {
 	 * Number of threads (and of files) to operate export with
 	 */
 	private int productsExportThreads = 4;
+
+	/**
+	 * Page size used while streaming products for copy operations.
+	 */
+	private int copyPageSize = 5000;
+
+	/**
+	 * Bulk size used while indexing products for copy operations.
+	 */
+	private int copyBulkSize = 500;
+
+	/**
+	 * Number of threads used for copy operations.
+	 */
+	private int copyThreads = 4;
+
+	/**
+	 * Queue size for copy operation batches.
+	 */
+	private int copyQueueSize = 50;
 
 
 	/**
@@ -146,6 +170,38 @@ public class BackupConfig {
 
 	public void setProductImportThreads(int productImportThreads) {
 		this.productImportThreads = productImportThreads;
+	}
+
+	public int getCopyPageSize() {
+		return copyPageSize;
+	}
+
+	public void setCopyPageSize(int copyPageSize) {
+		this.copyPageSize = copyPageSize;
+	}
+
+	public int getCopyBulkSize() {
+		return copyBulkSize;
+	}
+
+	public void setCopyBulkSize(int copyBulkSize) {
+		this.copyBulkSize = copyBulkSize;
+	}
+
+	public int getCopyThreads() {
+		return copyThreads;
+	}
+
+	public void setCopyThreads(int copyThreads) {
+		this.copyThreads = copyThreads;
+	}
+
+	public int getCopyQueueSize() {
+		return copyQueueSize;
+	}
+
+	public void setCopyQueueSize(int copyQueueSize) {
+		this.copyQueueSize = copyQueueSize;
 	}
 
 

--- a/api/src/main/java/org/open4goods/api/controller/api/BackupController.java
+++ b/api/src/main/java/org/open4goods/api/controller/api/BackupController.java
@@ -57,6 +57,12 @@ public class BackupController {
 	public void productsImport() throws InvalidParameterException, IOException {
 		backupService.importProducts();
 	}
+
+	@PostMapping("/backup/products/copy-to")
+	@Operation(summary = "Copy products index to a new index suffix")
+	public void copyTo(@RequestParam String suffix) throws InvalidParameterException, IOException {
+		backupService.copyTo(suffix);
+	}
 	
 	
 }

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -2,6 +2,16 @@
 rootFolder: ./
 datasourcesfolder: "./datasources/"
 
+api:
+  backup:
+    xwiki-backup-file: ./backup/xwiki-backup.zip
+    data-backup-folder: ./backup/products
+    import-product-path: ./backup/import
+    copy-page-size: 5000
+    copy-bulk-size: 500
+    copy-threads: 2
+    copy-queue-size: 25
+
 # Port the server will be running on
 server:
   port: 8081

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -23,6 +23,16 @@ spring:
 rootFolder: ./
 datasourcesfolder: "./datasources/"
 
+api:
+  backup:
+    xwiki-backup-file: ./backup/xwiki-backup.zip
+    data-backup-folder: ./backup/products
+    import-product-path: ./backup/import
+    copy-page-size: 5000
+    copy-bulk-size: 500
+    copy-threads: 2
+    copy-queue-size: 25
+
 embedding:
   modelPath: ./models/distilcamembert-base
 
@@ -46,4 +56,3 @@ xwiki:
   baseUrl: http://localhost:8080/xwiki
   password: mock
   username: mock
-

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -20,6 +20,16 @@ logging:
 
 aggregationLogLevel: warn
 
+api:
+  backup:
+    xwiki-backup-file: /opt/open4goods/backup/xwiki-backup.zip
+    data-backup-folder: /opt/open4goods/backup/products
+    import-product-path: /opt/open4goods/backup/import
+    copy-page-size: 5000
+    copy-bulk-size: 500
+    copy-threads: 4
+    copy-queue-size: 50
+
 management:
   health:
     diskspace:


### PR DESCRIPTION
### Motivation
- Provide an administrative REST endpoint to copy the product index into a new index suffix and make copy/export behaviour configurable via dedicated properties under `api.backup`.

### Description
- Add a `POST /backup/products/copy-to` endpoint that calls `BackupService.copyTo(String)` to trigger the index copy.
- Implement `BackupService.copyTo` with a producer/consumer batching pipeline, configurable page/bulk/thread/queue sizes, and copy-specific error tracking (`dataCopyException`) and run flag (`productCopyRunning`).
- Move backup settings out of `ApiProperties` into a dedicated `BackupConfig` annotated with `@ConfigurationProperties(prefix = "api.backup")` and update `ApiConfigDev`, `ApiConfigBeta`, `ApiConfigProd`, and `LocalDevConfig` to inject `BackupConfig`.
- Add repository helpers in `ProductRepository` (`exportAll(int)`, `store(Collection, String)`, `createIndex(String)`) to stream products with configurable page size, bulk-index into a target index, and create a new index using `Product` mapping/settings.
- Add default `api.backup` entries to `application.yml`, `application-local.yml`, and `application-dev.yml` to document and drive the new copy/export settings.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ffb9676cc832294ecf049e0c73181)