### PR TITLE
Add geocode microservice with GeoNames lookup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
         <module>services/contribution</module>
         <module>services/eprel-service</module>
         <module>services/exposed-docs</module>
+        <module>services/geocode</module>
 
 
 

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -419,6 +419,22 @@ Each service has unique responsibilities and may have specific conventions beyon
 
 ---
 
+### geocode
+
+**Purpose**: Offline city geocoding and distance lookup service backed by GeoNames cities5000.txt.
+
+**Key Responsibilities**:
+- Download and cache GeoNames cities5000.zip via `RemoteFileCachingService`
+- Parse and index cities into in-memory lookup maps for fast geocoding
+- Expose REST APIs to resolve city + country and compute distances
+- Provide health status based on successful dataset load
+
+**Configuration**:
+- Requires cache directory for `RemoteFileCachingService`
+- Uses GeoNames download URL `https://download.geonames.org/export/dump/cities5000.zip`
+
+---
+
 ## 6. Common Service Patterns
 
 ### 6.1 Configuration

--- a/services/geocode/README.md
+++ b/services/geocode/README.md
@@ -1,0 +1,81 @@
+# Geocode Service
+
+Offline geocoding microservice backed by the GeoNames `cities5000.txt` dataset.
+The service downloads the GeoNames archive at runtime, caches it using
+`RemoteFileCachingService`, extracts the dataset, and keeps a fully in-memory
+index for fast lookups.
+
+## Dataset download & caching
+
+The GeoNames dataset is fetched from:
+
+```
+https://download.geonames.org/export/dump/cities5000.zip
+```
+
+The download is cached on disk using `RemoteFileCachingService`. The extracted
+`cities5000.txt` file is stored next to the cached zip file and only re-extracted
+when the zip is newer.
+
+Configure caching with:
+
+```yaml
+geocode:
+  cache:
+    path: target/geocode-cache
+  geonames:
+    refresh-in-days: 7
+```
+
+## Running locally
+
+```bash
+mvn --offline -pl services/geocode -am clean install
+mvn --offline -pl services/geocode spring-boot:run
+```
+
+## Endpoints
+
+### Geocode
+
+`GET /v1/geocode?city=Paris&country=FR`
+
+```json
+{
+  "city": "Paris",
+  "country": "FR",
+  "matchedName": "Paris",
+  "geonameId": 2988507,
+  "latitude": 48.8566,
+  "longitude": 2.3522,
+  "population": 2148327,
+  "matchType": "PRIMARY"
+}
+```
+
+### Distance
+
+`GET /v1/distance?fromCity=Paris&fromCountry=FR&toCity=Berlin&toCountry=DE`
+
+```json
+{
+  "from": { "...": "..." },
+  "to": { "...": "..." },
+  "distanceKm": 878.4,
+  "distanceMeters": 878400
+}
+```
+
+### Health
+
+`GET /actuator/health`
+
+The service reports `UP` only when the GeoNames index is loaded and non-empty.
+
+## Testing
+
+Tests use local fixture data and never download the GeoNames dataset:
+
+```bash
+mvn --offline -pl services/geocode test
+```

--- a/services/geocode/pom.xml
+++ b/services/geocode/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.open4goods</groupId>
+    <artifactId>org.open4goods</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>geocode</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>remotefilecaching</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/GeocodeApplication.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/GeocodeApplication.java
@@ -1,0 +1,22 @@
+package org.open4goods.services.geocode;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+/**
+ * Spring Boot entry point for the geocode microservice.
+ */
+@SpringBootApplication(scanBasePackages = "org.open4goods")
+@ConfigurationPropertiesScan("org.open4goods")
+public class GeocodeApplication
+{
+    /**
+     * Application entry point.
+     *
+     * @param args command-line arguments
+     */
+    public static void main(String[] args)
+    {
+        org.springframework.boot.SpringApplication.run(GeocodeApplication.class, args);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/config/GeocodeConfiguration.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/config/GeocodeConfiguration.java
@@ -1,0 +1,28 @@
+package org.open4goods.services.geocode.config;
+
+import org.open4goods.services.geocode.config.yml.GeocodeCacheProperties;
+import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring configuration for geocode service infrastructure beans.
+ */
+@Configuration
+public class GeocodeConfiguration
+{
+    /**
+     * Creates a RemoteFileCachingService for dataset downloads.
+     *
+     * @param cacheProperties cache properties
+     * @param remoteFileCachingProperties remote caching configuration
+     * @return remote file caching service
+     */
+    @Bean
+    public RemoteFileCachingService remoteFileCachingService(GeocodeCacheProperties cacheProperties,
+            RemoteFileCachingProperties remoteFileCachingProperties)
+    {
+        return new RemoteFileCachingService(cacheProperties.getPath(), remoteFileCachingProperties);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/GeoNamesProperties.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/GeoNamesProperties.java
@@ -1,0 +1,74 @@
+package org.open4goods.services.geocode.config.yml;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for loading GeoNames datasets.
+ */
+@ConfigurationProperties(prefix = "geocode.geonames")
+public class GeoNamesProperties
+{
+    private String url = "https://download.geonames.org/export/dump/cities5000.zip";
+    private int refreshInDays = 7;
+    private String extractedFileName = "cities5000.txt";
+
+    /**
+     * Returns the remote GeoNames zip URL.
+     *
+     * @return GeoNames URL
+     */
+    public String getUrl()
+    {
+        return url;
+    }
+
+    /**
+     * Sets the remote GeoNames zip URL.
+     *
+     * @param url GeoNames URL
+     */
+    public void setUrl(String url)
+    {
+        this.url = url;
+    }
+
+    /**
+     * Returns the refresh interval in days for cached downloads.
+     *
+     * @return refresh interval in days
+     */
+    public int getRefreshInDays()
+    {
+        return refreshInDays;
+    }
+
+    /**
+     * Sets the refresh interval in days for cached downloads.
+     *
+     * @param refreshInDays refresh interval in days
+     */
+    public void setRefreshInDays(int refreshInDays)
+    {
+        this.refreshInDays = refreshInDays;
+    }
+
+    /**
+     * Returns the expected extracted file name within the GeoNames archive.
+     *
+     * @return extracted file name
+     */
+    public String getExtractedFileName()
+    {
+        return extractedFileName;
+    }
+
+    /**
+     * Sets the expected extracted file name within the GeoNames archive.
+     *
+     * @param extractedFileName extracted file name
+     */
+    public void setExtractedFileName(String extractedFileName)
+    {
+        this.extractedFileName = extractedFileName;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/GeocodeCacheProperties.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/GeocodeCacheProperties.java
@@ -1,0 +1,32 @@
+package org.open4goods.services.geocode.config.yml;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for local cache storage used by the geocode service.
+ */
+@ConfigurationProperties(prefix = "geocode.cache")
+public class GeocodeCacheProperties
+{
+    private String path = "target/geocode-cache";
+
+    /**
+     * Returns the filesystem path used for cached remote files.
+     *
+     * @return cache path
+     */
+    public String getPath()
+    {
+        return path;
+    }
+
+    /**
+     * Sets the filesystem path used for cached remote files.
+     *
+     * @param path cache path
+     */
+    public void setPath(String path)
+    {
+        this.path = path;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeBadRequestException.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeBadRequestException.java
@@ -1,0 +1,17 @@
+package org.open4goods.services.geocode.controller;
+
+/**
+ * Raised when a geocode request is missing required parameters.
+ */
+public class GeocodeBadRequestException extends RuntimeException
+{
+    /**
+     * Creates a new exception with the given message.
+     *
+     * @param message error message
+     */
+    public GeocodeBadRequestException(String message)
+    {
+        super(message);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeController.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeController.java
@@ -1,0 +1,119 @@
+package org.open4goods.services.geocode.controller;
+
+import org.open4goods.services.geocode.dto.DistanceResponse;
+import org.open4goods.services.geocode.dto.GeocodeResponse;
+import org.open4goods.services.geocode.model.CityMatch;
+import org.open4goods.services.geocode.service.GeocodeService;
+import org.open4goods.services.geocode.util.HaversineUtil;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for geocode lookups and distance calculations.
+ */
+@RestController
+@RequestMapping("/v1")
+public class GeocodeController
+{
+    private final GeocodeService geocodeService;
+
+    /**
+     * Creates a new geocode controller.
+     *
+     * @param geocodeService geocode service
+     */
+    public GeocodeController(GeocodeService geocodeService)
+    {
+        this.geocodeService = geocodeService;
+    }
+
+    /**
+     * Resolves a city and country code to a GeoNames location.
+     *
+     * @param city city name
+     * @param country country ISO-2 code
+     * @return geocode response
+     */
+    @GetMapping("/geocode")
+    public GeocodeResponse geocode(@RequestParam("city") String city, @RequestParam("country") String country)
+    {
+        validateRequired(city, "city");
+        validateRequired(country, "country");
+        CityMatch match = geocodeService.resolve(city, country);
+        if (match == null)
+        {
+            throw new GeocodeNotFoundException("City not found for " + city + ", " + country);
+        }
+        return toResponse(city, country, match);
+    }
+
+    /**
+     * Computes the distance between two resolved cities.
+     *
+     * @param fromCity origin city
+     * @param fromCountry origin country
+     * @param toCity destination city
+     * @param toCountry destination country
+     * @return distance response
+     */
+    @GetMapping("/distance")
+    public DistanceResponse distance(@RequestParam("fromCity") String fromCity, @RequestParam("fromCountry") String fromCountry, @RequestParam("toCity") String toCity, @RequestParam("toCountry") String toCountry)
+    {
+        validateRequired(fromCity, "fromCity");
+        validateRequired(fromCountry, "fromCountry");
+        validateRequired(toCity, "toCity");
+        validateRequired(toCountry, "toCountry");
+
+        CityMatch fromMatch = geocodeService.resolve(fromCity, fromCountry);
+        if (fromMatch == null)
+        {
+            throw new GeocodeNotFoundException("City not found for " + fromCity + ", " + fromCountry);
+        }
+        CityMatch toMatch = geocodeService.resolve(toCity, toCountry);
+        if (toMatch == null)
+        {
+            throw new GeocodeNotFoundException("City not found for " + toCity + ", " + toCountry);
+        }
+
+        double distanceKm = HaversineUtil.distanceKm(
+                fromMatch.record().latitude(),
+                fromMatch.record().longitude(),
+                toMatch.record().latitude(),
+                toMatch.record().longitude());
+        long distanceMeters = HaversineUtil.distanceMeters(
+                fromMatch.record().latitude(),
+                fromMatch.record().longitude(),
+                toMatch.record().latitude(),
+                toMatch.record().longitude());
+
+        return new DistanceResponse(
+                toResponse(fromCity, fromCountry, fromMatch),
+                toResponse(toCity, toCountry, toMatch),
+                distanceKm,
+                distanceMeters);
+    }
+
+    private void validateRequired(String value, String field)
+    {
+        if (!StringUtils.hasText(value))
+        {
+            throw new GeocodeBadRequestException("Missing required parameter: " + field);
+        }
+    }
+
+    private GeocodeResponse toResponse(String requestedCity, String requestedCountry, CityMatch match)
+    {
+        return new GeocodeResponse(
+                requestedCity,
+                requestedCountry,
+                match.record().name(),
+                match.record().geonameId(),
+                match.record().latitude(),
+                match.record().longitude(),
+                match.record().population(),
+                match.matchType());
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeExceptionHandler.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeExceptionHandler.java
@@ -1,0 +1,49 @@
+package org.open4goods.services.geocode.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Maps geocode exceptions to RFC 9457 Problem Detail responses.
+ */
+@RestControllerAdvice
+public class GeocodeExceptionHandler
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeocodeExceptionHandler.class);
+
+    /**
+     * Handles missing parameter errors.
+     *
+     * @param ex exception raised by the controller
+     * @return problem detail response
+     */
+    @ExceptionHandler(GeocodeBadRequestException.class)
+    public ProblemDetail handleBadRequest(GeocodeBadRequestException ex)
+    {
+        LOGGER.warn("Bad geocode request: {}", ex.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        pd.setTitle("Invalid request");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+
+    /**
+     * Handles missing city lookups.
+     *
+     * @param ex exception raised by the service
+     * @return problem detail response
+     */
+    @ExceptionHandler(GeocodeNotFoundException.class)
+    public ProblemDetail handleNotFound(GeocodeNotFoundException ex)
+    {
+        LOGGER.warn("Geocode result not found: {}", ex.getMessage());
+        ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
+        pd.setTitle("City not found");
+        pd.setDetail(ex.getMessage());
+        return pd;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeNotFoundException.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeNotFoundException.java
@@ -1,0 +1,17 @@
+package org.open4goods.services.geocode.controller;
+
+/**
+ * Raised when no geocode result can be found for the requested city.
+ */
+public class GeocodeNotFoundException extends RuntimeException
+{
+    /**
+     * Creates a new exception with the given message.
+     *
+     * @param message error message
+     */
+    public GeocodeNotFoundException(String message)
+    {
+        super(message);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/dto/DistanceResponse.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/dto/DistanceResponse.java
@@ -1,0 +1,17 @@
+package org.open4goods.services.geocode.dto;
+
+/**
+ * Response payload for distance computations.
+ *
+ * @param from origin geocode response
+ * @param to destination geocode response
+ * @param distanceKm distance in kilometers
+ * @param distanceMeters distance in meters
+ */
+public record DistanceResponse(
+        GeocodeResponse from,
+        GeocodeResponse to,
+        double distanceKm,
+        long distanceMeters)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/dto/GeocodeResponse.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/dto/GeocodeResponse.java
@@ -1,0 +1,27 @@
+package org.open4goods.services.geocode.dto;
+
+import org.open4goods.services.geocode.model.MatchType;
+
+/**
+ * Response payload for geocode lookups.
+ *
+ * @param city requested city name
+ * @param country requested country code
+ * @param matchedName canonical GeoNames name
+ * @param geonameId GeoNames identifier
+ * @param latitude latitude in decimal degrees
+ * @param longitude longitude in decimal degrees
+ * @param population population value (may be 0 when unknown)
+ * @param matchType match type used for lookup
+ */
+public record GeocodeResponse(
+        String city,
+        String country,
+        String matchedName,
+        long geonameId,
+        double latitude,
+        double longitude,
+        long population,
+        MatchType matchType)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/health/GeoNamesHealthIndicator.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/health/GeoNamesHealthIndicator.java
@@ -1,0 +1,38 @@
+package org.open4goods.services.geocode.health;
+
+import org.open4goods.services.geocode.service.GeoNamesIndexService;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator reporting whether the GeoNames index is loaded.
+ */
+@Component
+public class GeoNamesHealthIndicator implements HealthIndicator
+{
+    private final GeoNamesIndexService indexService;
+
+    /**
+     * Creates a new health indicator.
+     *
+     * @param indexService index service
+     */
+    public GeoNamesHealthIndicator(GeoNamesIndexService indexService)
+    {
+        this.indexService = indexService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health()
+    {
+        if (indexService.isLoaded())
+        {
+            return Health.up().withDetail("indexLoaded", true).build();
+        }
+        return Health.down().withDetail("indexLoaded", false).build();
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/model/CityMatch.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/model/CityMatch.java
@@ -1,0 +1,11 @@
+package org.open4goods.services.geocode.model;
+
+/**
+ * Represents a geocode match result with its match type.
+ *
+ * @param record resolved city record
+ * @param matchType match type used for lookup
+ */
+public record CityMatch(CityRecord record, MatchType matchType)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/model/CityRecord.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/model/CityRecord.java
@@ -1,0 +1,25 @@
+package org.open4goods.services.geocode.model;
+
+/**
+ * Immutable representation of a GeoNames city entry.
+ *
+ * @param geonameId GeoNames identifier
+ * @param name canonical city name
+ * @param asciiName ASCII-friendly city name
+ * @param countryCode ISO-2 country code
+ * @param latitude latitude in decimal degrees
+ * @param longitude longitude in decimal degrees
+ * @param population population value (may be 0 when unknown)
+ * @param featureClass GeoNames feature class for tie-break logic
+ */
+public record CityRecord(
+        long geonameId,
+        String name,
+        String asciiName,
+        String countryCode,
+        double latitude,
+        double longitude,
+        long population,
+        String featureClass)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/model/MatchType.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/model/MatchType.java
@@ -1,0 +1,20 @@
+package org.open4goods.services.geocode.model;
+
+/**
+ * Describes which name variant produced a geocode match.
+ */
+public enum MatchType
+{
+    /**
+     * Matched on the primary GeoNames name.
+     */
+    PRIMARY,
+    /**
+     * Matched on the ASCII name.
+     */
+    ASCII,
+    /**
+     * Matched on an alternate name.
+     */
+    ALTERNATE
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/CityIndex.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/CityIndex.java
@@ -1,0 +1,59 @@
+package org.open4goods.services.geocode.service;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.open4goods.services.geocode.model.CityMatch;
+
+/**
+ * Immutable in-memory index for geocode lookups.
+ */
+public class CityIndex
+{
+    private final Map<String, CityMatch> cityByKey;
+    private final long recordCount;
+
+    /**
+     * Creates a new city index instance.
+     *
+     * @param cityByKey indexed city matches
+     * @param recordCount number of GeoNames records loaded
+     */
+    public CityIndex(Map<String, CityMatch> cityByKey, long recordCount)
+    {
+        this.cityByKey = Map.copyOf(cityByKey);
+        this.recordCount = recordCount;
+    }
+
+    /**
+     * Finds a city match by lookup key.
+     *
+     * @param key normalized lookup key
+     * @return city match or null when not found
+     */
+    public CityMatch findByKey(String key)
+    {
+        Objects.requireNonNull(key, "key");
+        return cityByKey.get(key);
+    }
+
+    /**
+     * Returns the number of indexed lookup entries.
+     *
+     * @return index size
+     */
+    public int getIndexSize()
+    {
+        return cityByKey.size();
+    }
+
+    /**
+     * Returns the number of GeoNames records loaded into memory.
+     *
+     * @return record count
+     */
+    public long getRecordCount()
+    {
+        return recordCount;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeoNamesIndexService.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeoNamesIndexService.java
@@ -1,0 +1,79 @@
+package org.open4goods.services.geocode.service;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.annotation.PostConstruct;
+
+import org.open4goods.services.geocode.service.geonames.GeoNamesDatasetProvider;
+import org.open4goods.services.geocode.service.geonames.GeoNamesLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Loads the GeoNames dataset into memory during application startup.
+ */
+@Service
+public class GeoNamesIndexService
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoNamesIndexService.class);
+
+    private final GeoNamesDatasetProvider datasetProvider;
+    private final GeoNamesLoader loader;
+    private final AtomicReference<CityIndex> indexRef = new AtomicReference<>();
+
+    /**
+     * Creates a new index service.
+     *
+     * @param datasetProvider dataset provider
+     * @param loader GeoNames loader
+     */
+    public GeoNamesIndexService(GeoNamesDatasetProvider datasetProvider, GeoNamesLoader loader)
+    {
+        this.datasetProvider = datasetProvider;
+        this.loader = loader;
+    }
+
+    /**
+     * Loads the dataset at startup.
+     */
+    @PostConstruct
+    public void initialize()
+    {
+        Path datasetPath = datasetProvider.getDatasetPath();
+        CityIndex index = loader.load(datasetPath);
+        if (index.getIndexSize() == 0)
+        {
+            throw new IllegalStateException("GeoNames index is empty after loading");
+        }
+        indexRef.set(index);
+        LOGGER.info("GeoNames index ready: {} records", index.getRecordCount());
+    }
+
+    /**
+     * Returns the loaded city index.
+     *
+     * @return city index
+     */
+    public CityIndex getIndex()
+    {
+        CityIndex index = indexRef.get();
+        if (index == null)
+        {
+            throw new IllegalStateException("GeoNames index not loaded");
+        }
+        return index;
+    }
+
+    /**
+     * Returns whether the index has been loaded.
+     *
+     * @return true when loaded
+     */
+    public boolean isLoaded()
+    {
+        CityIndex index = indexRef.get();
+        return index != null && index.getIndexSize() > 0;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeocodeService.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeocodeService.java
@@ -1,0 +1,18 @@
+package org.open4goods.services.geocode.service;
+
+import org.open4goods.services.geocode.model.CityMatch;
+
+/**
+ * Service API for geocoding city names.
+ */
+public interface GeocodeService
+{
+    /**
+     * Resolves a city name to a GeoNames record.
+     *
+     * @param city city name
+     * @param countryCode ISO-2 country code
+     * @return city match
+     */
+    CityMatch resolve(String city, String countryCode);
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeocodeServiceImpl.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/GeocodeServiceImpl.java
@@ -1,0 +1,38 @@
+package org.open4goods.services.geocode.service;
+
+import java.util.Locale;
+
+import org.open4goods.services.geocode.model.CityMatch;
+import org.open4goods.services.geocode.util.NormalizationUtil;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default geocode service implementation backed by an in-memory index.
+ */
+@Service
+public class GeocodeServiceImpl implements GeocodeService
+{
+    private final GeoNamesIndexService indexService;
+
+    /**
+     * Creates a new geocode service.
+     *
+     * @param indexService index service
+     */
+    public GeocodeServiceImpl(GeoNamesIndexService indexService)
+    {
+        this.indexService = indexService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CityMatch resolve(String city, String countryCode)
+    {
+        String normalizedCity = NormalizationUtil.normalize(city);
+        String normalizedCountry = countryCode == null ? "" : countryCode.trim().toUpperCase(Locale.ROOT);
+        String key = normalizedCity + "|" + normalizedCountry;
+        return indexService.getIndex().findByKey(key);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesDatasetProvider.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesDatasetProvider.java
@@ -1,0 +1,108 @@
+package org.open4goods.services.geocode.service.geonames;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.open4goods.model.exceptions.InvalidParameterException;
+import org.open4goods.services.geocode.config.yml.GeoNamesProperties;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides the locally cached GeoNames dataset path.
+ */
+@Component
+public class GeoNamesDatasetProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoNamesDatasetProvider.class);
+
+    private final RemoteFileCachingService remoteFileCachingService;
+    private final GeoNamesProperties geoNamesProperties;
+
+    /**
+     * Creates a new dataset provider.
+     *
+     * @param remoteFileCachingService caching service
+     * @param geoNamesProperties GeoNames configuration
+     */
+    public GeoNamesDatasetProvider(RemoteFileCachingService remoteFileCachingService,
+            GeoNamesProperties geoNamesProperties)
+    {
+        this.remoteFileCachingService = remoteFileCachingService;
+        this.geoNamesProperties = geoNamesProperties;
+    }
+
+    /**
+     * Returns the local path to the cached cities5000.txt dataset.
+     *
+     * @return dataset path
+     */
+    public Path getDatasetPath()
+    {
+        try
+        {
+            File zipFile = remoteFileCachingService.getResource(
+                    geoNamesProperties.getUrl(),
+                    geoNamesProperties.getRefreshInDays());
+            Path zipPath = zipFile.toPath();
+            Path extractedPath = zipPath.getParent().resolve(geoNamesProperties.getExtractedFileName());
+
+            if (isExtractionUpToDate(zipPath, extractedPath))
+            {
+                return extractedPath;
+            }
+
+            LOGGER.info("Extracting GeoNames dataset from {} to {}", zipPath, extractedPath);
+            extractFile(zipPath, extractedPath, geoNamesProperties.getExtractedFileName());
+            Files.setLastModifiedTime(extractedPath, Files.getLastModifiedTime(zipPath));
+            return extractedPath;
+        }
+        catch (IOException | InvalidParameterException ex)
+        {
+            throw new IllegalStateException("Failed to prepare GeoNames dataset", ex);
+        }
+    }
+
+    private boolean isExtractionUpToDate(Path zipPath, Path extractedPath) throws IOException
+    {
+        if (Files.exists(extractedPath))
+        {
+            // Avoid re-extracting when the cached text file is newer than the zip.
+            return Files.getLastModifiedTime(extractedPath)
+                    .compareTo(Files.getLastModifiedTime(zipPath)) >= 0;
+        }
+        return false;
+    }
+
+    private void extractFile(Path zipPath, Path extractedPath, String expectedFileName) throws IOException
+    {
+        boolean extracted = false;
+        try (InputStream in = Files.newInputStream(zipPath);
+                ZipInputStream zis = new ZipInputStream(in))
+        {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null)
+            {
+                String entryName = entry.getName();
+                if (entryName.endsWith(expectedFileName))
+                {
+                    Files.copy(zis, extractedPath, StandardCopyOption.REPLACE_EXISTING);
+                    extracted = true;
+                    break;
+                }
+            }
+        }
+        if (!extracted)
+        {
+            throw new IOException("Expected GeoNames entry not found in archive: " + expectedFileName);
+        }
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesLoader.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesLoader.java
@@ -1,0 +1,138 @@
+package org.open4goods.services.geocode.service.geonames;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.open4goods.services.geocode.model.CityMatch;
+import org.open4goods.services.geocode.model.CityRecord;
+import org.open4goods.services.geocode.model.MatchType;
+import org.open4goods.services.geocode.service.CityIndex;
+import org.open4goods.services.geocode.util.NormalizationUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Loads and indexes GeoNames city data into memory.
+ */
+@Component
+public class GeoNamesLoader
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeoNamesLoader.class);
+
+    private final GeoNamesParser parser;
+
+    /**
+     * Creates a new loader with the given parser.
+     *
+     * @param parser GeoNames parser
+     */
+    public GeoNamesLoader(GeoNamesParser parser)
+    {
+        this.parser = parser;
+    }
+
+    /**
+     * Loads and indexes the GeoNames dataset into memory.
+     *
+     * @param datasetPath path to the cities file
+     * @return built city index
+     */
+    public CityIndex load(Path datasetPath)
+    {
+        Objects.requireNonNull(datasetPath, "datasetPath");
+        Instant start = Instant.now();
+        long recordCount = 0L;
+        Map<String, CityMatch> index = new HashMap<>();
+
+        try (BufferedReader reader = Files.newBufferedReader(datasetPath, StandardCharsets.UTF_8))
+        {
+            String line;
+            while ((line = reader.readLine()) != null)
+            {
+                GeoNamesEntry entry = parser.parseLine(line);
+                if (entry == null)
+                {
+                    continue;
+                }
+                recordCount++;
+                CityRecord record = entry.record();
+                String countryCode = record.countryCode().toUpperCase();
+
+                addCandidate(index, record.name(), countryCode, record, MatchType.PRIMARY);
+                if (!record.asciiName().isBlank() && !record.asciiName().equals(record.name()))
+                {
+                    addCandidate(index, record.asciiName(), countryCode, record, MatchType.ASCII);
+                }
+                for (String alternate : entry.alternateNames())
+                {
+                    addCandidate(index, alternate, countryCode, record, MatchType.ALTERNATE);
+                }
+            }
+        }
+        catch (IOException ex)
+        {
+            throw new IllegalStateException("Failed to load GeoNames dataset from " + datasetPath, ex);
+        }
+
+        Duration duration = Duration.between(start, Instant.now());
+        LOGGER.info("Loaded {} GeoNames records into {} lookup keys in {} ms",
+                recordCount, index.size(), duration.toMillis());
+        return new CityIndex(index, recordCount);
+    }
+
+    private void addCandidate(Map<String, CityMatch> index, String cityName, String countryCode,
+            CityRecord record, MatchType matchType)
+    {
+        String normalizedCity = NormalizationUtil.normalize(cityName);
+        if (normalizedCity.isBlank())
+        {
+            return;
+        }
+        // Using a single composite key keeps lookup O(1) while avoiding nested maps.
+        String key = normalizedCity + "|" + countryCode;
+
+        CityMatch existing = index.get(key);
+        CityMatch candidate = new CityMatch(record, matchType);
+        if (existing == null || isBetterCandidate(candidate, existing))
+        {
+            index.put(key, candidate);
+        }
+    }
+
+    private boolean isBetterCandidate(CityMatch candidate, CityMatch existing)
+    {
+        CityRecord candidateRecord = candidate.record();
+        CityRecord existingRecord = existing.record();
+        if (candidateRecord.population() > existingRecord.population())
+        {
+            return true;
+        }
+        if (candidateRecord.population() < existingRecord.population())
+        {
+            return false;
+        }
+        int candidateScore = featureClassScore(candidateRecord.featureClass());
+        int existingScore = featureClassScore(existingRecord.featureClass());
+        if (candidateScore != existingScore)
+        {
+            return candidateScore > existingScore;
+        }
+        // Keep the first encountered entry when all tie-breakers are equal.
+        return false;
+    }
+
+    private int featureClassScore(String featureClass)
+    {
+        // Prefer populated places (feature class "P") when population is equal.
+        return "P".equalsIgnoreCase(featureClass) ? 1 : 0;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesParser.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/geonames/GeoNamesParser.java
@@ -1,0 +1,125 @@
+package org.open4goods.services.geocode.service.geonames;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.open4goods.services.geocode.model.CityRecord;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses GeoNames tab-separated lines into city records.
+ */
+@Component
+public class GeoNamesParser
+{
+    private static final int INDEX_GEONAME_ID = 0;
+    private static final int INDEX_NAME = 1;
+    private static final int INDEX_ASCII_NAME = 2;
+    private static final int INDEX_ALTERNATE_NAMES = 3;
+    private static final int INDEX_LATITUDE = 4;
+    private static final int INDEX_LONGITUDE = 5;
+    private static final int INDEX_FEATURE_CLASS = 6;
+    private static final int INDEX_COUNTRY_CODE = 8;
+    private static final int INDEX_POPULATION = 14;
+
+    /**
+     * Parses a TSV line into a {@link GeoNamesEntry} structure.
+     *
+     * @param line input line
+     * @return parsed entry or null if required fields are missing
+     */
+    public GeoNamesEntry parseLine(String line)
+    {
+        String[] parts = line.split("\t", -1);
+        if (parts.length <= INDEX_COUNTRY_CODE)
+        {
+            return null;
+        }
+        String geonameIdText = get(parts, INDEX_GEONAME_ID);
+        String name = get(parts, INDEX_NAME);
+        String asciiName = get(parts, INDEX_ASCII_NAME);
+        String countryCode = get(parts, INDEX_COUNTRY_CODE);
+        String latitudeText = get(parts, INDEX_LATITUDE);
+        String longitudeText = get(parts, INDEX_LONGITUDE);
+        String featureClass = get(parts, INDEX_FEATURE_CLASS);
+        if (geonameIdText.isEmpty() || name.isEmpty() || countryCode.isEmpty()
+                || latitudeText.isEmpty() || longitudeText.isEmpty())
+        {
+            return null;
+        }
+
+        long geonameId = parseLong(geonameIdText);
+        double latitude = parseDouble(latitudeText);
+        double longitude = parseDouble(longitudeText);
+        long population = parseLong(get(parts, INDEX_POPULATION));
+        List<String> alternates = parseAlternates(get(parts, INDEX_ALTERNATE_NAMES));
+
+        CityRecord record = new CityRecord(
+                geonameId,
+                name,
+                asciiName,
+                countryCode,
+                latitude,
+                longitude,
+                population,
+                featureClass);
+        return new GeoNamesEntry(record, alternates);
+    }
+
+    private String get(String[] parts, int index)
+    {
+        if (index >= parts.length)
+        {
+            return "";
+        }
+        return parts[index];
+    }
+
+    private long parseLong(String value)
+    {
+        if (value == null || value.isBlank())
+        {
+            return 0L;
+        }
+        try
+        {
+            return Long.parseLong(value);
+        }
+        catch (NumberFormatException ex)
+        {
+            return 0L;
+        }
+    }
+
+    private double parseDouble(String value)
+    {
+        if (value == null || value.isBlank())
+        {
+            return 0d;
+        }
+        try
+        {
+            return Double.parseDouble(value);
+        }
+        catch (NumberFormatException ex)
+        {
+            return 0d;
+        }
+    }
+
+    private List<String> parseAlternates(String value)
+    {
+        if (value == null || value.isBlank())
+        {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(","))
+                .filter(entry -> !entry.isBlank())
+                .toList();
+    }
+}
+
+record GeoNamesEntry(CityRecord record, List<String> alternateNames)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/util/HaversineUtil.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/util/HaversineUtil.java
@@ -1,0 +1,55 @@
+package org.open4goods.services.geocode.util;
+
+/**
+ * Utility methods for great-circle distance calculations.
+ */
+public final class HaversineUtil
+{
+    /**
+     * Mean Earth radius in kilometers (WGS-84 mean radius).
+     */
+    public static final double EARTH_RADIUS_KM = 6371.0088d;
+
+    private HaversineUtil()
+    {
+    }
+
+    /**
+     * Computes the distance in kilometers between two coordinates.
+     *
+     * @param lat1 latitude of the first point
+     * @param lon1 longitude of the first point
+     * @param lat2 latitude of the second point
+     * @param lon2 longitude of the second point
+     * @return distance in kilometers
+     */
+    public static double distanceKm(double lat1, double lon1, double lat2, double lon2)
+    {
+        double latRad1 = Math.toRadians(lat1);
+        double latRad2 = Math.toRadians(lat2);
+        double deltaLat = Math.toRadians(lat2 - lat1);
+        double deltaLon = Math.toRadians(lon2 - lon1);
+
+        double sinLat = Math.sin(deltaLat / 2d);
+        double sinLon = Math.sin(deltaLon / 2d);
+
+        double a = sinLat * sinLat
+                + Math.cos(latRad1) * Math.cos(latRad2) * sinLon * sinLon;
+        double c = 2d * Math.atan2(Math.sqrt(a), Math.sqrt(1d - a));
+        return EARTH_RADIUS_KM * c;
+    }
+
+    /**
+     * Computes the distance in meters between two coordinates.
+     *
+     * @param lat1 latitude of the first point
+     * @param lon1 longitude of the first point
+     * @param lat2 latitude of the second point
+     * @param lon2 longitude of the second point
+     * @return distance in meters
+     */
+    public static long distanceMeters(double lat1, double lon1, double lat2, double lon2)
+    {
+        return Math.round(distanceKm(lat1, lon1, lat2, lon2) * 1000d);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/util/NormalizationUtil.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/util/NormalizationUtil.java
@@ -1,0 +1,42 @@
+package org.open4goods.services.geocode.util;
+
+import java.text.Normalizer;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for normalizing input strings for geocoding.
+ */
+public final class NormalizationUtil
+{
+    private static final Pattern COMBINING_MARKS = Pattern.compile("\\p{M}+");
+    private static final Pattern PUNCTUATION = Pattern.compile("[^\\p{IsAlphabetic}\\p{IsDigit}\\s-]");
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+    private NormalizationUtil()
+    {
+    }
+
+    /**
+     * Normalizes a string for case-insensitive matching and stable indexing.
+     *
+     * <p>The normalization lowers case, trims, removes diacritics, replaces punctuation
+     * with spaces (while keeping hyphens), and collapses repeated whitespace. This
+     * ensures consistent keys for GeoNames lookup while preserving common separators.</p>
+     *
+     * @param value input value
+     * @return normalized value, or empty string when input is null
+     */
+    public static String normalize(String value)
+    {
+        if (value == null)
+        {
+            return "";
+        }
+        String trimmed = value.trim().toLowerCase(Locale.ROOT);
+        String decomposed = Normalizer.normalize(trimmed, Normalizer.Form.NFD);
+        String withoutMarks = COMBINING_MARKS.matcher(decomposed).replaceAll("");
+        String withoutPunctuation = PUNCTUATION.matcher(withoutMarks).replaceAll(" ");
+        return WHITESPACE.matcher(withoutPunctuation).replaceAll(" ").trim();
+    }
+}

--- a/services/geocode/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/geocode/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,28 @@
+{
+  "properties": [
+    {
+      "name": "geocode.cache.path",
+      "type": "java.lang.String",
+      "description": "Filesystem path used for cached GeoNames downloads.",
+      "defaultValue": "target/geocode-cache"
+    },
+    {
+      "name": "geocode.geonames.url",
+      "type": "java.lang.String",
+      "description": "GeoNames download URL for the cities5000 dataset.",
+      "defaultValue": "https://download.geonames.org/export/dump/cities5000.zip"
+    },
+    {
+      "name": "geocode.geonames.refresh-in-days",
+      "type": "java.lang.Integer",
+      "description": "Number of days before refreshing the cached GeoNames download.",
+      "defaultValue": 7
+    },
+    {
+      "name": "geocode.geonames.extracted-file-name",
+      "type": "java.lang.String",
+      "description": "Expected filename of the cities dataset inside the GeoNames zip archive.",
+      "defaultValue": "cities5000.txt"
+    }
+  ]
+}

--- a/services/geocode/src/main/resources/application.yml
+++ b/services/geocode/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+geocode:
+  cache:
+    path: ${GEOCODE_CACHE_PATH:target/geocode-cache}
+  geonames:
+    url: ${GEOCODE_GEONAMES_URL:https://download.geonames.org/export/dump/cities5000.zip}
+    refresh-in-days: ${GEOCODE_GEONAMES_REFRESH_DAYS:7}
+    extracted-file-name: cities5000.txt
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/services/geocode/src/test/java/org/open4goods/services/geocode/controller/GeocodeControllerIntegrationTest.java
+++ b/services/geocode/src/test/java/org/open4goods/services/geocode/controller/GeocodeControllerIntegrationTest.java
@@ -1,0 +1,88 @@
+package org.open4goods.services.geocode.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.file.Path;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.open4goods.services.geocode.config.yml.GeoNamesProperties;
+import org.open4goods.services.geocode.service.geonames.GeoNamesDatasetProvider;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Integration tests for the geocode endpoints.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class GeocodeControllerIntegrationTest
+{
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void geocodeReturnsAlternateMatch() throws Exception
+    {
+        mockMvc.perform(get("/v1/geocode")
+                .param("city", "Berlyn")
+                .param("country", "DE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.matchedName").value("Berlin"))
+                .andExpect(jsonPath("$.matchType").value("ALTERNATE"));
+    }
+
+    @Test
+    void geocodePrefersHigherPopulation() throws Exception
+    {
+        mockMvc.perform(get("/v1/geocode")
+                .param("city", "Springfield")
+                .param("country", "US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.geonameId").value(4409896L));
+    }
+
+    @Test
+    void distanceReturnsExpectedRange() throws Exception
+    {
+        mockMvc.perform(get("/v1/distance")
+                .param("fromCity", "Paris")
+                .param("fromCountry", "FR")
+                .param("toCity", "Berlin")
+                .param("toCountry", "DE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.distanceKm", Matchers.greaterThan(850d)))
+                .andExpect(jsonPath("$.distanceKm", Matchers.lessThan(900d)));
+    }
+
+    @TestConfiguration
+    static class TestConfig
+    {
+        @Bean
+        @Primary
+        GeoNamesDatasetProvider geoNamesDatasetProvider() throws Exception
+        {
+            ClassPathResource resource = new ClassPathResource("geonames/cities5000_sample.txt");
+            Path fixturePath = resource.getFile().toPath();
+            RemoteFileCachingService stubCache = new RemoteFileCachingService("target/geocode-test-cache");
+            GeoNamesProperties properties = new GeoNamesProperties();
+            return new GeoNamesDatasetProvider(stubCache, properties)
+            {
+                @Override
+                public Path getDatasetPath()
+                {
+                    return fixturePath;
+                }
+            };
+        }
+    }
+}

--- a/services/geocode/src/test/java/org/open4goods/services/geocode/service/geonames/GeoNamesParserTest.java
+++ b/services/geocode/src/test/java/org/open4goods/services/geocode/service/geonames/GeoNamesParserTest.java
@@ -1,0 +1,35 @@
+package org.open4goods.services.geocode.service.geonames;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link GeoNamesParser}.
+ */
+class GeoNamesParserTest
+{
+    private final GeoNamesParser parser = new GeoNamesParser();
+
+    @Test
+    void parsesValidLine()
+    {
+        String line = "2988507\tParis\tParis\tParis,City of Paris\t48.8566\t2.3522\tP\tPPLC\tFR\t\t11\t75\t\t\t2148327\t35\t35\tEurope/Paris\t2023-01-01";
+
+        GeoNamesEntry entry = parser.parseLine(line);
+
+        assertThat(entry).isNotNull();
+        assertThat(entry.record().name()).isEqualTo("Paris");
+        assertThat(entry.record().countryCode()).isEqualTo("FR");
+        assertThat(entry.record().population()).isEqualTo(2148327L);
+        assertThat(entry.alternateNames()).contains("City of Paris");
+    }
+
+    @Test
+    void skipsLinesWithMissingColumns()
+    {
+        String line = "123\tIncomplete";
+        GeoNamesEntry entry = parser.parseLine(line);
+        assertThat(entry).isNull();
+    }
+}

--- a/services/geocode/src/test/java/org/open4goods/services/geocode/util/HaversineUtilTest.java
+++ b/services/geocode/src/test/java/org/open4goods/services/geocode/util/HaversineUtilTest.java
@@ -1,0 +1,23 @@
+package org.open4goods.services.geocode.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link HaversineUtil}.
+ */
+class HaversineUtilTest
+{
+    @Test
+    void distanceMatchesExpectedRange()
+    {
+        double parisLat = 48.8566;
+        double parisLon = 2.3522;
+        double nycLat = 40.7143;
+        double nycLon = -74.0060;
+
+        double distanceKm = HaversineUtil.distanceKm(parisLat, parisLon, nycLat, nycLon);
+        assertThat(distanceKm).isBetween(5800d, 5900d);
+    }
+}

--- a/services/geocode/src/test/java/org/open4goods/services/geocode/util/NormalizationUtilTest.java
+++ b/services/geocode/src/test/java/org/open4goods/services/geocode/util/NormalizationUtilTest.java
@@ -1,0 +1,25 @@
+package org.open4goods.services.geocode.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link NormalizationUtil}.
+ */
+class NormalizationUtilTest
+{
+    @Test
+    void normalizeRemovesDiacriticsAndPunctuation()
+    {
+        String result = NormalizationUtil.normalize("São-Paulo!!!");
+        assertThat(result).isEqualTo("sao-paulo");
+    }
+
+    @Test
+    void normalizeCollapsesWhitespace()
+    {
+        String result = NormalizationUtil.normalize("  New   York  City ");
+        assertThat(result).isEqualTo("new york city");
+    }
+}

--- a/services/geocode/src/test/resources/geonames/cities5000_sample.txt
+++ b/services/geocode/src/test/resources/geonames/cities5000_sample.txt
@@ -1,0 +1,7 @@
+2988507	Paris	Paris	Paris,City of Paris	48.8566	2.3522	P	PPLC	FR		11	75			2148327	35	35	Europe/Paris	2023-01-01
+4717560	Paris	Paris	Paris,Texas	33.6609	-95.5555	P	PPL	US		TX				25000	0	0	America/Chicago	2023-01-01
+4409896	Springfield	Springfield	Springfield	37.2153	-93.2982	P	PPL	US		MO				167000	0	0	America/Chicago	2023-01-01
+4990729	Springfield	Springfield	Springfield	42.1015	-72.5898	P	PPL	US		MA				150000	0	0	America/New_York	2023-01-01
+2950159	Berlin	Berlin	Berlin,Berlyn	52.5244	13.4105	P	PPLC	DE		16	00			3644826	34	34	Europe/Berlin	2023-01-01
+5128581	New York City	New York City	New York,NYC	40.7143	-74.006	P	PPLC	US		NY				8175133	10	10	America/New_York	2023-01-01
+3448439	São Paulo	Sao Paulo	Sao Paulo,Sampa	-23.5475	-46.6361	P	PPLC	BR		27				10021295	0	0	America/Sao_Paulo	2023-01-01


### PR DESCRIPTION
### Motivation

- Provide an offline geocoding microservice that can resolve city+country and compute distances without external runtime lookups.  
- Integrate with the existing `RemoteFileCachingService` to download/cache/extract the GeoNames `cities5000.zip` dataset.  
- Offer a small, testable module with health reporting and deterministic offline tests for other services to depend on.

### Description

- Added a new Maven module `services/geocode` and registered it in the parent `pom.xml`.  
- Implemented dataset plumbing: `GeoNamesDatasetProvider` (downloads/extracts via `RemoteFileCachingService`), `GeoNamesLoader` (parses/indexes), `GeoNamesParser`, and `CityIndex` to keep an in-memory lookup.  
- Exposed REST API controllers `GeocodeController` (`/v1/geocode`, `/v1/distance`), DTOs, exceptions and `GeocodeExceptionHandler`, plus `GeoNamesHealthIndicator` and `GeoNamesIndexService` to report readiness.  
- Added utilities for normalization and distance: `NormalizationUtil` and `HaversineUtil`, configuration properties and `additional-spring-configuration-metadata.json`, README, and updated `services/AGENTS.md` to document the new service.

### Testing

- Ran `mvn --offline -pl services/geocode -am test` to build dependencies and run the geocode module tests.  
- All automated tests passed; geocode module tests executed successfully (unit + integration), with the test run reporting 8 tests and no failures.  
- The `mvn` run completed with a `BUILD SUCCESS` for the geocode module and its upstream dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69800792bbe88322ad3cd4651fa27bdb)