### PR TITLE
Add MaxMind GeoIP integration and front-api user geolocation endpoint (remove local MMDB fixture)

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>remotefilecaching</artifactId>
       <version>${global.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>geocode</artifactId>
+      <version>${global.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.open4goods</groupId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GeocodeProperties.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/config/properties/GeocodeProperties.java
@@ -1,0 +1,35 @@
+package org.open4goods.nudgerfrontapi.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the geocode service integration.
+ */
+@ConfigurationProperties(prefix = "front.geocode")
+public class GeocodeProperties
+{
+    /**
+     * Base URL for the geocode microservice.
+     */
+    private String baseUrl = "http://localhost:8089";
+
+    /**
+     * Returns the base URL of the geocode service.
+     *
+     * @return base URL
+     */
+    public String getBaseUrl()
+    {
+        return baseUrl;
+    }
+
+    /**
+     * Sets the base URL of the geocode service.
+     *
+     * @param baseUrl base URL
+     */
+    public void setBaseUrl(String baseUrl)
+    {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/UserController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/UserController.java
@@ -1,0 +1,121 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.user.UserGeolocDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.UserGeolocationService;
+import org.open4goods.nudgerfrontapi.utils.IpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * REST controller exposing user-specific endpoints for the frontend.
+ */
+@RestController
+@RequestMapping("/user")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "User", description = "User-specific endpoints for the frontend")
+public class UserController
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserController.class);
+
+    private final UserGeolocationService userGeolocationService;
+
+    /**
+     * Creates a new user controller.
+     *
+     * @param userGeolocationService geolocation service
+     */
+    public UserController(UserGeolocationService userGeolocationService)
+    {
+        this.userGeolocationService = userGeolocationService;
+    }
+
+    /**
+     * Resolve the current user geolocation using the geocode microservice.
+     *
+     * @param domainLanguage language hint used for locale headers
+     * @param ip optional IP override
+     * @param httpRequest HTTP request used to resolve the client IP
+     * @return geolocation response
+     */
+    @GetMapping("/geoloc")
+    @Operation(
+            summary = "Get user geolocation",
+            description = "Resolve the requesting user IP address using the MaxMind GeoIP database.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields (future use).",
+                            schema = @Schema(implementation = DomainLanguage.class)),
+                    @Parameter(name = "ip", in = ParameterIn.QUERY, required = false,
+                            description = "Optional IP address override. Defaults to the client IP.",
+                            schema = @Schema(type = "string", example = "81.2.69.142"))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Geolocation returned",
+                            headers = @Header(name = "X-Locale",
+                                    description = "Resolved locale for textual payloads.",
+                                    schema = @Schema(type = "string", example = "fr-FR")),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = UserGeolocDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Missing or invalid IP parameter"),
+                    @ApiResponse(responseCode = "404", description = "Geolocation not found"),
+                    @ApiResponse(responseCode = "502", description = "Geocode service unavailable")
+            }
+    )
+    public ResponseEntity<UserGeolocDto> geoloc(@RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+                                                @RequestParam(name = "ip", required = false) String ip,
+                                                HttpServletRequest httpRequest)
+    {
+        LOGGER.info("User geolocation requested");
+        String resolvedIp = StringUtils.hasText(ip) ? ip : IpUtils.getIp(httpRequest);
+        if (!StringUtils.hasText(resolvedIp))
+        {
+            LOGGER.warn("User geolocation requested without a resolvable IP");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .build();
+        }
+        UserGeolocDto response;
+        try
+        {
+            response = userGeolocationService.resolve(resolvedIp);
+        }
+        catch (IllegalStateException ex)
+        {
+            LOGGER.error("Geocode service error while resolving user geolocation", ex);
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .build();
+        }
+        if (response == null)
+        {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .header("X-Locale", domainLanguage.languageTag())
+                    .build();
+        }
+        return ResponseEntity.ok()
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(response);
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/user/UserGeolocDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/user/UserGeolocDto.java
@@ -1,0 +1,66 @@
+package org.open4goods.nudgerfrontapi.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO containing enriched geolocation data for the current user.
+ *
+ * @param ip IP address used for resolution
+ * @param continentName continent name
+ * @param continentCode continent ISO code
+ * @param countryName country name
+ * @param countryIsoCode country ISO code
+ * @param registeredCountryName registered country name
+ * @param registeredCountryIsoCode registered country ISO code
+ * @param cityName city name
+ * @param subdivisionName subdivision (region/state) name
+ * @param subdivisionIsoCode subdivision ISO code
+ * @param postalCode postal code
+ * @param latitude latitude coordinate
+ * @param longitude longitude coordinate
+ * @param accuracyRadiusKm accuracy radius in kilometers
+ * @param timeZone time zone identifier
+ * @param metroCode metro code (where available)
+ * @param anonymousProxy whether the IP is flagged as anonymous proxy
+ * @param anycast whether the IP is flagged as anycast
+ */
+@Schema(name = "UserGeoloc", description = "MaxMind GeoIP geolocation data for the requesting user.")
+public record UserGeolocDto(
+        @Schema(description = "Resolved IP address.", example = "81.2.69.142")
+        String ip,
+        @Schema(description = "Continent name.", example = "Europe", nullable = true)
+        String continentName,
+        @Schema(description = "Continent ISO code.", example = "EU", nullable = true)
+        String continentCode,
+        @Schema(description = "Country name.", example = "United Kingdom", nullable = true)
+        String countryName,
+        @Schema(description = "Country ISO code.", example = "GB", nullable = true)
+        String countryIsoCode,
+        @Schema(description = "Registered country name.", example = "United Kingdom", nullable = true)
+        String registeredCountryName,
+        @Schema(description = "Registered country ISO code.", example = "GB", nullable = true)
+        String registeredCountryIsoCode,
+        @Schema(description = "City name.", example = "London", nullable = true)
+        String cityName,
+        @Schema(description = "Subdivision (region/state) name.", example = "England", nullable = true)
+        String subdivisionName,
+        @Schema(description = "Subdivision ISO code.", example = "ENG", nullable = true)
+        String subdivisionIsoCode,
+        @Schema(description = "Postal code.", example = "EC1A", nullable = true)
+        String postalCode,
+        @Schema(description = "Latitude.", example = "51.5142", nullable = true)
+        Double latitude,
+        @Schema(description = "Longitude.", example = "-0.0931", nullable = true)
+        Double longitude,
+        @Schema(description = "Accuracy radius in kilometers.", example = "5", nullable = true)
+        Integer accuracyRadiusKm,
+        @Schema(description = "Timezone identifier.", example = "Europe/London", nullable = true)
+        String timeZone,
+        @Schema(description = "Metro code.", example = "0", nullable = true)
+        Integer metroCode,
+        @Schema(description = "Whether the IP is flagged as anonymous proxy.", example = "false", nullable = true)
+        Boolean anonymousProxy,
+        @Schema(description = "Whether the IP is flagged as anycast.", example = "false", nullable = true)
+        Boolean anycast)
+{
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/UserGeolocationService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/UserGeolocationService.java
@@ -1,0 +1,17 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.dto.user.UserGeolocDto;
+
+/**
+ * Service API for retrieving user geolocation data.
+ */
+public interface UserGeolocationService
+{
+    /**
+     * Resolves geolocation data for the given IP address.
+     *
+     * @param ip IP address
+     * @return geolocation response, or null when the IP cannot be resolved
+     */
+    UserGeolocDto resolve(String ip);
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/UserGeolocationServiceImpl.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/UserGeolocationServiceImpl.java
@@ -1,0 +1,64 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import org.open4goods.nudgerfrontapi.config.properties.GeocodeProperties;
+import org.open4goods.nudgerfrontapi.dto.user.UserGeolocDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Service implementation that delegates user geolocation to the geocode microservice.
+ */
+@Service
+public class UserGeolocationServiceImpl implements UserGeolocationService
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserGeolocationServiceImpl.class);
+
+    private final RestClient restClient;
+
+    /**
+     * Creates a new geolocation service.
+     *
+     * @param restClientBuilder REST client builder
+     * @param geocodeProperties geocode configuration properties
+     */
+    public UserGeolocationServiceImpl(RestClient.Builder restClientBuilder, GeocodeProperties geocodeProperties)
+    {
+        this.restClient = restClientBuilder.baseUrl(geocodeProperties.getBaseUrl()).build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public UserGeolocDto resolve(String ip)
+    {
+        try
+        {
+            return restClient.get()
+                    .uri(uriBuilder -> uriBuilder.path("/v1/geoloc")
+                            .queryParam("ip", ip)
+                            .build())
+                    .retrieve()
+                    .body(UserGeolocDto.class);
+        }
+        catch (RestClientResponseException ex)
+        {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND)
+            {
+                return null;
+            }
+            LOGGER.warn("Unexpected geocode response status {} for user geolocation", ex.getStatusCode());
+            throw new IllegalStateException("Failed to retrieve user geolocation from geocode service", ex);
+        }
+        catch (RestClientException ex)
+        {
+            LOGGER.warn("Unable to call geocode service for user geolocation: {}", ex.getMessage());
+            throw new IllegalStateException("Failed to call geocode service", ex);
+        }
+    }
+}

--- a/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/front-api/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -42,6 +42,12 @@
       "defaultValue": "24h"
     },
     {
+      "name": "front.geocode.base-url",
+      "type": "java.lang.String",
+      "description": "Base URL of the geocode microservice.",
+      "defaultValue": "http://localhost:8089"
+    },
+    {
       "name": "front.search.suggest.semantic-fallback-enabled",
       "type": "java.lang.Boolean",
       "description": "Enable semantic fallback for product suggestions when prefix search yields no results.",

--- a/front-api/src/main/resources/application.yml
+++ b/front-api/src/main/resources/application.yml
@@ -41,6 +41,8 @@ front:
   exposed-docs:
     base-url: ${FRONT_EXPOSED_DOCS_BASE_URL:http://localhost:8086}
     public-access: ${FRONT_EXPOSED_DOCS_PUBLIC_ACCESS:true}
+  geocode:
+    base-url: ${FRONT_GEOCODE_BASE_URL:http://localhost:8089}
 
   affiliation-partners:
     api-base-url: ${FRONT_AFFILIATION_PARTNERS_API_BASE_URL:https://api.open4goods.org}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/UserControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/UserControllerTest.java
@@ -1,0 +1,76 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.open4goods.nudgerfrontapi.dto.user.UserGeolocDto;
+import org.open4goods.nudgerfrontapi.service.UserGeolocationService;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Unit tests for {@link UserController}.
+ */
+class UserControllerTest
+{
+    private MockMvc mockMvc;
+    private UserGeolocationService userGeolocationService;
+
+    @BeforeEach
+    void setUp()
+    {
+        userGeolocationService = ip -> new UserGeolocDto(
+                ip,
+                "Europe",
+                "EU",
+                "United Kingdom",
+                "GB",
+                "United Kingdom",
+                "GB",
+                "London",
+                "England",
+                "ENG",
+                "EC1A",
+                51.5142,
+                -0.0931,
+                5,
+                "Europe/London",
+                0,
+                false,
+                false);
+        mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userGeolocationService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    void shouldReturnGeolocation() throws Exception
+    {
+        mockMvc.perform(get("/user/geoloc")
+                .param("domainLanguage", "fr")
+                .param("ip", "81.2.69.142"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$.countryIsoCode").value("GB"))
+                .andExpect(jsonPath("$.cityName").value("London"));
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenMissing() throws Exception
+    {
+        userGeolocationService = ip -> null;
+        mockMvc = MockMvcBuilders.standaloneSetup(new UserController(userGeolocationService))
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+
+        mockMvc.perform(get("/user/geoloc")
+                .param("domainLanguage", "fr")
+                .param("ip", "203.0.113.1"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/services/geocode/pom.xml
+++ b/services/geocode/pom.xml
@@ -13,6 +13,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.maxmind.geoip2</groupId>
+      <artifactId>geoip2</artifactId>
+      <version>4.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.27.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/MaxMindProperties.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/config/yml/MaxMindProperties.java
@@ -1,0 +1,74 @@
+package org.open4goods.services.geocode.config.yml;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the MaxMind GeoIP dataset.
+ */
+@ConfigurationProperties(prefix = "geocode.maxmind")
+public class MaxMindProperties
+{
+    private String url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz";
+    private int refreshInDays = 7;
+    private String databaseFileName = "GeoLite2-City.mmdb";
+
+    /**
+     * Returns the MaxMind dataset download URL.
+     *
+     * @return download URL
+     */
+    public String getUrl()
+    {
+        return url;
+    }
+
+    /**
+     * Sets the MaxMind dataset download URL.
+     *
+     * @param url download URL
+     */
+    public void setUrl(String url)
+    {
+        this.url = url;
+    }
+
+    /**
+     * Returns the refresh interval in days for cached downloads.
+     *
+     * @return refresh interval in days
+     */
+    public int getRefreshInDays()
+    {
+        return refreshInDays;
+    }
+
+    /**
+     * Sets the refresh interval in days for cached downloads.
+     *
+     * @param refreshInDays refresh interval in days
+     */
+    public void setRefreshInDays(int refreshInDays)
+    {
+        this.refreshInDays = refreshInDays;
+    }
+
+    /**
+     * Returns the expected database filename inside the archive.
+     *
+     * @return database filename
+     */
+    public String getDatabaseFileName()
+    {
+        return databaseFileName;
+    }
+
+    /**
+     * Sets the expected database filename inside the archive.
+     *
+     * @param databaseFileName database filename
+     */
+    public void setDatabaseFileName(String databaseFileName)
+    {
+        this.databaseFileName = databaseFileName;
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeController.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeController.java
@@ -2,8 +2,10 @@ package org.open4goods.services.geocode.controller;
 
 import org.open4goods.services.geocode.dto.DistanceResponse;
 import org.open4goods.services.geocode.dto.GeocodeResponse;
+import org.open4goods.services.geocode.dto.IpGeolocationResponse;
 import org.open4goods.services.geocode.model.CityMatch;
 import org.open4goods.services.geocode.service.GeocodeService;
+import org.open4goods.services.geocode.service.IpGeolocationService;
 import org.open4goods.services.geocode.util.HaversineUtil;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,15 +21,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class GeocodeController
 {
     private final GeocodeService geocodeService;
+    private final IpGeolocationService ipGeolocationService;
 
     /**
      * Creates a new geocode controller.
      *
      * @param geocodeService geocode service
      */
-    public GeocodeController(GeocodeService geocodeService)
+    public GeocodeController(GeocodeService geocodeService, IpGeolocationService ipGeolocationService)
     {
         this.geocodeService = geocodeService;
+        this.ipGeolocationService = ipGeolocationService;
     }
 
     /**
@@ -48,6 +52,24 @@ public class GeocodeController
             throw new GeocodeNotFoundException("City not found for " + city + ", " + country);
         }
         return toResponse(city, country, match);
+    }
+
+    /**
+     * Resolves IP geolocation data using the MaxMind database.
+     *
+     * @param ip IP address to resolve
+     * @return geolocation response
+     */
+    @GetMapping("/geoloc")
+    public IpGeolocationResponse geoloc(@RequestParam("ip") String ip)
+    {
+        validateRequired(ip, "ip");
+        IpGeolocationResponse response = ipGeolocationService.resolve(ip);
+        if (response == null)
+        {
+            throw new GeocodeNotFoundException("IP address not found for " + ip);
+        }
+        return response;
     }
 
     /**

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeExceptionHandler.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/controller/GeocodeExceptionHandler.java
@@ -42,7 +42,7 @@ public class GeocodeExceptionHandler
     {
         LOGGER.warn("Geocode result not found: {}", ex.getMessage());
         ProblemDetail pd = ProblemDetail.forStatus(HttpStatus.NOT_FOUND);
-        pd.setTitle("City not found");
+        pd.setTitle("Geocode result not found");
         pd.setDetail(ex.getMessage());
         return pd;
     }

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/dto/IpGeolocationResponse.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/dto/IpGeolocationResponse.java
@@ -1,0 +1,45 @@
+package org.open4goods.services.geocode.dto;
+
+/**
+ * DTO carrying MaxMind GeoIP lookup information for an IP address.
+ *
+ * @param ip IP address that was resolved
+ * @param continentName continent name
+ * @param continentCode continent ISO code
+ * @param countryName country name
+ * @param countryIsoCode country ISO code
+ * @param registeredCountryName registered country name
+ * @param registeredCountryIsoCode registered country ISO code
+ * @param cityName city name
+ * @param subdivisionName subdivision (region/state) name
+ * @param subdivisionIsoCode subdivision ISO code
+ * @param postalCode postal code
+ * @param latitude latitude coordinate
+ * @param longitude longitude coordinate
+ * @param accuracyRadiusKm accuracy radius in kilometers
+ * @param timeZone time zone identifier
+ * @param metroCode metro code (where available)
+ * @param isAnonymousProxy flag indicating anonymous proxy usage
+ * @param isAnycast flag indicating anycast routing
+ */
+public record IpGeolocationResponse(
+        String ip,
+        String continentName,
+        String continentCode,
+        String countryName,
+        String countryIsoCode,
+        String registeredCountryName,
+        String registeredCountryIsoCode,
+        String cityName,
+        String subdivisionName,
+        String subdivisionIsoCode,
+        String postalCode,
+        Double latitude,
+        Double longitude,
+        Integer accuracyRadiusKm,
+        String timeZone,
+        Integer metroCode,
+        Boolean isAnonymousProxy,
+        Boolean isAnycast)
+{
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/health/MaxMindHealthIndicator.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/health/MaxMindHealthIndicator.java
@@ -1,0 +1,38 @@
+package org.open4goods.services.geocode.health;
+
+import org.open4goods.services.geocode.service.IpGeolocationService;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Health indicator reporting whether the MaxMind database is loaded.
+ */
+@Component
+public class MaxMindHealthIndicator implements HealthIndicator
+{
+    private final IpGeolocationService ipGeolocationService;
+
+    /**
+     * Creates a new health indicator.
+     *
+     * @param ipGeolocationService IP geolocation service
+     */
+    public MaxMindHealthIndicator(IpGeolocationService ipGeolocationService)
+    {
+        this.ipGeolocationService = ipGeolocationService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Health health()
+    {
+        if (ipGeolocationService.isLoaded())
+        {
+            return Health.up().withDetail("databaseLoaded", true).build();
+        }
+        return Health.down().withDetail("databaseLoaded", false).build();
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/IpGeolocationService.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/IpGeolocationService.java
@@ -1,0 +1,24 @@
+package org.open4goods.services.geocode.service;
+
+import org.open4goods.services.geocode.dto.IpGeolocationResponse;
+
+/**
+ * Service API for IP geolocation.
+ */
+public interface IpGeolocationService
+{
+    /**
+     * Resolves an IP address to MaxMind GeoIP information.
+     *
+     * @param ip IP address
+     * @return geolocation response, or null when not found
+     */
+    IpGeolocationResponse resolve(String ip);
+
+    /**
+     * Returns whether the GeoIP database has been loaded.
+     *
+     * @return true when loaded
+     */
+    boolean isLoaded();
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/MaxMindIpGeolocationService.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/MaxMindIpGeolocationService.java
@@ -1,0 +1,211 @@
+package org.open4goods.services.geocode.service;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.open4goods.services.geocode.dto.IpGeolocationResponse;
+import org.open4goods.services.geocode.service.maxmind.GeoIpDatabaseReader;
+import org.open4goods.services.geocode.service.maxmind.GeoIpDatabaseReaderFactory;
+import org.open4goods.services.geocode.service.maxmind.MaxMindDatasetProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.maxmind.geoip2.exception.AddressNotFoundException;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.record.Location;
+import com.maxmind.geoip2.record.Subdivision;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+/**
+ * MaxMind-backed implementation of the IP geolocation service.
+ */
+@Service
+public class MaxMindIpGeolocationService implements IpGeolocationService
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MaxMindIpGeolocationService.class);
+
+    private final MaxMindDatasetProvider datasetProvider;
+    private final GeoIpDatabaseReaderFactory readerFactory;
+    private final AtomicBoolean loaded = new AtomicBoolean(false);
+
+    private GeoIpDatabaseReader reader;
+
+    /**
+     * Creates a new MaxMind geolocation service.
+     *
+     * @param datasetProvider dataset provider
+     * @param readerFactory database reader factory
+     */
+    public MaxMindIpGeolocationService(MaxMindDatasetProvider datasetProvider,
+            GeoIpDatabaseReaderFactory readerFactory)
+    {
+        this.datasetProvider = datasetProvider;
+        this.readerFactory = readerFactory;
+    }
+
+    /**
+     * Loads the GeoIP database on startup.
+     */
+    @PostConstruct
+    public void initialize()
+    {
+        loadDatabase();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public IpGeolocationResponse resolve(String ip)
+    {
+        Objects.requireNonNull(ip, "ip");
+        if (!loaded.get())
+        {
+            loadDatabase();
+        }
+        InetAddress address = parseAddress(ip);
+        if (address == null)
+        {
+            return null;
+        }
+        try
+        {
+            CityResponse response = reader.city(address);
+            return toResponse(ip, response);
+        }
+        catch (AddressNotFoundException ex)
+        {
+            return null;
+        }
+        catch (IOException | GeoIp2Exception ex)
+        {
+            throw new IllegalStateException("Failed to resolve IP geolocation", ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isLoaded()
+    {
+        return loaded.get();
+    }
+
+    /**
+     * Closes the GeoIP database reader.
+     */
+    @PreDestroy
+    public void shutdown()
+    {
+        if (reader != null)
+        {
+            try
+            {
+                reader.close();
+            }
+            catch (IOException ex)
+            {
+                LOGGER.warn("Failed to close GeoIP database reader", ex);
+            }
+        }
+    }
+
+    /**
+     * Loads or reloads the GeoIP database from disk.
+     */
+    private void loadDatabase()
+    {
+        Instant start = Instant.now();
+        try
+        {
+            GeoIpDatabaseReader newReader = readerFactory.create(datasetProvider.getDatabasePath());
+            closeReader();
+            reader = newReader;
+            loaded.set(true);
+            Duration duration = Duration.between(start, Instant.now());
+            LOGGER.info("Loaded MaxMind GeoIP database in {} ms", duration.toMillis());
+        }
+        catch (IOException ex)
+        {
+            loaded.set(false);
+            throw new IllegalStateException("Failed to load MaxMind GeoIP database", ex);
+        }
+    }
+
+    /**
+     * Closes the current reader if present.
+     *
+     * @throws IOException when closing fails
+     */
+    private void closeReader() throws IOException
+    {
+        if (reader != null)
+        {
+            reader.close();
+        }
+    }
+
+    /**
+     * Parses the string IP into an {@link InetAddress}.
+     *
+     * @param ip IP address string
+     * @return parsed address or null when invalid
+     */
+    private InetAddress parseAddress(String ip)
+    {
+        try
+        {
+            return InetAddress.getByName(ip);
+        }
+        catch (UnknownHostException ex)
+        {
+            LOGGER.warn("Invalid IP address provided: {}", ip);
+            return null;
+        }
+    }
+
+    /**
+     * Maps MaxMind responses to the API DTO.
+     *
+     * @param ip IP address
+     * @param response MaxMind response
+     * @return geolocation response DTO
+     */
+    private IpGeolocationResponse toResponse(String ip, CityResponse response)
+    {
+        Location location = response.getLocation();
+        Subdivision subdivision = response.getSubdivisions().isEmpty()
+                ? null
+                : response.getSubdivisions().getFirst();
+        Integer accuracyRadius = location == null ? null : location.getAccuracyRadius();
+        return new IpGeolocationResponse(
+                ip,
+                response.getContinent().getName(),
+                response.getContinent().getCode(),
+                response.getCountry().getName(),
+                response.getCountry().getIsoCode(),
+                response.getRegisteredCountry().getName(),
+                response.getRegisteredCountry().getIsoCode(),
+                response.getCity().getName(),
+                subdivision == null ? null : subdivision.getName(),
+                subdivision == null ? null : subdivision.getIsoCode(),
+                response.getPostal().getCode(),
+                location == null ? null : location.getLatitude(),
+                location == null ? null : location.getLongitude(),
+                accuracyRadius,
+                location == null ? null : location.getTimeZone(),
+                location == null ? null : location.getMetroCode(),
+                response.getTraits().isAnonymousProxy(),
+                response.getTraits().isAnycast());
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/DefaultGeoIpDatabaseReaderFactory.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/DefaultGeoIpDatabaseReaderFactory.java
@@ -1,0 +1,22 @@
+package org.open4goods.services.geocode.service.maxmind;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Default factory creating MaxMind GeoIP readers.
+ */
+@Component
+public class DefaultGeoIpDatabaseReaderFactory implements GeoIpDatabaseReaderFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GeoIpDatabaseReader create(Path databasePath) throws IOException
+    {
+        return new MaxMindGeoIpDatabaseReader(databasePath);
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/GeoIpDatabaseReader.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/GeoIpDatabaseReader.java
@@ -1,0 +1,24 @@
+package org.open4goods.services.geocode.service.maxmind;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+
+/**
+ * Abstraction over the MaxMind GeoIP database reader.
+ */
+public interface GeoIpDatabaseReader extends Closeable
+{
+    /**
+     * Resolves a CityResponse for the given IP address.
+     *
+     * @param address IP address
+     * @return city response
+     * @throws IOException when IO fails
+     * @throws GeoIp2Exception when lookup fails
+     */
+    CityResponse city(InetAddress address) throws IOException, GeoIp2Exception;
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/GeoIpDatabaseReaderFactory.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/GeoIpDatabaseReaderFactory.java
@@ -1,0 +1,20 @@
+package org.open4goods.services.geocode.service.maxmind;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Factory for creating GeoIP database readers.
+ */
+@FunctionalInterface
+public interface GeoIpDatabaseReaderFactory
+{
+    /**
+     * Creates a reader for the given database path.
+     *
+     * @param databasePath path to the database file
+     * @return database reader
+     * @throws IOException when the database cannot be opened
+     */
+    GeoIpDatabaseReader create(Path databasePath) throws IOException;
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/MaxMindDatasetProvider.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/MaxMindDatasetProvider.java
@@ -1,0 +1,129 @@
+package org.open4goods.services.geocode.service.maxmind;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.open4goods.model.exceptions.InvalidParameterException;
+import org.open4goods.services.geocode.config.yml.MaxMindProperties;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides the locally cached MaxMind GeoIP database path.
+ */
+@Component
+public class MaxMindDatasetProvider
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MaxMindDatasetProvider.class);
+
+    private final RemoteFileCachingService remoteFileCachingService;
+    private final MaxMindProperties maxMindProperties;
+
+    /**
+     * Creates a new MaxMind dataset provider.
+     *
+     * @param remoteFileCachingService caching service
+     * @param maxMindProperties MaxMind configuration
+     */
+    public MaxMindDatasetProvider(RemoteFileCachingService remoteFileCachingService,
+            MaxMindProperties maxMindProperties)
+    {
+        this.remoteFileCachingService = remoteFileCachingService;
+        this.maxMindProperties = maxMindProperties;
+    }
+
+    /**
+     * Returns the local path to the cached GeoIP database.
+     *
+     * @return database path
+     */
+    public Path getDatabasePath()
+    {
+        try
+        {
+            File archiveFile = remoteFileCachingService.getResource(
+                    maxMindProperties.getUrl(),
+                    maxMindProperties.getRefreshInDays());
+            Path archivePath = archiveFile.toPath();
+            Path extractedPath = archivePath.getParent().resolve(maxMindProperties.getDatabaseFileName());
+
+            if (isExtractionUpToDate(archivePath, extractedPath))
+            {
+                return extractedPath;
+            }
+
+            LOGGER.info("Extracting MaxMind database from {} to {}", archivePath, extractedPath);
+            extractDatabase(archivePath, extractedPath, maxMindProperties.getDatabaseFileName());
+            Files.setLastModifiedTime(extractedPath, Files.getLastModifiedTime(archivePath));
+            return extractedPath;
+        }
+        catch (IOException | InvalidParameterException ex)
+        {
+            throw new IllegalStateException("Failed to prepare MaxMind dataset", ex);
+        }
+    }
+
+    /**
+     * Checks if the extracted database is newer than the archive.
+     *
+     * @param archivePath archive path
+     * @param extractedPath extracted database path
+     * @return true when extraction is current
+     * @throws IOException when file metadata cannot be read
+     */
+    private boolean isExtractionUpToDate(Path archivePath, Path extractedPath) throws IOException
+    {
+        if (Files.exists(extractedPath))
+        {
+            return Files.getLastModifiedTime(extractedPath)
+                    .compareTo(Files.getLastModifiedTime(archivePath)) >= 0;
+        }
+        return false;
+    }
+
+    /**
+     * Extracts the expected database file from the tar.gz archive.
+     *
+     * @param archivePath archive path
+     * @param extractedPath destination path
+     * @param expectedFileName expected database filename
+     * @throws IOException when extraction fails
+     */
+    private void extractDatabase(Path archivePath, Path extractedPath, String expectedFileName) throws IOException
+    {
+        boolean extracted = false;
+        try (InputStream in = Files.newInputStream(archivePath);
+                GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(in);
+                TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn))
+        {
+            TarArchiveEntry entry;
+            while ((entry = tarIn.getNextTarEntry()) != null)
+            {
+                if (entry.isDirectory())
+                {
+                    continue;
+                }
+                String entryName = entry.getName();
+                if (entryName.endsWith(expectedFileName))
+                {
+                    Files.copy(tarIn, extractedPath, StandardCopyOption.REPLACE_EXISTING);
+                    extracted = true;
+                    break;
+                }
+            }
+        }
+        if (!extracted)
+        {
+            throw new IOException("Expected MaxMind database not found in archive: " + expectedFileName);
+        }
+    }
+}

--- a/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/MaxMindGeoIpDatabaseReader.java
+++ b/services/geocode/src/main/java/org/open4goods/services/geocode/service/maxmind/MaxMindGeoIpDatabaseReader.java
@@ -1,0 +1,49 @@
+package org.open4goods.services.geocode.service.maxmind;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Path;
+
+import com.maxmind.db.CHMCache;
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+
+/**
+ * MaxMind database reader backed by the official GeoIP2 {@link DatabaseReader}.
+ */
+public class MaxMindGeoIpDatabaseReader implements GeoIpDatabaseReader
+{
+    private final DatabaseReader databaseReader;
+
+    /**
+     * Creates a new reader using the given database path.
+     *
+     * @param databasePath path to the MaxMind database
+     * @throws IOException when the database cannot be opened
+     */
+    public MaxMindGeoIpDatabaseReader(Path databasePath) throws IOException
+    {
+        this.databaseReader = new DatabaseReader.Builder(databasePath.toFile())
+                .withCache(new CHMCache())
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CityResponse city(InetAddress address) throws IOException, GeoIp2Exception
+    {
+        return databaseReader.city(address);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException
+    {
+        databaseReader.close();
+    }
+}

--- a/services/geocode/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/services/geocode/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -23,6 +23,24 @@
       "type": "java.lang.String",
       "description": "Expected filename of the cities dataset inside the GeoNames zip archive.",
       "defaultValue": "cities5000.txt"
+    },
+    {
+      "name": "geocode.maxmind.url",
+      "type": "java.lang.String",
+      "description": "MaxMind GeoIP download URL.",
+      "defaultValue": "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz"
+    },
+    {
+      "name": "geocode.maxmind.refresh-in-days",
+      "type": "java.lang.Integer",
+      "description": "Number of days before refreshing the cached MaxMind download.",
+      "defaultValue": 7
+    },
+    {
+      "name": "geocode.maxmind.database-file-name",
+      "type": "java.lang.String",
+      "description": "Expected database filename inside the MaxMind archive.",
+      "defaultValue": "GeoLite2-City.mmdb"
     }
   ]
 }

--- a/services/geocode/src/main/resources/application.yml
+++ b/services/geocode/src/main/resources/application.yml
@@ -5,6 +5,10 @@ geocode:
     url: ${GEOCODE_GEONAMES_URL:https://download.geonames.org/export/dump/cities5000.zip}
     refresh-in-days: ${GEOCODE_GEONAMES_REFRESH_DAYS:7}
     extracted-file-name: cities5000.txt
+  maxmind:
+    url: ${GEOCODE_MAXMIND_URL:https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz}
+    refresh-in-days: ${GEOCODE_MAXMIND_REFRESH_DAYS:7}
+    database-file-name: ${GEOCODE_MAXMIND_DATABASE_NAME:GeoLite2-City.mmdb}
 
 management:
   endpoints:


### PR DESCRIPTION
### Motivation
- Add MaxMind GeoIP support so the geocode service can resolve IPs to continent/country/city/timezone using a cached remote MaxMind archive instead of bundling an MMDB fixture. 
- Surface user geolocation to the frontend API so controllers can obtain geolocation without embedding MaxMind logic. 
- Keep tests deterministic/offline by removing the committed MMDB fixture and stubbing the IP geolocation lookup in tests via the `IpGeolocationService` abstraction.

### Description
- Introduced a MaxMind dataset pipeline: `MaxMindProperties`, `MaxMindDatasetProvider` (uses `RemoteFileCachingService` to fetch and extract the `tar.gz`), a `GeoIpDatabaseReader` abstraction with `MaxMindGeoIpDatabaseReader` and `DefaultGeoIpDatabaseReaderFactory`, and `MaxMindIpGeolocationService` that loads the DB and exposes `resolve(String)` and `isLoaded()`.
- Added `IpGeolocationResponse` DTO, `MaxMindHealthIndicator` (Actuator health based on `isLoaded()`), and wired a new geocode endpoint `GET /v1/geoloc?ip=...` in `GeocodeController` that returns `IpGeolocationResponse` or RFC-9457 style problems.
- Wired the front-api to call the geocode service by adding `GeocodeProperties`, `UserGeolocDto`, `UserGeolocationService` and `UserGeolocationServiceImpl` (REST client), and a new authenticated controller endpoint `GET /user/geoloc` with OpenAPI annotations and `X-Locale` header handling.
- Removed the committed local MMDB test file and updated tests to stub `IpGeolocationService` in `GeocodeControllerIntegrationTest` and added `UserControllerTest` to validate frontend behavior without requiring a local MMDB file; updated docs and configuration metadata (`additional-spring-configuration-metadata.json`, `application.yml`, and `README.md`) to document MaxMind properties and usage.

### Testing
- Attempted to run `mvn --offline -pl services/geocode test`, but the run failed because the `maven-compiler-plugin` (and/or other plugins) were not available in the local offline cache, so an automated test run could not complete in this offline environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69801596fea883228450ed4a581f2892)