### PR TITLE
Fix product hero video stage interactions

### DIFF
--- a/frontend/app/components/product/ProductHeroGallery.vue
+++ b/frontend/app/components/product/ProductHeroGallery.vue
@@ -64,10 +64,17 @@
           >
             <source :src="heroMedia.videoUrl" />
           </video>
-          <div class="product-gallery__video-badge">
+          <button
+            type="button"
+            class="product-gallery__video-badge"
+            :aria-label="$t('product.hero.videoBadge')"
+            @click="playHeroVideo"
+            @keydown.enter.prevent="playHeroVideo"
+            @keydown.space.prevent="playHeroVideo"
+          >
             <v-icon icon="mdi-play-circle-outline" size="24" />
             <span>{{ $t('product.hero.videoBadge') }}</span>
-          </div>
+          </button>
           <div
             class="product-gallery__stage-overlay product-gallery__stage-overlay--inline"
             aria-hidden="true"
@@ -427,6 +434,12 @@ const pauseHeroVideo = () => {
   }
 }
 
+const playHeroVideo = () => {
+  const element = heroVideoElement.value
+  if (!element) return
+  void element.play()
+}
+
 const galleryButtonLabel = computed(() =>
   te('product.hero.openGalleryCta')
     ? t('product.hero.openGalleryCta')
@@ -503,6 +516,10 @@ defineExpose({
   margin-bottom: 2rem; /* Add spacing below image for thumbnails */
 }
 
+.product-gallery__stage--video {
+  background: transparent;
+}
+
 .product-gallery__stage-trigger {
   border: none;
   background: transparent;
@@ -544,6 +561,13 @@ defineExpose({
   color: #fff;
   font-size: 0.9rem;
   font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+
+.product-gallery__video-badge:focus-visible {
+  outline: 2px solid rgba(var(--v-theme-accent-primary-highlight), 0.6);
+  outline-offset: 3px;
 }
 
 .product-gallery__video-gallery-btn {


### PR DESCRIPTION
### Motivation
- Improve accessibility and UX when a product hero media item is a video by making the play badge interactive and ensuring the video stage appears clean.
- Allow keyboard users to start playback using `Enter` or `Space` and provide visible focus styles for the control.

### Description
- Replaced the static video badge `div` with an interactive `button` that has `@click`, `@keydown.enter`, and `@keydown.space` handlers to trigger playback and an accessible `aria-label`.
- Added a `playHeroVideo` function that calls `heroVideoElement.play()` and kept existing `pauseHeroVideo` behavior for pausing/resetting playback.
- Removed the gray wash on video stages by adding `.product-gallery__stage--video { background: transparent; }` and added button styles including `cursor: pointer`, `border: none`, and a `:focus-visible` outline for accessibility.
- Kept gallery-open behavior intact and ensured the video gallery CTA remains available as a separate control.

### Testing
- Ran `pnpm lint` in `frontend` which failed due to missing `node_modules` and unresolved ESLint config in this environment. (failure)
- Ran `pnpm test` in `frontend` which failed because `vitest` was not found due to missing dependencies. (failure)
- Ran `pnpm generate` in `frontend` which failed because `nuxt` was not found due to missing dependencies. (failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980686120e8832bac83f79e95d654ac)