### PR TITLE
Collapse-aware product summary navigation and layout adjustments

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -25,7 +25,11 @@
 
     <v-skeleton-loader v-else-if="pending" type="article" class="mb-6" />
 
-    <div v-else-if="product" class="product-page__layout">
+    <div
+      v-else-if="product"
+      class="product-page__layout"
+      :class="{ 'product-page__layout--nav-collapsed': isNavCollapsed }"
+    >
       <aside
         class="product-page__nav"
         :class="{ 'product-page__nav--mobile': orientation === 'horizontal' }"
@@ -39,6 +43,7 @@
           :orientation="orientation"
           :aria-label="$t('product.navigation.label')"
           @navigate="scrollToSection"
+          @collapse-change="handleNavCollapseChange"
         />
       </aside>
 
@@ -1964,6 +1969,15 @@ const orientation = computed<'vertical' | 'horizontal'>(() =>
   display.mdAndDown.value ? 'horizontal' : 'vertical'
 )
 
+const navCollapsed = ref(false)
+const isNavCollapsed = computed(
+  () => navCollapsed.value && orientation.value === 'vertical'
+)
+
+const handleNavCollapseChange = (collapsed: boolean) => {
+  navCollapsed.value = collapsed
+}
+
 const activeSection = ref<string>(sectionIds.hero)
 
 const observer = ref<IntersectionObserver | null>(null)
@@ -2384,11 +2398,20 @@ useHead(() => {
   gap: 2rem;
 }
 
+.product-page__layout--nav-collapsed {
+  grid-template-columns: minmax(40px, 40px) minmax(0, 1fr);
+  gap: 1rem;
+}
+
 .product-page__nav {
   position: sticky;
   top: 108px; /* 64px header + 44px banner */
   align-self: start;
   height: fit-content;
+}
+
+.product-page__layout--nav-collapsed .product-page__nav {
+  width: 40px;
 }
 
 .product-page__nav--mobile {

--- a/frontend/app/components/product/ProductSummaryNavigation.spec.ts
+++ b/frontend/app/components/product/ProductSummaryNavigation.spec.ts
@@ -98,6 +98,23 @@ describe('ProductSummaryNavigation', () => {
     await wrapper.unmount()
   })
 
+  it('emits collapse-change when toggling collapse state', async () => {
+    const wrapper = await mountComponent()
+
+    const toggle = wrapper.find(
+      'button.product-summary-navigation__collapse-toggle'
+    )
+    await toggle.trigger('click')
+
+    expect(wrapper.emitted('collapse-change')).toBeTruthy()
+    expect(wrapper.emitted('collapse-change')?.[0]).toEqual([true])
+
+    await toggle.trigger('click')
+    expect(wrapper.emitted('collapse-change')?.[1]).toEqual([false])
+
+    await wrapper.unmount()
+  })
+
   it('renders admin panel and reacts to clicks', async () => {
     const adminSections = [
       { id: 'admin-json', label: 'Product JSON', icon: 'mdi-code-json' },

--- a/frontend/app/components/product/ProductSummaryNavigation.vue
+++ b/frontend/app/components/product/ProductSummaryNavigation.vue
@@ -233,12 +233,16 @@ const _props = defineProps({
   },
 })
 
-const emit = defineEmits<{ navigate: [string] }>()
+const emit = defineEmits<{
+  navigate: [string]
+  'collapse-change': [boolean]
+}>()
 
 const isCollapsed = ref(false)
 
 const toggleCollapse = () => {
   isCollapsed.value = !isCollapsed.value
+  emit('collapse-change', isCollapsed.value)
 }
 
 const openSectionId = ref<string | null>(null)


### PR DESCRIPTION
### Motivation
- Allow the product summary navigation to signal when it is collapsed so the page layout can adapt and give more space to content.
- Improve UX on vertical layouts by shrinking the navigation column when users collapse the menu.

### Description
- Emit a `collapse-change` event from `ProductSummaryNavigation.vue` when the collapse toggle is used via the `collapse-change` emit. (`ProductSummaryNavigation.vue`)
- Add a handler and local state in `ProductPage.vue` to track the nav collapsed state and pass it to the layout. (`ProductPage.vue`)
- Update the product page markup and CSS to apply a `product-page__layout--nav-collapsed` modifier that reduces the nav column width and adjusts spacing. (`ProductPage.vue`)
- Add a unit test in `ProductSummaryNavigation.spec.ts` that verifies the `collapse-change` event is emitted when toggling the collapse control. (`ProductSummaryNavigation.spec.ts`)

### Testing
- Ran `pnpm lint` in `frontend`; linting passed. 
- Ran `pnpm test` in `frontend`; test run executed 429 tests with 428 passing and 1 failing test: `ProductAlternatives > fetches alternatives with default filters` failed because the test expected `'/api/products/search'` but the code issued `'/api/products'`. 
- Ran `pnpm generate` (Nuxt generate); build and prerender completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806867bc18832ba756297574db9041)