### PR TITLE
frontend: group category sort options and highlight sorted fields

### DIFF
--- a/frontend/app/components/category/CategoryResultsToolbar.vue
+++ b/frontend/app/components/category/CategoryResultsToolbar.vue
@@ -38,10 +38,13 @@
                 item-title="title"
                 item-value="value"
                 clearable
-                :disabled="sortItems.length === 0"
+                :disabled="!hasSortItems"
                 hide-details
                 density="comfortable"
                 data-testid="results-toolbar-sort-select"
+                :menu-props="{
+                  contentClass: 'category-results-toolbar__sort-menu',
+                }"
                 @update:model-value="emit('update:sortField', $event)"
               />
             </template>
@@ -153,12 +156,23 @@ type SortItem = {
   value: string
 }
 
+type SortGroupItem =
+  | {
+      type: 'subheader'
+      title: string
+    }
+  | {
+      type: 'divider'
+    }
+
+type SortOption = SortItem | SortGroupItem
+
 const props = withDefaults(
   defineProps<{
     isDesktop: boolean
     resultsCount: number
     viewMode: CategoryViewMode
-    sortItems: SortItem[]
+    sortItems: SortOption[]
     sortField: string | null
     sortOrder: 'asc' | 'desc'
     searchTerm: string
@@ -198,6 +212,14 @@ const internalSortOrder = computed({
   get: () => props.sortOrder,
   set: value => emit('update:sortOrder', value),
 })
+
+const availableSortItems = computed(() =>
+  props.sortItems.filter(
+    (item): item is SortItem => 'value' in item && Boolean(item.value)
+  )
+)
+
+const hasSortItems = computed(() => availableSortItems.value.length > 0)
 </script>
 
 <style scoped lang="sass">
@@ -276,4 +298,14 @@ const internalSortOrder = computed({
   .category-results-toolbar__sort-select
     flex: 1 1 auto
     min-width: 130px
+
+:deep(.category-results-toolbar__sort-menu .v-list-subheader)
+  font-size: 0.7rem
+  font-weight: 700
+  letter-spacing: 0.08em
+  text-transform: uppercase
+  color: rgb(var(--v-theme-text-neutral-soft))
+
+:deep(.category-results-toolbar__sort-menu .v-divider)
+  margin: 0.25rem 0
 </style>

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -927,6 +927,14 @@
           "model": "Model",
           "offersCount": "Number of offers",
           "price": "Lowest price"
+        },
+        "groups": {
+          "standard": "Standard",
+          "popularAttributes": "Popular attributes",
+          "otherAttributes": "Other attributes"
+        },
+        "values": {
+          "impactScore": "{score} / {max}"
         }
       },
       "sortLabel": "Sort by",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -809,6 +809,14 @@
           "model": "Modèle",
           "offersCount": "Nombre d'offres",
           "price": "Prix le plus bas"
+        },
+        "groups": {
+          "standard": "Tri standards",
+          "popularAttributes": "Attributs populaires",
+          "otherAttributes": "Autres attributs"
+        },
+        "values": {
+          "impactScore": "{score} / {max}"
         }
       },
       "sortLabel": "Trier par",


### PR DESCRIPTION
### Motivation
- Improve the category results UX by grouping sort options into meaningful sections (standard / popular / other) so users can more easily find relevant sort fields.
- Surface the active sort value on product cards and list rows so the UI communicates why items are ordered the way they are.
- Reuse sort field metadata across list/table/card views to avoid duplicated logic and keep labels consistent.

### Description
- Grouped category sort options into `standard`, `popularAttributes` and `otherAttributes` groups and updated the toolbar to render grouped menu entries and styles (`CategoryResultsToolbar.vue` and `CategoryPage.vue`).
- Introduced a unified resolver `resolveSortedFieldDisplay` (and helpers) in `frontend/app/utils/_sort-attribute-display.ts` to build human-friendly display values for static sorts (impact, price, offers, brand, model) and attribute-based sorts.
- Highlighted active sort fields in UI by marking popular attributes and adding a bold/strong visual (chips / list items) and a dedicated sorted-field display in `ProductCard.vue` and `CategoryProductListView.vue`.
- Added i18n strings for sort groups and impact-score display in `frontend/i18n/locales/en-US.json` and `fr-FR.json` and small styling tweaks for the toolbar menu.

### Testing
- Ran `pnpm lint` in `frontend` and the lint checks passed (including `lint-forbidden`).
- Ran `pnpm test` (Vitest): 428 tests executed, 427 passed and 1 failed; the failing case is `app/components/product/impact/ProductAlternatives.spec.ts` which asserts the endpoint `/api/products/search` but the implementation used `/api/products` (investigation required).
- Ran `pnpm generate` (Nuxt build): generation completed successfully but emitted sitemap configuration warnings for some locales. The static build artifacts were produced.
- Started the dev server (`pnpm dev`) and captured a screenshot of the search page toolbar to validate the grouped sort UI (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806a06aca4832b9a78a1baa5185201)