### PR TITLE
Use compact ProductPriceRows inside sticky price banner

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -3,12 +3,8 @@
     <ClientOnly>
       <ProductStickyPriceBanner
         :open="isStickyBannerOpen"
-        :new-price-label="bannerNewPriceLabel"
-        :new-price-link="bannerNewPriceLink"
-        :used-price-label="bannerUsedPriceLabel"
-        :used-price-link="bannerUsedPriceLink"
+        :product="product ?? undefined"
         :offers-count-label="bannerOffersCountLabel"
-        @offers-click="scrollToSection(sectionIds.price)"
         @scroll-to-offers="scrollToSection(sectionIds.price)"
       />
     </ClientOnly>
@@ -204,7 +200,6 @@ import type {
   ProductReferenceDto,
   ProductScoreDto,
   ProductSearchResponseDto,
-  ProductAggregatedPriceDto,
 } from '~~/shared/api-client'
 import { AggTypeEnum } from '~~/shared/api-client/models/Agg'
 import { normalizeTimestamp } from '~/utils/date-parsing'
@@ -262,7 +257,7 @@ const ProductVigilanceSection = defineAsyncComponent(
 const route = useRoute()
 const requestURL = useRequestURL()
 const runtimeConfig = useRuntimeConfig()
-const { t, n, locale } = useI18n()
+const { t, locale } = useI18n()
 const { isLoggedIn } = useAuth()
 const display = useDisplay()
 const { y: scrollY } = useWindowScroll()
@@ -287,41 +282,6 @@ const PRODUCT_COMPONENTS = [
 
 const impactSectionRef = ref<HTMLElement | null>(null)
 const { top: _impactSectionTop } = useElementBounding(impactSectionRef)
-
-const bannerNewPriceLabel = computed(() => {
-  const offer = product.value?.offers?.bestNewOffer
-  if (!offer?.price) return undefined
-  return n(offer.price, {
-    style: 'currency',
-    currency: offer.currency ?? 'EUR',
-    maximumFractionDigits: 2,
-  })
-})
-
-const bannerUsedPriceLabel = computed(() => {
-  const offer = product.value?.offers?.bestOccasionOffer
-  if (!offer?.price) return undefined
-  return n(offer.price, {
-    style: 'currency',
-    currency: offer.currency ?? 'EUR',
-    maximumFractionDigits: 2,
-  })
-})
-
-const resolveOfferLink = (
-  offer: ProductAggregatedPriceDto | null | undefined
-) => {
-  if (!offer) return undefined
-  if (offer.affiliationToken) return `/contrib/${offer.affiliationToken}`
-  return offer.url ?? undefined
-}
-
-const bannerNewPriceLink = computed(() =>
-  resolveOfferLink(product.value?.offers?.bestNewOffer)
-)
-const bannerUsedPriceLink = computed(() =>
-  resolveOfferLink(product.value?.offers?.bestOccasionOffer)
-)
 
 const bannerOffersCountLabel = computed(() => {
   const count = product.value?.offers?.offersCount ?? 0

--- a/frontend/app/components/product/ProductPriceRows.vue
+++ b/frontend/app/components/product/ProductPriceRows.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="product-price-rows">
+  <div
+    class="product-price-rows"
+    :class="{ 'product-price-rows--compact': variant === 'compact' }"
+  >
     <template v-for="badge in offerBadges" :key="badge.key">
       <div
         class="product-price-rows__row"
@@ -136,6 +139,7 @@ import { formatBestPrice } from '~/utils/_product-pricing'
 
 const props = defineProps<{
   product: ProductDto
+  variant?: 'default' | 'compact'
 }>()
 
 const { t, n } = useI18n()
@@ -456,4 +460,23 @@ const offerBadges = computed<Badge[]>(() => {
 
   &__menu-list
      min-width: 200px
+
+.product-price-rows--compact
+  border-radius: 6px
+
+  .product-price-rows__row
+    min-height: 20px
+    padding: 0.1rem 0.35rem
+    gap: 0.3rem
+
+  .product-price-rows__label
+    font-size: 0.55rem
+    width: 3.25rem
+
+  .product-price-rows__amount
+    font-size: 0.9rem
+
+  .product-price-rows__favicon
+    width: 14px
+    height: 14px
 </style>

--- a/frontend/app/components/product/ProductStickyPriceBanner.vue
+++ b/frontend/app/components/product/ProductStickyPriceBanner.vue
@@ -32,32 +32,11 @@
 
         <div class="product-sticky-banner__right">
           <div class="product-sticky-banner__prices">
-            <v-btn
-              v-if="newPriceLabel"
-              color="primary"
-              variant="elevated"
-              size="small"
-              class="product-sticky-banner__price-btn"
-              :href="newPriceLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              @click="$emit('offer-click', 'new')"
-            >
-              {{ newPriceLabel }}
-            </v-btn>
-            <v-btn
-              v-if="usedPriceLabel"
-              color="secondary"
-              variant="elevated"
-              size="small"
-              class="product-sticky-banner__price-btn"
-              :href="usedPriceLink"
-              target="_blank"
-              rel="noopener noreferrer"
-              @click="$emit('offer-click', 'used')"
-            >
-              {{ usedPriceLabel }}
-            </v-btn>
+            <ProductPriceRows
+              v-if="product"
+              :product="product"
+              variant="compact"
+            />
           </div>
 
           <v-btn
@@ -77,6 +56,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import type { ProductDto } from '~~/shared/api-client'
 
 const { t } = useI18n()
 
@@ -86,29 +66,22 @@ withDefaults(
     color?: string
     elevation?: string | number
     ariaLabel?: string
-    newPriceLabel?: string
-    newPriceLink?: string
-    usedPriceLabel?: string
-    usedPriceLink?: string
     offersCountLabel?: string
     partnersLink?: string
+    product?: ProductDto
   }>(),
   {
     open: false,
     color: undefined,
     elevation: 8,
     ariaLabel: undefined,
-    newPriceLabel: undefined,
-    newPriceLink: undefined,
-    usedPriceLabel: undefined,
-    usedPriceLink: undefined,
     offersCountLabel: undefined,
     partnersLink: '/partners',
+    product: undefined,
   }
 )
 
 defineEmits<{
-  'offer-click': [type: 'new' | 'used']
   'scroll-to-offers': []
 }>()
 </script>
@@ -183,13 +156,6 @@ defineEmits<{
 .product-sticky-banner__prices {
   display: flex;
   gap: 0.5rem;
-}
-
-.product-sticky-banner__price-btn {
-  font-weight: 600;
-  text-transform: none;
-  min-width: 80px;
-  height: 28px !important;
 }
 
 .product-sticky-banner__count-btn {


### PR DESCRIPTION
### Motivation
- Replace duplicated sticky-banner price buttons with the shared `ProductPriceRows` component to unify price UI and reuse formatting/URL logic.
- Provide a compact visual variant so the rows fit tightly inside the sticky banner without altering the full-size row layout.

### Description
- `ProductPriceRows.vue`: added a `variant?: 'default' | 'compact'` prop and CSS for `.product-price-rows--compact`, and toggle the compact class on the root element when requested.
- `ProductStickyPriceBanner.vue`: replaced individual price buttons with `<ProductPriceRows variant="compact" />`, removed the explicit new/used price props and related click emit, and added an optional `product?: ProductDto` prop to feed data into the rows.
- `ProductPage.vue`: pass the loaded `product` into the sticky banner, removed banner-specific price/link computed properties and unused imports, and simplified the `useI18n` destructuring to avoid `n` usage where it was removed.

### Testing
- Ran `pnpm lint` in the frontend module and it passed without issues.
- Ran `pnpm test` (Vitest); 428 tests ran with 427 passing and 1 failing test: `app/components/product/impact/ProductAlternatives.spec.ts` failed because it expected a call to `/api/products/search` but the code made a request to `/api/products` (test failure unrelated to the banner change but surfaced during the run).
- Ran `pnpm generate` and the site build completed successfully although the sitemap generation emitted warnings about missing localized sitemap entries (non-blocking).
- Attempted to capture a runtime screenshot via Playwright of the sticky banner, but the navigation timed out in this environment and no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69806ae1f254832b8bf75362d9d0300b)