### PR TITLE
Replace condition SVGs with mdi icons and use theme tokens

### DIFF
--- a/frontend/app/components/category/filters/CategoryFilterCondition.vue
+++ b/frontend/app/components/category/filters/CategoryFilterCondition.vue
@@ -150,6 +150,8 @@ const onCheckboxChange = (key: string, checked: boolean) => {
     align-items: center
     justify-content: center
     flex-shrink: 0
+    font-size: 24px
+    line-height: 1
 
   &__label
     display: flex

--- a/frontend/app/components/nudge-tool/NudgeConditionNewIcon.vue
+++ b/frontend/app/components/nudge-tool/NudgeConditionNewIcon.vue
@@ -1,62 +1,13 @@
 <template>
-  <svg
-    viewBox="0 0 160 120"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    class="nudge-condition-icon"
-  >
-    <!-- Background glow/shape -->
-    <path
-      d="M80 110C118.66 110 150 87.6142 150 60C150 32.3858 118.66 10 80 10C41.3401 10 10 32.3858 10 60C10 87.6142 41.3401 110 80 110Z"
-      fill="currentColor"
-      fill-opacity="0.05"
-    />
-
-    <!-- Box shape -->
-    <rect
-      x="50"
-      y="40"
-      width="60"
-      height="50"
-      rx="4"
-      stroke="currentColor"
-      stroke-width="3"
-      fill="none"
-    />
-    <!-- Box lid/flaps -->
-    <path
-      d="M50 40 L80 25 L110 40"
-      stroke="currentColor"
-      stroke-width="3"
-      stroke-linejoin="round"
-      fill="none"
-    />
-    <path
-      d="M80 40 L80 90"
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-dasharray="4 4"
-      opacity="0.5"
-    />
-
-    <!-- Sparkles -->
-    <path
-      d="M125 30 L128 38 L136 39 L129 44 L130 52 L123 47 L116 52 L117 44 L110 39 L118 38 Z"
-      fill="currentColor"
-    />
-    <path
-      d="M35 80 L37 84 L41 84.5 L37.5 87 L38 91 L35 88.5 L32 91 L32.5 87 L29 84.5 L33 84 Z"
-      fill="currentColor"
-      opacity="0.6"
-    />
-  </svg>
+  <span class="nudge-condition-icon mdi mdi-tag" aria-hidden="true" />
 </template>
 
 <style scoped>
 .nudge-condition-icon {
   width: 100%;
   height: auto;
-  color: rgb(var(--v-theme-brand-primary));
+  font-size: 1em;
+  color: rgb(var(--v-theme-primary));
   max-width: 100%;
   max-height: 100%;
 }

--- a/frontend/app/components/nudge-tool/NudgeConditionUsedIcon.vue
+++ b/frontend/app/components/nudge-tool/NudgeConditionUsedIcon.vue
@@ -1,60 +1,13 @@
 <template>
-  <svg
-    viewBox="0 0 160 120"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    class="nudge-condition-icon"
-  >
-    <!-- Background glow -->
-    <path
-      d="M80 110C118.66 110 150 87.6142 150 60C150 32.3858 118.66 10 80 10C41.3401 10 10 32.3858 10 60C10 87.6142 41.3401 110 80 110Z"
-      fill="currentColor"
-      fill-opacity="0.05"
-    />
-
-    <!-- Circular Arrows (Recycle Metaphor) -->
-    <path
-      d="M80 35 C 60 35 45 50 45 70"
-      stroke="currentColor"
-      stroke-width="5"
-      stroke-linecap="round"
-      fill="none"
-    />
-    <path
-      d="M40 65 L 45 70 L 55 62"
-      stroke="currentColor"
-      stroke-width="5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      fill="none"
-    />
-
-    <path
-      d="M80 85 C 100 85 115 70 115 50"
-      stroke="currentColor"
-      stroke-width="5"
-      stroke-linecap="round"
-      fill="none"
-    />
-    <path
-      d="M120 55 L 115 50 L 105 58"
-      stroke="currentColor"
-      stroke-width="5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      fill="none"
-    />
-
-    <!-- Center Icon/Dot -->
-    <circle cx="80" cy="60" r="8" fill="currentColor" opacity="0.8" />
-  </svg>
+  <span class="nudge-condition-icon mdi mdi-recycle" aria-hidden="true" />
 </template>
 
 <style scoped>
 .nudge-condition-icon {
   width: 100%;
   height: auto;
-  color: rgb(var(--v-theme-brand-primary-alt));
+  font-size: 1em;
+  color: rgb(var(--v-theme-accent-supporting));
   max-width: 100%;
   max-height: 100%;
 }

--- a/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
+++ b/frontend/app/components/nudge-tool/NudgeToolStepCondition.vue
@@ -168,6 +168,8 @@ const toggleOption = (choice: ProductConditionChoice) => {
     &__illustration {
       max-width: 160px;
       max-height: 120px;
+      font-size: 72px;
+      line-height: 1;
       transition: transform 200ms ease;
     }
 


### PR DESCRIPTION
### Motivation
- Replace bespoke SVGs for product condition visuals with the same Material Design Icons used in product cards to ensure consistent visuals across the app. 
- Use existing Vuetify theme tokens instead of undefined custom CSS vars so icons and hover states render with the brand palette. 

### Description
- Replaced the custom SVG components `NudgeConditionNewIcon.vue` and `NudgeConditionUsedIcon.vue` with mdi icon markup (`mdi-tag` / `mdi-recycle`) and applied theme token colors (`--v-theme-primary` / `--v-theme-accent-supporting`). 
- Switched icon output to plain markup (span with `mdi` classes) to avoid relying on `v-icon` runtime defaults during tests. 
- Adjusted sizing/spacing to match the new icon approach by updating `NudgeToolStepCondition.vue` (illustration sizing) and `CategoryFilterCondition.vue` (icon font-size and line-height). 
- Kept color usage consistent by switching to `rgb(var(--v-theme-primary))` and `rgb(var(--v-theme-accent-supporting))` where appropriate. 

### Testing
- Ran `pnpm lint` and the linting step passed successfully. 
- Ran component/unit tests with `pnpm test` (Vitest); the suite largely passed but there are 2 failing tests in `app/components/product/ProductLifeTimeline.spec.ts` (errors: `Cannot read properties of undefined (reading 'PriceFirstSeenNew')`). 
- Ran `pnpm generate` (Nuxt build) which failed due to a missing export error: `ProductPage.vue` imports `AggTypeEnum` from `shared/api-client/index.ts` but that symbol is not exported, causing the build to abort.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803751172883228a71a0894aba4453)