### PR TITLE
Add homepage WebPage and breadcrumb JSON-LD

### DIFF
--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -732,6 +732,37 @@ const seoDescription = computed(() =>
 
 const seoImageAlt = computed(() => String(t('home.seo.imageAlt')))
 
+const webPageJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  name: seoTitle.value,
+  description: seoDescription.value,
+  url: canonicalUrl.value,
+  inLanguage: locale.value,
+  isPartOf: {
+    '@type': 'WebSite',
+    name: siteName.value,
+    url: canonicalUrl.value,
+  },
+  primaryImageOfPage: {
+    '@type': 'ImageObject',
+    url: ogImageUrl.value,
+  },
+}))
+
+const breadcrumbJsonLd = computed(() => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: String(t('navigation.home')),
+      item: canonicalUrl.value,
+    },
+  ],
+}))
+
 useSeoMeta({
   title: () => seoTitle.value,
   description: () => seoDescription.value,
@@ -765,6 +796,16 @@ useHead(() => ({
       key: 'home-website-jsonld',
       type: 'application/ld+json',
       children: JSON.stringify(websiteJsonLd.value),
+    },
+    {
+      key: 'home-webpage-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(webPageJsonLd.value),
+    },
+    {
+      key: 'home-breadcrumb-jsonld',
+      type: 'application/ld+json',
+      children: JSON.stringify(breadcrumbJsonLd.value),
     },
   ],
 }))


### PR DESCRIPTION
### Motivation
- Improve structured data on the homepage by adding a `WebPage` schema and a minimal `BreadcrumbList` to complement existing `Organization`/`WebSite` JSON-LD for better SEO and richer search results.

### Description
- Add `webPageJsonLd` and `breadcrumbJsonLd` computed objects to `frontend/app/pages/index.vue` and populate them from existing computed values (`seoTitle`, `seoDescription`, `canonicalUrl`, `locale`, `siteName`, `ogImageUrl`).
- Inject both JSON-LD blocks into the page head via `useHead()` alongside the existing FAQ/Organization/WebSite scripts so they are rendered as `application/ld+json`.
- Keep all fields internationalised and derived from existing i18n/computed values to remain consistent with current metadata generation.

### Testing
- Ran `pnpm lint --offline` and the linting/forbidden checks passed.
- Ran `pnpm test` (re-ran without `--offline` because `vitest` does not accept that flag) and all tests passed (`121 files, 435 tests passed`).
- Ran `pnpm generate --offline` and the Nuxt generate/build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698282e82e3883228b58ebbded78e279)