### PR TITLE
Frontend: add 1-hour TTL to IP quota cache and invalidate hook

### DIFF
--- a/frontend/app/components/product/ProductAiReviewSection.vue
+++ b/frontend/app/components/product/ProductAiReviewSection.vue
@@ -703,7 +703,8 @@ const props = defineProps({
 const { locale, t, n } = useI18n()
 const theme = useTheme()
 const { isLoggedIn } = useAuth()
-const { getRemaining, refreshQuota, recordUsage } = useIpQuota()
+const { getRemaining, invalidateQuota, refreshQuota, recordUsage } =
+  useIpQuota()
 
 const review = ref<ReviewContent | null>(normalizeReview(props.initialReview))
 const createdMs = ref<number | null>(props.reviewCreatedAt ?? null)
@@ -1107,6 +1108,7 @@ const triggerGeneration = async (force: boolean = false) => {
 
     isDialogOpen.value = false
     recordUsage(quotaCategory)
+    await invalidateQuota(quotaCategory)
   } catch (error) {
     errorMessage.value =
       error instanceof Error

--- a/frontend/app/pages/feedback/index.vue
+++ b/frontend/app/pages/feedback/index.vue
@@ -323,7 +323,7 @@ const loadIssuesForCategory = async (category: FeedbackCategory) => {
   }
 }
 
-const { getRemaining, recordUsage, refreshQuota } = useIpQuota()
+const { getRemaining, invalidateQuota, recordUsage, refreshQuota } = useIpQuota()
 const feedbackQuotaCategory: IpQuotaCategory = IpQuotaCategory.FeedbackVote
 
 const loadFeedbackQuota = async () => {
@@ -450,6 +450,7 @@ const handleVote = async (
     }
 
     recordUsage(feedbackQuotaCategory, 1)
+    await invalidateQuota(feedbackQuotaCategory)
 
     await loadIssuesForCategory(category)
 

--- a/frontend/docs/ip-quota.md
+++ b/frontend/docs/ip-quota.md
@@ -6,7 +6,7 @@ to use the generic quota composable.
 ## Storage details
 
 The composable persists the last known quota status in **localStorage** only.
-No cookies are written.
+No cookies are written. Cached entries are considered fresh for 1 hour.
 
 - **Key**: `nudger-ip-quota-v1`
 - **Value**: JSON object keyed by category
@@ -34,7 +34,7 @@ The API currently exposes:
 ## Usage
 
 ```ts
-const { refreshQuota, getRemaining, getUsed } = useIpQuota()
+const { invalidateQuota, refreshQuota, getRemaining, getUsed } = useIpQuota()
 
 await refreshQuota(IpQuotaStatusDtoCategoryEnum.FeedbackVote)
 const remaining = getRemaining(IpQuotaStatusDtoCategoryEnum.FeedbackVote)
@@ -44,3 +44,7 @@ const used = getUsed(IpQuotaStatusDtoCategoryEnum.FeedbackVote)
 The composable intentionally keeps read APIs (`getUsed`, `getRemaining`,
 `getLimit`) separate from the fetch logic (`refreshQuota`) so components can
 control when to sync with the backend.
+
+Use `invalidateQuota` after successful actions (feedback votes, AI review
+generation) to force a refresh and keep the cached count aligned with the
+backend.


### PR DESCRIPTION
### Motivation

- Reduce repeated backend calls for IP-based quota lookups by caching the last-known quota in the frontend for a short freshness window (1 hour).  
- Ensure the frontend view stays consistent after mutating actions by forcing a refresh only when an action that affects the quota succeeds (e.g. feedback vote, AI review generation).  
- Keep the change scoped to the frontend layer and provide a simple API for components to control cache invalidation.

### Description

- Added a `DEFAULT_TTL_MS = 60 * 60 * 1000` constant and made `refreshQuota` accept an `options: { force?: boolean }` parameter to allow skipping the cache when needed, returning cached data when `lastSync` is within the TTL.  
- Introduced `invalidateQuota(category)` which calls `refreshQuota(category, { force: true })` to force a backend sync.  
- Updated `feedback/index.vue` and `ProductAiReviewSection.vue` to call `invalidateQuota(...)` after successful feedback votes and AI review generation respectively, and retained `recordUsage(...)` updates to the local cache.  
- Documented the behavior in `frontend/docs/ip-quota.md`, including the 1-hour freshness window, storage key (`nudger-ip-quota-v1`), and guidance to call `invalidateQuota` after successful actions.

### Testing

- No automated tests were executed as part of this change.  
- Manual code changes were committed and compiled locally (no automated test runs reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828daf68608322a45eb11998b42585)