### PR TITLE
feat(frontend): add blog JSON-LD graph for org + breadcrumbs

### DIFF
--- a/frontend/app/components/domains/blog/TheArticle.spec.ts
+++ b/frontend/app/components/domains/blog/TheArticle.spec.ts
@@ -15,6 +15,11 @@ vi.mock('#imports', () => {
   }
 })
 
+vi.mock('#i18n', () => ({
+  useLocalePath: () => (input: unknown) =>
+    typeof input === 'string' ? input : '/',
+}))
+
 vi.mock('~/components/shared/images/RobustImage.vue', () => ({
   default: {
     name: 'RobustImageStub',
@@ -45,6 +50,14 @@ vi.mock('vue-i18n', () => ({
           return 'The content of this article will be available soon.'
         case 'blog.article.edit':
           return 'Edit this article'
+        case 'blog.breadcrumbs.home':
+          return 'Home'
+        case 'blog.breadcrumbs.blog':
+          return 'Blog'
+        case 'siteIdentity.siteName':
+          return 'Nudger'
+        case 'siteIdentity.links.linkedin':
+          return 'https://www.linkedin.com/company/nudger/'
         default:
           return key
       }

--- a/frontend/app/utils/blog-jsonld.ts
+++ b/frontend/app/utils/blog-jsonld.ts
@@ -1,0 +1,234 @@
+import { compactJsonLd, type JsonLdValue } from './product-jsonld'
+
+export interface BlogJsonLdSiteInfo {
+  name: string
+  origin: string
+  logoUrl?: string
+  sameAs?: string[]
+}
+
+export interface BlogJsonLdBreadcrumb {
+  name: string
+  link?: string
+}
+
+export interface BlogJsonLdPosting {
+  headline?: string
+  description?: string
+  url?: string
+  image?: string | string[]
+  datePublished?: string
+  dateModified?: string
+  author?: string
+}
+
+interface BlogJsonLdBaseInput {
+  canonicalUrl: string
+  locale: string
+  site: BlogJsonLdSiteInfo
+  breadcrumbs: BlogJsonLdBreadcrumb[]
+}
+
+export interface BlogJsonLdCollectionInput extends BlogJsonLdBaseInput {
+  pageTitle: string
+  description?: string
+  about?: string
+  posts: BlogJsonLdPosting[]
+}
+
+export interface BlogJsonLdArticleInput extends BlogJsonLdBaseInput {
+  pageTitle: string
+  description?: string
+  article: BlogJsonLdPosting
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0
+
+const normalizeString = (value: unknown): string | undefined =>
+  isNonEmptyString(value) ? value.trim() : undefined
+
+const toAbsoluteUrl = (origin: string, value: string): string | undefined => {
+  try {
+    return new URL(value, origin).toString()
+  } catch (error) {
+    if (import.meta.dev) {
+      console.warn('Failed to build absolute URL for blog JSON-LD.', error)
+    }
+    return undefined
+  }
+}
+
+const buildOrganizationEntry = (site: BlogJsonLdSiteInfo) =>
+  compactJsonLd({
+    '@type': 'Organization',
+    '@id': `${site.origin}#organization`,
+    name: normalizeString(site.name),
+    url: site.origin,
+    logo: normalizeString(site.logoUrl),
+    sameAs: site.sameAs
+      ?.map(value => normalizeString(value))
+      .filter((value): value is string => Boolean(value)),
+  })
+
+const buildBreadcrumbEntry = (
+  canonicalUrl: string,
+  siteOrigin: string,
+  breadcrumbs: BlogJsonLdBreadcrumb[]
+) =>
+  compactJsonLd({
+    '@type': 'BreadcrumbList',
+    '@id': `${canonicalUrl}#breadcrumb`,
+    itemListElement: breadcrumbs.map((crumb, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: normalizeString(crumb.name),
+      item: crumb.link ? toAbsoluteUrl(siteOrigin, crumb.link) : undefined,
+    })),
+  })
+
+const buildBlogPostingEntry = (siteOrigin: string, post: BlogJsonLdPosting) => {
+  const url = normalizeString(post.url)
+  const absoluteUrl = url ? toAbsoluteUrl(siteOrigin, url) ?? url : undefined
+
+  return compactJsonLd({
+    '@type': 'BlogPosting',
+    '@id': absoluteUrl ? `${absoluteUrl}#blogposting` : undefined,
+    headline: normalizeString(post.headline),
+    description: normalizeString(post.description),
+    url: absoluteUrl,
+    image: Array.isArray(post.image)
+      ? post.image
+          .map(value => normalizeString(value))
+          .filter((value): value is string => Boolean(value))
+      : normalizeString(post.image),
+    datePublished: normalizeString(post.datePublished),
+    dateModified: normalizeString(post.dateModified),
+    author: normalizeString(post.author)
+      ? {
+          '@type': 'Person',
+          name: normalizeString(post.author),
+        }
+      : undefined,
+  })
+}
+
+const buildWebsiteEntry = (site: BlogJsonLdSiteInfo) =>
+  compactJsonLd({
+    '@type': 'WebSite',
+    '@id': `${site.origin}#website`,
+    url: site.origin,
+    name: normalizeString(site.name),
+    publisher: { '@id': `${site.origin}#organization` },
+  })
+
+export const buildBlogCollectionJsonLd = (
+  input: BlogJsonLdCollectionInput
+): Record<string, JsonLdValue> | null => {
+  const organizationEntry = buildOrganizationEntry(input.site)
+  const breadcrumbEntry = buildBreadcrumbEntry(
+    input.canonicalUrl,
+    input.site.origin,
+    input.breadcrumbs
+  )
+  const websiteEntry = buildWebsiteEntry(input.site)
+
+  const pageEntry = compactJsonLd({
+    '@type': 'CollectionPage',
+    '@id': `${input.canonicalUrl}#webpage`,
+    url: input.canonicalUrl,
+    name: normalizeString(input.pageTitle),
+    description: normalizeString(input.description),
+    inLanguage: normalizeString(input.locale),
+    isPartOf: { '@id': `${input.site.origin}#website` },
+    about: normalizeString(input.about),
+  })
+
+  const blogEntry = compactJsonLd({
+    '@type': 'Blog',
+    '@id': `${input.canonicalUrl}#blog`,
+    name: normalizeString(input.pageTitle),
+    publisher: { '@id': `${input.site.origin}#organization` },
+  })
+
+  const blogPosts = input.posts
+    .map(post => buildBlogPostingEntry(input.site.origin, post))
+    .filter(Boolean)
+
+  const graphEntries = compactJsonLd([
+    organizationEntry,
+    websiteEntry,
+    breadcrumbEntry,
+    blogEntry,
+    pageEntry
+      ? {
+          ...pageEntry,
+          mainEntity: blogEntry ? { '@id': `${input.canonicalUrl}#blog` } : undefined,
+          hasPart: blogPosts.length ? blogPosts : undefined,
+        }
+      : undefined,
+    ...blogPosts,
+  ]) as JsonLdValue
+
+  const graph = compactJsonLd({
+    '@context': 'https://schema.org',
+    '@graph': graphEntries,
+  })
+
+  return (graph as Record<string, JsonLdValue>) ?? null
+}
+
+export const buildBlogArticleJsonLd = (
+  input: BlogJsonLdArticleInput
+): Record<string, JsonLdValue> | null => {
+  const organizationEntry = buildOrganizationEntry(input.site)
+  const breadcrumbEntry = buildBreadcrumbEntry(
+    input.canonicalUrl,
+    input.site.origin,
+    input.breadcrumbs
+  )
+  const websiteEntry = buildWebsiteEntry(input.site)
+
+  const webPageEntry = compactJsonLd({
+    '@type': 'WebPage',
+    '@id': `${input.canonicalUrl}#webpage`,
+    url: input.canonicalUrl,
+    name: normalizeString(input.pageTitle),
+    description: normalizeString(input.description),
+    inLanguage: normalizeString(input.locale),
+    isPartOf: { '@id': `${input.site.origin}#website` },
+  })
+
+  const blogPostingEntry = buildBlogPostingEntry(input.site.origin, {
+    ...input.article,
+    url: input.article.url ?? input.canonicalUrl,
+  })
+
+  const graphEntries = compactJsonLd([
+    organizationEntry,
+    websiteEntry,
+    breadcrumbEntry,
+    blogPostingEntry
+      ? {
+          ...blogPostingEntry,
+          mainEntityOfPage: { '@id': `${input.canonicalUrl}#webpage` },
+          publisher: { '@id': `${input.site.origin}#organization` },
+        }
+      : undefined,
+    webPageEntry
+      ? {
+          ...webPageEntry,
+          mainEntity: blogPostingEntry
+            ? { '@id': blogPostingEntry['@id'] }
+            : undefined,
+        }
+      : undefined,
+  ]) as JsonLdValue
+
+  const graph = compactJsonLd({
+    '@context': 'https://schema.org',
+    '@graph': graphEntries,
+  })
+
+  return (graph as Record<string, JsonLdValue>) ?? null
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -27,6 +27,10 @@
       "readingTime": "Approx. {minutes} min read",
       "updated": "Updated {date}"
     },
+    "breadcrumbs": {
+      "blog": "Blog",
+      "home": "Home"
+    },
     "hero": {
       "eyebrow": "Nudger blog",
       "subtitle": "Short reads on sustainable appliances, nudges and the lessons we learn while building Nudger.",

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -27,6 +27,10 @@
       "readingTime": "Env. {minutes} min de lecture",
       "updated": "Mis à jour {date}"
     },
+    "breadcrumbs": {
+      "blog": "Blog",
+      "home": "Accueil"
+    },
     "hero": {
       "eyebrow": "Blog Nudger",
       "subtitle": "Des articles courts sur la consommation responsable et les coulisses de Nudger.",


### PR DESCRIPTION
### Motivation
- Improve SEO and structured-data accuracy for the blog by emitting a full JSON-LD graph that includes Organization, WebSite, BreadcrumbList and BlogPosting/CollectionPage entries.
- Ensure blog list and article pages include organization and breadcrumb metadata so search engines can better understand site structure and content.

### Description
- Add a JSON-LD utility `frontend/app/utils/blog-jsonld.ts` that builds compact Schema.org graphs for blog collections and articles (Organization, WebSite, BreadcrumbList, BlogPosting, CollectionPage).
- Wire the blog list page to use `buildBlogCollectionJsonLd` in `frontend/app/components/domains/blog/TheArticles.vue` and emit the structured graph when available.
- Wire the blog article page to use `buildBlogArticleJsonLd` in `frontend/app/components/domains/blog/TheArticle.vue` and emit the structured graph when available.
- Add breadcrumb keys to `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` and update the blog tests (`TheArticles.spec.ts`, `TheArticle.spec.ts`) to mock/expect the new graph-shaped structured data.

### Testing
- Ran lint with `pnpm lint --offline` and it passed successfully.
- Attempted `pnpm test --offline` but the Vitest CLI rejects `--offline`, so the offline invocation failed with an unknown option error; this is a CLI flag issue rather than test failures.
- Ran `pnpm test` and the test suite passed with all tests green (`121 test files`, `435 tests` passed).
- Ran `pnpm generate --offline` to build the frontend and the static generation completed successfully producing the `.output/public` artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828cac6bbc8322a472f16d98431b0a)