### PR TITLE
Load YAML assistant configs and expose AssistantConfig API (TV assistant with distance question)

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AssistantConfigController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/AssistantConfigController.java
@@ -1,0 +1,300 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.open4goods.model.Localisable;
+import org.open4goods.model.RolesConstants;
+import org.open4goods.model.vertical.NudgeToolConfig;
+import org.open4goods.model.vertical.NudgeToolScore;
+import org.open4goods.model.vertical.NudgeToolSubsetGroup;
+import org.open4goods.model.vertical.SubsetCriteria;
+import org.open4goods.model.vertical.SubsetCriteriaOperator;
+import org.open4goods.model.vertical.VerticalSubset;
+import org.open4goods.nudgerfrontapi.controller.CacheControlConstants;
+import org.open4goods.nudgerfrontapi.dto.assistant.AssistantConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolConfigDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolScoreDto;
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolSubsetGroupDto;
+import org.open4goods.nudgerfrontapi.dto.category.VerticalSubsetDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST controller exposing assistant configurations derived from YAML resources.
+ */
+@RestController
+@RequestMapping("/assistant-configs")
+@Validated
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+@Tag(name = "Assistants", description = "Expose YAML-based assistant configurations for the frontend.")
+public class AssistantConfigController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssistantConfigController.class);
+
+    private final VerticalsConfigService verticalsConfigService;
+
+    public AssistantConfigController(VerticalsConfigService verticalsConfigService) {
+        this.verticalsConfigService = verticalsConfigService;
+    }
+
+    /**
+     * List all available assistant configurations.
+     *
+     * @param domainLanguage language used to localise the returned fields
+     * @return the assistant configurations with their identifiers
+     */
+    @GetMapping
+    @Operation(
+            summary = "List assistant configurations",
+            description = "Return YAML-based assistant configurations available for the nudge tool wizard.",
+            parameters = {
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Assistant configurations returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for the response"),
+                            content = @Content(mediaType = "application/json",
+                                    array = @ArraySchema(schema = @Schema(implementation = AssistantConfigDto.class)))),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<List<AssistantConfigDto>> listAssistants(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Listing assistant configurations for {}", domainLanguage);
+        List<AssistantConfigDto> body = verticalsConfigService.getAssistantConfigs().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(Comparator.naturalOrder()))
+                .map(entry -> new AssistantConfigDto(entry.getKey(), mapNudgeToolConfig(entry.getValue(), domainLanguage)))
+                .filter(dto -> dto.config() != null)
+                .toList();
+
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(body);
+    }
+
+    /**
+     * Retrieve an assistant configuration by identifier.
+     *
+     * @param assistantId identifier of the assistant to retrieve
+     * @param domainLanguage language used to localise the returned fields
+     * @return the assistant configuration, or 404 when missing
+     */
+    @GetMapping("/{assistantId}")
+    @Operation(
+            summary = "Get assistant configuration",
+            description = "Return the assistant configuration identified by its id.",
+            parameters = {
+                    @Parameter(name = "assistantId", in = ParameterIn.PATH, required = true,
+                            description = "Identifier of the assistant to retrieve.",
+                            schema = @Schema(type = "string", example = "tv")),
+                    @Parameter(name = "domainLanguage", in = ParameterIn.QUERY, required = true,
+                            description = "Language driving localisation of textual fields.",
+                            schema = @Schema(implementation = DomainLanguage.class))
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Assistant configuration returned",
+                            headers = @Header(name = "X-Locale", description = "Resolved locale for the response"),
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = NudgeToolConfigDto.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid assistant id"),
+                    @ApiResponse(responseCode = "404", description = "Assistant not found"),
+                    @ApiResponse(responseCode = "500", description = "Internal server error")
+            }
+    )
+    public ResponseEntity<NudgeToolConfigDto> getAssistant(
+            @PathVariable("assistantId") String assistantId,
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage) {
+        LOGGER.info("Fetching assistant configuration {} for {}", assistantId, domainLanguage);
+        if (!StringUtils.hasText(assistantId)) {
+            LOGGER.warn("Assistant id is required");
+            return ResponseEntity.badRequest().build();
+        }
+        NudgeToolConfig config = verticalsConfigService.getAssistantConfigById(assistantId);
+        if (config == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok()
+                .cacheControl(CacheControlConstants.FIFTEEN_MINUTES_PUBLIC_CACHE)
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(mapNudgeToolConfig(config, domainLanguage));
+    }
+
+    /**
+     * Map the backend nudge tool configuration to its DTO representation.
+     *
+     * @param nudgeToolConfig the configuration to map
+     * @param domainLanguage language used for localisation
+     * @return mapped DTO or {@code null} if the input is null
+     */
+    private NudgeToolConfigDto mapNudgeToolConfig(NudgeToolConfig nudgeToolConfig, DomainLanguage domainLanguage) {
+        if (nudgeToolConfig == null) {
+            return null;
+        }
+
+        List<NudgeToolScoreDto> scores = defaultList(nudgeToolConfig.getScores()).stream()
+                .map(score -> mapNudgeToolScore(score, domainLanguage))
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new NudgeToolConfigDto(scores,
+                mapVerticalSubsets(nudgeToolConfig.getSubsets(), domainLanguage),
+                mapNudgeToolSubsetGroups(nudgeToolConfig.getSubsetGroups(), domainLanguage));
+    }
+
+    /**
+     * Map a score entry to the DTO used by the frontend.
+     *
+     * @param score the score configuration
+     * @param domainLanguage language used for localisation
+     * @return mapped score DTO or {@code null} if the input is null
+     */
+    private NudgeToolScoreDto mapNudgeToolScore(NudgeToolScore score, DomainLanguage domainLanguage) {
+        if (score == null) {
+            return null;
+        }
+        return new NudgeToolScoreDto(
+                score.getScoreName(),
+                score.getScoreMinValue(),
+                score.getFromPercent(),
+                score.getToPercent(),
+                score.getMdiIcon(),
+                score.getDisabled(),
+                localise(score.getTitle(), domainLanguage),
+                localise(score.getDescription(), domainLanguage));
+    }
+
+    /**
+     * Map subset group definitions to DTOs.
+     *
+     * @param subsetGroups configured groups
+     * @param domainLanguage language used for localisation
+     * @return list of mapped group DTOs
+     */
+    private List<NudgeToolSubsetGroupDto> mapNudgeToolSubsetGroups(List<NudgeToolSubsetGroup> subsetGroups,
+            DomainLanguage domainLanguage) {
+        return defaultList(subsetGroups).stream()
+                .map(group -> mapNudgeToolSubsetGroup(group, domainLanguage))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Map a subset group to the DTO used by the frontend.
+     *
+     * @param group group configuration
+     * @param domainLanguage language used for localisation
+     * @return mapped group DTO or {@code null} if the input is null
+     */
+    private NudgeToolSubsetGroupDto mapNudgeToolSubsetGroup(NudgeToolSubsetGroup group, DomainLanguage domainLanguage) {
+        if (group == null) {
+            return null;
+        }
+        return new NudgeToolSubsetGroupDto(
+                group.getId(),
+                localise(group.getTitle(), domainLanguage),
+                localise(group.getDescription(), domainLanguage),
+                group.getMdiIcon(),
+                group.getLayout(),
+                localise(group.getCtaLabel(), domainLanguage));
+    }
+
+    /**
+     * Map vertical subsets to DTOs.
+     *
+     * @param subsets configured subsets
+     * @param domainLanguage language used for localisation
+     * @return list of mapped subset DTOs
+     */
+    private List<VerticalSubsetDto> mapVerticalSubsets(List<VerticalSubset> subsets, DomainLanguage domainLanguage) {
+        return defaultList(subsets).stream()
+                .map(subset -> mapVerticalSubset(subset, domainLanguage))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Map a single subset to its DTO, ensuring percentile operators are applied.
+     *
+     * @param subset the subset configuration
+     * @param domainLanguage language used for localisation
+     * @return mapped subset DTO or {@code null} if the input is null
+     */
+    private VerticalSubsetDto mapVerticalSubset(VerticalSubset subset, DomainLanguage domainLanguage) {
+        if (subset == null) {
+            return null;
+        }
+
+        List<SubsetCriteria> criterias = defaultList(subset.getCriterias()).stream()
+                .peek(criteria -> {
+                    if ((criteria.getFromPercent() != null || criteria.getToPercent() != null)
+                            && criteria.getOperator() == null) {
+                        criteria.setOperator(SubsetCriteriaOperator.RANKING_PERCENTILE);
+                    }
+                })
+                .toList();
+
+        return new VerticalSubsetDto(
+                subset.getId(),
+                subset.getGroup(),
+                criterias,
+                subset.getImage(),
+                localise(subset.getUrl(), domainLanguage),
+                localise(subset.getCaption(), domainLanguage),
+                localise(subset.getTitle(), domainLanguage),
+                localise(subset.getDescription(), domainLanguage));
+    }
+
+    /**
+     * Localise a localisable map into the requested language tag.
+     *
+     * @param localisable map of language keys to values
+     * @param domainLanguage language requested by the caller
+     * @return localised value or {@code null} if the map is null
+     */
+    private String localise(Localisable<String, String> localisable, DomainLanguage domainLanguage) {
+        if (localisable == null) {
+            return null;
+        }
+        String languageTag = domainLanguage == null ? null : domainLanguage.languageTag();
+        return localisable.i18n(languageTag);
+    }
+
+    /**
+     * Ensure list values are never null.
+     *
+     * @param list input list
+     * @param <T> list element type
+     * @return a non-null list
+     */
+    private <T> List<T> defaultList(List<T> list) {
+        return list == null ? List.of() : list;
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/assistant/AssistantConfigDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/assistant/AssistantConfigDto.java
@@ -1,0 +1,16 @@
+package org.open4goods.nudgerfrontapi.dto.assistant;
+
+import org.open4goods.nudgerfrontapi.dto.category.NudgeToolConfigDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * DTO exposing an assistant configuration with its identifier.
+ */
+public record AssistantConfigDto(
+        @Schema(description = "Identifier of the assistant configuration.", example = "tv")
+        String id,
+        @Schema(description = "Nudge tool configuration used by the assistant.")
+        NudgeToolConfigDto config
+) {
+}

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/AssistantConfigControllerTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/AssistantConfigControllerTest.java
@@ -1,0 +1,132 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.open4goods.model.Localisable;
+import org.open4goods.model.vertical.NudgeToolConfig;
+import org.open4goods.model.vertical.NudgeToolSubsetGroup;
+import org.open4goods.model.vertical.VerticalSubset;
+import org.open4goods.verticals.VerticalsConfigService;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+/**
+ * Unit tests for {@link AssistantConfigController}.
+ */
+@ExtendWith(MockitoExtension.class)
+class AssistantConfigControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private VerticalsConfigService verticalsConfigService;
+
+    @BeforeEach
+    void setUp() {
+        AssistantConfigController controller = new AssistantConfigController(verticalsConfigService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    /**
+     * Verify list endpoint returns assistant configurations with localisation header.
+     *
+     * @throws Exception when the request fails
+     */
+    @Test
+    void shouldListAssistantConfigs() throws Exception {
+        NudgeToolConfig config = buildSampleConfig();
+        Map<String, NudgeToolConfig> configs = new LinkedHashMap<>();
+        configs.put("tv", config);
+        when(verticalsConfigService.getAssistantConfigs()).thenReturn(configs);
+
+        mockMvc.perform(get("/assistant-configs").param("domainLanguage", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "fr"))
+                .andExpect(jsonPath("$[0].id").value("tv"))
+                .andExpect(jsonPath("$[0].config.subsetGroups[0].id").value("distance"));
+    }
+
+    /**
+     * Verify a known assistant identifier returns the configuration.
+     *
+     * @throws Exception when the request fails
+     */
+    @Test
+    void shouldGetAssistantConfig() throws Exception {
+        NudgeToolConfig config = buildSampleConfig();
+        when(verticalsConfigService.getAssistantConfigById("tv")).thenReturn(config);
+
+        mockMvc.perform(get("/assistant-configs/tv").param("domainLanguage", "en"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Locale", "en"))
+                .andExpect(jsonPath("$.subsetGroups[0].id").value("distance"));
+    }
+
+    /**
+     * Ensure unknown assistant identifiers return 404.
+     *
+     * @throws Exception when the request fails
+     */
+    @Test
+    void shouldReturnNotFoundForUnknownAssistant() throws Exception {
+        when(verticalsConfigService.getAssistantConfigById("unknown")).thenReturn(null);
+
+        mockMvc.perform(get("/assistant-configs/unknown").param("domainLanguage", "fr"))
+                .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Build a minimal assistant configuration for test scenarios.
+     *
+     * @return a sample nudge tool configuration
+     */
+    private NudgeToolConfig buildSampleConfig() {
+        NudgeToolSubsetGroup group = new NudgeToolSubsetGroup();
+        group.setId("distance");
+        group.setMdiIcon("mdi-ruler");
+        group.setLayout("grid");
+        group.setTitle(localisable("fr", "À quelle distance ?", "en", "How far?"));
+
+        VerticalSubset subset = new VerticalSubset();
+        subset.setId("price_lower_500");
+        subset.setGroup("price");
+        subset.setTitle(localisable("fr", "< 500 €", "en", "< 500 €"));
+
+        NudgeToolConfig config = new NudgeToolConfig();
+        config.setSubsetGroups(List.of(group));
+        config.setSubsets(List.of(subset));
+        return config;
+    }
+
+    /**
+     * Create a localisable payload with FR/EN entries.
+     *
+     * @param frKey key for the French value
+     * @param frValue French label
+     * @param enKey key for the English value
+     * @param enValue English label
+     * @return localisable map with both entries
+     */
+    private Localisable<String, String> localisable(String frKey, String frValue, String enKey, String enValue) {
+        Localisable<String, String> localisable = new Localisable<>();
+        localisable.put(frKey, frValue);
+        localisable.put(enKey, enValue);
+        return localisable;
+    }
+}

--- a/verticals/src/main/resources/assistant/tv.yml
+++ b/verticals/src/main/resources/assistant/tv.yml
@@ -1,0 +1,340 @@
+scores:
+  - scoreName: "ENERGY_CONSUMPTION"
+    fromPercent: 50
+    mdiIcon: "mdi-lightning-bolt"
+    title:
+      en: "Energy consumption"
+      fr: "Consommation énergétique"
+    description:
+      en: "Televisions with low energy consumption"
+      fr: "Téléviseurs avec une faible consommation énergétique"
+  - scoreName: "DURABILITY"
+    fromPercent: 50
+    mdiIcon: "mdi-archive-outline"
+    title:
+      en: "Durability"
+      fr: "Durabilité"
+    description:
+      en: "Televisions with a good durability"
+      fr: "Téléviseurs avec une bonne durabilité"
+
+  - scoreName: "REPARABILITY"
+    fromPercent: 50
+    mdiIcon: "mdi-tools"
+    title:
+      en: "Reparability"
+      fr: "Réparabilité"
+    description:
+      en: "Televisions with a good reparability"
+      fr: "Téléviseurs avec une bonne réparabilité"
+  - scoreName: "ESG"
+    disabled: true
+    fromPercent: 50
+    mdiIcon: "mdi-scale-balance"
+    title:
+      en: "ESG criterias"
+      fr: "Critères ESG"
+    description:
+      en: "Models from brands with good ESG ratings"
+      fr: "Modèles dont la marque dispose d'un bon indice ESG"
+subsetGroups:
+  - id: "distance"
+    mdiIcon: "mdi-ruler"
+    layout: "grid"
+    title:
+      en: "How far is your head from the screen?"
+      fr: "À quelle distance est installée votre tête de l'écran ?"
+    description:
+      en: "Wellness score = 1 - |distance_cm - (diagonal_in × 2.54 × 2.5)| / (diagonal_in × 2.54 × 2.5)."
+      fr: "Indice bien-être = 1 - |distance_cm - (diagonale_pouces × 2.54 × 2.5)| / (diagonale_pouces × 2.54 × 2.5)."
+    ctaLabel:
+      en: "Continue"
+      fr: "Continuer"
+  - id: "price"
+    mdiIcon: "mdi-currency-eur"
+    layout: "grid"
+    title:
+      en: "Budget"
+      fr: "Budget"
+    description:
+      en: "Pick a price comfort zone."
+      fr: "Votre budget"
+    ctaLabel:
+      en: "Continue"
+      fr: "Continuer"
+  - id: "screen_size"
+    mdiIcon: "mdi-television-classic"
+    layout: "grid"
+    title:
+      en: "Screen size"
+      fr: "Taille d'écran"
+    description:
+      en: "Find the diagonal that fits your space."
+      fr: "Trouvez la diagonale adaptée à votre espace."
+    ctaLabel:
+      en: "Continue"
+      fr: "Continuer"
+subsets:
+  ################
+  # Distance
+  ################
+  - id: "distance_close"
+    group: "distance"
+    criterias:
+      - field: "assistant.viewingDistanceCm"
+        operator: "LOWER_THAN"
+        value: "150"
+    image: "distance-close.png"
+    url:
+      en: "distance-close"
+      fr: "distance-proche"
+    caption:
+      en: "< 1.5 m"
+      fr: "< 1,5 m"
+    title:
+      en: "Very close"
+      fr: "Très proche"
+    description:
+      en: "Viewing distance below 1.5 meters."
+      fr: "Distance de visionnage inférieure à 1,5 m."
+
+  - id: "distance_comfort"
+    group: "distance"
+    criterias:
+      - field: "assistant.viewingDistanceCm"
+        operator: "GREATER_THAN_OR_EQUAL"
+        value: "150"
+      - field: "assistant.viewingDistanceCm"
+        operator: "LOWER_THAN"
+        value: "300"
+    image: "distance-comfort.png"
+    url:
+      en: "distance-comfort"
+      fr: "distance-confort"
+    caption:
+      en: "1.5 m - 3 m"
+      fr: "1,5 m - 3 m"
+    title:
+      en: "Comfort distance"
+      fr: "Distance confort"
+    description:
+      en: "Typical comfort range for living rooms."
+      fr: "Distance de confort courante pour un salon."
+
+  - id: "distance_far"
+    group: "distance"
+    criterias:
+      - field: "assistant.viewingDistanceCm"
+        operator: "GREATER_THAN_OR_EQUAL"
+        value: "300"
+    image: "distance-far.png"
+    url:
+      en: "distance-far"
+      fr: "distance-loin"
+    caption:
+      en: "> 3 m"
+      fr: "> 3 m"
+    title:
+      en: "Far"
+      fr: "Loin"
+    description:
+      en: "Viewing distance above 3 meters."
+      fr: "Distance de visionnage supérieure à 3 m."
+
+  ################
+  # Impact Score
+  ################
+  - id: "impact_high" # Unique identifier for the subset - Worst 33% (high environmental impact)
+    group: "impactscore"
+    criterias:
+      - field: "scores.ECOSCORE.ranking"
+        fromPercent: 0
+        toPercent: 33
+    image: "example-image.png"
+    url:
+      en: "high-impact"
+      fr: "fort-impact"
+    caption:
+      en: "High "
+      fr: "Élevé "
+    title:
+      en: "High Impact"
+      fr: "Impact Élevé"
+    description:
+      en: "Products with a high environmental impact"
+      fr: "Produits ayant un fort impact environnemental"
+
+  - id: "impact_medium" # Middle 34%
+    group: "impactscore"
+    criterias:
+      - field: "scores.ECOSCORE.ranking"
+        fromPercent: 33
+        toPercent: 67
+    image: "example-image.png"
+    url:
+      en: "medium-impact"
+      fr: "impact-moyen"
+    caption:
+      en: "Medium"
+      fr: "Moyen "
+    title:
+      en: "Medium Impact"
+      fr: "Impact Moyen"
+    description:
+      en: "Products with a medium environmental impact"
+      fr: "Produits ayant un impact environnemental moyen"
+
+  - id: "impact_low" # Best 33% (low environmental impact)
+    group: "impactscore"
+    criterias:
+      - field: "scores.ECOSCORE.ranking"
+        fromPercent: 67
+        toPercent: 100
+    image: "example-image.png"
+    url:
+      en: "low-impact"
+      fr: "faible-impact"
+    caption:
+      en: "Low "
+      fr: "Faible "
+    title:
+      en: "Low Impact"
+      fr: "Impact Faible"
+    description:
+      en: "Products with a low environmental impact"
+      fr: "Produits ayant un faible impact environnemental"
+
+  ################
+  # Price
+  ################
+  - id: "price_lower_500" # Unique identifier for the subset
+    group: "price"
+    criterias:
+      - field: "price.minPrice.price"
+        operator: "LOWER_THAN"
+        value: "500"
+      - field: "price.minPrice.price"
+        operator: "GREATER_THAN"
+        value: "0"
+    image: "example-image.png"
+    url:
+      en: "low-price"
+      fr: "petits-prix"
+    caption:
+      en: "TVs priced under €500."
+      fr: "Les TV dont le prix est inférieur à 500€."
+    title:
+      en: "< 500 €"
+      fr: "< 500 €"
+    description:
+      en: ""
+      fr: ""
+
+  - id: "price_500_1000"
+    group: "price"
+    criterias:
+      - field: "price.minPrice.price"
+        operator: "GREATER_THAN"
+        value: "500"
+      - field: "price.minPrice.price"
+        operator: "LOWER_THAN"
+        value: "1000"
+    image: "example-image.png"
+    url:
+      en: "tv-500-1000-euros"
+      fr: "tv-500-1000-euros"
+    caption:
+      en: "TVs priced between €500 and €1000."
+      fr: "Les TV dont le prix est compris entre 500€ et 1000€."
+    title:
+      en: "500 - 1000 €"
+      fr: "500 - 1000 €"
+    description:
+      en: "500 - 1000 €"
+      fr: "500 - 1000 €"
+
+  - id: "price_greater_1000"
+    group: "price"
+    criterias:
+      - field: "price.minPrice.price"
+        operator: "GREATER_THAN"
+        value: "1000"
+    image: "example-image.png"
+    url:
+      en: "premium-price"
+      fr: "haut-de-gamme"
+    caption:
+      en: "Premium TVs"
+      fr: "Les TV dont le prix est supérieur à 1000€."
+    title:
+      en: "> 1000 €"
+      fr: "> 1000 €"
+    description:
+      en: "TVs priced over €1000."
+      fr: "Les TV dont le prix est supérieur à 1000€."
+
+  ################
+  # Screen Size
+  ################
+  - id: "small_screens"
+    group: "screen_size"
+    criterias:
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "LOWER_THAN"
+        value: "32"
+    image: "small-screen.png"
+    url:
+      en: "small-screens"
+      fr: "petits-ecrans"
+    caption:
+      en: 'Small screens (< 32")'
+      fr: "Diagonale < 32 pouces"
+    title:
+      en: "Small Screen TVs"
+      fr: "Petits écrans"
+    description:
+      en: "TVs with a screen size smaller than 32 inches."
+      fr: "Les TV avec une taille d'écran inférieure à 32 pouces."
+
+  - id: "medium_screens"
+    group: "screen_size"
+    criterias:
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "GREATER_THAN"
+        value: "32"
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "LOWER_THAN"
+        value: "55"
+    image: "medium-screen.png"
+    url:
+      en: "medium-screens"
+      fr: "ecrans-moyens"
+    caption:
+      en: 'Medium screens (32" - 55")'
+      fr: "Diagonale entre 32 et 55 pouces"
+    title:
+      en: "Medium Screen TVs"
+      fr: "Écrans moyens"
+    description:
+      en: "TVs with a screen size between 32 and 55 inches."
+      fr: "Les TV avec une taille d'écran comprise entre 32 et 55 pouces."
+
+  - id: "large_screens"
+    group: "screen_size"
+    criterias:
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "GREATER_THAN"
+        value: "55"
+    image: "large-screen.png"
+    url:
+      en: "large-screens"
+      fr: "grands-ecrans"
+    caption:
+      en: 'Large screens (> 55")'
+      fr: "Diagonale > 55 pouces"
+    title:
+      en: "Large Screen TVs"
+      fr: "Grands écrans"
+    description:
+      en: "TVs with a screen size greater than 55 inches."
+      fr: "Les TV avec une taille d'écran supérieure à 55 pouces."

--- a/verticals/src/test/java/org/open4goods/verticals/AssistantConfigServiceTest.java
+++ b/verticals/src/test/java/org/open4goods/verticals/AssistantConfigServiceTest.java
@@ -1,0 +1,53 @@
+package org.open4goods.verticals;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.open4goods.model.vertical.NudgeToolConfig;
+import org.open4goods.services.serialisation.service.SerialisationService;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+/**
+ * Tests loading assistant configurations from classpath resources.
+ */
+class AssistantConfigServiceTest {
+
+    private static VerticalsConfigService verticalsConfigService;
+
+    /**
+     * Build a config service with the classpath resources to exercise assistant loading.
+     *
+     * @throws Exception when initialization fails
+     */
+    @BeforeAll
+    static void setUp() throws Exception {
+        SerialisationService serialisationService = new SerialisationService();
+        GoogleTaxonomyService googleTaxonomyService = mock(GoogleTaxonomyService.class);
+        ResourcePatternResolver resourceResolver = new PathMatchingResourcePatternResolver();
+
+        verticalsConfigService = new VerticalsConfigService(serialisationService, googleTaxonomyService, resourceResolver);
+    }
+
+    /**
+     * Ensure the assistant configuration for tv is available and contains the distance question group.
+     */
+    @Test
+    void shouldLoadAssistantConfigWithDistanceGroup() {
+        NudgeToolConfig config = verticalsConfigService.getAssistantConfigById("tv");
+
+        assertThat(config).as("TV assistant config should be loaded").isNotNull();
+        assertThat(config.getSubsetGroups())
+                .as("Subset groups should be available")
+                .isNotEmpty();
+        assertThat(config.getSubsetGroups().get(0).getId())
+                .as("Distance group must be the first question")
+                .isEqualTo("distance");
+        assertThat(config.getSubsets())
+                .as("Existing filters should be preserved")
+                .extracting(subset -> subset.getId())
+                .contains("price_lower_500", "large_screens");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a YAML-driven assistant for the nudge tool that asks the distance question first (French label: "À quelle distance est installée votre tête de l'écran ?") and keeps existing TV filters.
- Surface assistant configurations to the frontend so the nudge wizard can be populated from classpath resources.

### Description
- Added a sample assistant definition `verticals/src/main/resources/assistant/tv.yml` containing a distance-first `subsetGroups` entry, subsets (distance ranges) and a wellness formula description.
- Enhanced `VerticalsConfigService` to load assistant YAMLs from `classpath:/assistant/*.yml` with `refreshAssistantConfigs()`, and added `getAssistantConfigById()` and `getAssistantConfigs()` accessors.
- Introduced `AssistantConfigController` and `AssistantConfigDto` in `front-api` to expose list and single-assistant endpoints and added mapping helpers to convert backend `NudgeToolConfig` to DTOs.
- Added unit tests `verticals/src/test/java/org/open4goods/verticals/AssistantConfigServiceTest.java` and `front-api/src/test/java/org/open4goods/nudgerfrontapi/controller/api/AssistantConfigControllerTest.java` covering loading and controller behaviour.

### Testing
- Ran `mvn --offline -pl verticals -am -Dtest=AssistantConfigServiceTest -Dsurefire.failIfNoSpecifiedTests=false test` and the `AssistantConfigServiceTest` succeeded.
- Attempted `mvn --offline -pl front-api -am -Dtest=AssistantConfigControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`, but the build failed due to an unavailable offline dependency (`com.google.http-client:google-http-client-bom:2.1.0`) preventing `front-api` tests from completing in the offline environment.
- Test commands used during verification were `mvn --offline -pl verticals -am -Dtest=AssistantConfigServiceTest test` and `mvn --offline -pl front-api -am -Dtest=AssistantConfigControllerTest test`, with the former passing and the latter blocked by the offline dependency cache issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982abdc5580832292e6f59516b2b69c)