### PR TITLE
feat(frontend): add 24h domain-aware cache for commercial events

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -1544,9 +1544,11 @@ const radarData = computed<RadarDataset>(() => {
 const { data: commercialEventsData } = await useAsyncData<
   CommercialEvent[] | null
 >(
-  'commercial-events',
+  () => `commercial-events-${locale.value}`,
   async () => {
     try {
+      // Keep the async-data cache key aligned with the domain/language-aware
+      // server cache strategy (`Vary: Host, X-Forwarded-Host`).
       return await $fetch<CommercialEvent[]>('/api/commercial-events')
     } catch (eventError) {
       console.error('Failed to load commercial events', eventError)

--- a/frontend/server/api/commercial-events/index.get.spec.ts
+++ b/frontend/server/api/commercial-events/index.get.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type CommercialEventsRouteHandler = (typeof import('./index.get'))['default']
+
+const listCommercialEventsMock = vi.hoisted(() => vi.fn())
+const useCommercialEventsServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({ listCommercialEvents: listCommercialEventsMock }))
+)
+const resolveDomainLanguageMock = vi.hoisted(() => vi.fn())
+const setDomainLanguageCacheHeadersMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~~/shared/api-client/services/commercial-events.services', () => ({
+  useCommercialEventsService: useCommercialEventsServiceMock,
+}))
+
+vi.mock('~~/shared/utils/domain-language', () => ({
+  resolveDomainLanguage: resolveDomainLanguageMock,
+}))
+
+vi.mock('../../utils/cache-headers', () => ({
+  setDomainLanguageCacheHeaders: setDomainLanguageCacheHeadersMock,
+}))
+
+vi.mock('../../utils/log-backend-error', () => ({
+  extractBackendErrorDetails: vi.fn(),
+}))
+
+vi.mock('h3', async importOriginal => {
+  const actual = await importOriginal<typeof import('h3')>()
+
+  return {
+    ...actual,
+    createError: (input: unknown) => ({
+      ...(typeof input === 'object' && input ? input : {}),
+      isCreateError: true,
+    }),
+  }
+})
+
+vi.mock('nitropack/runtime/internal/cache', () => ({
+  cachedEventHandler: (
+    handler: (event: unknown) => unknown | Promise<unknown>,
+    options?: {
+      name?: string
+      maxAge?: number
+      getKey?: (event: unknown) => string
+    }
+  ) => {
+    const cache = new Map<string, { payload: unknown; expiresAt: number }>()
+    const name = options?.name ?? 'default'
+    const maxAgeMs = (options?.maxAge ?? 0) * 1000
+
+    return async (event: unknown) => {
+      const key = `${name}:${options?.getKey?.(event) ?? ''}`
+      const now = Date.now()
+      const cached = cache.get(key)
+
+      if (cached && cached.expiresAt > now) {
+        return cached.payload
+      }
+
+      const payload = await handler(event)
+      cache.set(key, {
+        payload,
+        expiresAt: now + maxAgeMs,
+      })
+
+      return payload
+    }
+  },
+}))
+
+describe('server/api/commercial-events/index.get', () => {
+  let handler: CommercialEventsRouteHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    listCommercialEventsMock.mockReset()
+    useCommercialEventsServiceMock.mockClear()
+    resolveDomainLanguageMock.mockImplementation((host?: string) => ({
+      domainLanguage: host === 'nudger.fr' ? 'fr' : 'en',
+    }))
+    setDomainLanguageCacheHeadersMock.mockReset()
+
+    handler = (await import('./index.get')).default
+  })
+
+  it('fetches commercial events with a 24-hour cache policy', async () => {
+    const payload = [{ title: 'Promo', startsAt: '2026-01-01' }]
+    listCommercialEventsMock.mockResolvedValue(payload)
+
+    const event = {
+      context: {},
+      node: {
+        req: { headers: { host: 'nudger.fr' } },
+      },
+    } as unknown as Parameters<CommercialEventsRouteHandler>[0]
+
+    const response = await handler(event)
+
+    expect(response).toEqual(payload)
+    expect(resolveDomainLanguageMock).toHaveBeenCalledWith('nudger.fr')
+    expect(useCommercialEventsServiceMock).toHaveBeenCalledWith('fr')
+    expect(setDomainLanguageCacheHeadersMock).toHaveBeenCalledWith(
+      event,
+      'public, max-age=86400, s-maxage=86400'
+    )
+  })
+
+  it('keeps independent cache entries per domain language', async () => {
+    listCommercialEventsMock.mockResolvedValue([{ title: 'Promo' }])
+
+    const frEvent = {
+      context: {},
+      node: {
+        req: { headers: { host: 'nudger.fr' } },
+      },
+    } as unknown as Parameters<CommercialEventsRouteHandler>[0]
+
+    const enEvent = {
+      context: {},
+      node: {
+        req: { headers: { host: 'nudger.org' } },
+      },
+    } as unknown as Parameters<CommercialEventsRouteHandler>[0]
+
+    await handler(frEvent)
+    await handler(frEvent)
+    await handler(enEvent)
+
+    expect(listCommercialEventsMock).toHaveBeenCalledTimes(2)
+    expect(useCommercialEventsServiceMock).toHaveBeenNthCalledWith(1, 'fr')
+    expect(useCommercialEventsServiceMock).toHaveBeenNthCalledWith(2, 'en')
+  })
+})

--- a/frontend/server/api/commercial-events/index.get.ts
+++ b/frontend/server/api/commercial-events/index.get.ts
@@ -1,4 +1,6 @@
-import { createError, defineEventHandler } from 'h3'
+import { cachedEventHandler } from 'nitropack/runtime/internal/cache'
+import { createError } from 'h3'
+import type { H3Event } from 'h3'
 import type { CommercialEvent } from '~~/shared/api-client'
 import { useCommercialEventsService } from '~~/shared/api-client/services/commercial-events.services'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
@@ -6,13 +8,40 @@ import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
 
-export default defineEventHandler(async (event): Promise<CommercialEvent[]> => {
-  setDomainLanguageCacheHeaders(event, 'public, max-age=600, s-maxage=600')
+type CommercialEventsCacheContext = {
+  domainLanguage: string
+}
+
+declare module 'h3' {
+  interface H3EventContext {
+    commercialEventsCacheContext?: CommercialEventsCacheContext
+  }
+}
+
+const resolveCommercialEventsCacheContext = (
+  event: H3Event
+): CommercialEventsCacheContext => {
+  if (event.context.commercialEventsCacheContext) {
+    return event.context.commercialEventsCacheContext
+  }
 
   const rawHost =
     event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
   const { domainLanguage } = resolveDomainLanguage(rawHost)
 
+  const context: CommercialEventsCacheContext = {
+    domainLanguage,
+  }
+
+  event.context.commercialEventsCacheContext = context
+
+  return context
+}
+
+const handler = async (event: H3Event): Promise<CommercialEvent[]> => {
+  setDomainLanguageCacheHeaders(event, 'public, max-age=86400, s-maxage=86400')
+
+  const { domainLanguage } = resolveCommercialEventsCacheContext(event)
   const service = useCommercialEventsService(domainLanguage)
 
   try {
@@ -31,4 +60,14 @@ export default defineEventHandler(async (event): Promise<CommercialEvent[]> => {
       cause: error,
     })
   }
+}
+
+export default cachedEventHandler(handler, {
+  name: 'commercial-events',
+  maxAge: 86400,
+  getKey: event => {
+    const { domainLanguage } = resolveCommercialEventsCacheContext(event)
+
+    return `${domainLanguage}:all`
+  },
 })


### PR DESCRIPTION
### Motivation
- The `/api/commercial-events` payload is domain-language sensitive and previously only used short-lived response headers, so responses should be cached server-side per domain/language with a longer TTL to reduce backend calls.
- The frontend `useAsyncData` key for commercial events must be aligned with the server-side cache key to avoid incorrect reuse across domains/locales.

### Description
- Reworked `frontend/server/api/commercial-events/index.get.ts` to use `cachedEventHandler` with `maxAge: 86400` (24h) and a domain-language-aware cache key (`${domainLanguage}:all`).
- Introduced a lightweight cache context resolver using the `H3Event` context to resolve and store `domainLanguage` for consistent key computation.
- Updated the endpoint response headers via `setDomainLanguageCacheHeaders` to `Cache-Control: public, max-age=86400, s-maxage=86400` while keeping host-aware `Vary` behaviour.
- Updated `frontend/app/components/pages/ProductPage.vue` to use a locale-aware `useAsyncData` key: `() => `commercial-events-${locale.value}`` and added a comment explaining alignment with the server cache.
- Added unit tests at `frontend/server/api/commercial-events/index.get.spec.ts` to assert the 24-hour cache header policy and cache isolation per domain language.

### Testing
- Ran targeted unit tests with `pnpm -C frontend test -- --run server/api/commercial-events/index.get.spec.ts app/components/product/ProductPriceSection.spec.ts` and both test files passed (server tests: 2 tests; product price component: 11 tests).
- Ran ESLint against the changed files using `pnpm -C frontend exec eslint` and the modified files passed ESLint checks; a full `pnpm -C frontend lint` run still fails due to pre-existing unrelated issues in `app/plugins/error-handler.ts` and `app/tests/error-handler.spec.ts`.
- Performed a production build preview via `pnpm -C frontend generate`, which completed successfully.
- Added and committed the changes; tests and builds above were executed on the modified codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849cecb0388322aceec6353aca20b4)