### PR TITLE
frontend: unify product page SSR payload and propagate product include

### DIFF
--- a/frontend/server/api/product-page/[gtin].spec.ts
+++ b/frontend/server/api/product-page/[gtin].spec.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProductIncludeEnum } from '~~/shared/api-client/apis/ProductApi'
+
+type ProductPageRouteHandler = (typeof import('./[gtin]'))['default']
+
+const getProductByGtinMock = vi.hoisted(() => vi.fn())
+const searchProductsMock = vi.hoisted(() => vi.fn())
+const useProductServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    getProductByGtin: getProductByGtinMock,
+    searchProducts: searchProductsMock,
+  }))
+)
+const getCategoriesMock = vi.hoisted(() => vi.fn())
+const getCategoryByIdMock = vi.hoisted(() => vi.fn())
+const useCategoriesServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    getCategories: getCategoriesMock,
+    getCategoryById: getCategoryByIdMock,
+  }))
+)
+const listCommercialEventsMock = vi.hoisted(() => vi.fn())
+const useCommercialEventsServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    listCommercialEvents: listCommercialEventsMock,
+  }))
+)
+const resolveDomainLanguageMock = vi.hoisted(() =>
+  vi.fn(() => ({ domainLanguage: 'en' as const }))
+)
+const setDomainLanguageCacheHeadersMock = vi.hoisted(() => vi.fn())
+const extractBackendErrorDetailsMock = vi.hoisted(() => vi.fn())
+const normaliseProductDtoMock = vi.hoisted(() => vi.fn())
+const getRouterParamMock = vi.hoisted(() =>
+  vi.fn<(event: unknown, name: string) => string | undefined>()
+)
+const getQueryMock = vi.hoisted(() => vi.fn<(event: unknown) => Record<string, unknown>>())
+const createErrorMock = vi.hoisted(() =>
+  vi.fn((input: { statusCode: number; statusMessage: string; cause?: unknown }) => ({
+    ...input,
+    isCreateError: true,
+  }))
+)
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: ProductPageRouteHandler) => fn,
+  getRouterParam: getRouterParamMock,
+  getQuery: getQueryMock,
+  createError: createErrorMock,
+}))
+
+vi.mock('~~/shared/api-client/services/products.services', () => ({
+  useProductService: useProductServiceMock,
+}))
+
+vi.mock('~~/shared/api-client/services/categories.services', () => ({
+  useCategoriesService: useCategoriesServiceMock,
+}))
+
+vi.mock('~~/shared/api-client/services/commercial-events.services', () => ({
+  useCommercialEventsService: useCommercialEventsServiceMock,
+}))
+
+vi.mock('~~/shared/utils/domain-language', () => ({
+  resolveDomainLanguage: resolveDomainLanguageMock,
+}))
+
+vi.mock('../../utils/cache-headers', () => ({
+  setDomainLanguageCacheHeaders: setDomainLanguageCacheHeadersMock,
+}))
+
+vi.mock('../../utils/log-backend-error', () => ({
+  extractBackendErrorDetails: extractBackendErrorDetailsMock,
+}))
+
+vi.mock('../../utils/normalise-product-sourcing', () => ({
+  normaliseProductDto: normaliseProductDtoMock,
+}))
+
+describe('server/api/product-page/[gtin]', () => {
+  let handler: ProductPageRouteHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    getProductByGtinMock.mockReset()
+    searchProductsMock.mockReset()
+    getCategoriesMock.mockReset()
+    getCategoryByIdMock.mockReset()
+    listCommercialEventsMock.mockReset()
+    setDomainLanguageCacheHeadersMock.mockReset()
+    resolveDomainLanguageMock.mockReturnValue({ domainLanguage: 'fr' })
+    normaliseProductDtoMock.mockImplementation(input => input)
+    extractBackendErrorDetailsMock.mockResolvedValue({
+      statusCode: 502,
+      statusMessage: 'Bad Gateway',
+      logMessage: 'HTTP 502 - Bad Gateway',
+    })
+    getRouterParamMock.mockImplementation((event, name) => {
+      const context = (event as { context?: { params?: Record<string, string> } }).context
+      return context?.params?.[name]
+    })
+    getQueryMock.mockImplementation(
+      event => (event as { context?: { query?: Record<string, unknown> } }).context?.query ?? {}
+    )
+
+    handler = (await import('./[gtin]')).default
+  })
+
+  it('returns aggregated product page payload from a single route call', async () => {
+    getProductByGtinMock.mockResolvedValue({ gtin: 123, slug: 'p' })
+    getCategoriesMock.mockResolvedValue([{ id: 'c1', verticalHomeUrl: '/tv' }])
+    getCategoryByIdMock.mockResolvedValue({
+      id: 'c1',
+      impactScoreConfig: { criteriasPonderation: { water: 0.3 } },
+    })
+    searchProductsMock.mockResolvedValue({
+      aggregations: [{ name: 'score_ECOSCORE', buckets: [] }],
+    })
+    listCommercialEventsMock.mockResolvedValue([{ id: 'event-1' }])
+
+    const event = {
+      node: {
+        req: { headers: { host: 'nudger.example' } },
+      },
+      context: {
+        params: { gtin: '123' },
+        query: { include: 'base,attributes', categorySlug: 'tv' },
+      },
+    } as unknown as Parameters<ProductPageRouteHandler>[0]
+
+    const response = await handler(event)
+
+    expect(getProductByGtinMock).toHaveBeenCalledWith(123, [
+      ProductIncludeEnum.Base,
+      ProductIncludeEnum.Attributes,
+    ])
+    expect(getCategoriesMock).toHaveBeenCalledOnce()
+    expect(getCategoryByIdMock).toHaveBeenCalledWith('c1')
+    expect(searchProductsMock).toHaveBeenCalledOnce()
+    expect(response.categoryDetail?.id).toBe('c1')
+    expect(response.commercialEvents).toEqual([{ id: 'event-1' }])
+    expect(response.aggregations.score_ECOSCORE).toBeDefined()
+  })
+})

--- a/frontend/server/api/product-page/[gtin].ts
+++ b/frontend/server/api/product-page/[gtin].ts
@@ -1,0 +1,151 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+} from 'h3'
+import { useCategoriesService } from '~~/shared/api-client/services/categories.services'
+import { useCommercialEventsService } from '~~/shared/api-client/services/commercial-events.services'
+import { useProductService } from '~~/shared/api-client/services/products.services'
+import {
+  AggTypeEnum,
+  type Agg,
+  type AggregationResponseDto,
+  type ProductSearchResponseDto,
+} from '~~/shared/api-client'
+import type { ProductPageData } from '~~/shared/types/product-page-data'
+import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
+
+import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
+import { extractBackendErrorDetails } from '../../utils/log-backend-error'
+import { normaliseProductDto } from '../../utils/normalise-product-sourcing'
+import { parseProductIncludes } from '../../utils/product-include'
+
+const resolveScoreIds = (categoryDetail: ProductPageData['categoryDetail']) => {
+  const ids: string[] = ['ECOSCORE']
+  const ponderations = categoryDetail?.impactScoreConfig?.criteriasPonderation ?? {}
+
+  Object.keys(ponderations).forEach(key => {
+    const normalized = key.trim()
+    if (normalized.length > 0 && !ids.includes(normalized)) {
+      ids.push(normalized)
+    }
+  })
+
+  return ids
+}
+
+const resolveCategoryBySlug = async (
+  slug: string,
+  domainLanguage: 'en' | 'fr'
+): Promise<ProductPageData['categoryDetail']> => {
+  const categoriesService = useCategoriesService(domainLanguage)
+  const categories = await categoriesService.getCategories()
+  const category = categories.find(
+    item => (item.verticalHomeUrl?.replace(/^\//, '') ?? '') === slug
+  )
+
+  if (!category?.id) {
+    return null
+  }
+
+  return categoriesService.getCategoryById(category.id)
+}
+
+export default defineEventHandler(async (event): Promise<ProductPageData> => {
+  setDomainLanguageCacheHeaders(event, 'public, max-age=300, s-maxage=300')
+
+  const gtinParam = getRouterParam(event, 'gtin')
+  if (!gtinParam) {
+    throw createError({ statusCode: 400, statusMessage: 'Product GTIN is required' })
+  }
+
+  const parsedGtin = Number.parseInt(gtinParam, 10)
+  if (!Number.isFinite(parsedGtin)) {
+    throw createError({ statusCode: 400, statusMessage: 'Product GTIN must be numeric' })
+  }
+
+  const query = getQuery(event)
+  const include = parseProductIncludes(query.include)
+  const categorySlug = typeof query.categorySlug === 'string' ? query.categorySlug.trim() : ''
+
+  const rawHost =
+    event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
+  const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+  const productService = useProductService(domainLanguage)
+  const commercialEventsService = useCommercialEventsService(domainLanguage)
+
+  try {
+    const product = normaliseProductDto(
+      await productService.getProductByGtin(parsedGtin, include)
+    )
+
+    let categoryDetail: ProductPageData['categoryDetail'] = null
+    if (categorySlug.length > 0) {
+      try {
+        categoryDetail = await resolveCategoryBySlug(categorySlug, domainLanguage)
+      } catch (categoryError) {
+        console.error('Failed to resolve category detail for product page.', categoryError)
+      }
+    }
+
+    const scoreIds = resolveScoreIds(categoryDetail)
+    let aggregations: Record<string, AggregationResponseDto> = {}
+
+    if (categoryDetail?.id && scoreIds.length > 0) {
+      const aggs: Agg[] = scoreIds.map(scoreId => ({
+        name: `score_${scoreId}`,
+        field: `scores.${scoreId}.value`,
+        type: AggTypeEnum.Range,
+        step: 0.5,
+      }))
+
+      try {
+        const response = await productService.searchProducts({
+          verticalId: categoryDetail.id,
+          pageSize: 0,
+          body: { aggs: { aggs } },
+        })
+
+        aggregations = (response as ProductSearchResponseDto).aggregations?.reduce<
+          Record<string, AggregationResponseDto>
+        >((accumulator, aggregation) => {
+          if (aggregation.name) {
+            accumulator[aggregation.name] = aggregation
+          }
+          return accumulator
+        }, {}) ?? {}
+      } catch (aggregationError) {
+        console.error('Failed to fetch impact aggregations', aggregationError)
+      }
+    }
+
+    let commercialEvents: ProductPageData['commercialEvents'] = []
+    try {
+      commercialEvents = await commercialEventsService.listCommercialEvents()
+    } catch (eventsError) {
+      console.error('Failed to load commercial events', eventsError)
+    }
+
+    return {
+      product,
+      categoryDetail,
+      aggregations,
+      commercialEvents,
+    }
+  } catch (error) {
+    const backendError = await extractBackendErrorDetails(error)
+    console.error(
+      'Error fetching product page data:',
+      backendError.logMessage,
+      backendError
+    )
+
+    throw createError({
+      statusCode: backendError.statusCode,
+      statusMessage: backendError.statusMessage,
+      cause: error,
+    })
+  }
+})

--- a/frontend/server/utils/product-include.spec.ts
+++ b/frontend/server/utils/product-include.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { ProductIncludeEnum } from '~~/shared/api-client/apis/ProductApi'
+import { parseProductIncludes } from './product-include'
+
+describe('parseProductIncludes', () => {
+  it('parses csv include values', () => {
+    expect(parseProductIncludes('base,attributes,scores')).toEqual([
+      ProductIncludeEnum.Base,
+      ProductIncludeEnum.Attributes,
+      ProductIncludeEnum.Scores,
+    ])
+  })
+
+  it('parses array values and filters invalid entries', () => {
+    expect(
+      parseProductIncludes(['base,attributes', 'invalid', ProductIncludeEnum.Timeline])
+    ).toEqual([
+      ProductIncludeEnum.Base,
+      ProductIncludeEnum.Attributes,
+      ProductIncludeEnum.Timeline,
+    ])
+  })
+
+  it('returns an empty list for unsupported values', () => {
+    expect(parseProductIncludes(undefined)).toEqual([])
+    expect(parseProductIncludes(['invalid'])).toEqual([])
+  })
+})

--- a/frontend/server/utils/product-include.ts
+++ b/frontend/server/utils/product-include.ts
@@ -1,0 +1,34 @@
+import {
+  ProductIncludeEnum,
+  type ProductIncludeEnum as ProductIncludeEnumType,
+} from '~~/shared/api-client/apis/ProductApi'
+
+const VALID_PRODUCT_INCLUDES = new Set<string>(Object.values(ProductIncludeEnum))
+
+/**
+ * Parse and validate include values accepted by ProductApi.product().
+ */
+export const parseProductIncludes = (
+  rawInclude: unknown
+): ProductIncludeEnumType[] => {
+  const values =
+    typeof rawInclude === 'string'
+      ? rawInclude.split(',')
+      : Array.isArray(rawInclude)
+        ? rawInclude.flatMap(value =>
+            typeof value === 'string' ? value.split(',') : []
+          )
+        : []
+
+  const deduped = new Set<ProductIncludeEnumType>()
+
+  values.forEach(value => {
+    const normalized = value.trim()
+    if (VALID_PRODUCT_INCLUDES.has(normalized)) {
+      deduped.add(normalized as ProductIncludeEnumType)
+    }
+  })
+
+  return Array.from(deduped)
+}
+

--- a/frontend/shared/api-client/services/products.services.ts
+++ b/frontend/shared/api-client/services/products.services.ts
@@ -15,6 +15,7 @@ import type {
 } from '..'
 import type {
   FilterableFieldsForVerticalRequest,
+  ProductIncludeEnum,
   ProductsRequest,
   SortableFieldsForVerticalRequest,
 } from '../apis/ProductApi'
@@ -42,7 +43,8 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
   }
 
   const getProductByGtin = async (
-    gtin: string | number
+    gtin: string | number,
+    include?: ProductIncludeEnum[]
   ): Promise<ProductDto> => {
     const parsedGtin =
       typeof gtin === 'number' ? gtin : Number.parseInt(gtin, 10)
@@ -55,6 +57,7 @@ export const useProductService = (domainLanguage: DomainLanguage) => {
       return await resolveApi().product({
         gtin: parsedGtin,
         domainLanguage,
+        include,
       })
     } catch (error) {
       console.error('Error fetching product:', error)

--- a/frontend/shared/types/product-page-data.ts
+++ b/frontend/shared/types/product-page-data.ts
@@ -1,0 +1,16 @@
+import type {
+  AggregationResponseDto,
+  CommercialEvent,
+  ProductDto,
+  VerticalConfigFullDto,
+} from '~~/shared/api-client'
+
+/**
+ * Product page SSR payload used to reduce request fan-out.
+ */
+export interface ProductPageData {
+  product: ProductDto | null
+  categoryDetail: VerticalConfigFullDto | null
+  aggregations: Record<string, AggregationResponseDto>
+  commercialEvents: CommercialEvent[]
+}


### PR DESCRIPTION
### Motivation
- Reduce client-side request fan-out by aggregating product, category, score aggregations and commercial events into a single SSR payload.  
- Ensure the `include` query parameter is validated and forwarded to the backend so product responses can be hydrated with requested components.  
- Improve server-side performance and consistency for product pages and make the frontend composables/pages consume a single typed payload.  

### Description
- Added `parseProductIncludes` utility (`frontend/server/utils/product-include.ts`) to parse CSV/array `include` values and validate them against `ProductIncludeEnum`.  
- Introduced a new SSR aggregator route `GET /api/product-page/:gtin` (`frontend/server/api/product-page/[gtin].ts`) that returns a typed `ProductPageData` payload containing `product`, `categoryDetail`, `aggregations`, and `commercialEvents`.  
- Updated `ProductPage.vue` to call the new endpoint via a single `useAsyncData('product-page-<gtin>')` and consume `product`, `categoryDetail`, `aggregations`, and `commercialEvents` from the aggregated payload (`frontend/app/components/pages/ProductPage.vue` and new `frontend/shared/types/product-page-data.ts`).  
- Propagated validated includes into the existing `/api/products/:gtin` route and extended the product service API to accept an optional include list (`frontend/server/api/products/[gtin].ts`, `frontend/shared/api-client/services/products.services.ts`).  
- Added unit tests for include parsing and the new product-page route behavior (`frontend/server/utils/product-include.spec.ts`, `frontend/server/api/product-page/[gtin].spec.ts`) and updated the existing product route spec to cover include propagation (`frontend/server/api/products/[gtin].spec.ts`).  

### Testing
- Ran targeted Vitest tests for changed pieces with `cd frontend && pnpm test server/utils/product-include.spec.ts server/api/products/[gtin].spec.ts server/api/product-page/[gtin].spec.ts`, and all tests in that suite passed.  
- Executed `pnpm lint` in `frontend` which surfaced pre-existing unrelated lint errors in `app/plugins/error-handler.ts` and `app/tests/error-handler.spec.ts`; those lint failures are unrelated to this change and were not introduced here.  
- The modified server-side routes and utilities are covered by the added/updated unit tests which succeeded in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698499e2a4108322bd9e49ee412df7f0)