### PR TITLE
fix(frontend): robustify product JSON-LD attribute resolution

### DIFF
--- a/frontend/app/utils/product-jsonld.spec.ts
+++ b/frontend/app/utils/product-jsonld.spec.ts
@@ -124,4 +124,47 @@ describe('buildProductJsonLdGraph', () => {
       'https://schema.org/UsedCondition'
     )
   })
+
+  it('resolves additional properties from normalized attribute aliases', () => {
+    const result = buildProductJsonLdGraph({
+      ...baseInput,
+      product: {
+        gtin: 1234567890123,
+        names: {
+          prettyName: 'Sample Product',
+        },
+        attributes: {
+          referentialAttributes: {
+            "RESOLUTION DE L'ECRAN": '3840 x 2160',
+            QUANTITEDEPORTSUSB20: '2',
+            NOMDELACOULEUR: 'Noir',
+          },
+          indexedAttributes: {
+            WEIGHT: { numericValue: 12.5 },
+            HEIGHT: { numericValue: 720 },
+          },
+        },
+      },
+    })
+
+    const graph = result?.['@graph'] as Array<Record<string, unknown>>
+    const productEntry = graph.find(
+      entry => entry['@type'] === 'Product'
+    ) as Record<string, unknown>
+
+    expect(productEntry?.color).toBe('Noir')
+    expect((productEntry?.weight as Record<string, unknown>)?.value).toBe(12.5)
+    expect((productEntry?.height as Record<string, unknown>)?.value).toBe(720)
+
+    const additionalProperty = (productEntry?.additionalProperty ?? []) as Array<
+      Record<string, unknown>
+    >
+    const resolutionEntry = additionalProperty.find(
+      entry => entry.name === 'Résolution'
+    )
+    const usbEntry = additionalProperty.find(entry => entry.name === 'Ports USB')
+
+    expect(resolutionEntry?.value).toBe('3840 x 2160')
+    expect(usbEntry?.value).toBe('2')
+  })
 })


### PR DESCRIPTION
### Motivation
- Product JSON-LD `additionalProperty` values were often missing because the builder relied on fragile literal attribute names (accent/space/punctuation sensitive) while vertical configs use normalized keys.
- This change aims to align JSON-LD attribute lookup with the verticals key conventions to avoid silent data loss in structured data.

### Description
- Added `normalizeAttributeKey` to strip accents, remove non-alphanumeric characters, and uppercase keys for stable matching.  
- Built normalized maps for both `referentialAttributes` and `indexedAttributes` and made `resolveAttributeValue` fall back to these normalized keys.  
- Introduced stable key aliases (`COLOR`, `WEIGHT`, `WIDTH`, `HEIGHT`, `DEPTH`) when resolving product fields so verticals that use normalized keys are matched first.  
- Added a regression test in `product-jsonld.spec.ts` to verify alias/normalized-key resolution for color, resolution, USB ports and numeric dimensions/weight.

### Testing
- Ran the unit tests for the changed module with `pnpm test app/utils/product-jsonld.spec.ts`, and all tests passed (4 tests, Vitest run successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984ba847b408322bc3514ce803f99f5)