### PR TITLE
fix(frontend): deduplicate category filter and sort options

### DIFF
--- a/frontend/app/utils/_field-options-normalizer.spec.ts
+++ b/frontend/app/utils/_field-options-normalizer.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { FieldMetadataDto, ProductFieldOptionsResponse } from '~~/shared/api-client'
+import {
+  deduplicateFieldMetadataList,
+  normalizeFieldOptionsResponse,
+} from './_field-options-normalizer'
+
+describe('deduplicateFieldMetadataList', () => {
+  it('deduplicates duplicated mappings and keeps the best metadata quality', () => {
+    const fields: FieldMetadataDto[] = [
+      {
+        mapping: 'power.hdr',
+        title: 'Consommation électrique (HDR)',
+        valueType: 'numeric',
+      },
+      {
+        mapping: 'power.hdr',
+        title: 'Consommation électrique (HDR)',
+        description: 'HDR consumption',
+        valueType: 'numeric',
+      },
+    ]
+
+    const deduplicated = deduplicateFieldMetadataList(fields)
+
+    expect(deduplicated).toHaveLength(1)
+    expect(deduplicated[0]?.description).toBe('HDR consumption')
+  })
+
+  it('falls back to title-based deduplication when mappings are missing', () => {
+    const fields: FieldMetadataDto[] = [
+      {
+        title: 'Disponibilité pièces détachées',
+        valueType: 'numeric',
+      },
+      {
+        title: '  disponibilité   pièces détachées  ',
+        description: 'duplicate with spacing',
+        valueType: 'numeric',
+      },
+    ]
+
+    const deduplicated = deduplicateFieldMetadataList(fields)
+
+    expect(deduplicated).toHaveLength(1)
+    expect(deduplicated[0]?.description).toBe('duplicate with spacing')
+  })
+})
+
+describe('normalizeFieldOptionsResponse', () => {
+  it('normalizes each section independently', () => {
+    const options: ProductFieldOptionsResponse = {
+      global: [
+        { mapping: 'price.minPrice.price', title: 'Prix', valueType: 'numeric' },
+        { mapping: 'price.minPrice.price', title: 'Prix', valueType: 'numeric' },
+      ],
+      impact: [
+        {
+          mapping: 'impact.ecoscore',
+          title: 'Eco score',
+          valueType: 'numeric',
+        },
+      ],
+      technical: [
+        {
+          mapping: 'power.hdr',
+          title: 'Consommation électrique (HDR)',
+          valueType: 'numeric',
+        },
+        {
+          mapping: 'power.hdr',
+          title: 'Consommation électrique (HDR)',
+          valueType: 'numeric',
+        },
+      ],
+    }
+
+    const normalized = normalizeFieldOptionsResponse(options)
+
+    expect(normalized?.global).toHaveLength(1)
+    expect(normalized?.impact).toHaveLength(1)
+    expect(normalized?.technical).toHaveLength(1)
+  })
+})

--- a/frontend/app/utils/_field-options-normalizer.ts
+++ b/frontend/app/utils/_field-options-normalizer.ts
@@ -1,0 +1,99 @@
+import type {
+  FieldMetadataDto,
+  ProductFieldOptionsResponse,
+} from '~~/shared/api-client'
+
+type FieldMetadataGroup = FieldMetadataDto[]
+
+const normalizeText = (value: string | null | undefined): string => {
+  return String(value ?? '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+}
+
+const buildFieldDeduplicationKey = (field: FieldMetadataDto): string => {
+  const mappingKey = normalizeText(field.mapping)
+  if (mappingKey) {
+    return `mapping:${mappingKey}`
+  }
+
+  const titleKey = normalizeText(field.title)
+  if (titleKey) {
+    return `title:${titleKey}`
+  }
+
+  return `fallback:${normalizeText(JSON.stringify(field))}`
+}
+
+const computeFieldQualityScore = (field: FieldMetadataDto): number => {
+  let score = 0
+
+  if (normalizeText(field.mapping)) {
+    score += 4
+  }
+
+  if (normalizeText(field.description)) {
+    score += 2
+  }
+
+  if (normalizeText(field.title)) {
+    score += 1
+  }
+
+  return score
+}
+
+/**
+ * Deduplicates field metadata entries using `mapping` as primary key and
+ * normalized title as fallback key.
+ */
+export const deduplicateFieldMetadataList = (
+  fields: FieldMetadataGroup | null | undefined
+): FieldMetadataGroup => {
+  if (!fields?.length) {
+    return []
+  }
+
+  const deduplicated: FieldMetadataDto[] = []
+  const indexByKey = new Map<string, number>()
+
+  fields.forEach(field => {
+    const key = buildFieldDeduplicationKey(field)
+    const currentIndex = indexByKey.get(key)
+
+    if (currentIndex == null) {
+      indexByKey.set(key, deduplicated.length)
+      deduplicated.push(field)
+      return
+    }
+
+    const existing = deduplicated[currentIndex]
+    const nextScore = computeFieldQualityScore(field)
+    const existingScore = computeFieldQualityScore(existing)
+
+    if (nextScore > existingScore) {
+      deduplicated[currentIndex] = field
+    }
+  })
+
+  return deduplicated
+}
+
+/**
+ * Returns normalized field option groups to prevent duplicate filter/sort
+ * entries in category pages.
+ */
+export const normalizeFieldOptionsResponse = (
+  options: ProductFieldOptionsResponse | null | undefined
+): ProductFieldOptionsResponse | null => {
+  if (!options) {
+    return null
+  }
+
+  return {
+    global: deduplicateFieldMetadataList(options.global),
+    impact: deduplicateFieldMetadataList(options.impact),
+    technical: deduplicateFieldMetadataList(options.technical),
+  }
+}

--- a/frontend/app/utils/_sort-options-normalizer.spec.ts
+++ b/frontend/app/utils/_sort-options-normalizer.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deduplicateSortItemsByTitle,
+  type SortFieldItem,
+} from './_sort-options-normalizer'
+
+describe('deduplicateSortItemsByTitle', () => {
+  it('deduplicates sort options sharing the same visible title', () => {
+    const items: SortFieldItem[] = [
+      {
+        value: 'attributes.indexedAttributes.HDR_A.numericValue',
+        title: 'Consommation électrique (HDR)',
+      },
+      {
+        value: 'attributes.indexedAttributes.HDR_B.numericValue',
+        title: '  consommation   électrique (hdr) ',
+      },
+      {
+        value: 'price.minPrice.price',
+        title: 'Prix',
+      },
+    ]
+
+    const deduplicated = deduplicateSortItemsByTitle(items, item =>
+      item.value.includes('HDR_B') ? 100 : 10
+    )
+
+    expect(deduplicated).toEqual([
+      {
+        value: 'attributes.indexedAttributes.HDR_B.numericValue',
+        title: '  consommation   électrique (hdr) ',
+      },
+      {
+        value: 'price.minPrice.price',
+        title: 'Prix',
+      },
+    ])
+  })
+})

--- a/frontend/app/utils/_sort-options-normalizer.ts
+++ b/frontend/app/utils/_sort-options-normalizer.ts
@@ -1,0 +1,31 @@
+export type SortFieldItem = {
+  title: string
+  value: string
+}
+
+const normalizeSortTitle = (value: string): string => {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/**
+ * Deduplicates sort options by normalized visible title while preserving the
+ * highest-priority option for each title.
+ */
+export const deduplicateSortItemsByTitle = (
+  items: SortFieldItem[],
+  computePriority: (item: SortFieldItem) => number
+): SortFieldItem[] => {
+  const byTitle = new Map<string, { item: SortFieldItem; priority: number }>()
+
+  items.forEach(item => {
+    const normalizedTitle = normalizeSortTitle(item.title)
+    const current = byTitle.get(normalizedTitle)
+    const priority = computePriority(item)
+
+    if (!current || priority > current.priority) {
+      byTitle.set(normalizedTitle, { item, priority })
+    }
+  })
+
+  return Array.from(byTitle.values()).map(entry => entry.item)
+}


### PR DESCRIPTION
### Motivation
- Category pages could show duplicate filter and sort entries when backend field metadata contained repeated mappings or different mappings resolving to the same visible label, degrading UX.

### Description
- Added `frontend/app/utils/_field-options-normalizer.ts` with `deduplicateFieldMetadataList` and `normalizeFieldOptionsResponse` to normalize and deduplicate field metadata by `mapping` (fallback to normalized `title`) and pick the best-quality metadata.
- Added `frontend/app/utils/_sort-options-normalizer.ts` with `deduplicateSortItemsByTitle` to collapse sort choices sharing the same visible title while preserving the highest-priority mapping.
- Integrated normalization and deduplication into `CategoryPage.vue` by normalizing `filterOptions`/`sortOptions`, deduplicating sort menu items by title, and deduplicating merged table fields before building lookup maps.
- Added unit tests for both new utilities in `frontend/app/utils/_field-options-normalizer.spec.ts` and `frontend/app/utils/_sort-options-normalizer.spec.ts` to verify mapping/title deduping and priority resolution.

### Testing
- Ran linter with `pnpm lint` which passed successfully.
- Ran the full test suite with `pnpm test`; there is a pre-existing unrelated failure (`app/pages/index.spec.ts > Home page > registers FAQ structured data`) so the full suite did not fully pass.
- Executed targeted unit tests with `pnpm vitest run app/utils/_field-options-normalizer.spec.ts app/utils/_sort-options-normalizer.spec.ts` which passed.
- Built/generate step executed with `pnpm generate` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc6f7a44832b81a5a6561472cf38)