### PR TITLE
fix(frontend): restore mobile Nudger assistant access on home

### DIFF
--- a/frontend/app/components/pwa/PwaMobileLanding.spec.ts
+++ b/frontend/app/components/pwa/PwaMobileLanding.spec.ts
@@ -1,0 +1,143 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const messages: Record<string, string> = {
+  'home.hero.title': 'Nudger home',
+  'pwa.landing.hero.subtitle': 'Mobile subtitle',
+  'pwa.landing.search.title': 'Search',
+  'pwa.landing.search.label': 'Search label',
+  'pwa.landing.search.placeholder': 'Search placeholder',
+  'pwa.landing.search.ariaLabel': 'Search aria',
+  'pwa.landing.search.cta': 'Search now',
+  'pwa.landing.actions.scan.title': 'Scan',
+  'pwa.landing.actions.scan.description': 'Scan description',
+  'pwa.landing.actions.scan.helper': 'Scan helper',
+  'pwa.landing.actions.scan.loading': 'Loading',
+  'pwa.landing.actions.scan.error': 'Error',
+  'pwa.landing.actions.wizard.title': 'Assistant Nudger',
+  'pwa.landing.actions.wizard.description': 'Wizard description',
+  'pwa.landing.actions.search.title': 'Search action',
+  'pwa.landing.actions.search.description': 'Search action description',
+}
+
+const smAndDown = { value: true }
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key,
+  }),
+}))
+
+vi.mock('vuetify', () => ({
+  useDisplay: () => ({
+    smAndDown,
+  }),
+}))
+
+describe('PwaMobileLanding', () => {
+  beforeEach(() => {
+    smAndDown.value = true
+  })
+
+  it('opens the wizard dialog from the hero button', async () => {
+    const component = (await import('./PwaMobileLanding.vue')).default
+
+    const wrapper = mount(component, {
+      global: {
+        stubs: {
+          VContainer: { template: '<div><slot /></div>' },
+          VRow: { template: '<div><slot /></div>' },
+          VCol: { template: '<div><slot /></div>' },
+          VSheet: { template: '<div><slot /></div>' },
+          VCard: { template: '<div><slot /></div>' },
+          VCardTitle: { template: '<div><slot /></div>' },
+          VCardText: { template: '<div><slot /></div>' },
+          VCardItem: { template: '<div><slot /></div>' },
+          VCardSubtitle: { template: '<div><slot /></div>' },
+          VAvatar: { template: '<div><slot /></div>' },
+          VIcon: { template: '<i><slot /></i>' },
+          VChip: { template: '<div><slot /></div>' },
+          ClientOnly: { template: '<div><slot /></div>' },
+          VSnackbar: { template: '<div><slot /></div>' },
+          SearchSuggestField: { template: '<div />' },
+          CategoryBadgesRow: { template: '<div />' },
+          PwaBarcodeScanner: { template: '<div />' },
+          NudgeToolWizard: { template: '<div data-testid="nudge-tool-wizard" />' },
+          VBtn: {
+            emits: ['click'],
+            template:
+              '<button @click="$emit(\'click\')"><slot /></button>',
+          },
+          VDialog: {
+            props: ['modelValue'],
+            template:
+              '<div v-if="modelValue" class="v-dialog-stub"><slot /></div>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="nudge-tool-wizard"]').exists()).toBe(
+      false
+    )
+
+    await wrapper.get('[data-testid="pwa-open-wizard"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="nudge-tool-wizard"]').exists()).toBe(
+      true
+    )
+  })
+
+  it('opens the wizard dialog from the wizard quick action card', async () => {
+    const component = (await import('./PwaMobileLanding.vue')).default
+
+    const wrapper = mount(component, {
+      global: {
+        stubs: {
+          VContainer: { template: '<div><slot /></div>' },
+          VRow: { template: '<div><slot /></div>' },
+          VCol: { template: '<div><slot /></div>' },
+          VSheet: { template: '<div><slot /></div>' },
+          VCard: {
+            emits: ['click'],
+            inheritAttrs: false,
+            template: '<div v-bind="$attrs" @click="$emit(\'click\')"><slot /></div>',
+          },
+          VCardTitle: { template: '<div><slot /></div>' },
+          VCardText: { template: '<div><slot /></div>' },
+          VCardItem: { template: '<div><slot /></div>' },
+          VCardSubtitle: { template: '<div><slot /></div>' },
+          VAvatar: { template: '<div><slot /></div>' },
+          VIcon: { template: '<i><slot /></i>' },
+          VChip: { template: '<div><slot /></div>' },
+          ClientOnly: { template: '<div><slot /></div>' },
+          VSnackbar: { template: '<div><slot /></div>' },
+          SearchSuggestField: { template: '<div />' },
+          CategoryBadgesRow: { template: '<div />' },
+          PwaBarcodeScanner: { template: '<div />' },
+          NudgeToolWizard: { template: '<div data-testid="nudge-tool-wizard" />' },
+          VBtn: {
+            emits: ['click'],
+            template:
+              '<button @click="$emit(\'click\')"><slot /></button>',
+          },
+          VDialog: {
+            props: ['modelValue'],
+            template:
+              '<div v-if="modelValue" class="v-dialog-stub"><slot /></div>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('[data-testid="nudge-tool-wizard"]').exists()).toBe(
+      false
+    )
+
+    await wrapper.get('[data-testid="pwa-quick-action-wizard"]').trigger('click')
+
+    expect(wrapper.find('[data-testid="nudge-tool-wizard"]').exists()).toBe(
+      true
+    )
+  })
+})

--- a/frontend/app/components/pwa/PwaMobileLanding.vue
+++ b/frontend/app/components/pwa/PwaMobileLanding.vue
@@ -56,6 +56,18 @@
                   >
                     {{ t('pwa.landing.search.cta') }}
                   </v-btn>
+                  <v-btn
+                    block
+                    color="primary"
+                    variant="tonal"
+                    size="large"
+                    class="font-weight-bold mt-3"
+                    prepend-icon="mdi-sparkles"
+                    data-testid="pwa-open-wizard"
+                    @click="isWizardOpen = true"
+                  >
+                    {{ t('pwa.landing.actions.wizard.title') }}
+                  </v-btn>
                 </v-card-text>
               </v-card>
 
@@ -82,6 +94,7 @@
             border
             rounded="xl"
             color="surface-default"
+            :data-testid="`pwa-quick-action-${action.key}`"
             @click="action.onClick()"
           >
             <v-card-item>
@@ -166,7 +179,6 @@
             <NudgeToolWizard
               :verticals="verticals"
               @navigate="handleWizardNavigate"
-              @close="isWizardOpen = false"
             />
           </v-card-text>
         </v-card>


### PR DESCRIPTION
### Motivation
- The mobile home assistant entry was hard to discover compared to desktop and the mobile wrapper listened to a `close` event that `NudgeToolWizard` does not emit, causing a broken assistant flow.
- Improve testability and UI automation by adding stable selectors for mobile quick actions.

### Description
- Added a dedicated assistant CTA button in the mobile hero search card with `data-testid="pwa-open-wizard"` to open the wizard immediately on mobile in `frontend/app/components/pwa/PwaMobileLanding.vue`.
- Added `data-testid="pwa-quick-action-<key>"` attributes to quick action cards to provide stable selectors for tests and UI checks in `PwaMobileLanding.vue`.
- Removed the non-existent `@close` listener on `NudgeToolWizard` and retained the actual `@navigate` flow so the dialog state is controlled by the surrounding component.
- Added `frontend/app/components/pwa/PwaMobileLanding.spec.ts` with tests that verify the wizard opens from both the hero CTA and the wizard quick action card.

### Testing
- Ran `pnpm lint` in the `frontend` module and it passed without errors.
- Ran the focused spec with `pnpm exec vitest run app/components/pwa/PwaMobileLanding.spec.ts` and the new tests passed.
- Ran `pnpm generate` and the Nuxt generation completed successfully.
- Running broader `pnpm test` in this environment surfaced one pre-existing unrelated failing test (`app/pages/index.spec.ts`); this failure is not caused by these changes and the focused component tests remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc88a884832ba71d17e8ca44d5b7)