### PR TITLE
Fix mobile product timeline left-edge clipping

### DIFF
--- a/frontend/app/components/product/ProductLifeTimeline.vue
+++ b/frontend/app/components/product/ProductLifeTimeline.vue
@@ -422,19 +422,20 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   overflow-x: auto;
   padding-bottom: 0.25rem;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
+  scroll-padding-inline-start: 0.5rem;
 }
 
 .product-life-timeline__rail {
   display: flex;
   gap: 1.75rem;
   align-items: flex-start;
-  justify-content: center;
+  justify-content: flex-start;
   width: max-content;
   min-width: 100%;
   padding: 0.25rem 0.5rem;
   scroll-snap-type: x mandatory;
-  margin: 0 auto;
+  margin: 0;
 }
 
 .product-life-timeline--vertical .product-life-timeline__rail {
@@ -609,5 +610,18 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   margin: 0;
   color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
   font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .product-life-timeline__body {
+    justify-content: flex-start;
+    scroll-padding-inline-start: 0.75rem;
+  }
+
+  .product-life-timeline__rail {
+    justify-content: flex-start;
+    margin: 0;
+    padding-inline-start: 0.75rem;
+  }
 }
 </style>


### PR DESCRIPTION
### Motivation

- The product life timeline was centered on overflow which could clip the left/start edge on small viewports and make the first year/month markers hard to access.

### Description

- Updated CSS in `frontend/app/components/product/ProductLifeTimeline.vue` to anchor horizontal scrolling to the start by setting `.product-life-timeline__body` and `.product-life-timeline__rail` to `justify-content: flex-start`, removing centering margins and adding `scroll-padding-inline-start`.
- Added an explicit small-screen rule (`@media (max-width: 600px)`) that enforces start alignment and adds `padding-inline-start` so the first timeline items have breathing room.

### Testing

- Ran `pnpm lint` in the `frontend` workspace and it passed.
- Ran the component unit tests for the timeline with `pnpm vitest run app/components/product/ProductLifeTimeline.spec.ts` and they passed.
- Executed full test suite with `pnpm test`; most tests passed but an existing unrelated test (`app/pages/index.spec.ts` → "registers FAQ structured data in head tags") failed.
- Built the frontend with `pnpm generate` and the generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc945d1c832b930473a9a9e413b4)