### PR TITLE
Add Cody orchestration config/docs and `run_agent.mjs --check` preflight mode

### DIFF
--- a/.github/ai/README.md
+++ b/.github/ai/README.md
@@ -1,0 +1,115 @@
+# Cody Orchestrator and Multi‑LLM Agent
+
+## Overview
+
+The repository ships two complementary AI automation layers:
+
+- **Multi‑LLM runner** (`scripts/ai/run_agent.mjs`) for state-driven prompts and JSON contract output.
+- **Cody orchestrator settings** (`.github/ai/cody.json`) for high-level workflow controls used by GitHub workflows/UI integrations.
+
+Cody remains **stateless**: labels and issue comments are the source of truth.
+
+## Cody defaults (validated decisions)
+
+- `cody:evaluate` is not part of the default workflow.
+- Default path is `UNDERSTANDING -> PLANNING -> READY_TO_CODE`.
+- Manual resume is mandatory via `cody:retry` (or `cody:evaluate` if kept as compatibility trigger).
+- `cody:ask` is a free-form assistant answer (simple comment mode).
+- Single continuously-updated assistant thread comment (`comment_thread.marker`).
+- Coding phase should open a PR linked to the source issue.
+
+## `cody.json` reference
+
+Main file: `.github/ai/cody.json`.
+
+### Labels
+
+- `labels.enabled`: main switch (`cody:enabled`).
+- `labels.triggers.ask`: direct Q/A mode.
+- `labels.triggers.clarify`: starts/continues clarification path.
+- `labels.triggers.code`: starts coding/PR creation phase.
+- `labels.triggers.retry`: explicit manual resume trigger.
+- `labels.triggers.evaluate`: optional compatibility trigger.
+
+### Workflow behavior
+
+- `workflow.default_sequence`: ordered states for default orchestration.
+- `workflow.auto_transition`: if `true`, transitions proceed automatically until a human gate.
+- `workflow.manual_retry_labels`: labels accepted for manual resume.
+- `workflow.single_thread_comment`: keep one edited thread comment.
+
+### Provider mapping
+
+- `providers.default`: fallback provider when no explicit provider is set.
+- `providers.by_step`: flexible provider mapping by logical step (`ASK`, `UNDERSTANDING`, ...).
+- `providers.fallback_order`: provider fallback order.
+
+### PR linking
+
+- `pull_request.link_mode`: `close` or `reference` style behavior.
+- `pull_request.closing_keyword`: keyword used for auto-close (`Closes`, `Fixes`, ...).
+- `pull_request.link_template`: issue link format used in PR body.
+- Other fields (`branch_prefix`, templates...) control branch/commit/title conventions.
+
+### Check mode
+
+- `check_mode.validate_required_secrets`: enables secrets verification logic.
+- `check_mode.required_secrets_by_provider`: required secrets mapping.
+
+## Runner check mode (`run_agent.mjs --check`)
+
+Use this mode in CI or locally to validate runtime prerequisites before calling providers.
+
+### What is validated
+
+- AI config can be loaded.
+- Optional referenced files exist (`--template`, `--schema`, `--context`).
+- Required API secrets exist for selected providers.
+
+### Command examples
+
+Check a single provider:
+
+```bash
+node scripts/ai/run_agent.mjs \
+  --check \
+  --config .github/ai/agent.config.json \
+  --provider codex \
+  --template .github/ai/prompts/UNDERSTANDING.md \
+  --schema .github/ai/schema/agent_contract.schema.json \
+  --context ai_context.json \
+  --out ai_check.json
+```
+
+Check all configured providers:
+
+```bash
+node scripts/ai/run_agent.mjs \
+  --check \
+  --config .github/ai/agent.config.json \
+  --out ai_check.json
+```
+
+### Exit codes
+
+- `0`: checks passed.
+- `1`: missing required secrets.
+- `2`: invalid arguments/config/provider.
+
+### Output format
+
+`--out` writes a JSON report with:
+
+- `ok`: global status.
+- `checked_at`: UTC timestamp.
+- `providers[]`: provider metadata + secret presence.
+- `missing_secrets[]`: unique missing secret names.
+
+## Bot identity recommendation
+
+For production usage, prefer a **GitHub App named Cody** over a personal bot account:
+
+- Clear audit trail (`Cody[bot]`).
+- Principle of least privilege.
+- Easier key rotation and permission scoping.
+

--- a/.github/ai/cody.json
+++ b/.github/ai/cody.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "labels": {
+    "enabled": "cody:enabled",
+    "triggers": {
+      "ask": "cody:ask",
+      "clarify": "cody:clarify",
+      "code": "cody:code",
+      "retry": "cody:retry",
+      "evaluate": "cody:evaluate"
+    }
+  },
+  "workflow": {
+    "default_sequence": [
+      "UNDERSTANDING",
+      "PLANNING",
+      "READY_TO_CODE"
+    ],
+    "auto_transition": true,
+    "manual_retry_labels": [
+      "cody:retry",
+      "cody:evaluate"
+    ],
+    "single_thread_comment": true
+  },
+  "providers": {
+    "default": "codex",
+    "by_step": {
+      "ASK": "claude",
+      "UNDERSTANDING": "claude",
+      "PLANNING": "claude",
+      "READY_TO_CODE": "codex",
+      "CODE": "codex"
+    },
+    "fallback_order": [
+      "codex",
+      "claude",
+      "gemini"
+    ]
+  },
+  "pull_request": {
+    "enabled": true,
+    "link_mode": "close",
+    "closing_keyword": "Closes",
+    "link_template": "Closes #{issue_number}",
+    "branch_prefix": "cody/issue-",
+    "commit_message_template": "feat(cody): implement issue #{issue_number}",
+    "title_template": "[Cody] #{issue_number} {issue_title}"
+  },
+  "check_mode": {
+    "validate_required_secrets": true,
+    "required_secrets_by_provider": {
+      "codex": [
+        "OPENAI_API_KEY"
+      ],
+      "claude": [
+        "ANTHROPIC_API_KEY"
+      ],
+      "gemini": [
+        "GEMINI_API_KEY"
+      ]
+    }
+  },
+  "comment_thread": {
+    "marker": "<!-- AI_MULTI_AGENT_THREAD v1 -->",
+    "title": "🤖 Cody Assistant"
+  }
+}

--- a/.github/workflows/ai-agent.md
+++ b/.github/workflows/ai-agent.md
@@ -48,3 +48,27 @@ tests reproductibles sur les PRs ciblant la branche par défaut.
   - télécharge les artefacts et poste un commentaire de synthèse sur la PR
   - applique le label `agent:DEV_CHECKS` en cas de succès ou `agent:needs_human`
     si un contrôle échoue
+
+
+## Cody orchestration conventions
+
+Cody orchestration settings are documented in `.github/ai/README.md` and configured in `.github/ai/cody.json`.
+
+Current agreed behavior:
+
+- Default flow: `UNDERSTANDING -> PLANNING -> READY_TO_CODE`.
+- `evaluate` is not in default flow.
+- Resume after `needs_human` is manual, using `cody:retry` (and optionally `cody:evaluate` for compatibility).
+- `cody:ask` is a free-form assistant response (simple comment).
+- Single updated thread comment should be used for assistant output.
+- Coding mode should open a PR linked to the issue, with auto-close keyword configurable in `cody.json`.
+
+## Runner check mode
+
+The runner supports a prerequisite validation mode:
+
+```bash
+node scripts/ai/run_agent.mjs --check --config .github/ai/agent.config.json --provider codex --out ai_check.json
+```
+
+This validates provider configuration and required secrets (for example `OPENAI_API_KEY` for `codex`).

--- a/scripts/tests/run_agent_check.test.mjs
+++ b/scripts/tests/run_agent_check.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function buildArgs(baseDir, outFile, provider = '') {
+  const args = [
+    'scripts/ai/run_agent.mjs',
+    '--check',
+    '--config',
+    '.github/ai/agent.config.json',
+    '--template',
+    join(baseDir, 'template.md'),
+    '--schema',
+    join(baseDir, 'schema.json'),
+    '--context',
+    join(baseDir, 'context.json'),
+    '--out',
+    outFile
+  ];
+  if (provider) {
+    args.push('--provider', provider);
+  }
+  return args;
+}
+
+function setupFiles() {
+  const dir = mkdtempSync(join(tmpdir(), 'run-agent-check-'));
+  writeFileSync(join(dir, 'template.md'), '# Test template');
+  writeFileSync(join(dir, 'schema.json'), '{}');
+  writeFileSync(join(dir, 'context.json'), '{}');
+  return dir;
+}
+
+test('check mode fails when provider secret is missing', () => {
+  const dir = setupFiles();
+  const outFile = join(dir, 'out.json');
+
+  const env = { ...process.env };
+  delete env.OPENAI_API_KEY;
+
+  const result = spawnSync('node', buildArgs(dir, outFile, 'codex'), {
+    encoding: 'utf8',
+    env
+  });
+
+  assert.equal(result.status, 1);
+  const report = JSON.parse(readFileSync(outFile, 'utf8'));
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.missing_secrets, ['OPENAI_API_KEY']);
+});
+
+test('check mode succeeds when provider secret is present', () => {
+  const dir = setupFiles();
+  const outFile = join(dir, 'out.json');
+
+  const env = {
+    ...process.env,
+    OPENAI_API_KEY: 'test-key'
+  };
+
+  const result = spawnSync('node', buildArgs(dir, outFile, 'codex'), {
+    encoding: 'utf8',
+    env
+  });
+
+  assert.equal(result.status, 0);
+  const report = JSON.parse(readFileSync(outFile, 'utf8'));
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.missing_secrets, []);
+  assert.equal(report.providers[0].provider, 'codex');
+});


### PR DESCRIPTION
### Motivation
- Provide a documented, configurable Cody orchestration policy for the multi‑LLM agent and codify agreed defaults (state sequence, trigger labels, PR linking, manual retry behavior). 
- Add a safe preflight/check mode to the runner to detect missing provider secrets and missing input files before attempting provider API calls.

### Description
- Added `.github/ai/cody.json` containing Cody defaults (labels, workflow sequence, provider mapping, PR linking and check_mode secret requirements). 
- Added `.github/ai/README.md` with full reference for `cody.json`, runner `--check` usage, exit codes, and operator guidance. 
- Extended documentation `.github/workflows/ai-agent.md` to describe Cody orchestration conventions and the new runner check mode. 
- Implemented `--check` behaviour in `scripts/ai/run_agent.mjs` which validates config, optional paths (`--template`, `--schema`, `--context`), and required provider secrets and emits a structured JSON report to `--out`. 
- Added node tests `scripts/tests/run_agent_check.test.mjs` covering missing-secret failure and secret-present success cases. 

### Testing
- Ran unit tests with `node --test scripts/tests/run_agent_check.test.mjs` and both tests passed (2/2). 
- Performed a smoke check with `OPENAI_API_KEY=dummy node scripts/ai/run_agent.mjs --check --config .github/ai/agent.config.json --provider codex --template <tmp>/template.md --schema <tmp>/schema.json --context <tmp>/context.json --out <tmp>/out.json` which produced a valid JSON report and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a5d3c4ffc832b93afcc301883e13c)