### PR TITLE
Simplify category sorting: primary/advanced groups, explicit default, dedupe, and analytics

### DIFF
--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -228,8 +228,8 @@
             :show-filters-button="true"
             @toggle-filters="filtersDrawer = true"
             @update:search-term="searchTerm = $event"
-            @update:sort-field="sortField = $event"
-            @update:sort-order="sortOrder = $event"
+            @update:sort-field="onToolbarSortFieldUpdate"
+            @update:sort-order="onToolbarSortOrderUpdate"
             @update:view-mode="viewMode = $event"
           />
 
@@ -385,7 +385,7 @@ const router = useRouter()
 const { locale, t } = useI18n()
 const requestURL = useRequestURL()
 const { isLoggedIn, roles } = useAuth()
-const { trackFilterChange } = useAnalytics()
+const { trackFilterChange, trackSortUsage } = useAnalytics()
 const listComponents = [
   'base',
   'identity',
@@ -1295,29 +1295,36 @@ type SortMenuItem =
       type: 'divider'
     }
 
-const STANDARD_SORT_FIELDS = [
-  ECOSCORE_RELATIVE_FIELD,
-  'price.minPrice.price',
-  'offersCount',
-]
+const PRIMARY_SORT_STRATEGY = [
+  {
+    key: 'relevance',
+    candidates: ['_score', 'relevance', 'scores.RELEVANCE.value'],
+  },
+  {
+    key: 'impact',
+    candidates: [ECOSCORE_RELATIVE_FIELD],
+  },
+  {
+    key: 'price',
+    candidates: ['price.minPrice.price'],
+  },
+  {
+    key: 'popularity',
+    candidates: ['offersCount', 'offers.offersCount', 'popularity'],
+  },
+  {
+    key: 'novelty',
+    candidates: ['createdAt', 'updatedAt', 'releaseDate', 'dateCreated'],
+    matcher: /(created|updated|release|novel|new|date)/i,
+  },
+] as const
 
-const extractAttributeKeyFromMapping = (mapping: string): string | null => {
-  const patterns = [
-    /attributes\.(?:indexed(?:Attributes)?|referential(?:Attributes)?|referentielAttributes|indexedAttributes)\.([^.]+)/i,
-    /attributes\.([^.]+)/i,
-  ]
-
-  for (const pattern of patterns) {
-    const match = mapping.match(pattern)
-    if (match?.[1]) {
-      return match[1]
-    }
-  }
-
-  return null
+type SortFieldEntry = {
+  mapping: string
+  field: FieldMetadataDto
 }
 
-const sortFieldEntries = computed(() => {
+const allSortFieldEntries = computed<SortFieldEntry[]>(() => {
   const fields = [
     ...(sortOptions.value?.global ?? []),
     ...(sortOptions.value?.impact ?? []),
@@ -1325,10 +1332,12 @@ const sortFieldEntries = computed(() => {
   ]
 
   const seen = new Set<string>()
+
   return fields
     .filter(field => typeof field.mapping === 'string' && Boolean(field.mapping))
     .filter(field => {
       const mapping = field.mapping as string
+
       if (seen.has(mapping)) {
         return false
       }
@@ -1336,28 +1345,13 @@ const sortFieldEntries = computed(() => {
       seen.add(mapping)
       return true
     })
-    .map(field => {
-      const mapping = field.mapping as string
-      return { mapping, field }
-    })
+    .map(field => ({
+      mapping: field.mapping as string,
+      field,
+    }))
 })
 
-const computeSortEntryPriority = (
-  mapping: string,
-  popularKeys: Set<string>
-): number => {
-  if (STANDARD_SORT_FIELDS.includes(mapping)) {
-    return 300 - STANDARD_SORT_FIELDS.indexOf(mapping)
-  }
-
-  const attributeKey = extractAttributeKeyFromMapping(mapping)
-
-  if (attributeKey && popularKeys.has(attributeKey)) {
-    return 200
-  }
-
-  return 100
-}
+const sortFieldEntries = computed(() => allSortFieldEntries.value)
 
 const sortFieldItems = computed<SortFieldItem[]>(() => {
   const fieldMap = new Map(
@@ -1373,48 +1367,61 @@ const sortFieldItems = computed<SortFieldItem[]>(() => {
     ]
   }
 
-  const popularKeys = new Set(
-    popularAttributes.value
-      .map(config => config.key)
-      .filter(Boolean) as string[]
-  )
+  const items = sortFieldEntries.value
+    .map(entry => ({
+      value: entry.mapping,
+      title: resolveSortFieldTitle(entry.field, t),
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title))
 
-  const buildItem = (mapping: string): SortFieldItem => {
-    const field = fieldMap.get(mapping)
-    return {
-      value: mapping,
-      title: resolveSortFieldTitle(field ?? { mapping, title: '' }, t),
+  return deduplicateSortItemsByTitle(items)
+})
+
+const primarySortItems = computed<SortFieldItem[]>(() => {
+  const byValue = new Map(sortFieldItems.value.map(item => [item.value, item]))
+  const primary: SortFieldItem[] = []
+  const used = new Set<string>()
+
+  PRIMARY_SORT_STRATEGY.forEach(strategy => {
+    let selected: SortFieldItem | undefined
+
+    for (const candidate of strategy.candidates) {
+      const current = byValue.get(candidate)
+      if (current) {
+        selected = current
+        break
+      }
     }
+
+    if (!selected && strategy.matcher) {
+      selected = sortFieldItems.value.find(item => strategy.matcher?.test(item.value))
+    }
+
+    if (selected && !used.has(selected.value)) {
+      primary.push(selected)
+      used.add(selected.value)
+    }
+  })
+
+  return primary
+})
+
+const advancedSortItems = computed<SortFieldItem[]>(() => {
+  const primaryValues = new Set(primarySortItems.value.map(item => item.value))
+
+  return sortFieldItems.value.filter(item => !primaryValues.has(item.value))
+})
+
+const defaultSortField = computed<string | null>(() => {
+  if (primarySortItems.value.length > 0) {
+    return primarySortItems.value[0].value
   }
 
-  const standardItems = STANDARD_SORT_FIELDS.filter(mapping =>
-    fieldMap.has(mapping)
-  ).map(buildItem)
+  if (advancedSortItems.value.length > 0) {
+    return advancedSortItems.value[0].value
+  }
 
-  const remainingEntries = sortFieldEntries.value.filter(
-    entry => !STANDARD_SORT_FIELDS.includes(entry.mapping)
-  )
-
-  const popularItems = remainingEntries
-    .filter(entry => {
-      const attributeKey = extractAttributeKeyFromMapping(entry.mapping)
-      return attributeKey ? popularKeys.has(attributeKey) : false
-    })
-    .map(entry => buildItem(entry.mapping))
-    .sort((a, b) => a.title.localeCompare(b.title))
-
-  const otherItems = remainingEntries
-    .filter(entry => {
-      const attributeKey = extractAttributeKeyFromMapping(entry.mapping)
-      return attributeKey ? !popularKeys.has(attributeKey) : true
-    })
-    .map(entry => buildItem(entry.mapping))
-    .sort((a, b) => a.title.localeCompare(b.title))
-
-  return deduplicateSortItemsByTitle(
-    [...standardItems, ...popularItems, ...otherItems],
-    item => computeSortEntryPriority(item.value, popularKeys)
-  )
+  return hasSortOptions.value ? null : ECOSCORE_RELATIVE_FIELD
 })
 
 const sortItems = computed<SortMenuItem[]>(() => {
@@ -1422,11 +1429,19 @@ const sortItems = computed<SortMenuItem[]>(() => {
     return []
   }
 
-  if (sortFieldEntries.value.length === 0) {
-    return sortFieldItems.value
-  }
-
   const items: SortMenuItem[] = []
+  const defaultField = defaultSortField.value
+
+  const withDefaultLabel = (option: SortFieldItem): SortFieldItem => {
+    if (option.value !== defaultField) {
+      return option
+    }
+
+    return {
+      ...option,
+      title: t('category.products.sort.defaultLabel', { label: option.title }),
+    }
+  }
 
   const group = (title: string, options: SortFieldItem[]) => {
     if (!options.length) {
@@ -1438,50 +1453,13 @@ const sortItems = computed<SortMenuItem[]>(() => {
     }
 
     items.push({ type: 'subheader', title })
-    items.push(...options)
+    items.push(...options.map(withDefaultLabel))
   }
 
-  const standardItems = sortFieldItems.value.filter(item =>
-    STANDARD_SORT_FIELDS.includes(item.value)
-  )
-  const popularKeys = new Set(
-    popularAttributes.value
-      .map(config => config.key)
-      .filter(Boolean) as string[]
-  )
-
-  const popularItems = sortFieldItems.value.filter(item => {
-    if (STANDARD_SORT_FIELDS.includes(item.value)) {
-      return false
-    }
-
-    const attributeKey = extractAttributeKeyFromMapping(item.value)
-    return attributeKey ? popularKeys.has(attributeKey) : false
-  })
-
-  const otherItems = sortFieldItems.value.filter(item => {
-    if (STANDARD_SORT_FIELDS.includes(item.value)) {
-      return false
-    }
-
-    const attributeKey = extractAttributeKeyFromMapping(item.value)
-    return attributeKey ? !popularKeys.has(attributeKey) : true
-  })
-
-  group(t('category.products.sort.groups.standard'), standardItems)
-  group(t('category.products.sort.groups.popularAttributes'), popularItems)
-  group(t('category.products.sort.groups.otherAttributes'), otherItems)
+  group(t('category.products.sort.groups.main'), primarySortItems.value)
+  group(t('category.products.sort.groups.advanced'), advancedSortItems.value)
 
   return items
-})
-
-const defaultSortField = computed<string | null>(() => {
-  const options = sortFieldItems.value
-  if (options.length > 0) {
-    return options[0].value
-  }
-
-  return hasSortOptions.value ? null : ECOSCORE_RELATIVE_FIELD
 })
 
 const applyDefaultSort = () => {
@@ -1497,7 +1475,6 @@ const applyDefaultSort = () => {
   lastAppliedDefaultSort.value = defaultSortField.value
   return true
 }
-
 const sortFieldMap = computed<Record<string, FieldMetadataDto>>(() => {
   return sortFieldEntries.value.reduce<Record<string, FieldMetadataDto>>(
     (accumulator, entry) => {
@@ -2092,16 +2069,67 @@ const hashState = computed<CategoryHashState>(() => ({
   technicalExpanded: technicalExpanded.value || undefined,
 }))
 
-const onTableSortFieldUpdate = (field: string | null) => {
-  if (sortField.value !== field) {
-    sortField.value = field
+
+const resolveSortGroup = (field: string | null): 'primary' | 'advanced' | 'unknown' => {
+  if (!field) {
+    return 'unknown'
   }
+
+  if (primarySortItems.value.some(item => item.value === field)) {
+    return 'primary'
+  }
+
+  if (advancedSortItems.value.some(item => item.value === field)) {
+    return 'advanced'
+  }
+
+  return 'unknown'
+}
+
+const trackSortUsageEvent = (
+  action: 'exposed' | 'selected' | 'order-updated',
+  overrides: {
+    selectedField?: string | null
+    sortOrder?: 'asc' | 'desc'
+  } = {}
+) => {
+  trackSortUsage({
+    categoryId: category.value?.id ?? null,
+    categorySlug: slug,
+    action,
+    selectedField: overrides.selectedField ?? sortField.value,
+    selectedGroup: resolveSortGroup(overrides.selectedField ?? sortField.value),
+    sortOrder: overrides.sortOrder ?? sortOrder.value,
+    defaultField: defaultSortField.value,
+    primaryOptions: primarySortItems.value.map(item => item.value),
+    advancedOptions: advancedSortItems.value.map(item => item.value),
+    totalOptions: sortFieldItems.value.length,
+  })
+}
+
+const onToolbarSortFieldUpdate = (field: string | null) => {
+  if (sortField.value === field) {
+    return
+  }
+
+  sortField.value = field
+  trackSortUsageEvent('selected', { selectedField: field })
+}
+
+const onToolbarSortOrderUpdate = (order: 'asc' | 'desc') => {
+  if (sortOrder.value === order) {
+    return
+  }
+
+  sortOrder.value = order
+  trackSortUsageEvent('order-updated', { sortOrder: order })
+}
+const onTableSortFieldUpdate = (field: string | null) => {
+  onToolbarSortFieldUpdate(field)
 }
 
 const onTableSortOrderUpdate = (order: 'asc' | 'desc') => {
-  if (sortOrder.value !== order) {
-    sortOrder.value = order
-  }
+  onToolbarSortOrderUpdate(order)
 }
 
 watch(
@@ -2146,6 +2174,7 @@ onMounted(async () => {
       if (!sortField.value) {
         applyDefaultSort()
       }
+      trackSortUsageEvent('exposed')
     } catch (err) {
       console.error('Failed to load filter/sort options:', err)
     }

--- a/frontend/app/composables/useAnalytics.ts
+++ b/frontend/app/composables/useAnalytics.ts
@@ -70,6 +70,19 @@ type FilterChangeContext = {
   subsetIds?: string[]
 }
 
+type SortUsageContext = {
+  categoryId?: string | number | null
+  categorySlug?: string | null
+  action: 'exposed' | 'selected' | 'order-updated'
+  selectedField?: string | null
+  selectedGroup?: 'primary' | 'advanced' | 'unknown'
+  sortOrder?: 'asc' | 'desc'
+  defaultField?: string | null
+  primaryOptions?: string[]
+  advancedOptions?: string[]
+  totalOptions?: number
+}
+
 type SearchContext = {
   query: string
   source: SearchSource
@@ -219,6 +232,34 @@ export const useAnalytics = () => {
     })
   }
 
+  const trackSortUsage = ({
+    categoryId,
+    categorySlug,
+    action,
+    selectedField,
+    selectedGroup,
+    sortOrder,
+    defaultField,
+    primaryOptions,
+    advancedOptions,
+    totalOptions,
+  }: SortUsageContext) => {
+    trackEvent('category-sort-usage', {
+      props: {
+        categoryId,
+        categorySlug,
+        action,
+        selectedField,
+        selectedGroup,
+        sortOrder,
+        defaultField,
+        primaryOptions,
+        advancedOptions,
+        totalOptions,
+      },
+    })
+  }
+
   const trackOpenDataDownload = ({
     datasetId,
     method,
@@ -282,6 +323,7 @@ export const useAnalytics = () => {
     trackFileDownload,
     trackSectionView,
     trackFilterChange,
+    trackSortUsage,
     isAnalyticsEnabled: isEnabled,
     extractTokenFromLink,
     isClientContribLink,

--- a/frontend/app/utils/_sort-options-normalizer.spec.ts
+++ b/frontend/app/utils/_sort-options-normalizer.spec.ts
@@ -13,7 +13,7 @@ describe('deduplicateSortItemsByTitle', () => {
       },
       {
         value: 'attributes.indexedAttributes.HDR_B.numericValue',
-        title: '  consommation   électrique (hdr) ',
+        title: '  consommation   electrique (hdr) ',
       },
       {
         value: 'price.minPrice.price',
@@ -21,14 +21,12 @@ describe('deduplicateSortItemsByTitle', () => {
       },
     ]
 
-    const deduplicated = deduplicateSortItemsByTitle(items, item =>
-      item.value.includes('HDR_B') ? 100 : 10
-    )
+    const deduplicated = deduplicateSortItemsByTitle(items)
 
     expect(deduplicated).toEqual([
       {
-        value: 'attributes.indexedAttributes.HDR_B.numericValue',
-        title: '  consommation   électrique (hdr) ',
+        value: 'attributes.indexedAttributes.HDR_A.numericValue',
+        title: 'Consommation électrique (HDR)',
       },
       {
         value: 'price.minPrice.price',

--- a/frontend/app/utils/_sort-options-normalizer.ts
+++ b/frontend/app/utils/_sort-options-normalizer.ts
@@ -4,28 +4,30 @@ export type SortFieldItem = {
 }
 
 const normalizeSortTitle = (value: string): string => {
-  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+  return value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
 }
 
 /**
  * Deduplicates sort options by normalized visible title while preserving the
- * highest-priority option for each title.
+ * first option order from the provided list.
  */
 export const deduplicateSortItemsByTitle = (
-  items: SortFieldItem[],
-  computePriority: (item: SortFieldItem) => number
+  items: SortFieldItem[]
 ): SortFieldItem[] => {
-  const byTitle = new Map<string, { item: SortFieldItem; priority: number }>()
+  const byTitle = new Map<string, SortFieldItem>()
 
   items.forEach(item => {
     const normalizedTitle = normalizeSortTitle(item.title)
-    const current = byTitle.get(normalizedTitle)
-    const priority = computePriority(item)
 
-    if (!current || priority > current.priority) {
-      byTitle.set(normalizedTitle, { item, priority })
+    if (!byTitle.has(normalizedTitle)) {
+      byTitle.set(normalizedTitle, item)
     }
   })
 
-  return Array.from(byTitle.values()).map(entry => entry.item)
+  return Array.from(byTitle.values())
 }

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -930,10 +930,10 @@
           "price": "Lowest price"
         },
         "groups": {
-          "standard": "Standard",
-          "popularAttributes": "Popular attributes",
-          "otherAttributes": "Other attributes"
+          "main": "Main sorting",
+          "advanced": "Advanced sorting"
         },
+        "defaultLabel": "{label} (default)",
         "values": {
           "impactScore": "{score} / {max}"
         }

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -813,10 +813,10 @@
           "price": "Prix le plus bas"
         },
         "groups": {
-          "standard": "Tri standards",
-          "popularAttributes": "Attributs populaires",
-          "otherAttributes": "Autres attributs"
+          "main": "Tris principaux",
+          "advanced": "Tris avancés"
         },
+        "defaultLabel": "{label} (par défaut)",
         "values": {
           "impactScore": "{score} / {max}"
         }


### PR DESCRIPTION
### Motivation
- Reduce clutter and duplicate entries in the category sort menu and make the primary sorting choices explicit and product-driven.  
- Provide a stable, user-visible default sort and surface a secondary “advanced” level for less-used options.  
- Add telemetry to measure sort exposure/selection/order changes so the simplification can be validated before/after rollout.

### Description
- Normalize and deduplicate visible sort titles (accent-insensitive, whitespace/case normalisation) via `frontend/app/utils/_sort-options-normalizer.ts` and update unit test accordingly.  
- Extract full backend-provided sort fields (`global`, `impact`, `technical`) and build a normalized list, then split into `primary` and `advanced` groups using a product-driven strategy (`PRIMARY_SORT_STRATEGY`) in `frontend/app/components/pages/CategoryPage.vue`.  
- Compute and apply a stable explicit default sort (`defaultSortField`) and display a localized “(default)” label next to the default option.  
- Wire toolbar/table sort handlers through new handlers so both toolbar and table sorting calls go through the same logic, and emit analytics events when the sort menu is exposed, when a field is selected, and when order is updated.  
- Add `category-sort-usage` telemetry via `frontend/app/composables/useAnalytics.ts` (new `trackSortUsage` API) to capture action (`exposed|selected|order-updated`), selected group (`primary|advanced|unknown`), default field, primary/advanced option lists and totals.  
- Update i18n keys for new grouping labels and default wording in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json`.

### Testing
- Ran targeted ESLint on modified files: `pnpm eslint app/components/pages/CategoryPage.vue app/composables/useAnalytics.ts app/utils/_sort-options-normalizer.ts app/utils/_sort-options-normalizer.spec.ts` and it passed for the changed files.  
- Unit tests: `pnpm vitest run app/utils/_sort-options-normalizer.spec.ts app/components/category/CategoryResultsToolbar.spec.ts` — all tests passed.  
- Full `pnpm lint` failed due to unrelated existing `no-explicit-any` errors in `app/composables/useMetriks.ts` (pre-existing, not introduced by this change).  
- Built/generate: `pnpm generate` completed successfully but Nuxt sitemap emitted configuration warnings about missing sitemap entries (environment/config warnings), not caused by the sorting change.  
- Preview/playwright attempt failed to start a stable preview in this environment (nitro path/runtime issue), so end-to-end browser capture was not produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69970c5371808322b37b50876ef5930a)