### PR TITLE
Harden Effiliation feed retrieval: pagination, stale-cache fallback, jitter, and validation

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -103,3 +103,4 @@ feed:
     cron: 30 43 1 * * ?
     enabled: true
     cache-ttl-days: 1
+    max-jitter-seconds: 30

--- a/commons/src/main/java/org/open4goods/commons/util/HttpUtils.java
+++ b/commons/src/main/java/org/open4goods/commons/util/HttpUtils.java
@@ -1,0 +1,65 @@
+package org.open4goods.commons.util;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility methods for HTTP query handling and safe logging.
+ */
+public final class HttpUtils {
+
+    private HttpUtils() {
+    }
+
+    /**
+     * Returns {@code true} when the input is {@code null}, empty, or whitespace-only.
+     *
+     * @param value input string
+     * @return {@code true} when blank
+     */
+    public static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    /**
+     * URL-encodes a value using UTF-8.
+     *
+     * @param value input value
+     * @return encoded value, never {@code null}
+     */
+    public static String urlEncode(String value) {
+        return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Masks the {@code key=} query parameter value in an URL for safe logging.
+     *
+     * @param endpoint endpoint URL
+     * @return endpoint with masked key parameter
+     */
+    public static String safeEndpointForLogs(String endpoint) {
+        if (endpoint == null) {
+            return null;
+        }
+        return endpoint.replaceAll("(key=)([^&]+)", "$1****");
+    }
+
+    /**
+     * Normalizes URLs by adding a protocol when missing and trimming whitespace.
+     *
+     * @param url input URL
+     * @return normalized URL or empty string for blank input
+     */
+    public static String normalizeUrl(String url) {
+        if (isBlank(url)) {
+            return "";
+        }
+
+        String normalized = url.trim();
+        if (!normalized.matches("^[a-zA-Z][a-zA-Z0-9+.-]*://.*")) {
+            normalized = "https://" + normalized;
+        }
+
+        return normalized;
+    }
+}

--- a/services/feedservice/README.md
+++ b/services/feedservice/README.md
@@ -14,3 +14,12 @@ mvn test
 ```
 
 See the [main project](../../README.md) for details.
+
+### Effiliation scheduler
+
+Effiliation refresh is controlled by `feed.effiliation.*` properties:
+
+- `cron`: refresh schedule
+- `enabled`: enables/disables all Effiliation retrieval methods
+- `cache-ttl-days`: remote cache TTL
+- `max-jitter-seconds`: random delay applied before scheduled execution

--- a/services/feedservice/src/main/java/org/open4goods/services/feedservice/config/FeedConfiguration.java
+++ b/services/feedservice/src/main/java/org/open4goods/services/feedservice/config/FeedConfiguration.java
@@ -44,6 +44,7 @@ public class FeedConfiguration {
         private String cron = "30 43 1 * * ?";
         private boolean enabled = true;
         private int cacheTtlDays = 1;
+        private int maxJitterSeconds = 30;
 
         public String getCron() { return cron; }
         public void setCron(String cron) { this.cron = cron; }
@@ -51,6 +52,8 @@ public class FeedConfiguration {
         public void setEnabled(boolean enabled) { this.enabled = enabled; }
         public int getCacheTtlDays() { return cacheTtlDays; }
         public void setCacheTtlDays(int cacheTtlDays) { this.cacheTtlDays = cacheTtlDays; }
+        public int getMaxJitterSeconds() { return maxJitterSeconds; }
+        public void setMaxJitterSeconds(int maxJitterSeconds) { this.maxJitterSeconds = maxJitterSeconds; }
     }
     
 	public String getCatalogUrl() {

--- a/services/feedservice/src/test/java/org/open4goods/services/feedservice/service/EffiliationFeedServiceTest.java
+++ b/services/feedservice/src/test/java/org/open4goods/services/feedservice/service/EffiliationFeedServiceTest.java
@@ -1,0 +1,148 @@
+package org.open4goods.services.feedservice.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.open4goods.commons.config.yml.datasource.CsvDataSourceProperties;
+import org.open4goods.commons.config.yml.datasource.DataSourceProperties;
+import org.open4goods.commons.services.DataSourceConfigService;
+import org.open4goods.services.feedservice.config.FeedConfiguration;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.open4goods.services.serialisation.service.SerialisationService;
+
+/**
+ * Tests for {@link EffiliationFeedService} pagination, enablement and cache fallback behavior.
+ */
+class EffiliationFeedServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void retrieveEffiliationFeedsShouldThrowWhenDisabled() {
+        EffiliationFeedService service = buildService(false, mock(RemoteFileCachingService.class));
+
+        assertThatThrownBy(() -> service.retrieveEffiliationFeeds("api-key", "fr", null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("disabled");
+    }
+
+    @Test
+    void retrieveEffiliationFeedsShouldMergePaginatedPayloads() throws Exception {
+        RemoteFileCachingService cacheService = mock(RemoteFileCachingService.class);
+        File page1 = jsonFile("""
+                {"total_pages":2,"feeds":[{"nom":"Feed One","code":"https://one.test/feed.csv","id_affilieur":"11"}]}
+                """);
+        File page2 = jsonFile("""
+                {"total_pages":2,"feeds":[{"nom":"Feed Two","code":"https://two.test/feed.csv","id_affilieur":"22"}]}
+                """);
+
+        when(cacheService.getResource(contains("page=1"), anyInt())).thenReturn(page1);
+        when(cacheService.getResource(contains("page=2"), anyInt())).thenReturn(page2);
+
+        EffiliationFeedService service = buildService(true, cacheService);
+
+        var merged = service.retrieveEffiliationFeeds("api-key", "fr", null);
+
+        assertThat(merged.path("feeds")).hasSize(2);
+        assertThat(merged.path("feeds").get(0).path("nom").asText()).isEqualTo("Feed One");
+        assertThat(merged.path("feeds").get(1).path("nom").asText()).isEqualTo("Feed Two");
+    }
+
+    @Test
+    void getDatasourcesShouldUseStaleCacheWhenRefreshFails() throws Exception {
+        RemoteFileCachingService cacheService = mock(RemoteFileCachingService.class);
+
+        File programs = jsonFile("""
+                {"programs":[{"id_affilieur":101,"url_tracke":"track.example","urllo":"logo.example","etat":"actif","pays":"fr"}]}
+                """);
+        File feeds = jsonFile("""
+                {"feeds":[{"nom":"Merchant","code":"merchant.example/feed.csv","url_affilieur":"merchant.example","id_affilieur":"101"}]}
+                """);
+
+        when(cacheService.getResource(contains("programs.json"), anyInt())).thenReturn(programs);
+        when(cacheService.getResource(contains("productfeeds.json"), eq(1))).thenThrow(new IOException("network down"));
+        when(cacheService.getResource(contains("productfeeds.json"), eq(Integer.MAX_VALUE))).thenReturn(feeds);
+
+        EffiliationFeedService service = buildService(true, cacheService);
+        Set<DataSourceProperties> datasources = service.getDatasources();
+
+        assertThat(datasources).hasSize(1);
+        DataSourceProperties datasource = datasources.iterator().next();
+        assertThat(datasource.getPortalUrl()).isEqualTo("https://merchant.example");
+        assertThat(datasource.getAffiliatedPortalUrl()).isEqualTo("https://track.example");
+    }
+
+    @Test
+    void getDatasourcesShouldSkipInvalidIdAndInactiveProgram() throws Exception {
+        RemoteFileCachingService cacheService = mock(RemoteFileCachingService.class);
+
+        File programs = jsonFile("""
+                {"programs":[
+                  {"id_affilieur":101,"url_tracke":"https://active.example/track","urllo":"https://active.example/logo.png","etat":"actif","pays":"fr"},
+                  {"id_affilieur":303,"url_tracke":"https://inactive.example/track","urllo":"https://inactive.example/logo.png","etat":"suspended","pays":"fr"}
+                ]}
+                """);
+        File feeds = jsonFile("""
+                {"feeds":[
+                  {"nom":"Valid Merchant","code":"https://active.example/feed.csv","url_affilieur":"https://active.example","id_affilieur":"101"},
+                  {"nom":"Invalid Id Merchant","code":"https://invalid.example/feed.csv","url_affilieur":"https://invalid.example","id_affilieur":"invalid"},
+                  {"nom":"Inactive Merchant","code":"https://inactive.example/feed.csv","url_affilieur":"https://inactive.example","id_affilieur":"303"}
+                ]}
+                """);
+
+        when(cacheService.getResource(contains("programs.json"), anyInt())).thenReturn(programs);
+        when(cacheService.getResource(contains("productfeeds.json"), anyInt())).thenReturn(feeds);
+
+        EffiliationFeedService service = buildService(true, cacheService);
+
+        Set<DataSourceProperties> datasources = service.getDatasources();
+
+        assertThat(datasources).hasSize(1);
+        assertThat(datasources.iterator().next().getDatasourceConfigName()).isEqualTo("Valid Merchant");
+    }
+
+    private EffiliationFeedService buildService(boolean enabled, RemoteFileCachingService cacheService) {
+        FeedConfiguration config = new FeedConfiguration();
+        FeedConfiguration.EffiliationConfig effiliation = new FeedConfiguration.EffiliationConfig();
+        effiliation.setEnabled(enabled);
+        effiliation.setCacheTtlDays(1);
+        effiliation.setMaxJitterSeconds(0);
+        config.setEffiliation(effiliation);
+
+        CsvDataSourceProperties csvDataSourceProperties = new CsvDataSourceProperties();
+        config.setDefaultCsvProperties(csvDataSourceProperties);
+
+        DataSourceConfigService dataSourceConfigService = mock(DataSourceConfigService.class);
+        when(dataSourceConfigService.getDatasourcePropertiesForFeed(org.mockito.ArgumentMatchers.anyString())).thenReturn(null);
+        when(dataSourceConfigService.datasourceConfigs()).thenReturn(Map.of());
+
+        return new EffiliationFeedService(
+                config,
+                cacheService,
+                dataSourceConfigService,
+                new SerialisationService(),
+                "api-key");
+    }
+
+    private File jsonFile(String content) throws IOException {
+        Path file = Files.createTempFile(tempDir, "effiliation", ".json");
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+        return file.toFile();
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent synchronized spikes and partial/empty datasource results when fetching Effiliation feeds by adding jitter, pagination and more robust cache handling.
- Improve safety and observability by centralizing HTTP helpers, masking keys in logs, validating fields and skipping inactive/invalid programs.

### Description

- Added a new `HttpUtils` in `commons` with `isBlank`, `urlEncode`, `safeEndpointForLogs` and `normalizeUrl` and replaced local helpers in `EffiliationFeedService` with it.
- Implemented paginated retrieval for both `programs` and `productfeeds` with `page` support and `hasNextPage` logic, and merged multi-page results into a single response.
- Added stale-while-revalidate behavior in `readCachedJson` to retry using a stale cache when live refresh fails, plus `assertEnabled()` guards on public retrieval methods and a scheduler jitter applied by `applySchedulingJitter()` driven by new `feed.effiliation.max-jitter-seconds` config.
- Hardened datasource creation by normalizing URLs, validating `id_affilieur` with a numeric pattern, filtering out inactive programs via `etat`, and updating `FeedConfiguration` and `application.yml`; also updated README and added unit tests covering the new behaviors.

### Testing

- Attempted offline run `mvn --offline -pl services/feedservice -am test` failed due to missing offline artifacts in this environment (expected in offline mode). 
- Built the reactor and installed locally with `mvn -pl services/feedservice -am -DskipTests install`, which completed successfully.
- Ran module tests with `mvn -pl services/feedservice test` and the `EffiliationFeedService` unit tests passed (all automated tests in the module succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699833a86264832289c8be7ba65ad198)