### PR TITLE
Validate cached WebP writes and improve error handling in ImageResizeInterceptor

### DIFF
--- a/ui/src/main/java/org/open4goods/ui/interceptors/ImageResizeInterceptor.java
+++ b/ui/src/main/java/org/open4goods/ui/interceptors/ImageResizeInterceptor.java
@@ -135,11 +135,9 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
 					logger.info("Image resized to {}x{}", dimensions[0], dimensions[1]);
 				}
 
-				// Save the resized image in WebP format to cache
-				if (!ImageIO.write(sourceImage, "webp", cachedFile)) {
-					logger.info("Could not write file: {}", cachedFile.getAbsolutePath());
-				} else {
-					logger.info("Cached image saved: {}", cachedFile.getAbsolutePath());
+				if (!saveToCache(sourceImage, cachedFile)) {
+					response.sendError(HttpServletResponse.SC_NOT_FOUND, "Image not found");
+					return false;
 				}
 			} else {
 				logger.info("Cache hit for file: {}", cachedFile.getAbsolutePath());
@@ -150,12 +148,43 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
 				serveImage(response, cachedFile);
 			} catch (IOException e) {
 				logger.error("Error serving cached image: {}", cachedFile.getAbsolutePath(), e);
+				response.resetBuffer();
+				response.setContentType("application/json");
 				response.sendError(HttpServletResponse.SC_NOT_FOUND, "Image not found");
 				return false;
 			}
 			return false; // Prevent further request processing
 		}
 
+		return true;
+	}
+
+	/**
+	 * Saves the source image in cache as WebP and validates the generated file.
+	 *
+	 * @param sourceImage the source image to store
+	 * @param cachedFile  the cache file destination
+	 * @return {@code true} if the cache file was successfully generated and is
+	 *         readable, {@code false} otherwise
+	 */
+	boolean saveToCache(BufferedImage sourceImage, File cachedFile) {
+		File parent = cachedFile.getParentFile();
+		if (parent != null && !parent.exists() && !parent.mkdirs()) {
+			logger.error("Could not create cache folder for file: {}", cachedFile.getAbsolutePath());
+			return false;
+		}
+
+		if (!ImageIO.write(sourceImage, "webp", cachedFile)) {
+			logger.error("Could not write file: {}", cachedFile.getAbsolutePath());
+			return false;
+		}
+
+		if (!cachedFile.exists() || cachedFile.length() <= 0 || !cachedFile.isFile() || !cachedFile.canRead()) {
+			logger.error("Generated cache file is invalid: {}", cachedFile.getAbsolutePath());
+			return false;
+		}
+
+		logger.info("Cached image saved: {}", cachedFile.getAbsolutePath());
 		return true;
 	}
 
@@ -314,6 +343,9 @@ public class ImageResizeInterceptor implements HandlerInterceptor {
 	 * @throws IOException if an error occurs during file transfer
 	 */
 	private void serveImage(HttpServletResponse response, File cachedFile) throws IOException {
+		if (!cachedFile.isFile() || !cachedFile.canRead()) {
+			throw new IOException("Cached image does not exist or is unreadable");
+		}
 		response.setContentType("image/webp");
 		response.setHeader("Cache-Control", "public, max-age=86400");
 		FileUtils.copyFile(cachedFile, response.getOutputStream());

--- a/ui/src/test/java/org/open4goods/ui/interceptors/ImageResizeInterceptorTest.java
+++ b/ui/src/test/java/org/open4goods/ui/interceptors/ImageResizeInterceptorTest.java
@@ -6,16 +6,17 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doThrow;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -152,6 +153,60 @@ class ImageResizeInterceptorTest {
 
          assertThat(result).isFalse();
          verify(response).sendError(HttpServletResponse.SC_NOT_FOUND, "Image not found");
+    }
+
+
+    @Test
+    void saveToCacheReturnsFalseWhenParentFolderCannotBeCreated() throws IOException {
+        File tempDir = java.nio.file.Files.createTempDirectory("image-cache-test").toFile();
+        File blockingFile = new File(tempDir, "blocking-file");
+        assertThat(blockingFile.createNewFile()).isTrue();
+        File cachedFile = new File(new File(blockingFile, "C/H/E"), "cached.webp");
+
+        ImageResizeInterceptor interceptor = new ImageResizeInterceptor(resourceService, allowedResize, "http://example.com");
+
+        boolean saved = interceptor.saveToCache(new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB), cachedFile);
+
+        assertThat(saved).isFalse();
+        assertThat(cachedFile.exists()).isFalse();
+    }
+
+    @Test
+    void preHandleReturns404AndResetsContentTypeWhenCachedFileIsMissing() throws Exception {
+        ResourceService resourceService = mock(ResourceService.class);
+        File missingFile = new File("/tmp/this-file-does-not-exist.webp");
+
+        ImageResizeInterceptor interceptor = new ImageResizeInterceptor(resourceService, new HashSet<>(), "http://example.com") {
+            @Override
+            Resource buildResource(String requestURI) {
+                Resource resource = new Resource();
+                resource.setFileName(requestURI);
+                resource.setCacheKey("cached-file.webp");
+                return resource;
+            }
+
+            @Override
+            boolean saveToCache(BufferedImage sourceImage, File cachedFile) {
+                return true;
+            }
+
+            @Override
+            BufferedImage findSourceImage(String baseImageName, boolean hasDimensionsArgument) {
+                return new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+            }
+        };
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/images/example.webp");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(resourceService.getCacheFile(any(Resource.class))).thenReturn(missingFile);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isFalse();
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_FOUND);
+        assertThat(response.getContentType()).isEqualTo("application/json");
     }
 
     private byte[] createPngBytes() throws IOException {


### PR DESCRIPTION
### Motivation
- Prevent serving or caching invalid/empty WebP files and provide clearer error responses when cache creation or serving fails.
- Centralize cache write logic to validate generated files and ensure cache directories exist.
- Ensure response state is reset and a consistent content type is returned on serve failures.

### Description
- Extracted cache persistence into a new `saveToCache(BufferedImage, File)` method that creates parent folders, writes WebP via `ImageIO`, and validates the generated file before returning success or failure.
- Change call sites to return a 404 when `saveToCache` fails instead of silently continuing; log detailed errors on write or validation failures.
- Add a pre-check in `serveImage` to ensure the cached file exists and is readable and throw an `IOException` otherwise, and reset response buffer and content type to `application/json` before sending a 404 when serving fails.
- Updated and extended unit tests in `ImageResizeInterceptorTest` to cover failure to create parent cache folders and to verify that `preHandle` sets 404 and `application/json` content type when the cached file is missing; also adjusted imports and minor test scaffolding.

### Testing
- Ran unit tests in `ImageResizeInterceptorTest`, including new tests `saveToCacheReturnsFalseWhenParentFolderCannotBeCreated` and `preHandleReturns404AndResetsContentTypeWhenCachedFileIsMissing`, and they passed.
- Existing tests that simulate IO errors when writing/serving the cached image were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ddfef32483228f1881b1e274857b)