### PR TITLE
Move feed-related asset serving to front-api and remove UI feedservice dependency

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>remotefilecaching</artifactId>
       <version>${global.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.open4goods</groupId>
+      <artifactId>favicon</artifactId>
+      <version>${global.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.open4goods</groupId>
       <artifactId>geocode</artifactId>

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ResourceAssetController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ResourceAssetController.java
@@ -1,0 +1,131 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.model.affiliation.AffiliationPartner;
+import org.open4goods.nudgerfrontapi.service.AffiliationPartnerService;
+import org.open4goods.services.favicon.dto.FaviconResponse;
+import org.open4goods.services.favicon.service.FaviconService;
+import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller exposing partner and datasource assets through front-api.
+ */
+@RestController
+@RequestMapping
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+public class ResourceAssetController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceAssetController.class);
+    private static final MediaType DEFAULT_MEDIA_TYPE = MediaType.IMAGE_PNG;
+
+    private final AffiliationPartnerService affiliationPartnerService;
+    private final RemoteFileCachingService remoteFileCachingService;
+    private final FaviconService faviconService;
+
+    /**
+     * Build the resource controller.
+     *
+     * @param affiliationPartnerService partner cache service
+     * @param remoteFileCachingService remote file cache used for partner logos
+     * @param faviconService favicon lookup service
+     */
+    public ResourceAssetController(AffiliationPartnerService affiliationPartnerService,
+            RemoteFileCachingService remoteFileCachingService,
+            FaviconService faviconService) {
+        this.affiliationPartnerService = affiliationPartnerService;
+        this.remoteFileCachingService = remoteFileCachingService;
+        this.faviconService = faviconService;
+    }
+
+    /**
+     * Return the configured partner logo.
+     *
+     * @param partnerName encoded partner name
+     * @return logo content or 404 when unavailable
+     */
+    @GetMapping("/logo/{partnerName}")
+    public ResponseEntity<byte[]> logo(@PathVariable String partnerName) {
+        String decodedName = URLDecoder.decode(partnerName, StandardCharsets.UTF_8);
+        Optional<AffiliationPartner> partner = affiliationPartnerService.getPartners().stream()
+                .filter(candidate -> decodedName.equalsIgnoreCase(candidate.getName()))
+                .findFirst();
+
+        if (partner.isEmpty() || partner.get().getLogoUrl() == null || partner.get().getLogoUrl().isBlank()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return fetchImage(partner.get().getLogoUrl());
+    }
+
+    /**
+     * Return a datasource icon, aliasing partner logos.
+     *
+     * @param datasourceName datasource identifier
+     * @return icon content or 404 when unavailable
+     */
+    @GetMapping("/icon/{datasourceName}")
+    public ResponseEntity<byte[]> icon(@PathVariable String datasourceName) {
+        return logo(datasourceName);
+    }
+
+    /**
+     * Return the favicon for a provided portal URL.
+     *
+     * @param url source URL used to derive the favicon
+     * @return favicon bytes or 404 when unavailable
+     */
+    @GetMapping("/favicon")
+    public ResponseEntity<byte[]> favicon(@RequestParam("url") String url) {
+        FaviconResponse faviconResponse = faviconService.getFavicon(url);
+        if (faviconResponse == null || faviconResponse.faviconData() == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        MediaType mediaType = parseMediaType(faviconResponse.contentType());
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .body(faviconResponse.faviconData());
+    }
+
+    private ResponseEntity<byte[]> fetchImage(String imageUrl) {
+        try {
+            File file = remoteFileCachingService.getResource(imageUrl, 1);
+            byte[] content = Files.readAllBytes(file.toPath());
+            MediaType mediaType = parseMediaType(Files.probeContentType(file.toPath()));
+            return ResponseEntity.ok().contentType(mediaType).body(content);
+        }
+        catch (Exception exception) {
+            LOGGER.warn("Unable to load remote asset from {}: {}", imageUrl, exception.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    private MediaType parseMediaType(String value) {
+        if (value == null || value.isBlank()) {
+            return DEFAULT_MEDIA_TYPE;
+        }
+        try {
+            return MediaType.parseMediaType(value);
+        }
+        catch (Exception exception) {
+            return DEFAULT_MEDIA_TYPE;
+        }
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/AffiliationPartnerService.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.open4goods.model.affiliation.AffiliationPartner;
 import org.open4goods.model.constants.UrlConstants;
 import org.open4goods.nudgerfrontapi.config.properties.AffiliationPartnersProperties;
-import org.open4goods.nudgerfrontapi.config.properties.ApiProperties;
 import org.open4goods.nudgerfrontapi.dto.partner.AffiliationPartnerDto;
 import org.open4goods.services.contribution.model.ContributionVote;
 import org.open4goods.services.contribution.service.ContributionService;
@@ -38,14 +37,15 @@ public class AffiliationPartnerService {
 
     private final RestClient restClient;
     private final AffiliationPartnersProperties properties;
-    private final ApiProperties apiProperties;
     private final AtomicReference<List<AffiliationPartner>> partners = new AtomicReference<>(List.of());
+    private static final String LOGO_ENDPOINT = "/api/logo/";
+    private static final String FAVICON_ENDPOINT = "/api/favicon?url=";
+
     private final AffiliationService affiliationService;
 
     public AffiliationPartnerService(RestClient.Builder restClientBuilder, AffiliationPartnersProperties properties,
-            ApiProperties apiProperties, AffiliationService affiliationService) {
+            AffiliationService affiliationService) {
         this.properties = properties;
-        this.apiProperties = apiProperties;
         this.affiliationService = affiliationService;
         this.restClient = restClientBuilder.baseUrl(properties.getApiBaseUrl())
                 .defaultHeader(UrlConstants.APIKEY_PARAMETER, properties.getApiKey())
@@ -106,8 +106,8 @@ public class AffiliationPartnerService {
      * @return immutable DTO ready to be serialised
      */
     private AffiliationPartnerDto mapToDto(AffiliationPartner partner) {
-        String logoUrl = buildAssetUrl("/logo/", partner.getName());
-        String faviconUrl = buildAssetUrl("/favicon?url=", partner.getName());
+        String logoUrl = buildAssetUrl(LOGO_ENDPOINT, partner.getName());
+        String faviconUrl = buildAssetUrl(FAVICON_ENDPOINT, partner.getName());
         List<String> countryCodes = partner.getCountryCodes() == null
                 ? List.of()
                 : partner.getCountryCodes().stream()
@@ -128,22 +128,17 @@ public class AffiliationPartnerService {
     }
 
     /**
-     * Build an asset URL relative to the configured static resource root.
+     * Build an asset URL exposed through the Nuxt API proxy.
      *
      * @param pathSuffix suffix prepended with a slash (e.g. {@code /logo/})
      * @param partnerName partner name used as key in the asset storage
      * @return fully qualified asset URL or {@code null} when data is missing
      */
     private String buildAssetUrl(String pathSuffix, String partnerName) {
-        if (!StringUtils.hasText(pathSuffix) || !StringUtils.hasText(partnerName)
-                || !StringUtils.hasText(apiProperties.getResourceRootPath())) {
+        if (!StringUtils.hasText(pathSuffix) || !StringUtils.hasText(partnerName)) {
             return null;
         }
-        String base = apiProperties.getResourceRootPath();
-        if (base.endsWith("/")) {
-            base = base.substring(0, base.length() - 1);
-        }
         String encodedName = URLEncoder.encode(partnerName, StandardCharsets.UTF_8);
-        return base + pathSuffix + encodedName;
+        return pathSuffix + encodedName;
     }
 }

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -138,7 +138,7 @@ public class ProductMappingService {
     private static final String PDFS_PATH = "/pdfs/";
     private static final String VIDEOS_PATH = "/videos/";
     private static final String ICON_PATH = "/icon/";
-    private static final String FAVICON_ENDPOINT = "/favicon?url=";
+    private static final String FAVICON_ENDPOINT = "/api/favicon?url=";
     private static final String IMAGE_WEBP_MEDIATYPE = "image/webp";
     private static final String PRODUCT_REFERENCE_CACHE_PREFIX = "product-ref";
     private static final IpQuotaCategory REVIEW_GENERATION_QUOTA_CATEGORY = IpQuotaCategory.REVIEW_GENERATION;
@@ -1586,15 +1586,11 @@ public class ProductMappingService {
         if (!StringUtils.hasText(sourceUrl)) {
             return null;
         }
-        String resourceRoot = apiProperties.getResourceRootPath();
-        if (!StringUtils.hasText(resourceRoot)) {
-            return null;
-        }
         String root = safeCall(() -> extractRootUrl(sourceUrl));
         if (!StringUtils.hasText(root)) {
             return null;
         }
-        return resourceRoot + FAVICON_ENDPOINT + root;
+        return FAVICON_ENDPOINT + root;
     }
 
     /**

--- a/frontend/server/api/favicon.get.ts
+++ b/frontend/server/api/favicon.get.ts
@@ -1,0 +1,6 @@
+import { proxyRequest } from 'h3'
+
+export default defineEventHandler(event => {
+  const config = useRuntimeConfig(event)
+  return proxyRequest(event, `${config.apiUrl}${event.path.replace('/api', '')}`)
+})

--- a/frontend/server/api/icon/[datasourceName].ts
+++ b/frontend/server/api/icon/[datasourceName].ts
@@ -1,0 +1,6 @@
+import { proxyRequest } from 'h3'
+
+export default defineEventHandler(event => {
+  const config = useRuntimeConfig(event)
+  return proxyRequest(event, `${config.apiUrl}${event.path.replace('/api', '')}`)
+})

--- a/frontend/server/api/logo/[partnerName].ts
+++ b/frontend/server/api/logo/[partnerName].ts
@@ -1,0 +1,6 @@
+import { proxyRequest } from 'h3'
+
+export default defineEventHandler(event => {
+  const config = useRuntimeConfig(event)
+  return proxyRequest(event, `${config.apiUrl}${event.path.replace('/api', '')}`)
+})

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -99,12 +99,6 @@
 
         <dependency>
             <groupId>org.open4goods</groupId>
-            <artifactId>feedservice</artifactId>
-            <version>${global.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.open4goods</groupId>
             <artifactId>opendata</artifactId>
             <version>${global.version}</version>
         </dependency>

--- a/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/AppConfig.java
@@ -3,7 +3,6 @@ package org.open4goods.ui.config;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.open4goods.brand.service.BrandService;
@@ -12,11 +11,6 @@ import org.open4goods.commons.services.DataSourceConfigService;
 import org.open4goods.commons.services.ResourceService;
 import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.services.blog.service.BlogService;
-import org.open4goods.services.feedservice.config.FeedConfiguration;
-import org.open4goods.services.feedservice.service.AbstractFeedService;
-import org.open4goods.services.feedservice.service.AwinFeedService;
-import org.open4goods.services.feedservice.service.EffiliationFeedService;
-import org.open4goods.services.feedservice.service.FeedService;
 import org.open4goods.services.imageprocessing.service.ImageMagickService;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.remotefilecaching.config.RemoteFileCachingProperties;
@@ -64,39 +58,6 @@ public class AppConfig {
 	}
 
 
-
-
-
-    @Bean
-    public AwinFeedService awinFeedService(
-                                           RemoteFileCachingService remoteFileCachingService,
-                                           DataSourceConfigService dataSourceConfigService,
-                                           SerialisationService serialisationService,
-                                           UiConfig uiConfig
-
-    		) {
-        // Retrieve Awin-specific feed configuration from the fetcher properties
-        FeedConfiguration awinConfig = uiConfig.getFeedConfigs().get("awin");
-        return new AwinFeedService(awinConfig, remoteFileCachingService, dataSourceConfigService, serialisationService, uiConfig.getAffiliationConfig().getAwinAdvertiserId(), uiConfig.getAffiliationConfig().getAwinAccessToken());
-    }
-
-    @Bean
-    public EffiliationFeedService effiliationFeedService(
-                                                         RemoteFileCachingService remoteFileCachingService,
-                                                         DataSourceConfigService dataSourceConfigService,
-                                                         SerialisationService serialisationService,
-                                                         UiConfig uiConfig) {
-        // Retrieve Effiliation-specific feed configuration from the fetcher properties
-        FeedConfiguration effiliationConfig = uiConfig.getFeedConfigs().get("effiliation");
-        return new EffiliationFeedService(effiliationConfig, remoteFileCachingService, dataSourceConfigService, serialisationService, uiConfig.getAffiliationConfig().getEffiliationApiKey());
-    }
-
-    @Bean
-    public FeedService feedService(List<AbstractFeedService> feedServices,
-                                   DataSourceConfigService dataSourceConfigService) {
-        // The FeedService aggregates all concrete feed implementations.
-        return new FeedService(feedServices, dataSourceConfigService);
-    }
 
 
 

--- a/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
+++ b/ui/src/main/java/org/open4goods/ui/config/yml/UiConfig.java
@@ -15,8 +15,6 @@ import org.open4goods.model.Localisable;
 import org.open4goods.model.priceevents.PriceRestitutionConfig;
 import org.open4goods.model.vertical.SiteNaming;
 import org.open4goods.services.blog.config.BlogConfiguration;
-import org.open4goods.services.feedservice.config.AffiliationConfig;
-import org.open4goods.services.feedservice.config.FeedConfiguration;
 import org.open4goods.ui.interceptors.ImageResizeInterceptor;
 import org.open4goods.xwiki.config.XWikiServiceProperties;
 import org.slf4j.Logger;
@@ -142,11 +140,6 @@ public class UiConfig {
 	 */
 	private UrlCheckConfig urlcheck;
 
-
-	private AffiliationConfig affiliationConfig = new AffiliationConfig();
-
-
-	private Map<String, FeedConfiguration> feedConfigs = new HashMap<>();
 
 	/***
 	 * Config for IP and UA banChecking
@@ -486,27 +479,6 @@ public class UiConfig {
 	public void setPriceConfig(PriceRestitutionConfig priceConfig) {
 		this.priceConfig = priceConfig;
 	}
-
-
-	public AffiliationConfig getAffiliationConfig() {
-		return affiliationConfig;
-	}
-
-
-	public void setAffiliationConfig(AffiliationConfig affiliationConfig) {
-		this.affiliationConfig = affiliationConfig;
-	}
-
-
-	public Map<String, FeedConfiguration> getFeedConfigs() {
-		return feedConfigs;
-	}
-
-
-	public void setFeedConfigs(Map<String, FeedConfiguration> feedConfigs) {
-		this.feedConfigs = feedConfigs;
-	}
-
 
 
 	public Localisable<String, FunFactsConfig> getFunFacts() {

--- a/ui/src/main/java/org/open4goods/ui/controllers/ui/ResourceController.java
+++ b/ui/src/main/java/org/open4goods/ui/controllers/ui/ResourceController.java
@@ -22,7 +22,6 @@ import org.open4goods.model.exceptions.ValidationException;
 import org.open4goods.model.resource.Resource;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.services.favicon.service.FaviconService;
-import org.open4goods.services.feedservice.service.FeedService;
 import org.open4goods.services.gtinservice.service.GtinService;
 import org.open4goods.services.productrepository.services.ProductRepository;
 import org.open4goods.services.remotefilecaching.service.RemoteFileCachingService;
@@ -65,7 +64,6 @@ public class ResourceController {
 	private final BrandService brandService;
 	private final ResourceService resourceService;
 	private final GtinService gtinService;
-	private final FeedService feedservice;
 	private final RemoteFileCachingService remoteFilecache;
 	private final FaviconService faviconService;
 	private final  DatasourceImageService datasourceImageService;
@@ -76,7 +74,7 @@ public class ResourceController {
 
 	private VerticalsConfigService verticalsConfigService;
 
-	public ResourceController( VerticalsConfigService verticalsConfigService,  ProductRepository productRepository,  UiConfig config, DataSourceConfigService dsConfigService, ResourceService resourceService, BrandService brandService,  GtinService gtinService, FeedService feedservice, RemoteFileCachingService remoteFilecache, FaviconService faviconService, DatasourceImageService datasourceImageService) {
+	public ResourceController( VerticalsConfigService verticalsConfigService,  ProductRepository productRepository,  UiConfig config, DataSourceConfigService dsConfigService, ResourceService resourceService, BrandService brandService,  GtinService gtinService,  RemoteFileCachingService remoteFilecache, FaviconService faviconService, DatasourceImageService datasourceImageService) {
 		this.productRepository = productRepository;
 		this.config = config;
 		this.datasourceConfigService = dsConfigService;
@@ -84,7 +82,6 @@ public class ResourceController {
 		this.resourceService = resourceService;
 		this.gtinService = gtinService;
 		this.verticalsConfigService = verticalsConfigService;
-		this.feedservice = feedservice;
 		this.remoteFilecache = remoteFilecache;
 		this.faviconService = faviconService;
 		this.datasourceImageService = datasourceImageService;

--- a/ui/src/main/java/org/open4goods/ui/services/DatasourceImageService.java
+++ b/ui/src/main/java/org/open4goods/ui/services/DatasourceImageService.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
-import org.open4goods.services.feedservice.service.FeedService;
 import org.open4goods.commons.config.yml.datasource.DataSourceProperties;
 import org.open4goods.commons.services.DataSourceConfigService;
-import org.open4goods.model.affiliation.AffiliationPartner;
 import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.model.exceptions.InvalidParameterException;
 import org.open4goods.model.helper.IdHelper;
@@ -32,16 +30,13 @@ public class DatasourceImageService {
     private static final String CONTENT_TYPE_IMAGE_PNG = "image/png";
 
     private final DataSourceConfigService datasourceConfigService;
-    private final FeedService feedService;
     private final RemoteFileCachingService remoteFileCachingService;
     private final FaviconService faviconService;
 
     public DatasourceImageService(DataSourceConfigService datasourceConfigService,
-                                  FeedService feedService,
                                   RemoteFileCachingService remoteFileCachingService,
                                   FaviconService faviconService) {
         this.datasourceConfigService = datasourceConfigService;
-        this.feedService = feedService;
         this.remoteFileCachingService = remoteFileCachingService;
         this.faviconService = faviconService;
     }
@@ -105,18 +100,8 @@ public class DatasourceImageService {
         DataSourceProperties ds = datasourceConfigService.getDatasourceConfig(datasourceName);
         String imageUrl = (ds != null) ? ds.getLogo() : null;
 
-        if (imageUrl == null) {
-            AffiliationPartner partner = feedService.getPartners().stream()
-                    .filter(e -> datasourceName.equalsIgnoreCase(cleanName(e.getName())) || datasourceName.equalsIgnoreCase(cleanName(e.getName())))
-                    .findAny().orElse(null);
-
-            if (partner != null) {
-            	imageUrl = partner.getLogoUrl();
-            }
-            if (imageUrl == null && allowFaviconFallback && ds != null) {
-
-            	imageUrl = ds.getFavico();
-            }
+        if (imageUrl == null && allowFaviconFallback && ds != null) {
+        	imageUrl = ds.getFavico();
         }
 
         if (allowFaviconFallback && (imageUrl == null || imageUrl.isBlank()) && ds != null && ds.getPortalUrl() != null) {


### PR DESCRIPTION
## Why
The legacy `ui` module was instantiating `FeedService` without feed configuration, which caused startup failures (`feedConfig` null pointer) when rendering datasource resources.

## What
- Removed `feedservice` dependency wiring from `ui`:
  - deleted feed beans from `ui` `AppConfig`
  - removed feed config properties from `UiConfig`
  - removed `FeedService` injection usage from `ResourceController` and `DatasourceImageService`
  - removed `feedservice` dependency from `ui/pom.xml`
- Exposed feed-related partner asset endpoints from `front-api`:
  - added `ResourceAssetController` with `/logo/{partnerName}`, `/icon/{datasourceName}`, `/favicon?url=...`
  - added `favicon` module dependency in `front-api/pom.xml`
- Switched front-api generated partner and datasource favicon URLs to relative Nuxt-proxied routes:
  - `AffiliationPartnerService` now emits `/api/logo/...` and `/api/favicon?...`
  - `ProductMappingService` now emits `/api/favicon?...`
- Added frontend proxy routes to reuse existing server-side API proxy pattern:
  - `frontend/server/api/logo/[partnerName].ts`
  - `frontend/server/api/icon/[datasourceName].ts`
  - `frontend/server/api/favicon.get.ts`

## Validation
- `mvn -pl ui -DskipTests compile`
- `mvn -pl front-api -DskipTests compile`
- `mvn --offline -pl ui,front-api -am -DskipTests compile` *(fails due unrelated offline dependency resolution in `google-indexation`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa10fab1b88322b46ebd7d9faaeafe)