### PR TITLE
feat(frontend): simplify product impact details with accordions

### DIFF
--- a/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreChart.vue
@@ -3,20 +3,6 @@
     <p class="impact-subscore-chart__title">
       {{ t('product.impact.subscoreChart.title') }}
     </p>
-    <v-btn-toggle
-      v-if="hasNormalizedView"
-      v-model="viewMode"
-      density="compact"
-      class="impact-subscore-chart__toggle"
-      mandatory
-    >
-      <v-btn value="absolute" variant="text" size="small">
-        {{ t('product.impact.subscoreChart.toggleAbsolute') }}
-      </v-btn>
-      <v-btn value="normalized" variant="text" size="small">
-        {{ t('product.impact.subscoreChart.toggleNormalized') }}
-      </v-btn>
-    </v-btn-toggle>
     <ClientOnly>
       <VueECharts
         v-if="chartOption"
@@ -32,13 +18,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { EChartsOption } from 'echarts'
-import type {
-  DistributionBucket,
-  ScoreNormalizationParams,
-} from './impact-types'
+import type { DistributionBucket } from './impact-types'
 import { ensureECharts } from '~/utils/echarts-loader'
 
 let echartsRegistered = false
@@ -48,19 +31,12 @@ const props = defineProps<{
   label: string
   averageValue?: number | null
   currentValue?: number | null
-  normalizedCurrentValue?: number | null
-  normalizationMethod?: string | null
-  normalizationParams?: ScoreNormalizationParams | null
-  scale?: { min?: number | null; max?: number | null } | null
   impactBetterIs?: 'GREATER' | 'LOWER' | null
-  stdDev?: number | null
   productName?: string
-  productImage?: string | null
   numericMapping?: Record<string, number> | null
 }>()
 
 const { t } = useI18n()
-const viewMode = ref<'absolute' | 'normalized'>('absolute')
 
 const VueECharts = defineAsyncComponent(async () => {
   if (import.meta.client) {
@@ -92,13 +68,6 @@ const filteredDistribution = computed(() =>
 )
 
 const hasData = computed(() => filteredDistribution.value.length > 0)
-const hasNormalizedView = computed(
-  () => resolveNormalizationAvailability().supported
-)
-const normalizationMethod = computed(() =>
-  (props.normalizationMethod ?? 'SIGMA').toUpperCase()
-)
-
 type BucketRange = {
   min?: number
   max?: number
@@ -318,21 +287,12 @@ const chartOption = computed<EChartsOption | null>(() => {
     return null
   }
 
-  const displayDistribution =
-    viewMode.value === 'normalized' && hasNormalizedView.value
-      ? buildNormalizedDistribution()
-      : buildAbsoluteDistribution()
+  const displayDistribution = buildAbsoluteDistribution()
   const dataValues = displayDistribution.map(bucket => bucket.value)
   const maxValue = Math.max(0, ...dataValues)
   const yAxisMax = Math.max(1, Math.ceil(maxValue * 1.2))
-  const productValue =
-    viewMode.value === 'normalized' && hasNormalizedView.value
-      ? (props.normalizedCurrentValue ?? null)
-      : props.currentValue
-  const averageValue =
-    viewMode.value === 'normalized' && hasNormalizedView.value
-      ? resolveNormalizedAverage()
-      : props.averageValue
+  const productValue = props.currentValue
+  const averageValue = props.averageValue
   const productIndex = resolveBucketIndex(productValue, displayDistribution)
   const averageIndex = resolveBucketIndex(averageValue, displayDistribution)
 
@@ -441,226 +401,6 @@ const chartOption = computed<EChartsOption | null>(() => {
   }
 })
 
-const resolveNormalizationAvailability = () => {
-  const method = normalizationMethod.value
-  if (method === 'SIGMA') {
-    return {
-      supported:
-        typeof props.averageValue === 'number' &&
-        typeof props.stdDev === 'number',
-    }
-  }
-  if (method === 'MINMAX_FIXED') {
-    return {
-      supported:
-        typeof props.normalizationParams?.fixedMin === 'number' &&
-        typeof props.normalizationParams?.fixedMax === 'number',
-    }
-  }
-  if (method === 'MINMAX_QUANTILE') {
-    return {
-      supported:
-        typeof props.normalizationParams?.quantileLow === 'number' &&
-        typeof props.normalizationParams?.quantileHigh === 'number',
-    }
-  }
-  if (method === 'FIXED_MAPPING') {
-    return {
-      supported: Boolean(props.normalizationParams?.mapping),
-    }
-  }
-  if (method === 'BINARY') {
-    return {
-      supported: typeof props.normalizationParams?.threshold === 'number',
-    }
-  }
-  if (method === 'CONSTANT') {
-    return {
-      supported: typeof props.normalizationParams?.constantValue === 'number',
-    }
-  }
-  if (method === 'PERCENTILE') {
-    return {
-      supported: hasData.value,
-    }
-  }
-
-  return { supported: false }
-}
-
-const resolveScaleMin = () => props.scale?.min ?? 0
-const resolveScaleMax = () => props.scale?.max ?? 5
-
-const normalizeValue = (value: number | null | undefined): number | null => {
-  if (value == null || !Number.isFinite(value)) {
-    return null
-  }
-
-  const method = normalizationMethod.value
-  if (method === 'SIGMA') {
-    if (
-      typeof props.averageValue !== 'number' ||
-      typeof props.stdDev !== 'number'
-    ) {
-      return null
-    }
-    const sigmaK = props.normalizationParams?.sigmaK ?? 2
-    const lowerBound = props.averageValue - sigmaK * props.stdDev
-    const upperBound = props.averageValue + sigmaK * props.stdDev
-    if (Math.abs(upperBound - lowerBound) < 0.000001) {
-      return (resolveScaleMin() + resolveScaleMax()) / 2
-    }
-    const normalized = (value - lowerBound) / (upperBound - lowerBound)
-    const scaled = normalized * resolveScaleMax()
-    return applyImpactDirection(clampValue(scaled))
-  }
-
-  if (method === 'MINMAX_FIXED') {
-    const min = props.normalizationParams?.fixedMin
-    const max = props.normalizationParams?.fixedMax
-    if (typeof min !== 'number' || typeof max !== 'number') {
-      return null
-    }
-    const normalized = (value - min) / (max - min)
-    const scaled = normalized * resolveScaleMax()
-    return applyImpactDirection(clampValue(scaled))
-  }
-
-  if (method === 'MINMAX_QUANTILE') {
-    const min = props.normalizationParams?.quantileLow
-    const max = props.normalizationParams?.quantileHigh
-    if (typeof min !== 'number' || typeof max !== 'number') {
-      return null
-    }
-    const normalized = (value - min) / (max - min)
-    const scaled = normalized * resolveScaleMax()
-    return applyImpactDirection(clampValue(scaled))
-  }
-
-  if (method === 'FIXED_MAPPING') {
-    const mapping = props.normalizationParams?.mapping
-    if (!mapping) {
-      return null
-    }
-    const key = Number.isFinite(value) ? String(value) : ''
-    const mapped = mapping[key] ?? mapping[String(value)]
-    if (typeof mapped !== 'number') {
-      return null
-    }
-    return applyImpactDirection(clampValue(mapped))
-  }
-
-  if (method === 'BINARY') {
-    const threshold = props.normalizationParams?.threshold
-    if (typeof threshold !== 'number') {
-      return null
-    }
-    const greaterIsPass = props.normalizationParams?.greaterIsPass ?? true
-    const pass = greaterIsPass ? value >= threshold : value <= threshold
-    return applyImpactDirection(pass ? resolveScaleMax() : resolveScaleMin())
-  }
-
-  if (method === 'CONSTANT') {
-    const constantValue = props.normalizationParams?.constantValue
-    if (typeof constantValue !== 'number') {
-      return null
-    }
-    return applyImpactDirection(clampValue(constantValue))
-  }
-
-  return null
-}
-
-const clampValue = (value: number) => {
-  const min = resolveScaleMin()
-  const max = resolveScaleMax()
-  return Math.max(min, Math.min(max, value))
-}
-
-const applyImpactDirection = (value: number) => {
-  if (props.impactBetterIs !== 'LOWER') {
-    return value
-  }
-  return resolveScaleMax() - value + resolveScaleMin()
-}
-
-const buildNormalizedDistribution = () => {
-  if (normalizationMethod.value === 'PERCENTILE') {
-    const total = filteredDistribution.value.reduce(
-      (sum, bucket) => sum + bucket.value,
-      0
-    )
-    if (!total) {
-      return filteredDistribution.value
-    }
-    let cumulative = 0
-    return filteredDistribution.value.map(bucket => {
-      const percentile = (cumulative + 0.5 * bucket.value) / total
-      cumulative += bucket.value
-      const scaled = percentile * resolveScaleMax()
-      const normalized = applyImpactDirection(clampValue(scaled))
-      return {
-        ...bucket,
-        label: formatBucketValue(normalized),
-      }
-    })
-  }
-
-  return filteredDistribution.value.map(bucket => {
-    const range = parseBucketRange(bucket.label)
-    if (!range) {
-      return bucket
-    }
-
-    if (range.exact != null) {
-      const normalized = normalizeValue(range.exact)
-      return {
-        ...bucket,
-        label:
-          normalized != null ? formatBucketValue(normalized) : bucket.label,
-      }
-    }
-
-    const min = range.min != null ? normalizeValue(range.min) : null
-    const max = range.max != null ? normalizeValue(range.max) : null
-    if (min != null && max != null) {
-      return {
-        ...bucket,
-        label: `${formatBucketValue(min)}–${formatBucketValue(max)}`,
-      }
-    }
-
-    if (min != null) {
-      return {
-        ...bucket,
-        label: `≥ ${formatBucketValue(min)}`,
-      }
-    }
-
-    if (max != null) {
-      return {
-        ...bucket,
-        label: `≤ ${formatBucketValue(max)}`,
-      }
-    }
-
-    return bucket
-  })
-}
-
-const formatBucketValue = (value: number) =>
-  new Intl.NumberFormat(undefined, {
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 0,
-  }).format(value)
-
-const resolveNormalizedAverage = () => {
-  if (normalizationMethod.value === 'PERCENTILE') {
-    return null
-  }
-  return normalizeValue(props.averageValue)
-}
-
 const buildAbsoluteDistribution = () => {
   if (!props.numericMapping) {
     return filteredDistribution.value
@@ -703,10 +443,6 @@ const buildAbsoluteDistribution = () => {
   font-size: 0.95rem;
   font-weight: 600;
   color: rgb(var(--v-theme-text-neutral-strong));
-}
-
-.impact-subscore-chart__toggle {
-  align-self: flex-start;
 }
 
 .impact-subscore-chart__echart {

--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.spec.ts
@@ -36,6 +36,43 @@ describe('ProductImpactSubscoreExplanation', () => {
       return () => h('div', { class: 'v-card-stub' }, slots.default?.())
     },
   })
+  const VBtnStub = defineComponent({
+    name: 'VBtnStub',
+    setup(_props, { slots }) {
+      return () => h('button', { class: 'v-btn-stub' }, slots.default?.())
+    },
+  })
+
+  const VExpansionPanelsStub = defineComponent({
+    name: 'VExpansionPanelsStub',
+    setup(_props, { slots }) {
+      return () =>
+        h('div', { class: 'v-expansion-panels-stub' }, slots.default?.())
+    },
+  })
+
+  const VExpansionPanelStub = defineComponent({
+    name: 'VExpansionPanelStub',
+    setup(_props, { slots }) {
+      return () => h('section', { class: 'v-expansion-panel-stub' }, slots.default?.())
+    },
+  })
+
+  const VExpansionPanelTitleStub = defineComponent({
+    name: 'VExpansionPanelTitleStub',
+    setup(_props, { slots }) {
+      return () =>
+        h('h5', { class: 'v-expansion-panel-title-stub' }, slots.default?.())
+    },
+  })
+
+  const VExpansionPanelTextStub = defineComponent({
+    name: 'VExpansionPanelTextStub',
+    setup(_props, { slots }) {
+      return () =>
+        h('div', { class: 'v-expansion-panel-text-stub' }, slots.default?.())
+    },
+  })
 
   const globalOptions = {
     plugins: [i18n],
@@ -43,6 +80,11 @@ describe('ProductImpactSubscoreExplanation', () => {
       VIcon: VIconStub,
       VChip: VChipStub,
       VCard: VCardStub,
+      VBtn: VBtnStub,
+      VExpansionPanels: VExpansionPanelsStub,
+      VExpansionPanel: VExpansionPanelStub,
+      VExpansionPanelTitle: VExpansionPanelTitleStub,
+      VExpansionPanelText: VExpansionPanelTextStub,
     },
   }
 

--- a/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreExplanation.vue
@@ -12,77 +12,95 @@
       </p>
     </div>
 
-    <div
-      v-if="hasReadIndicatorContent"
-      class="impact-subscore-explanation__section"
+    <v-expansion-panels
+      v-if="hasEducationalPanels"
+      class="impact-subscore-explanation__accordion"
+      variant="accordion"
+      density="compact"
+      multiple
     >
-      <h5 class="impact-subscore-explanation__title">
-        {{ readIndicatorTitle }}
-      </h5>
-      <ul
-        v-if="readIndicatorHighlights.length"
-        class="impact-subscore-explanation__bullet-list"
-      >
-        <li
-          v-for="item in readIndicatorHighlights"
-          :key="item.id"
-          class="impact-subscore-explanation__bullet-item"
-        >
-          <v-icon
-            icon="mdi-check-circle-outline"
-            size="18"
-            class="impact-subscore-explanation__bullet-icon"
-          />
-          <!-- eslint-disable vue/no-v-html -->
-          <span v-html="item.text" />
-          <!-- eslint-enable vue/no-v-html -->
-        </li>
-      </ul>
-      <p
-        v-for="(paragraph, index) in readIndicatorDetails"
-        :key="`detail-${index}`"
-        class="impact-subscore-explanation__paragraph"
-      >
-        {{ paragraph }}
-      </p>
-    </div>
+      <v-expansion-panel v-if="hasReadIndicatorContent">
+        <v-expansion-panel-title class="impact-subscore-explanation__accordion-title">
+          {{ readIndicatorTitle }}
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <ul
+            v-if="readIndicatorHighlights.length"
+            class="impact-subscore-explanation__bullet-list"
+          >
+            <li
+              v-for="item in readIndicatorHighlights"
+              :key="item.id"
+              class="impact-subscore-explanation__bullet-item"
+            >
+              <v-icon
+                icon="mdi-check-circle-outline"
+                size="18"
+                class="impact-subscore-explanation__bullet-icon"
+              />
+              <!-- eslint-disable vue/no-v-html -->
+              <span v-html="item.text" />
+              <!-- eslint-enable vue/no-v-html -->
+            </li>
+          </ul>
+          <p
+            v-for="(paragraph, index) in readIndicatorDetails"
+            :key="`detail-${index}`"
+            class="impact-subscore-explanation__paragraph"
+          >
+            {{ paragraph }}
+          </p>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
 
-    <div
-      v-if="statisticalMethodItems.length"
-      class="impact-subscore-explanation__section"
-    >
-      <h5 class="impact-subscore-explanation__title">
-        {{ statisticalMethodTitle }}
-      </h5>
-      <ul class="impact-subscore-explanation__bullet-list">
-        <li
-          v-for="(item, index) in statisticalMethodItems"
-          :key="`method-${index}`"
-          class="impact-subscore-explanation__bullet-item"
-        >
-          <v-icon
-            icon="mdi-chart-bell-curve"
-            size="18"
-            class="impact-subscore-explanation__bullet-icon"
-          />
-          <span>{{ item }}</span>
-        </li>
-      </ul>
-      <v-card
-        v-if="statisticalMethodInfo"
-        variant="tonal"
-        class="impact-subscore-explanation__info-card"
-      >
-        <div class="impact-subscore-explanation__info-card-content">
-          <p class="impact-subscore-explanation__info-title">
-            {{ statisticalMethodInfo.title }}
-          </p>
-          <p class="impact-subscore-explanation__info-body">
-            {{ statisticalMethodInfo.body }}
-          </p>
-        </div>
-      </v-card>
-    </div>
+      <v-expansion-panel v-if="statisticalMethodItems.length">
+        <v-expansion-panel-title class="impact-subscore-explanation__accordion-title">
+          {{ statisticalMethodTitle }}
+        </v-expansion-panel-title>
+        <v-expansion-panel-text>
+          <ul class="impact-subscore-explanation__bullet-list">
+            <li
+              v-for="(item, index) in statisticalMethodItems"
+              :key="`method-${index}`"
+              class="impact-subscore-explanation__bullet-item"
+            >
+              <v-icon
+                icon="mdi-chart-bell-curve"
+                size="18"
+                class="impact-subscore-explanation__bullet-icon"
+              />
+              <span>{{ item }}</span>
+            </li>
+          </ul>
+          <v-card
+            v-if="statisticalMethodInfo"
+            variant="tonal"
+            class="impact-subscore-explanation__info-card"
+          >
+            <div class="impact-subscore-explanation__info-card-content">
+              <p class="impact-subscore-explanation__info-title">
+                {{ statisticalMethodInfo.title }}
+              </p>
+              <p class="impact-subscore-explanation__info-body">
+                {{ statisticalMethodInfo.body }}
+              </p>
+            </div>
+          </v-card>
+          <v-btn
+            variant="text"
+            color="primary"
+            size="small"
+            class="impact-subscore-explanation__method-link"
+            :href="methodologyUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="t('product.impact.methodologyLinkAria')"
+          >
+            {{ t('product.impact.methodologyLink') }}
+          </v-btn>
+        </v-expansion-panel-text>
+      </v-expansion-panel>
+    </v-expansion-panels>
 
     <dl v-if="infoItems.length" class="impact-subscore-explanation__list">
       <div
@@ -610,6 +628,12 @@ const rankingBadgeText = computed(() => {
 const readIndicatorTitle = computed(() =>
   resolveTranslation('readIndicator.title', readIndicatorParams.value)
 )
+
+const hasEducationalPanels = computed(
+  () => hasReadIndicatorContent.value || statisticalMethodItems.value.length > 0
+)
+
+const methodologyUrl = 'https://nudger.fr/frigos/ecoscore'
 
 const readIndicatorHighlights = computed(() => {
   const items: Array<{ id: string; text: string }> = []

--- a/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
+++ b/frontend/app/components/product/impact/ProductImpactSubscoreGenericCard.spec.ts
@@ -20,6 +20,42 @@ const VIconStub = defineComponent({
       h('span', { class: 'v-icon-stub', 'data-icon': props.icon }, props.icon)
   },
 })
+const VCardStub = defineComponent({
+  name: 'VCardStub',
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'v-card-stub' }, slots.default?.())
+  },
+})
+const VBtnStub = defineComponent({
+  name: 'VBtnStub',
+  setup(_props, { slots }) {
+    return () => h('button', { class: 'v-btn-stub' }, slots.default?.())
+  },
+})
+const VExpansionPanelsStub = defineComponent({
+  name: 'VExpansionPanelsStub',
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'v-expansion-panels-stub' }, slots.default?.())
+  },
+})
+const VExpansionPanelStub = defineComponent({
+  name: 'VExpansionPanelStub',
+  setup(_props, { slots }) {
+    return () => h('section', { class: 'v-expansion-panel-stub' }, slots.default?.())
+  },
+})
+const VExpansionPanelTitleStub = defineComponent({
+  name: 'VExpansionPanelTitleStub',
+  setup(_props, { slots }) {
+    return () => h('h5', { class: 'v-expansion-panel-title-stub' }, slots.default?.())
+  },
+})
+const VExpansionPanelTextStub = defineComponent({
+  name: 'VExpansionPanelTextStub',
+  setup(_props, { slots }) {
+    return () => h('div', { class: 'v-expansion-panel-text-stub' }, slots.default?.())
+  },
+})
 
 describe('ProductImpactSubscoreGenericCard', () => {
   // ... existing i18n setup ...
@@ -129,6 +165,12 @@ describe('ProductImpactSubscoreGenericCard', () => {
           ProductImpactSubscoreChart: true,
           VChip: VChipStub,
           VIcon: VIconStub,
+          VCard: VCardStub,
+          VBtn: VBtnStub,
+          VExpansionPanels: VExpansionPanelsStub,
+          VExpansionPanel: VExpansionPanelStub,
+          VExpansionPanelTitle: VExpansionPanelTitleStub,
+          VExpansionPanelText: VExpansionPanelTextStub,
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
             props: [
@@ -192,6 +234,12 @@ describe('ProductImpactSubscoreGenericCard', () => {
           ProductImpactSubscoreChart: true,
           VChip: VChipStub,
           VIcon: VIconStub,
+          VCard: VCardStub,
+          VBtn: VBtnStub,
+          VExpansionPanels: VExpansionPanelsStub,
+          VExpansionPanel: VExpansionPanelStub,
+          VExpansionPanelTitle: VExpansionPanelTitleStub,
+          VExpansionPanelText: VExpansionPanelTextStub,
           ImpactCoefficientBadge: defineComponent({
             name: 'ImpactCoefficientBadgeStub',
             props: [
@@ -244,6 +292,12 @@ describe('ProductImpactSubscoreGenericCard', () => {
           ProductImpactSubscoreChart: true,
           VChip: VChipStub,
           VIcon: VIconStub,
+          VCard: VCardStub,
+          VBtn: VBtnStub,
+          VExpansionPanels: VExpansionPanelsStub,
+          VExpansionPanel: VExpansionPanelStub,
+          VExpansionPanelTitle: VExpansionPanelTitleStub,
+          VExpansionPanelText: VExpansionPanelTextStub,
           ImpactCoefficientBadge: true,
           ClientOnly: true,
         },


### PR DESCRIPTION
## Why
Product impact cards were too dense because explanation blocks and statistical method details were always expanded. Stakeholder feedback asked to lighten product sheets while preserving transparency, and to remove the absolute/relative chart toggle.

## What
- Removed the absolute/normalized toggle from `ProductImpactSubscoreChart` and kept a single absolute-distribution chart mode.
- Refactored `ProductImpactSubscoreExplanation` so:
  - "Comment lire cet indicateur" is displayed inside an accordion panel.
  - "Méthode statistique ..." is displayed inside another accordion panel.
  - Added an explicit transparency link to `https://nudger.fr/frigos/ecoscore` inside the statistical method panel.
- Updated component tests to stub the newly used Vuetify expansion-panel and button components:
  - `ProductImpactSubscoreExplanation.spec.ts`
  - `ProductImpactSubscoreGenericCard.spec.ts`

## Validation
- `pnpm -C frontend lint`
- `pnpm -C frontend test -- ProductImpactSubscoreExplanation.spec.ts`
- `pnpm -C frontend test -- ProductImpactSubscoreGenericCard.spec.ts`
- `pnpm -C frontend generate` (succeeds, with existing sitemap configuration warnings unrelated to this change)

## Notes
- I attempted to capture a screenshot via Playwright, but `http://127.0.0.1:3000/...` returned `net::ERR_EMPTY_RESPONSE` in this environment, so no artifact could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1f1b10a88322a54d7eaf5f721812)