### PR TITLE
feat(frontend): add i18n “More characteristics” hero link with smooth scroll

### DIFF
--- a/frontend/app/components/product/ProductHero.spec.ts
+++ b/frontend/app/components/product/ProductHero.spec.ts
@@ -48,6 +48,7 @@ const createI18nInstance = () =>
               differentCategory: 'Different',
               missingIdentifier: 'Missing identifier',
             },
+            moreCharacteristics: 'More characteristics',
           },
         },
       },
@@ -176,6 +177,7 @@ const mountComponent = async () =>
       product: baseProduct,
       breadcrumbs: [{ title: 'Category' }],
       popularAttributes: [],
+      hasCategory: true,
     },
     global: {
       plugins: [createI18nInstance()],
@@ -203,6 +205,47 @@ describe('ProductHero', () => {
     await wrapper.unmount()
   })
 
+
+  it('scrolls to the attributes section from the more characteristics link', async () => {
+    const scrollToMock = vi.fn()
+    const attributesSection = document.createElement('section')
+    attributesSection.id = 'caracteristiques'
+    document.body.appendChild(attributesSection)
+
+    Object.defineProperty(attributesSection, 'getBoundingClientRect', {
+      value: () => ({
+        top: 400,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    })
+
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 100,
+    })
+
+    vi.stubGlobal('scrollTo', scrollToMock)
+
+    const wrapper = await mountComponent()
+    const button = wrapper.find('.product-hero__more-characteristics')
+
+    expect(button.exists()).toBe(true)
+    await button.trigger('click')
+
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 380, behavior: 'smooth' })
+
+    document.body.removeChild(attributesSection)
+    vi.unstubAllGlobals()
+    await wrapper.unmount()
+  })
+
   it('renders gallery when images are present', async () => {
     const productWithImages: ProductDto = {
       ...baseProduct,
@@ -222,6 +265,7 @@ describe('ProductHero', () => {
         product: productWithImages,
         breadcrumbs: [{ title: 'Category' }],
         popularAttributes: [],
+        hasCategory: true,
       },
       global: {
         plugins: [createI18nInstance()],

--- a/frontend/app/components/product/ProductHero.vue
+++ b/frontend/app/components/product/ProductHero.vue
@@ -112,6 +112,14 @@
               </div>
 
               <div class="mt-6 product-hero__centered-info">
+                <v-btn
+                  v-if="hasCategory"
+                  variant="text"
+                  class="product-hero__more-characteristics"
+                  @click="handleMoreCharacteristicsClick"
+                >
+                  {{ t('product.hero.moreCharacteristics') }}
+                </v-btn>
                 <ul
                   v-if="heroAttributes.length"
                   class="product-hero__attributes"
@@ -507,6 +515,18 @@ const handleImpactScoreClick = () => {
   const element = document.getElementById('impact')
   if (element) {
     const offset = 120 // Adjust based on header height
+    const top = element.getBoundingClientRect().top + window.scrollY - offset
+    window.scrollTo({ top, behavior: 'smooth' })
+  }
+}
+
+const handleMoreCharacteristicsClick = () => {
+  const element =
+    document.getElementById('caracteristiques') ||
+    document.querySelector('.product-attributes')
+
+  if (element) {
+    const offset = 120
     const top = element.getBoundingClientRect().top + window.scrollY - offset
     window.scrollTo({ top, behavior: 'smooth' })
   }
@@ -1142,6 +1162,13 @@ const heroBreadcrumbProps = computed(() => ({
   justify-content: center;
   flex: 1;
   min-height: 0;
+}
+
+.product-hero__more-characteristics {
+  align-self: center;
+  text-transform: none;
+  letter-spacing: normal;
+  margin-bottom: 0.75rem;
 }
 
 .product-hero__heading-group {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2668,6 +2668,7 @@
         "showMore": "Show more",
         "showLess": "Show less"
       },
+      "moreCharacteristics": "More characteristics",
       "gtin": "GTIN code",
       "gtinTooltip": "Based on the product GTIN code, this does not necessarily indicate the manufacturing location.",
       "mediaType": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2562,6 +2562,7 @@
         "showMore": "Afficher plus",
         "showLess": "Afficher moins"
       },
+      "moreCharacteristics": "Plus de caractéristiques",
       "gtin": "Code Baarre (GTIN)",
       "gtinTooltip": "Basé sur le code GTIN du produit, cela n'indique pas nécessairement le lieu de fabrication.",
       "mediaType": {


### PR DESCRIPTION
## Why
On product pages, users need a quick shortcut from the hero area to the technical attributes section.

## What
- Added a new hero action link in `frontend/app/components/product/ProductHero.vue`:
  - Label is internationalized via `product.hero.moreCharacteristics`
  - Text shown as **"Plus de caractéristiques"** in French
  - Click performs smooth scroll to the attributes section (`#caracteristiques`) with existing header offset behavior
- Added localization entries:
  - `frontend/i18n/locales/fr-FR.json`
  - `frontend/i18n/locales/en-US.json`
- Updated `frontend/app/components/product/ProductHero.spec.ts`:
  - Added i18n key for the new label in test messages
  - Added test coverage to ensure clicking the new link triggers the expected smooth scroll target

## Notes
- Attempted to take a browser screenshot, but `http://localhost:3000` returned `ERR_EMPTY_RESPONSE` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa236894b483229cb20ccf83466deb)