### PR TITLE
Add DJL tokenizers properties fallback and Spring Boot unpack config for native libs

### DIFF
--- a/front-api/pom.xml
+++ b/front-api/pom.xml
@@ -243,6 +243,16 @@
           <layers>
             <enabled>true</enabled>
           </layers>
+          <requiresUnpack>
+            <dependency>
+              <groupId>ai.djl.huggingface</groupId>
+              <artifactId>tokenizers</artifactId>
+            </dependency>
+            <dependency>
+              <groupId>ai.djl.pytorch</groupId>
+              <artifactId>pytorch-native-cpu</artifactId>
+            </dependency>
+          </requiresUnpack>
         </configuration>
       </plugin>
     </plugins>

--- a/services/embedding-djl/src/main/java/org/open4goods/embedding/service/DefaultTextModelFactory.java
+++ b/services/embedding-djl/src/main/java/org/open4goods/embedding/service/DefaultTextModelFactory.java
@@ -14,9 +14,9 @@ import ai.djl.training.util.ProgressBar;
  * Default implementation that loads DJL models using HuggingFace tokenizers and translators.
  * <p>
  * This factory relies on tokenizer-native metadata shipped by DJL dependencies.
- * Application resources must not provide a competing
- * {@code /native/lib/tokenizers.properties} file, otherwise packaged Spring Boot
- * jars can shadow DJL metadata and fail at startup.
+ * The embedding module also contributes a compatible
+ * {@code /native/lib/tokenizers.properties} fallback for Spring Boot executable
+ * jars where nested-jar resource ordering may hide DJL metadata at runtime.
  * </p>
  */
 public class DefaultTextModelFactory extends AbstractTextModelFactory

--- a/services/embedding-djl/src/main/resources/native/lib/tokenizers.properties
+++ b/services/embedding-djl/src/main/resources/native/lib/tokenizers.properties
@@ -1,0 +1,2 @@
+tokenizers_version=0.21.0-0.36.0
+djl_version=0.36.0

--- a/services/embedding-djl/src/test/java/org/open4goods/embedding/TokenizersPlatformPropertiesTest.java
+++ b/services/embedding-djl/src/test/java/org/open4goods/embedding/TokenizersPlatformPropertiesTest.java
@@ -2,6 +2,9 @@ package org.open4goods.embedding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 
 import ai.djl.util.Platform;
@@ -11,6 +14,20 @@ import ai.djl.util.Platform;
  */
 class TokenizersPlatformPropertiesTest
 {
+    @Test
+    void shouldExposeFallbackNativeTokenizersProperties()
+            throws Exception
+    {
+        try (InputStream stream = getClass().getResourceAsStream("/native/lib/tokenizers.properties"))
+        {
+            assertThat(stream).isNotNull();
+            Properties properties = new Properties();
+            properties.load(stream);
+            assertThat(properties.getProperty("tokenizers_version")).isEqualTo("0.21.0-0.36.0");
+            assertThat(properties.getProperty("djl_version")).isEqualTo("0.36.0");
+        }
+    }
+
     @Test
     void shouldExposeTokenizersVersionFromEngineProperties()
     {


### PR DESCRIPTION
### Motivation

- Ensure DJL's HuggingFace tokenizers metadata is available at runtime for Spring Boot executable jars where nested-jar resource ordering can hide DJL-provided metadata. 
- Prevent startup failures when using the embedding module with DJL tokenizers and PyTorch native libraries packaged inside layered Spring Boot jars.

### Description

- Add a fallback properties file at `services/embedding-djl/src/main/resources/native/lib/tokenizers.properties` that declares `tokenizers_version` and `djl_version` for the tokenizers native engine.
- Update `DefaultTextModelFactory` Javadoc to document the presence of the fallback ` /native/lib/tokenizers.properties` resource for Spring Boot executable jars.
- Configure the `spring-boot-maven-plugin` in `front-api/pom.xml` to `requiresUnpack` the `ai.djl.huggingface:tokenizers` and `ai.djl.pytorch:pytorch-native-cpu` dependencies so their native artifacts are unpacked at runtime.
- Add `TokenizersPlatformPropertiesTest` to assert the fallback properties file is present on the classpath and contains the expected `tokenizers_version` and `djl_version` values.

### Testing

- Ran the module unit tests including `TokenizersPlatformPropertiesTest` in `services/embedding-djl` and the existing `shouldExposeTokenizersVersionFromEngineProperties`, and both tests passed. 
- Build verified that the new resource is packaged and accessible on the classpath during test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa5bd3362c8322b67db1293e2705ed)