### PR TITLE
Expose assistant IDs to article component, add inclusive range operators for subsets, and update TV-size assistant mapping

### DIFF
--- a/frontend/app/components/domains/blog/TheArticle.vue
+++ b/frontend/app/components/domains/blog/TheArticle.vue
@@ -21,6 +21,8 @@ type BodyPart = { type: 'html' | 'assistant'; content?: string }
 
 const props = defineProps<{
   article: BlogArticle
+  assistantId?: string | null
+  assistantCategoryId?: string | null
 }>()
 
 const article = computed(() => props.article)
@@ -39,6 +41,10 @@ const showAssistant = computed(() => {
 })
 
 const assistantCategoryId = computed(() => {
+  if (props.assistantCategoryId?.trim()) {
+    return props.assistantCategoryId
+  }
+
   // Extract category ID from the article's category list if possible.
   // For now, assume the first category or a specific field maps to it.
   // The user prompt said "l'assistant qui correspond à la page" (assistant corresponding to the page).
@@ -52,6 +58,19 @@ const assistantCategoryId = computed(() => {
     // Let's iterate to find a known vertical ID or just use the first one.
     return cats[0].toLowerCase()
   }
+  return null
+})
+
+const assistantId = computed(() => {
+  if (props.assistantId?.trim()) {
+    return props.assistantId
+  }
+
+  const articleUrl = article.value.url?.trim()
+  if (articleUrl) {
+    return articleUrl
+  }
+
   return null
 })
 
@@ -406,6 +425,7 @@ useHead(() => ({
           class="my-8"
         >
           <NudgeToolAssistantWizard
+            :assistant-id="assistantId"
             :assistant-category-id="assistantCategoryId"
             compact
           />

--- a/frontend/app/pages/blog/[slug].vue
+++ b/frontend/app/pages/blog/[slug].vue
@@ -85,10 +85,9 @@ const assistantCategoryId = computed(() =>
           {{ error }}
         </v-alert>
 
-        <TheArticle v-else-if="article" :article="article" />
-
-        <NudgeToolAssistantWizard
-          v-if="article && assistantConfigId"
+        <TheArticle
+          v-else-if="article"
+          :article="article"
           :assistant-id="assistantConfigId"
           :assistant-category-id="assistantCategoryId"
         />

--- a/frontend/app/utils/_subset-to-filters.spec.ts
+++ b/frontend/app/utils/_subset-to-filters.spec.ts
@@ -213,4 +213,42 @@ describe('_subset-to-filters helpers', () => {
       ],
     })
   })
+
+  it('supports GREATER_THAN_OR_EQUAL and LOWER_THAN_OR_EQUAL operators', () => {
+    const subsets: VerticalSubsetDto[] = [
+      {
+        id: 'distance-comfort',
+        group: 'distance',
+        criterias: [
+          {
+            field: 'attributes.indexed.DIAGONALE_POUCES.numericValue',
+            operator: 'GREATER_THAN_OR_EQUAL',
+            value: '24',
+          },
+          {
+            field: 'attributes.indexed.DIAGONALE_POUCES.numericValue',
+            operator: 'LOWER_THAN_OR_EQUAL',
+            value: '47',
+          },
+        ],
+      },
+    ]
+
+    const request = buildFilterRequestFromSubsets(subsets, ['distance-comfort'])
+
+    expect(request).toEqual({
+      filterGroups: [
+        {
+          should: [
+            {
+              field: 'attributes.indexed.DIAGONALE_POUCES.numericValue',
+              operator: 'range',
+              min: 24,
+              max: 47,
+            },
+          ],
+        },
+      ],
+    })
+  })
 })

--- a/frontend/app/utils/_subset-to-filters.ts
+++ b/frontend/app/utils/_subset-to-filters.ts
@@ -73,7 +73,23 @@ const convertCriteria = (
     }
   }
 
+  if (criteria.operator === 'LOWER_THAN_OR_EQUAL') {
+    return {
+      field: criteria.field,
+      operator: 'range',
+      max: numericValue,
+    }
+  }
+
   if (criteria.operator === 'GREATER_THAN') {
+    return {
+      field: criteria.field,
+      operator: 'range',
+      min: numericValue,
+    }
+  }
+
+  if (criteria.operator === 'GREATER_THAN_OR_EQUAL') {
     return {
       field: criteria.field,
       operator: 'range',

--- a/verticals/src/main/resources/assistant/quelle-taille-de-tv-choisir-pour-son-salon.yml
+++ b/verticals/src/main/resources/assistant/quelle-taille-de-tv-choisir-pour-son-salon.yml
@@ -81,9 +81,9 @@ subsets:
   - id: "distance_close"
     group: "distance"
     criterias:
-      - field: "assistant.viewingDistanceCm"
-        operator: "LOWER_THAN"
-        value: "150"
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "LOWER_THAN_OR_EQUAL"
+        value: "24"
     image: "distance-close.png"
     url:
       en: "distance-close"
@@ -101,12 +101,12 @@ subsets:
   - id: "distance_comfort"
     group: "distance"
     criterias:
-      - field: "assistant.viewingDistanceCm"
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
         operator: "GREATER_THAN_OR_EQUAL"
-        value: "150"
-      - field: "assistant.viewingDistanceCm"
-        operator: "LOWER_THAN"
-        value: "300"
+        value: "24"
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
+        operator: "LOWER_THAN_OR_EQUAL"
+        value: "47"
     image: "distance-comfort.png"
     url:
       en: "distance-comfort"
@@ -124,9 +124,9 @@ subsets:
   - id: "distance_far"
     group: "distance"
     criterias:
-      - field: "assistant.viewingDistanceCm"
+      - field: "attributes.indexed.DIAGONALE_POUCES.numericValue"
         operator: "GREATER_THAN_OR_EQUAL"
-        value: "300"
+        value: "47"
     image: "distance-far.png"
     url:
       en: "distance-far"


### PR DESCRIPTION
### Motivation
- Allow the blog article page to provide the assistant configuration (ID and category) directly to the article component so the assistant wizard can be rendered in-context. 
- Align the TV-size assistant subsets with product attributes and support inclusive numeric range operators so subsets like "24–47 inches" map correctly to search filters.

### Description
- Added `assistantId` and `assistantCategoryId` props to `TheArticle.vue` and compute fallbacks from the article payload when props are not provided. 
- Moved the `NudgeToolAssistantWizard` usage into `TheArticle.vue` and pass `:assistant-id` and `:assistant-category-id` from the blog page by wiring `assistantConfigId` and `assistantCategoryId` in `pages/blog/[slug].vue`. 
- Extended `convertCriteria` in `utils/_subset-to-filters.ts` to handle `GREATER_THAN_OR_EQUAL` and `LOWER_THAN_OR_EQUAL` by emitting `range` filters with `min`/`max`. 
- Updated the TV-size assistant definition `verticals/.../quelle-taille-de-tv-choisir-pour-son-salon.yml` to use `attributes.indexed.DIAGONALE_POUCES.numericValue` with inclusive operators and adjusted numeric values to match inch-based thresholds. 
- Added a unit test in `utils/_subset-to-filters.spec.ts` to cover the inclusive operators case.

### Testing
- Ran the unit tests for `utils/_subset-to-filters.spec.ts` which include the new `GREATER_THAN_OR_EQUAL`/`LOWER_THAN_OR_EQUAL` test and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa628eb6c88322ba7de68782e8c223)