### PR TITLE
Introduce `buildProductMeta` for product SEO and integrate into ProductPage

### DIFF
--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -220,6 +220,7 @@ import { normalizeTimestamp } from '~/utils/date-parsing'
 import type { ProductRouteMatch } from '~~/shared/utils/_product-route'
 import { isBackendNotFoundError } from '~~/shared/utils/_product-route'
 import { buildProductJsonLdGraph } from '~/utils/product-jsonld'
+import { buildProductMeta } from '~/utils/seo/product-meta'
 
 import ProductSummaryNavigation from '~/components/product/ProductSummaryNavigation.vue'
 import ProductHero from '~/components/product/ProductHero.vue'
@@ -898,23 +899,7 @@ const productMetaDescription = computed(() => {
     return explicit
   }
 
-  const brandModelSuffix =
-    brandModelTitle.value && brandModelTitle.value !== productMetaTitle.value
-      ? ` ${brandModelTitle.value}`
-      : ''
-
-  if (normalizedVerticalTitle.value) {
-    return t('product.meta.defaultDescriptionWithVertical', {
-      productTitle: productMetaTitle.value,
-      brandModel: brandModelSuffix,
-      verticalTitle: normalizedVerticalTitle.value,
-    })
-  }
-
-  return t('product.meta.defaultDescription', {
-    productTitle: productMetaTitle.value,
-    brandModel: brandModelSuffix,
-  })
+  return seoMetaDescription.value
 })
 
 const toAbsoluteUrl = (value?: string | null) => {
@@ -2163,23 +2148,98 @@ const productJsonLdGraph = computed(() => {
   })
 })
 
-const metaTitle = computed(() => {
-  const title = productTitle.value
-  const score = impactScoreOutOf20.value
+const seoMetaBase = computed(() =>
+  buildProductMeta({
+    productName: productMetaTitle.value,
+    brandModel: brandModelTitle.value,
+    score: impactScoreOutOf20.value,
+    verticalTitle: normalizedVerticalTitle.value,
+    maxTitleLength: 60,
+    maxDescriptionLength: 160,
+    titleTemplates: {
+      withImpactFull: String(t('product.meta.serp.title.withImpact.full')),
+      withImpactCompact: String(
+        t('product.meta.serp.title.withImpact.compact')
+      ),
+      withImpactMinimal: String(
+        t('product.meta.serp.title.withImpact.minimal')
+      ),
+      withoutImpactFull: String(
+        t('product.meta.serp.title.withoutImpact.full')
+      ),
+      withoutImpactCompact: String(
+        t('product.meta.serp.title.withoutImpact.compact')
+      ),
+      withoutImpactMinimal: String(
+        t('product.meta.serp.title.withoutImpact.minimal')
+      ),
+    },
+    descriptionTemplates: {
+      withImpact: String(t('product.meta.serp.description.withImpact')),
+      withImpactVertical: String(
+        t('product.meta.serp.description.withImpactVertical')
+      ),
+      withoutImpact: String(t('product.meta.serp.description.withoutImpact')),
+      withoutImpactVertical: String(
+        t('product.meta.serp.description.withoutImpactVertical')
+      ),
+    },
+  })
+)
 
-  if (title.length < 35 && score != null) {
-    return `${title}${t('product.meta.impactScore', { score })}`
-  }
+const socialMetaBase = computed(() =>
+  buildProductMeta({
+    productName: productMetaTitle.value,
+    brandModel: brandModelTitle.value,
+    score: impactScoreOutOf20.value,
+    verticalTitle: normalizedVerticalTitle.value,
+    maxTitleLength: 70,
+    maxDescriptionLength: 180,
+    titleTemplates: {
+      withImpactFull: String(t('product.meta.social.title.withImpact.full')),
+      withImpactCompact: String(
+        t('product.meta.social.title.withImpact.compact')
+      ),
+      withImpactMinimal: String(
+        t('product.meta.social.title.withImpact.minimal')
+      ),
+      withoutImpactFull: String(
+        t('product.meta.social.title.withoutImpact.full')
+      ),
+      withoutImpactCompact: String(
+        t('product.meta.social.title.withoutImpact.compact')
+      ),
+      withoutImpactMinimal: String(
+        t('product.meta.social.title.withoutImpact.minimal')
+      ),
+    },
+    descriptionTemplates: {
+      withImpact: String(t('product.meta.social.description.withImpact')),
+      withImpactVertical: String(
+        t('product.meta.social.description.withImpactVertical')
+      ),
+      withoutImpact: String(
+        t('product.meta.social.description.withoutImpact')
+      ),
+      withoutImpactVertical: String(
+        t('product.meta.social.description.withoutImpactVertical')
+      ),
+    },
+  })
+)
 
-  return title
-})
+const seoMetaTitle = computed(() => seoMetaBase.value.title)
+const seoMetaDescription = computed(() => seoMetaBase.value.description)
+
+const socialMetaTitle = computed(() => socialMetaBase.value.title)
+const socialMetaDescription = computed(() => socialMetaBase.value.description)
 
 useSeoMeta({
-  title: () => metaTitle.value,
+  title: () => seoMetaTitle.value,
   description: () => productMetaDescription.value,
-  ogTitle: () => product.value?.names?.ogTitle ?? metaTitle.value,
+  ogTitle: () => product.value?.names?.ogTitle ?? socialMetaTitle.value,
   ogDescription: () =>
-    product.value?.names?.ogDescription ?? productMetaDescription.value,
+    product.value?.names?.ogDescription ?? socialMetaDescription.value,
   ogUrl: () => canonicalUrl.value,
   ogType: 'product',
   ogImage: () => ogImageUrl.value,

--- a/frontend/app/utils/seo/product-meta.spec.ts
+++ b/frontend/app/utils/seo/product-meta.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { buildProductMeta } from './product-meta'
+
+const serpTemplates = {
+  title: {
+    withImpactFull:
+      '{productName} : ImpactScore : {score}/20 | Meilleurs prix, manuels, et caractéristiques pour le {brandModel}',
+    withImpactCompact:
+      '{productName} : ImpactScore : {score}/20 | Meilleurs prix pour {brandModel}',
+    withImpactMinimal: '{productName} : ImpactScore : {score}/20',
+    withoutImpactFull:
+      '{productName} | Meilleurs prix, manuels, et caractéristiques pour le {brandModel}',
+    withoutImpactCompact: '{productName} | Meilleurs prix pour {brandModel}',
+    withoutImpactMinimal: '{productName}',
+  },
+  description: {
+    withImpact:
+      'Comparez {productName} ({brandModel}) : score d\'impact {score}/20, meilleurs prix, manuels et caractéristiques sur Nudger.',
+    withImpactVertical:
+      'Comparez {productName} ({brandModel}) dans la catégorie {verticalTitle} : score d\'impact {score}/20, meilleurs prix, manuels et caractéristiques sur Nudger.',
+    withoutImpact:
+      'Comparez {productName} ({brandModel}) : meilleurs prix, manuels et caractéristiques sur Nudger.',
+    withoutImpactVertical:
+      'Comparez {productName} ({brandModel}) dans la catégorie {verticalTitle} : meilleurs prix, manuels et caractéristiques sur Nudger.',
+  },
+}
+
+describe('buildProductMeta', () => {
+  it('keeps the impact score in title when score exists', () => {
+    const meta = buildProductMeta({
+      productName: 'iPhone 16 Pro',
+      brandModel: 'Apple iPhone 16 Pro',
+      score: 16.4,
+      titleTemplates: serpTemplates.title,
+      descriptionTemplates: serpTemplates.description,
+    })
+
+    expect(meta.title).toContain('ImpactScore : 16.4/20')
+    expect(meta.description).toContain('score d\'impact 16.4/20')
+  })
+
+  it('does not mention impact score when score is missing', () => {
+    const meta = buildProductMeta({
+      productName: 'iPhone 16 Pro',
+      brandModel: 'Apple iPhone 16 Pro',
+      score: null,
+      titleTemplates: serpTemplates.title,
+      descriptionTemplates: serpTemplates.description,
+    })
+
+    expect(meta.title).not.toContain('ImpactScore')
+    expect(meta.description).not.toContain('score d\'impact')
+  })
+
+  it('drops manuals/features phrase first when title is too long', () => {
+    const meta = buildProductMeta({
+      productName: 'Aspirateur balai sans fil ultra puissant autonomie longue durée',
+      brandModel:
+        'Marque Excellence Modèle Premium Hyper Edition Max Performance',
+      score: 14.8,
+      maxTitleLength: 80,
+      titleTemplates: serpTemplates.title,
+      descriptionTemplates: serpTemplates.description,
+    })
+
+    expect(meta.title).toContain('ImpactScore')
+    expect(meta.title).not.toContain('manuels, et caractéristiques')
+  })
+
+  it('respects max lengths for title and description', () => {
+    const meta = buildProductMeta({
+      productName:
+        'Montre connectée sport et santé génération avancée avec fonctionnalités premium',
+      brandModel: 'Sportech Ultra Perform X Series',
+      score: 12.2,
+      maxTitleLength: 60,
+      maxDescriptionLength: 120,
+      verticalTitle: 'montres connectées',
+      titleTemplates: serpTemplates.title,
+      descriptionTemplates: serpTemplates.description,
+    })
+
+    expect(meta.title.length).toBeLessThanOrEqual(60)
+    expect(meta.description.length).toBeLessThanOrEqual(120)
+  })
+})

--- a/frontend/app/utils/seo/product-meta.ts
+++ b/frontend/app/utils/seo/product-meta.ts
@@ -1,0 +1,143 @@
+export interface ProductMetaTemplates
+{
+  withImpactFull: string
+  withImpactCompact: string
+  withImpactMinimal: string
+  withoutImpactFull: string
+  withoutImpactCompact: string
+  withoutImpactMinimal: string
+}
+
+export interface ProductMetaDescriptionTemplates
+{
+  withImpact: string
+  withImpactVertical: string
+  withoutImpact: string
+  withoutImpactVertical: string
+}
+
+export interface ProductMetaBuildOptions
+{
+  productName: string
+  brandModel: string
+  score: number | null
+  verticalTitle?: string
+  maxTitleLength?: number
+  maxDescriptionLength?: number
+  titleTemplates: ProductMetaTemplates
+  descriptionTemplates: ProductMetaDescriptionTemplates
+}
+
+const DEFAULT_TITLE_LENGTH = 60
+const DEFAULT_DESCRIPTION_LENGTH = 160
+
+const normalizeText = (value: string): string => value.trim().replace(/\s+/g, ' ')
+
+const formatScore = (score: number | null): string => {
+  if (typeof score !== 'number') {
+    return ''
+  }
+
+  return Number(score.toFixed(1)).toString()
+}
+
+const truncateAtWordBoundary = (value: string, maxLength: number): string => {
+  const normalized = normalizeText(value)
+
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+
+  const safeLimit = Math.max(1, maxLength - 1)
+  const truncated = normalized.slice(0, safeLimit)
+  const lastSpace = truncated.lastIndexOf(' ')
+  const compact =
+    lastSpace > Math.floor(safeLimit * 0.6)
+      ? truncated.slice(0, lastSpace)
+      : truncated
+
+  return `${compact.trimEnd()}…`
+}
+
+const resolveTitleCandidates = (options: ProductMetaBuildOptions): string[] => {
+  const productName = normalizeText(options.productName)
+  const brandModel = normalizeText(options.brandModel)
+  const score = formatScore(options.score)
+
+  if (!productName.length) {
+    return [brandModel]
+  }
+
+  if (score) {
+    return [
+      options.titleTemplates.withImpactFull,
+      options.titleTemplates.withImpactCompact,
+      options.titleTemplates.withImpactMinimal,
+    ]
+      .map(template =>
+        template
+          .replaceAll('{productName}', productName)
+          .replaceAll('{score}', score)
+          .replaceAll('{brandModel}', brandModel)
+      )
+      .map(normalizeText)
+      .filter(Boolean)
+  }
+
+  return [
+    options.titleTemplates.withoutImpactFull,
+    options.titleTemplates.withoutImpactCompact,
+    options.titleTemplates.withoutImpactMinimal,
+  ]
+    .map(template =>
+      template
+        .replaceAll('{productName}', productName)
+        .replaceAll('{brandModel}', brandModel)
+    )
+    .map(normalizeText)
+    .filter(Boolean)
+}
+
+/**
+ * Build localized SEO metadata for product pages with explicit variants when
+ * an impact score exists and when it does not.
+ */
+export const buildProductMeta = (options: ProductMetaBuildOptions) => {
+  const maxTitleLength = options.maxTitleLength ?? DEFAULT_TITLE_LENGTH
+  const maxDescriptionLength =
+    options.maxDescriptionLength ?? DEFAULT_DESCRIPTION_LENGTH
+  const score = formatScore(options.score)
+  const productName = normalizeText(options.productName)
+  const brandModel = normalizeText(options.brandModel)
+  const verticalTitle = normalizeText(options.verticalTitle ?? '')
+
+  const titleCandidates = resolveTitleCandidates(options)
+  const matchingTitle =
+    titleCandidates.find(candidate => candidate.length <= maxTitleLength) ??
+    titleCandidates.at(-1) ??
+    productName
+
+  const title = truncateAtWordBoundary(matchingTitle, maxTitleLength)
+
+  const descriptionTemplate = score
+    ? verticalTitle
+      ? options.descriptionTemplates.withImpactVertical
+      : options.descriptionTemplates.withImpact
+    : verticalTitle
+      ? options.descriptionTemplates.withoutImpactVertical
+      : options.descriptionTemplates.withoutImpact
+
+  const description = truncateAtWordBoundary(
+    descriptionTemplate
+      .replaceAll('{productName}', productName)
+      .replaceAll('{score}', score)
+      .replaceAll('{brandModel}', brandModel)
+      .replaceAll('{verticalTitle}', verticalTitle),
+    maxDescriptionLength
+  )
+
+  return {
+    title,
+    description,
+  }
+}

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -69,7 +69,9 @@
       "eyebrow": "Responsible shopping",
       "title": "Nudger: The eco-friendly comparator",
       "animatedSubtitle": "",
-      "titleSubtitle": ["Buy better. Spend smarter."],
+      "titleSubtitle": [
+        "Buy better. Spend smarter."
+      ],
       "subtitles": [
         "Save time, stay true to your values. Compare effortlessly, choose freely.",
         "Shop smarter without compromise. Nudger balances planet and price.",
@@ -134,7 +136,9 @@
         ],
         "partnerLinkLabel": "{formattedCount} partner | {formattedCount} partners",
         "partnerLinkFallback": "our partners",
-        "placeholders": ["Search a product (e.g. television, smartphone...)"]
+        "placeholders": [
+          "Search a product (e.g. television, smartphone...)"
+        ]
       },
       "highlights": [
         {
@@ -3056,9 +3060,47 @@
       "noScore": "No evaluation available for this product!"
     },
     "meta": {
-      "defaultDescription": "Compare {productTitle}{brandModel} on Nudger for pricing, environmental impact, and buying options.",
-      "defaultDescriptionWithVertical": "Compare {productTitle}{brandModel} on Nudger for pricing, environmental impact, and top options in {verticalTitle}.",
-      "gtinFallback": "GTIN {gtin}"
+      "gtinFallback": "GTIN {gtin}",
+      "serp": {
+        "title": {
+          "withImpact": {
+            "full": "{productName}: ImpactScore {score}/20 | Best prices, manuals and specs for {brandModel}",
+            "compact": "{productName}: ImpactScore {score}/20 | Best prices for {brandModel}",
+            "minimal": "{productName}: ImpactScore {score}/20"
+          },
+          "withoutImpact": {
+            "full": "{productName} | Best prices, manuals and specs for {brandModel}",
+            "compact": "{productName} | Best prices for {brandModel}",
+            "minimal": "{productName}"
+          }
+        },
+        "description": {
+          "withImpact": "Compare {productName} ({brandModel}) with impact score {score}/20, best prices, manuals and key specs on Nudger.",
+          "withImpactVertical": "Compare {productName} ({brandModel}) in {verticalTitle} with impact score {score}/20, best prices, manuals and key specs on Nudger.",
+          "withoutImpact": "Compare {productName} ({brandModel}) for best prices, manuals and key specs on Nudger.",
+          "withoutImpactVertical": "Compare {productName} ({brandModel}) in {verticalTitle} for best prices, manuals and key specs on Nudger."
+        }
+      },
+      "social": {
+        "title": {
+          "withImpact": {
+            "full": "{productName} rated {score}/20: prices, highlights and alternatives",
+            "compact": "{productName}: rated {score}/20 on Nudger",
+            "minimal": "{productName}: {score}/20"
+          },
+          "withoutImpact": {
+            "full": "{productName}: prices, highlights and alternatives on Nudger",
+            "compact": "{productName}: compare prices and highlights",
+            "minimal": "{productName}"
+          }
+        },
+        "description": {
+          "withImpact": "See {productName} at a glance with impact score ({score}/20), best prices and key buying insights.",
+          "withImpactVertical": "Explore {productName} in {verticalTitle} with impact score ({score}/20), prices and key buying insights.",
+          "withoutImpact": "Explore {productName} with best prices, useful highlights and alternatives to choose with confidence.",
+          "withoutImpactVertical": "Explore {productName} in {verticalTitle} with best prices, useful highlights and alternatives."
+        }
+      }
     }
   },
   "siteIdentity": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -69,7 +69,9 @@
       "eyebrow": "Comparateur responsable",
       "title": "Acheter mieux. Sans dépenser plus.",
       "animatedSubtitle": "",
-      "titleSubtitle": ["Nudger : le comparateur écologique tech & électro"],
+      "titleSubtitle": [
+        "Nudger : le comparateur écologique tech & électro"
+      ],
       "subtitles": [
         "Gagnez du temps. Choisissez librement.",
         "Consommez mieux sans payer plus. Nudger équilibre planète et budget.",
@@ -2951,9 +2953,47 @@
       "noScore": "Pas d'évaluation sur ce produit !"
     },
     "meta": {
-      "defaultDescriptionWithVertical": "Découvrez {productTitle} ({brandModel}) dans la catégorie {verticalTitle}. Comparez son impact environnemental et ses prix sur Nudger.",
-      "impactScore": " - Impact Score : {score}/20",
-      "gtinFallback": "GTIN non disponible : {gtin}"
+      "gtinFallback": "GTIN non disponible : {gtin}",
+      "serp": {
+        "title": {
+          "withImpact": {
+            "full": "{productName} : ImpactScore : {score}/20 | Meilleurs prix, manuels, et caractéristiques pour le {brandModel}",
+            "compact": "{productName} : ImpactScore : {score}/20 | Meilleurs prix pour {brandModel}",
+            "minimal": "{productName} : ImpactScore : {score}/20"
+          },
+          "withoutImpact": {
+            "full": "{productName} | Meilleurs prix, manuels, et caractéristiques pour le {brandModel}",
+            "compact": "{productName} | Meilleurs prix pour {brandModel}",
+            "minimal": "{productName}"
+          }
+        },
+        "description": {
+          "withImpact": "Comparez {productName} ({brandModel}) : score d'impact {score}/20, meilleurs prix, manuels et caractéristiques sur Nudger.",
+          "withImpactVertical": "Comparez {productName} ({brandModel}) dans la catégorie {verticalTitle} : score d'impact {score}/20, meilleurs prix, manuels et caractéristiques sur Nudger.",
+          "withoutImpact": "Comparez {productName} ({brandModel}) : meilleurs prix, manuels et caractéristiques sur Nudger.",
+          "withoutImpactVertical": "Comparez {productName} ({brandModel}) dans la catégorie {verticalTitle} : meilleurs prix, manuels et caractéristiques sur Nudger."
+        }
+      },
+      "social": {
+        "title": {
+          "withImpact": {
+            "full": "{productName} noté {score}/20 : prix, infos clés et alternatives",
+            "compact": "{productName} : noté {score}/20 sur Nudger",
+            "minimal": "{productName} : {score}/20"
+          },
+          "withoutImpact": {
+            "full": "{productName} : prix, infos clés et alternatives sur Nudger",
+            "compact": "{productName} : comparez prix et infos clés",
+            "minimal": "{productName}"
+          }
+        },
+        "description": {
+          "withImpact": "Voyez en un coup d'œil le score d'impact ({score}/20), les meilleurs prix et les infos clés de {productName}.",
+          "withImpactVertical": "Découvrez {productName} en {verticalTitle} : score d'impact ({score}/20), prix et informations utiles.",
+          "withoutImpact": "Découvrez {productName} : meilleurs prix, informations utiles et alternatives pour mieux choisir.",
+          "withoutImpactVertical": "Découvrez {productName} dans {verticalTitle} : meilleurs prix, informations utiles et alternatives."
+        }
+      }
     }
   },
   "siteIdentity": {


### PR DESCRIPTION
### Motivation
- Centralize and improve generation of product SEO and social metadata to handle impact scores, vertical-aware descriptions and length constraints. 
- Replace ad-hoc title/description logic in the product page with a reusable utility to ensure consistent localization and truncation behavior. 
- Add localized template keys so both SERP and social meta variants can be composed from translations.

### Description
- Add `frontend/app/utils/seo/product-meta.ts` implementing `buildProductMeta` to produce truncated, localized `title` and `description` variants based on product name, brand/model, optional `score`, and `verticalTitle` with configurable max lengths. 
- Replace inline meta logic in `ProductPage.vue` with imports of `buildProductMeta`, creating `seoMetaBase` and `socialMetaBase` computed values and exposing `seoMetaTitle`, `seoMetaDescription`, `socialMetaTitle`, and `socialMetaDescription`; wire these into `useSeoMeta` and OG fields. 
- Add translation templates in `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` under `meta.serp` and `meta.social` to drive the new meta builder. 
- Add unit tests `frontend/app/utils/seo/product-meta.spec.ts` covering score inclusion/exclusion, length constraints, and template selection.

### Testing
- Added unit tests for `buildProductMeta` in `product-meta.spec.ts` and executed them with `vitest`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa64360cb8832291a394969dd1d9df)