### PR TITLE
Validate DJL tokenizer metadata at startup and add packaging guidance

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -16,3 +16,13 @@ A health indicator (`DjlEmbeddingHealthIndicator`) publishes which model was loa
 ## Usage
 
 Add the `embedding-djl` module as a dependency and configure the properties above. The service loads remote DJL models directly and logs failures on startup when configured to fail fast.
+
+## Runtime packaging guidance
+
+`embedding-djl` now performs a startup preflight (`DjlTokenizersResourceValidator`) that validates both DJL tokenizers metadata resources:
+
+- `native/lib/tokenizers.properties`
+- `tokenizers-engine.properties`
+
+If these files are not visible to the runtime classloader, startup fails fast with diagnostics.
+For container/server deployments, prefer an exploded classpath launch (`BOOT-INF/classes` + `BOOT-INF/lib/*`) when executable nested jars hide JNI metadata resources.

--- a/services/embedding-djl/pom.xml
+++ b/services/embedding-djl/pom.xml
@@ -13,6 +13,27 @@
     <properties>
         <djl.version>0.36.0</djl.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>ai.djl.pytorch</groupId>
+                <artifactId>pytorch-engine</artifactId>
+                <version>${djl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.djl.huggingface</groupId>
+                <artifactId>tokenizers</artifactId>
+                <version>${djl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.djl.pytorch</groupId>
+                <artifactId>pytorch-model-zoo</artifactId>
+                <version>${djl.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>
@@ -28,7 +49,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
-        <!-- TODO : To import bad lglobal TextService interface...)-->
         <dependency>
             <groupId>org.open4goods</groupId>
             <artifactId>model</artifactId>
@@ -38,7 +58,6 @@
         <dependency>
             <groupId>ai.djl.pytorch</groupId>
             <artifactId>pytorch-engine</artifactId>
-            <version>${djl.version}</version>
         </dependency>
         <dependency>
             <groupId>ai.djl.pytorch</groupId>
@@ -48,13 +67,10 @@
         <dependency>
             <groupId>ai.djl.huggingface</groupId>
             <artifactId>tokenizers</artifactId>
-            <version>${djl.version}</version>
         </dependency>
-        <!-- IMPORTANT : PyTorch Model Zoo (sinon ton erreur arrive) -->
         <dependency>
             <groupId>ai.djl.pytorch</groupId>
             <artifactId>pytorch-model-zoo</artifactId>
-            <version>${djl.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlEmbeddingAutoConfiguration.java
+++ b/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlEmbeddingAutoConfiguration.java
@@ -25,6 +25,13 @@ import org.springframework.context.annotation.Bean;
 public class DjlEmbeddingAutoConfiguration
 {
     @Bean
+    @ConditionalOnMissingBean
+    DjlTokenizersResourceValidator djlTokenizersResourceValidator()
+    {
+        return new DjlTokenizersResourceValidator();
+    }
+
+    @Bean
     @ConditionalOnMissingBean(AbstractTextModelFactory.class)
     AbstractTextModelFactory embeddingModelFactory()
     {

--- a/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlTokenizersResourceValidator.java
+++ b/services/embedding-djl/src/main/java/org/open4goods/embedding/config/DjlTokenizersResourceValidator.java
@@ -1,0 +1,75 @@
+package org.open4goods.embedding.config;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates that DJL tokenizers metadata resources are visible from runtime classloaders.
+ * <p>
+ * Spring Boot executable jars can change resource lookup behaviour for nested jars. This
+ * validator performs an early startup check so deployment issues fail fast with diagnostics
+ * instead of surfacing later during asynchronous model loading.
+ * </p>
+ */
+public class DjlTokenizersResourceValidator
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DjlTokenizersResourceValidator.class);
+
+    private static final String NATIVE_PROPERTIES_PATH = "native/lib/tokenizers.properties";
+    private static final String ENGINE_PROPERTIES_PATH = "tokenizers-engine.properties";
+
+    /**
+     * Creates a validator and immediately performs the resource validation.
+     */
+    public DjlTokenizersResourceValidator()
+    {
+        validateResources(Thread.currentThread().getContextClassLoader(), ClassLoader.getSystemClassLoader());
+    }
+
+    /**
+     * Validates both required tokenizers property resources.
+     *
+     * @param contextClassLoader current thread context classloader
+     * @param systemClassLoader JVM system classloader
+     */
+    public static void validateResources(ClassLoader contextClassLoader, ClassLoader systemClassLoader)
+    {
+        validateResource(NATIVE_PROPERTIES_PATH, contextClassLoader, systemClassLoader);
+        validateResource(ENGINE_PROPERTIES_PATH, contextClassLoader, systemClassLoader);
+    }
+
+    private static void validateResource(String resourcePath, ClassLoader contextClassLoader, ClassLoader systemClassLoader)
+    {
+        URL contextUrl = contextClassLoader == null ? null : contextClassLoader.getResource(resourcePath);
+        URL systemUrl = systemClassLoader == null ? null : systemClassLoader.getResource(resourcePath);
+
+        if (contextUrl != null || systemUrl != null)
+        {
+            LOGGER.info(
+                    "Validated DJL tokenizer resource '{}' (contextClassLoaderUrl={}, systemClassLoaderUrl={})",
+                    resourcePath,
+                    contextUrl,
+                    systemUrl);
+            return;
+        }
+
+        List<String> diagnostics = new ArrayList<>();
+        diagnostics.add("resource=" + resourcePath);
+        diagnostics.add("contextClassLoader=" + classLoaderName(contextClassLoader));
+        diagnostics.add("systemClassLoader=" + classLoaderName(systemClassLoader));
+
+        throw new IllegalStateException(
+                "Missing required DJL tokenizer metadata resource. "
+                        + "This commonly happens when running from packaged executable jars with nested dependency resources. "
+                        + String.join(", ", diagnostics));
+    }
+
+    private static String classLoaderName(ClassLoader classLoader)
+    {
+        return classLoader == null ? "null" : classLoader.getClass().getName();
+    }
+}

--- a/services/embedding-djl/src/test/java/org/open4goods/embedding/DjlTokenizersResourceValidatorTest.java
+++ b/services/embedding-djl/src/test/java/org/open4goods/embedding/DjlTokenizersResourceValidatorTest.java
@@ -1,0 +1,42 @@
+package org.open4goods.embedding;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.jupiter.api.Test;
+import org.open4goods.embedding.config.DjlTokenizersResourceValidator;
+
+/**
+ * Tests startup validation for tokenizers metadata resources.
+ */
+class DjlTokenizersResourceValidatorTest
+{
+    @Test
+    void shouldValidateResourcesForRuntimeClassLoaders()
+    {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+
+        assertThatCode(() -> DjlTokenizersResourceValidator.validateResources(contextClassLoader, systemClassLoader))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldFailFastWhenTokenizerResourcesAreMissing()
+    {
+        try (URLClassLoader emptyClassLoader = new URLClassLoader(new URL[0], null))
+        {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> DjlTokenizersResourceValidator.validateResources(emptyClassLoader, emptyClassLoader))
+                    .withMessageContaining("Missing required DJL tokenizer metadata resource")
+                    .withMessageContaining("native/lib/tokenizers.properties");
+        }
+        catch (Exception e)
+        {
+            throw new AssertionError("Unable to create test classloader", e);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent obscure runtime failures when DJL tokenizer metadata resources are hidden by executable nested jars by failing fast with diagnostics.  
- Provide guidance for container/server deployments to prefer exploded classpaths so JNI/tokenizer metadata remains visible.

### Description

- Add `DjlTokenizersResourceValidator` that checks for `native/lib/tokenizers.properties` and `tokenizers-engine.properties` on the runtime classloaders and throws an informative `IllegalStateException` if they are missing.  
- Register the validator as a bean in `DjlEmbeddingAutoConfiguration` via `djlTokenizersResourceValidator()` so validation runs during auto-configuration.  
- Update `services/embedding-djl/pom.xml` to introduce `dependencyManagement` for DJL artifacts and remove duplicated explicit versions from several DJL dependencies so they use the managed `djl.version`.  
- Add unit tests `DjlTokenizersResourceValidatorTest` that cover successful validation with real classloaders and failure when resources are absent, and update `docs/embedding.md` with runtime packaging guidance about exploded classpaths and the new preflight validation.

### Testing

- Executed the new unit tests in `DjlTokenizersResourceValidatorTest`, which include `shouldValidateResourcesForRuntimeClassLoaders` and `shouldFailFastWhenTokenizerResourcesAreMissing`, and they passed.  
- The code compiles and the added tests exercise both success and failure validation paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa7e7bd7bc8322860230b918ac1c56)