### PR TITLE
frontend: hide EPREL market-end dates beyond 15 years in lifecycle timeline

### DIFF
--- a/frontend/app/components/product/ProductLifeTimeline.spec.ts
+++ b/frontend/app/components/product/ProductLifeTimeline.spec.ts
@@ -45,6 +45,10 @@ const i18n = createI18n({
               eprelOrganisationClosed: 'Organisation closed',
               generic: 'Lifecycle event',
             },
+            notes: {
+              eprelOnMarketEndFarFutureHidden:
+                'Events with market end dates beyond {maxYears} years are hidden because manufacturers can adjust them later in EPREL.',
+            },
             descriptions: {
               priceFirstSeenNew: 'First new offer detected.',
               priceFirstSeenOccasion: 'First second-hand offer detected.',
@@ -161,6 +165,30 @@ describe('ProductLifeTimeline', () => {
     expect(wrapper.find('.product-life-timeline--horizontal').exists()).toBe(
       true
     )
+  })
+
+
+  it('hides EPREL market end dates beyond 15 years and shows explanatory note', async () => {
+    const timeline: ProductTimelineDto = {
+      events: [
+        {
+          type: ProductTimelineEventType.EprelOnMarketEnd,
+          source: ProductTimelineEventSource.Eprel,
+          timestamp: Date.UTC(new Date().getFullYear() + 16, 0, 1),
+        },
+        {
+          type: ProductTimelineEventType.EprelOnMarketStart,
+          source: ProductTimelineEventSource.Eprel,
+          timestamp: Date.UTC(2024, 5, 1),
+        },
+      ],
+    }
+
+    const wrapper = await mountComponent(timeline)
+
+    expect(wrapper.text()).not.toContain('Market end')
+    expect(wrapper.text()).toContain('Market start')
+    expect(wrapper.text()).toContain('beyond 15 years are hidden')
   })
 
   it('renders empty state when no events', async () => {

--- a/frontend/app/components/product/ProductLifeTimeline.vue
+++ b/frontend/app/components/product/ProductLifeTimeline.vue
@@ -110,6 +110,14 @@
     <p v-else class="product-life-timeline__empty">
       {{ $t('product.attributes.timeline.empty') }}
     </p>
+
+    <p v-if="hasFilteredFarFutureEndDate" class="product-life-timeline__note">
+      {{
+        $t('product.attributes.timeline.notes.eprelOnMarketEndFarFutureHidden', {
+          maxYears: MAX_ALLOWED_MARKET_END_YEARS,
+        })
+      }}
+    </p>
   </v-card>
 </template>
 
@@ -135,6 +143,21 @@ const props = withDefaults(
 )
 
 const { t, locale } = useI18n()
+const MAX_ALLOWED_MARKET_END_YEARS = 15
+
+const isFarFutureMarketEndDate = (
+  event: ProductTimelineEventDto & { timestamp: number }
+) => {
+  if (event.type !== 'EPREL_ON_MARKET_END') {
+    return false
+  }
+
+  const now = new Date()
+  const maxAllowedDate = new Date(now)
+  maxAllowedDate.setFullYear(now.getFullYear() + MAX_ALLOWED_MARKET_END_YEARS)
+
+  return event.timestamp > maxAllowedDate.getTime()
+}
 
 type TimelineEventViewModel = {
   key: string
@@ -264,16 +287,7 @@ const eventDescriptionKeys: Record<string, string> = {
 
 const groupedEvents = computed<TimelineYearGroup[]>(() => {
   const rawEvents = props.timeline?.events ?? []
-  const yearGroups = new Map<
-    number,
-    {
-      key: string
-      year: number
-      months: Map<number, TimelineMonthGroup>
-    }
-  >()
-
-  rawEvents
+  const normalizedEvents = rawEvents
     .filter(
       (event): event is ProductTimelineEventDto & { timestamp: number } =>
         typeof event?.timestamp === 'number' &&
@@ -285,6 +299,18 @@ const groupedEvents = computed<TimelineYearGroup[]>(() => {
       ...event,
       timestamp: normalizeTimestamp(event.timestamp) ?? 0,
     }))
+
+  const yearGroups = new Map<
+    number,
+    {
+      key: string
+      year: number
+      months: Map<number, TimelineMonthGroup>
+    }
+  >()
+
+  normalizedEvents
+    .filter(event => !isFarFutureMarketEndDate(event))
     .sort((a, b) => a.timestamp - b.timestamp)
     .forEach((event, index) => {
       const type = event.type
@@ -381,6 +407,20 @@ const groupedEvents = computed<TimelineYearGroup[]>(() => {
 })
 
 const hasEvents = computed(() => groupedEvents.value.length > 0)
+const hasFilteredFarFutureEndDate = computed(() => {
+  const rawEvents = props.timeline?.events ?? []
+
+  return rawEvents
+    .filter(
+      (event): event is ProductTimelineEventDto & { timestamp: number } =>
+        typeof event?.timestamp === 'number'
+    )
+    .map(event => ({
+      ...event,
+      timestamp: normalizeTimestamp(event.timestamp) ?? 0,
+    }))
+    .some(event => isFarFutureMarketEndDate(event))
+})
 </script>
 
 <style scoped>
@@ -611,6 +651,15 @@ const hasEvents = computed(() => groupedEvents.value.length > 0)
   margin: 0;
   color: rgba(var(--v-theme-text-neutral-secondary), 0.9);
   font-style: italic;
+}
+
+.product-life-timeline__note {
+  margin: 0;
+  margin-left: auto;
+  text-align: right;
+  font-size: 0.82rem;
+  color: rgba(var(--v-theme-text-neutral-soft), 0.95);
+  max-width: 54ch;
 }
 
 @media (max-width: 600px) {

--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -2567,6 +2567,9 @@
           "eprelImported": "Date when the EPREL entry was imported.",
           "eprelOrganisationClosed": "EPREL organisation close date.",
           "generic": "Lifecycle event"
+        },
+        "notes": {
+          "eprelOnMarketEndFarFutureHidden": "Events with market end dates beyond {maxYears} years are hidden because manufacturers can adjust them later in EPREL."
         }
       },
       "detailed": {

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -2461,6 +2461,9 @@
           "eprelImported": "Date d'import de l'entrée EPREL.",
           "eprelOrganisationClosed": "Date de fermeture de l'organisation EPREL.",
           "generic": "Événement du cycle de vie"
+        },
+        "notes": {
+          "eprelOnMarketEndFarFutureHidden": "Les événements de fin de commercialisation au-delà de {maxYears} ans sont masqués car les fabricants peuvent ajuster cette date ensuite dans EPREL."
         }
       },
       "detailed": {
@@ -2992,6 +2995,14 @@
           "withoutImpactVertical": "Découvrez {productName} dans {verticalTitle} : meilleurs prix, informations utiles et alternatives."
         }
       }
+    },
+    "eprel": {
+      "detailsTitle": "Registre européen de l'étiquetage énergétique",
+      "marketEndDate": "Date de fin de commercialisation",
+      "minSoftwareUpdates": "Mises à jour logicielles minimales",
+      "minSpareParts": "Disponibilité minimale des pièces détachées",
+      "outOfMarketDuration": "Hors marché depuis",
+      "supportGuaranteedUntil": "Support garanti jusqu'en"
     }
   },
   "siteIdentity": {


### PR DESCRIPTION
## Why
Users reported confusing lifecycle entries such as an end-of-commercialisation date in the distant future (e.g. 2053). These dates can be placeholders in EPREL and create misleading UI signals.

## What changed
- Updated `ProductLifeTimeline` to filter out `EPREL_ON_MARKET_END` events when the date is more than 15 years ahead of today.
- Added a bottom-right explanatory note in the timeline card when such events are hidden.
- Added i18n strings for that explanation in both English and French locales.
- Added a unit test to verify:
  - far-future `EPREL_ON_MARKET_END` events are hidden,
  - other events still render,
  - the explanation note is displayed.

## Validation
- `pnpm test app/components/product/ProductLifeTimeline.spec.ts` ✅
- `pnpm lint` ✅
- `pnpm generate` ⚠️ failed in this environment due process memory limits (OOM / killed), even after retrying with increased Node heap.

## Notes
- I also added missing French `product.eprel` translation keys used by `EprelDetailsTable` to avoid unresolved i18n keys in FR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade80b9c988322939cced88278fabc)