### PR TITLE
Make article hero image responsive and remove fixed image props

### DIFF
--- a/frontend/app/components/domains/blog/TheArticle.vue
+++ b/frontend/app/components/domains/blog/TheArticle.vue
@@ -393,8 +393,6 @@ useHead(() => ({
       <RobustImage
         :src="article.image"
         :alt="t('blog.article.featuredImageAlt', { title: articleTitle })"
-        width="70%"
-        :height="360"
         class="article-hero__image"
       />
       <figcaption class="d-sr-only">
@@ -515,13 +513,15 @@ useHead(() => ({
     gap: 0.35rem
 
 .article-hero
+  width: 100%
   margin: 0
+  aspect-ratio: 16 / 9
   border-radius: 16px
   overflow: hidden
 
   &__image
     width: 100%
-    height: auto
+    height: 100%
 
 .article-divider
   opacity: 0.4


### PR DESCRIPTION
### Motivation
- Ensure the article featured image scales responsively and fills the hero area without relying on fixed `width`/`height` attributes.

### Description
- Remove `width="70%"` and `:height="360"` props from the `RobustImage` component, set `.article-hero` to `width: 100%` and `aspect-ratio: 16 / 9`, and change `.article-hero__image` `height` from `auto` to `100%` so the image fills the container.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13653c1988322a59a136c01ea015c)