### PR TITLE
Remove Decitre classification fields from ISBN open data export and update translations

### DIFF
--- a/frontend/i18n/locales/en-US.json
+++ b/frontend/i18n/locales/en-US.json
@@ -1602,7 +1602,7 @@
           },
           "description": "Dedicated export for books with pricing, availability and classification information.",
           "features": {
-            "catalogue": "Includes publisher, format and Decitre classifications",
+            "catalogue": "Includes publisher, format and editorial subcategories",
             "refresh": "Weekly refreshed snapshot",
             "research": "Great for catalogue enrichment, research and cultural analytics"
           },
@@ -1773,18 +1773,6 @@
       },
       "isbn": {
         "columns": {
-          "classification_decitre_1": {
-            "description": "Decitre classification - level 1.",
-            "label": "classification_decitre_1"
-          },
-          "classification_decitre_2": {
-            "description": "Decitre classification - level 2.",
-            "label": "classification_decitre_2"
-          },
-          "classification_decitre_3": {
-            "description": "Decitre classification - level 3.",
-            "label": "classification_decitre_3"
-          },
           "currency": {
             "description": "Currency code of the lowest price.",
             "label": "currency"

--- a/frontend/i18n/locales/fr-FR.json
+++ b/frontend/i18n/locales/fr-FR.json
@@ -1477,7 +1477,7 @@
           },
           "description": "Export dédié aux livres avec informations de prix, de catégories, de classifications, ...",
           "features": {
-            "catalogue": "Inclut éditeur, format et classifications Decitre",
+            "catalogue": "Inclut éditeur, format et sous-catégories éditoriales",
             "refresh": "Mise à jour chaque semaine",
             "research": "Parfait pour l'enrichissement de catalogue, la recherche et les analyses culturelles"
           },
@@ -1648,18 +1648,6 @@
       },
       "isbn": {
         "columns": {
-          "classification_decitre_1": {
-            "description": "Classification Decitre - niveau 1.",
-            "label": "classification_decitre_1"
-          },
-          "classification_decitre_2": {
-            "description": "Classification Decitre - niveau 2.",
-            "label": "classification_decitre_2"
-          },
-          "classification_decitre_3": {
-            "description": "Classification Decitre - niveau 3.",
-            "label": "classification_decitre_3"
-          },
           "currency": {
             "description": "Devise du prix le plus bas.",
             "label": "currency"

--- a/services/opendata/src/main/java/org/open4goods/services/opendata/service/OpenDataService.java
+++ b/services/opendata/src/main/java/org/open4goods/services/opendata/service/OpenDataService.java
@@ -91,9 +91,6 @@ public class OpenDataService implements HealthIndicator {
             "editeur",
             "format",
             "nb_page",
-            "classification_decitre_1",
-            "classification_decitre_2",
-            "classification_decitre_3",
             "souscategorie",
             "souscategorie2"
     };
@@ -123,9 +120,6 @@ public class OpenDataService implements HealthIndicator {
             "EDITEUR",
             "FORMAT",
             "NB DE PAGES",
-            "CLASSIFICATION DECITRE 1",
-            "CLASSIFICATION DECITRE 2",
-            "CLASSIFICATION DECITRE 3",
             "SOUSCATEGORIE",
             "SOUSCATEGORIE2"
     );
@@ -468,11 +462,8 @@ public class OpenDataService implements HealthIndicator {
         line[7] = StringUtils.defaultString(isbnAttributes.get("EDITEUR"));
         line[8] = StringUtils.defaultString(isbnAttributes.get("FORMAT"));
         line[9] = StringUtils.defaultString(isbnAttributes.get("NB DE PAGES"));
-        line[10] = StringUtils.defaultString(isbnAttributes.get("CLASSIFICATION DECITRE 1"));
-        line[11] = StringUtils.defaultString(isbnAttributes.get("CLASSIFICATION DECITRE 2"));
-        line[12] = StringUtils.defaultString(isbnAttributes.get("CLASSIFICATION DECITRE 3"));
-        line[13] = StringUtils.defaultString(isbnAttributes.get("SOUSCATEGORIE"));
-        line[14] = StringUtils.defaultString(isbnAttributes.get("SOUSCATEGORIE2"));
+        line[10] = StringUtils.defaultString(isbnAttributes.get("SOUSCATEGORIE"));
+        line[11] = StringUtils.defaultString(isbnAttributes.get("SOUSCATEGORIE2"));
 
         return line;
     }

--- a/services/opendata/src/test/java/org/open4goods/services/opendata/service/OpenDataServiceTest.java
+++ b/services/opendata/src/test/java/org/open4goods/services/opendata/service/OpenDataServiceTest.java
@@ -143,6 +143,10 @@ class OpenDataServiceTest {
         List<String> gtinLines = readZipLines(tmpGtin, "open4goods-gtin-dataset.csv");
 
         assertThat(isbnLines).hasSize(2);
+        assertThat(isbnLines.get(0))
+                .doesNotContain("classification_decitre_1")
+                .doesNotContain("classification_decitre_2")
+                .doesNotContain("classification_decitre_3");
         assertThat(isbnLines.get(1)).contains("Test Editor", "https://nudger.fr/9781234567890");
         assertThat(gtinLines).hasSize(2);
         assertThat(gtinLines.get(1)).contains("TestBrand", "https://nudger.fr/1234567890123");
@@ -204,9 +208,6 @@ class OpenDataServiceTest {
         addIndexedAttribute(attributes, "EDITEUR", "Test Editor");
         addIndexedAttribute(attributes, "FORMAT", "Broché");
         addIndexedAttribute(attributes, "NB DE PAGES", "320");
-        addIndexedAttribute(attributes, "CLASSIFICATION DECITRE 1", "Class1");
-        addIndexedAttribute(attributes, "CLASSIFICATION DECITRE 2", "Class2");
-        addIndexedAttribute(attributes, "CLASSIFICATION DECITRE 3", "Class3");
         addIndexedAttribute(attributes, "SOUSCATEGORIE", "SousCat1");
         addIndexedAttribute(attributes, "SOUSCATEGORIE2", "SousCat2");
         product.setAttributes(attributes);
@@ -251,4 +252,3 @@ class OpenDataServiceTest {
         throw new IllegalStateException("Unable to locate entry " + entryName + " in " + file);
     }
 }
-


### PR DESCRIPTION
### Motivation
- Remove Decitre-specific classification columns from the ISBN open data export and simplify the exported schema to use editorial subcategory fields instead.
- Update user-facing text to no longer reference Decitre classifications and reflect the new description for ISBN dataset features.

### Description
- Remove `classification_decitre_1`, `classification_decitre_2` and `classification_decitre_3` from the `ISBN_HEADER` and from the `ISBN_ATTRIBUTE_KEYS` used by `OpenDataService` when generating the CSV export.
- Adjust the CSV mapping in `OpenDataService` to shift indices so `SOUSCATEGORIE` and `SOUSCATEGORIE2` are written at the correct positions after removing the Decitre fields.
- Update localization files `frontend/i18n/locales/en-US.json` and `frontend/i18n/locales/fr-FR.json` to replace references to Decitre classifications with wording for editorial subcategories.
- Update `OpenDataServiceTest` to stop injecting Decitre attributes into built products and to assert the generated ISBN CSV header does not contain the `classification_decitre_*` column names.

### Testing
- Ran the `OpenDataServiceTest` unit tests which include `processDataFilesShouldWriteCsvRows`, `generateOpendataShouldNotMoveFilesWhenProcessingFails`, and other CSV export tests, and they passed.
- Ran the opendata service unit test suite (via the project test runner) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f7dc58ec8322a955f9920c6fad6f)