### PR TITLE
Add rag-engine module, frontend RAG plan, and docs metadata lint script

### DIFF
--- a/frontend/docs/rag-frontend-externalization.md
+++ b/frontend/docs/rag-frontend-externalization.md
@@ -1,0 +1,31 @@
+# Frontend RAG externalization plan
+
+## Goal
+
+Create a reusable RAG component package while preserving current docs UX (`/docs` and `/docs/[...slug]`).
+
+## Recommended packaging
+
+1. `frontend/app/components/docs-rag/` for UI building blocks
+2. `frontend/app/composables/useRagClient.ts` for client-side orchestration
+3. `frontend/server/api/rag/*` routes as the only backend entrypoint
+4. Optional extraction later to a workspace package when APIs stabilise
+
+## Contracts
+
+- `RagChatPanel` should consume a typed query/response contract only.
+- Metadata-driven hero/summary sections should consume a dedicated metadata DTO.
+- Missing metadata must fail loudly in development and fallback gracefully in production.
+
+## Suggested first refactor steps
+
+1. Split `RagChatPanel.vue` into pure-presentational + orchestration wrapper.
+2. Introduce shared `RagDocumentSummaryCard` and `RagSourceList` components.
+3. Centralize request/stream/error handling in `useRagClient`.
+4. Add schema validation in server routes before returning data to components.
+
+## Test strategy
+
+- Component tests for error/loading/sources rendering.
+- Route-level tests for metadata validation and fallback behavior.
+- Snapshot checks for docs page hero/summary rendering.

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <module>services/eprel-service</module>
         <module>services/exposed-docs</module>
         <module>services/geocode</module>
+        <module>services/rag-engine</module>
 
 
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+required = ["scope", "author", "contributors", "tags", "locale"]
+errors = []
+for path in Path("docs").rglob("*.md") if Path("docs").exists() else []:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        continue
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        continue
+    fm = text[4:end]
+    missing = [k for k in required if not re.search(rf"^\s*{re.escape(k)}\s*:", fm, re.M)]
+    if missing:
+        errors.append(f"{path}: missing metadata keys: {', '.join(missing)}")
+
+if errors:
+    print("RAG metadata lint failed:")
+    for e in errors:
+        print(" -", e)
+    sys.exit(1)
+
+print("RAG metadata lint passed")
+PY
+
+echo "lint.sh completed"

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -318,6 +318,16 @@ Each service has unique responsibilities and may have specific conventions beyon
 
 ---
 
+### rag-engine
+
+**Purpose**: Reusable retrieval-augmented generation engine for document ingestion, indexing, and query orchestration.
+
+**Key Responsibilities**:
+- Scan Markdown content from GitHub using configurable include rules and tags
+- Support pluggable provider contracts for chat, embeddings, and summaries
+- Support raw and annotated markdown indexing workflows with shared metadata contracts
+- Expose reusable Spring Boot auto-configuration for downstream services
+
 ### remotefilecaching
 
 **Purpose**: Remote file fetching and caching service.

--- a/services/rag-engine/README.md
+++ b/services/rag-engine/README.md
@@ -1,0 +1,60 @@
+# rag-engine
+
+`rag-engine` is a reusable Maven module designed for multi-project RAG usage.
+
+## Scope
+
+- GitHub-based ingestion (runtime, configurable include patterns)
+- Markdown-first processing (`.md` default, extensible later)
+- Use-case-based provider routing (`chat`, `embedding`, `summary`)
+- Tag enrichment by extension and folder pattern
+
+## Initial metadata contract (v2 draft)
+
+Mandatory fields:
+
+- `scope` (access-control binding; role-oriented)
+- `author`
+- `contributors`
+- `tags`
+- `locale`
+
+Document modes:
+
+- **raw**: unannotated markdown indexed as-is
+- **annotated**: markdown plus explicit custom header schema
+
+## Example configuration
+
+```yaml
+rag-engine:
+  github:
+    repository: open4good/open4goods
+    branch: main
+    include-patterns:
+      - "**/*.md"
+    extension-tag-mappings:
+      - extension: "*.vue"
+        tags: ["frontend", "technical"]
+    folder-tag-mappings:
+      - folder-pattern: "frontend/**"
+        tags: ["frontend"]
+  providers:
+    - name: infera
+      endpoint: https://api.infera.example/v1
+      api-key: ${INFERA_API_KEY}
+      model: infera-embed-1
+    - name: openai-compatible
+      endpoint: https://example-openai-compatible/v1
+      api-key: ${OPENAI_COMPAT_KEY}
+      model: text-embedding-3-large
+  use-cases:
+    chat-provider: infera
+    embedding-provider: openai-compatible
+    summary-provider: infera
+```
+
+## Notes
+
+This module currently provides contracts and bootstrap auto-configuration.
+Implementation adapters (GitHub scanner, chunkers/parsers, vector stores) should be added in follow-up slices.

--- a/services/rag-engine/pom.xml
+++ b/services/rag-engine/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.open4goods</groupId>
+        <artifactId>org.open4goods</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>rag-engine</artifactId>
+    <name>open4goods-rag-engine</name>
+    <description>Reusable RAG engine contracts and Spring Boot auto-configuration.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/services/rag-engine/src/main/java/org/open4goods/ragengine/config/RagEngineAutoConfiguration.java
+++ b/services/rag-engine/src/main/java/org/open4goods/ragengine/config/RagEngineAutoConfiguration.java
@@ -1,0 +1,28 @@
+package org.open4goods.ragengine.config;
+
+import org.open4goods.ragengine.service.RagProviderRouter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Boot auto-configuration entry point for the RAG engine module.
+ */
+@Configuration
+@EnableConfigurationProperties(RagEngineProperties.class)
+public class RagEngineAutoConfiguration
+{
+    /**
+     * Creates the default provider router responsible for use-case based provider selection.
+     *
+     * @param properties validated module configuration
+     * @return default router implementation
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public RagProviderRouter ragProviderRouter(final RagEngineProperties properties)
+    {
+        return new RagProviderRouter(properties);
+    }
+}

--- a/services/rag-engine/src/main/java/org/open4goods/ragengine/config/RagEngineProperties.java
+++ b/services/rag-engine/src/main/java/org/open4goods/ragengine/config/RagEngineProperties.java
@@ -1,0 +1,240 @@
+package org.open4goods.ragengine.config;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration properties for the reusable RAG engine module.
+ */
+@ConfigurationProperties(prefix = "rag-engine")
+@Validated
+public class RagEngineProperties
+{
+    @Valid
+    private Github github = new Github();
+
+    @Valid
+    private List<Provider> providers = new ArrayList<>();
+
+    @Valid
+    private UseCases useCases = new UseCases();
+
+    public Github getGithub()
+    {
+        return github;
+    }
+
+    public void setGithub(final Github github)
+    {
+        this.github = github;
+    }
+
+    public List<Provider> getProviders()
+    {
+        return providers;
+    }
+
+    public void setProviders(final List<Provider> providers)
+    {
+        this.providers = providers;
+    }
+
+    public UseCases getUseCases()
+    {
+        return useCases;
+    }
+
+    public void setUseCases(final UseCases useCases)
+    {
+        this.useCases = useCases;
+    }
+
+    public static class Github
+    {
+        @NotBlank
+        private String repository;
+
+        private String branch = "main";
+
+        @NotEmpty
+        private List<String> includePatterns = new ArrayList<>(List.of("**/*.md"));
+
+        private List<ExtensionTagMapping> extensionTagMappings = new ArrayList<>();
+
+        private List<FolderTagMapping> folderTagMappings = new ArrayList<>();
+
+        public String getRepository()
+        {
+            return repository;
+        }
+
+        public void setRepository(final String repository)
+        {
+            this.repository = repository;
+        }
+
+        public String getBranch()
+        {
+            return branch;
+        }
+
+        public void setBranch(final String branch)
+        {
+            this.branch = branch;
+        }
+
+        public List<String> getIncludePatterns()
+        {
+            return includePatterns;
+        }
+
+        public void setIncludePatterns(final List<String> includePatterns)
+        {
+            this.includePatterns = includePatterns;
+        }
+
+        public List<ExtensionTagMapping> getExtensionTagMappings()
+        {
+            return extensionTagMappings;
+        }
+
+        public void setExtensionTagMappings(final List<ExtensionTagMapping> extensionTagMappings)
+        {
+            this.extensionTagMappings = extensionTagMappings;
+        }
+
+        public List<FolderTagMapping> getFolderTagMappings()
+        {
+            return folderTagMappings;
+        }
+
+        public void setFolderTagMappings(final List<FolderTagMapping> folderTagMappings)
+        {
+            this.folderTagMappings = folderTagMappings;
+        }
+    }
+
+    public static class Provider
+    {
+        @NotBlank
+        private String name;
+
+        @NotBlank
+        private String endpoint;
+
+        @NotBlank
+        private String apiKey;
+
+        @NotBlank
+        private String model;
+
+        private Duration timeout = Duration.ofSeconds(30);
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(final String name)
+        {
+            this.name = name;
+        }
+
+        public String getEndpoint()
+        {
+            return endpoint;
+        }
+
+        public void setEndpoint(final String endpoint)
+        {
+            this.endpoint = endpoint;
+        }
+
+        public String getApiKey()
+        {
+            return apiKey;
+        }
+
+        public void setApiKey(final String apiKey)
+        {
+            this.apiKey = apiKey;
+        }
+
+        public String getModel()
+        {
+            return model;
+        }
+
+        public void setModel(final String model)
+        {
+            this.model = model;
+        }
+
+        public Duration getTimeout()
+        {
+            return timeout;
+        }
+
+        public void setTimeout(final Duration timeout)
+        {
+            this.timeout = timeout;
+        }
+    }
+
+    public static class UseCases
+    {
+        @NotBlank
+        private String chatProvider;
+
+        @NotBlank
+        private String embeddingProvider;
+
+        @NotBlank
+        private String summaryProvider;
+
+        public String getChatProvider()
+        {
+            return chatProvider;
+        }
+
+        public void setChatProvider(final String chatProvider)
+        {
+            this.chatProvider = chatProvider;
+        }
+
+        public String getEmbeddingProvider()
+        {
+            return embeddingProvider;
+        }
+
+        public void setEmbeddingProvider(final String embeddingProvider)
+        {
+            this.embeddingProvider = embeddingProvider;
+        }
+
+        public String getSummaryProvider()
+        {
+            return summaryProvider;
+        }
+
+        public void setSummaryProvider(final String summaryProvider)
+        {
+            this.summaryProvider = summaryProvider;
+        }
+    }
+
+    public record ExtensionTagMapping(@NotBlank String extension, @NotEmpty List<String> tags)
+    {
+    }
+
+    public record FolderTagMapping(@NotBlank String folderPattern, @NotEmpty List<String> tags)
+    {
+    }
+}

--- a/services/rag-engine/src/main/java/org/open4goods/ragengine/service/RagProviderRouter.java
+++ b/services/rag-engine/src/main/java/org/open4goods/ragengine/service/RagProviderRouter.java
@@ -1,0 +1,48 @@
+package org.open4goods.ragengine.service;
+
+import org.open4goods.ragengine.config.RagEngineProperties;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves configured providers by explicit use-case contracts.
+ */
+public class RagProviderRouter
+{
+    private final RagEngineProperties properties;
+    private final Map<String, RagEngineProperties.Provider> providersByName;
+
+    public RagProviderRouter(final RagEngineProperties properties)
+    {
+        this.properties = properties;
+        this.providersByName = properties.getProviders().stream()
+                .collect(Collectors.toMap(RagEngineProperties.Provider::getName, Function.identity()));
+    }
+
+    public RagEngineProperties.Provider chatProvider()
+    {
+        return resolve(properties.getUseCases().getChatProvider());
+    }
+
+    public RagEngineProperties.Provider embeddingProvider()
+    {
+        return resolve(properties.getUseCases().getEmbeddingProvider());
+    }
+
+    public RagEngineProperties.Provider summaryProvider()
+    {
+        return resolve(properties.getUseCases().getSummaryProvider());
+    }
+
+    private RagEngineProperties.Provider resolve(final String providerName)
+    {
+        final var provider = providersByName.get(providerName);
+        if (provider == null)
+        {
+            throw new IllegalArgumentException("Unknown rag-engine provider: " + providerName);
+        }
+        return provider;
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a reusable RAG engine library and start the frontend externalization plan to enable consistent ingestion, provider routing and document metadata contracts across projects.
- Add a simple documentation lint check to enforce required RAG metadata fields in Markdown sources.

### Description

- Added a new Maven module `services/rag-engine` with `pom.xml`, `README.md`, and Spring Boot auto-configuration in `RagEngineAutoConfiguration.java` to bootstrap the module.
- Implemented configuration and validation classes in `RagEngineProperties.java` and a provider selection helper `RagProviderRouter.java` to route use-cases to configured providers.
- Updated top-level `pom.xml` to include the new `services/rag-engine` module and expanded `services/AGENTS.md` with a `rag-engine` service description.
- Added frontend planning documentation at `frontend/docs/rag-frontend-externalization.md` and a repository lint script at `scripts/lint.sh` to validate required frontmatter keys (`scope`, `author`, `contributors`, `tags`, `locale`) in `docs/*.md` files.

### Testing

- No automated test suite was executed as part of this change; the new module includes `spring-boot-starter-test` as a dependency for future unit tests.
- The added lint tool can be run via `scripts/lint.sh` to validate Markdown metadata and will exit non-zero when metadata keys are missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c96797108322895e630fca95a0f4)