### PR TITLE
Add profile dashboard API, DTOs and service

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProfileController.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/controller/api/ProfileController.java
@@ -1,0 +1,58 @@
+package org.open4goods.nudgerfrontapi.controller.api;
+
+import org.open4goods.model.RolesConstants;
+import org.open4goods.nudgerfrontapi.dto.profile.ProfileDashboardDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.open4goods.nudgerfrontapi.service.ProfileService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+/**
+ * REST endpoints exposing authenticated user profile dashboards.
+ */
+@RestController
+@RequestMapping("/profile")
+@Tag(name = "Profile", description = "Authenticated profile dashboards")
+@PreAuthorize("hasAnyAuthority('" + RolesConstants.ROLE_FRONTEND + "', '" + RolesConstants.ROLE_EDITOR + "')")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    public ProfileController(ProfileService profileService) {
+        this.profileService = profileService;
+    }
+
+    /**
+     * Return profile dashboard metrics and statuses for the authenticated user.
+     *
+     * @param domainLanguage requested domain language
+     * @param authentication current authenticated principal
+     * @return profile dashboard payload
+     */
+    @GetMapping("/dashboard")
+    @Operation(
+            summary = "Get profile dashboard",
+            description = "Return account metrics, trust status and profile KPIs for the authenticated user.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Profile dashboard resolved"),
+                    @ApiResponse(responseCode = "401", description = "Authentication required")
+            })
+    public ResponseEntity<ProfileDashboardDto> getDashboard(
+            @RequestParam(name = "domainLanguage") DomainLanguage domainLanguage,
+            Authentication authentication) {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .header("X-Locale", domainLanguage.languageTag())
+                .body(profileService.getDashboard(authentication, domainLanguage));
+    }
+}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/profile/ProfileDashboardDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/profile/ProfileDashboardDto.java
@@ -1,0 +1,23 @@
+package org.open4goods.nudgerfrontapi.dto.profile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Aggregate dashboard payload for the authenticated profile pages.
+ *
+ * @param displayName authenticated user display name
+ * @param trustTier internal trust tier resolved for the user
+ * @param identityStatus current identity validation status
+ * @param metrics key profile metrics used by dashboard hero and summaries
+ */
+@Schema(description = "Aggregated profile dashboard data for the authenticated user.")
+public record ProfileDashboardDto(
+        @Schema(description = "Authenticated user display name.", example = "alice")
+        String displayName,
+        @Schema(description = "Current trust tier assigned to the user.", example = "trusted")
+        String trustTier,
+        @Schema(description = "Current internal identity validation status.", example = "pending")
+        String identityStatus,
+        @Schema(description = "Profile metrics used to render dashboard KPIs.")
+        ProfileMetricsDto metrics
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/profile/ProfileMetricsDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/profile/ProfileMetricsDto.java
@@ -1,0 +1,41 @@
+package org.open4goods.nudgerfrontapi.dto.profile;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Immutable profile metrics used by profile dashboard and detail pages.
+ *
+ * @param nodesConfiguredCount count of configured agents for the authenticated user
+ * @param apiKeysCount count of API keys owned by the user
+ * @param organizationsCount count of organizations linked to the user
+ * @param billedMonthTokens billed tokens for the current month
+ * @param billedLifetimeTokens billed tokens across all time
+ * @param paidMonthTokens paid tokens for the current month
+ * @param paidLifetimeTokens paid tokens across all time
+ * @param paidMonthAmount paid monetary amount for the current month
+ * @param paidLifetimeAmount paid monetary amount across all time
+ * @param currency ISO-4217 currency code for amount fields
+ */
+@Schema(description = "Profile KPI metrics.")
+public record ProfileMetricsDto(
+        @Schema(description = "Configured agent count.", example = "3")
+        int nodesConfiguredCount,
+        @Schema(description = "API key count.", example = "2")
+        int apiKeysCount,
+        @Schema(description = "Linked organizations count.", example = "1")
+        int organizationsCount,
+        @Schema(description = "Billed token volume for current month.", example = "120345")
+        long billedMonthTokens,
+        @Schema(description = "Billed token volume for lifetime.", example = "987654")
+        long billedLifetimeTokens,
+        @Schema(description = "Paid token volume for current month.", example = "100000")
+        long paidMonthTokens,
+        @Schema(description = "Paid token volume for lifetime.", example = "910000")
+        long paidLifetimeTokens,
+        @Schema(description = "Paid amount for current month.", example = "39.90")
+        double paidMonthAmount,
+        @Schema(description = "Paid amount for lifetime.", example = "462.15")
+        double paidLifetimeAmount,
+        @Schema(description = "Currency used by amount fields.", example = "EUR")
+        String currency
+) {}

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProfileService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProfileService.java
@@ -1,0 +1,64 @@
+package org.open4goods.nudgerfrontapi.service;
+
+import java.util.Objects;
+
+import org.open4goods.nudgerfrontapi.dto.profile.ProfileDashboardDto;
+import org.open4goods.nudgerfrontapi.dto.profile.ProfileMetricsDto;
+import org.open4goods.nudgerfrontapi.localization.DomainLanguage;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service exposing profile dashboard aggregates for authenticated users.
+ */
+@Service
+public class ProfileService {
+
+    private final AgentService agentService;
+
+    public ProfileService(AgentService agentService) {
+        this.agentService = agentService;
+    }
+
+    /**
+     * Build the profile dashboard payload for the authenticated user.
+     *
+     * @param authentication current authentication principal
+     * @param domainLanguage requested domain language
+     * @return dashboard aggregate payload
+     */
+    public ProfileDashboardDto getDashboard(Authentication authentication, DomainLanguage domainLanguage) {
+        String username = authentication != null ? authentication.getName() : "unknown";
+        int configuredAgents = agentService.listTemplates(domainLanguage).stream()
+                .filter(template -> template.allowedRoles() == null || template.allowedRoles().isEmpty()
+                        || hasAnyRole(authentication, template.allowedRoles()))
+                .toList()
+                .size();
+
+        ProfileMetricsDto metrics = new ProfileMetricsDto(
+                configuredAgents,
+                0,
+                0,
+                0L,
+                0L,
+                0L,
+                0L,
+                0.0,
+                0.0,
+                "EUR");
+
+        return new ProfileDashboardDto(username, "basic", "pending", metrics);
+    }
+
+    private boolean hasAnyRole(Authentication authentication, java.util.List<String> allowedRoles) {
+        if (authentication == null || authentication.getAuthorities() == null) {
+            return false;
+        }
+
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(Objects::nonNull)
+                .anyMatch(allowedRoles::contains);
+    }
+}


### PR DESCRIPTION
### Motivation

- Expose an authenticated profile dashboard endpoint that returns account metrics, trust status and KPIs for the signed-in user.
- Provide immutable DTOs to model aggregated dashboard data and metrics for use by front-end pages and API documentation.

### Description

- Add `ProfileController` with a `/profile/dashboard` GET endpoint that is secured with `@PreAuthorize` for `ROLE_FRONTEND` and `ROLE_EDITOR`, returns a `ResponseEntity<ProfileDashboardDto>`, sets `Cache-Control: no-cache` and the `X-Locale` header, and is annotated for OpenAPI documentation.
- Add `ProfileDashboardDto` and `ProfileMetricsDto` record types to represent the aggregated dashboard payload and KPI metrics used by the frontend.
- Add `ProfileService` which injects `AgentService` and implements `getDashboard(Authentication, DomainLanguage)` to compute `nodesConfiguredCount` by filtering agent templates by their `allowedRoles` via a helper `hasAnyRole` method and returns default placeholders for other metrics and statuses.

### Testing

- No automated tests were added for this change and the existing automated test suite was not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c752908883228dc18f64396ae1d3)