### PR TITLE
Add async Google Indexing submission with deduplication and review-generation hook

### DIFF
--- a/services/google-indexation/README.md
+++ b/services/google-indexation/README.md
@@ -29,3 +29,8 @@ The service records:
 A health indicator is exposed through Spring Boot Actuator. When disabled, the
 indicator reports `UP` with `enabled=false`. When enabled, it reports `DOWN` if
 credentials are missing or the last request failed.
+
+## Review-generation integration
+
+Use `GoogleIndexationService.submitUrl(...)` from asynchronous hooks/listeners.
+The method applies a short deduplication window (5 minutes) and a single immediate retry on failure.

--- a/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/GoogleIndexationService.java
+++ b/services/google-indexation/src/main/java/org/open4goods/services/googleindexation/service/GoogleIndexationService.java
@@ -11,8 +11,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.open4goods.services.googleindexation.config.GoogleIndexationConfig;
@@ -35,6 +39,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 /**
  * Service responsible for publishing URLs to the Google Indexing API.
+ * <p>
+ * The service exposes:
+ * <ul>
+ * <li>{@link #submitUrl(String)} for asynchronous submission (recommended for hooks/event listeners),</li>
+ * <li>{@link #publishUrl(String)} for immediate synchronous publication,</li>
+ * <li>{@link #publishUrls(List)} for synchronous batch publication.</li>
+ * </ul>
  */
 @Service
 public class GoogleIndexationService implements HealthIndicator {
@@ -46,6 +57,8 @@ public class GoogleIndexationService implements HealthIndicator {
     private final MeterRegistry meterRegistry;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpClient httpClient;
+    private final ExecutorService submitExecutor;
+    private final Map<String, Instant> recentSubmissions = java.util.Collections.synchronizedMap(new LinkedHashMap<>());
 
     private final AtomicReference<GoogleCredentials> credentials = new AtomicReference<>();
     private final CredentialsProvider credentialsProvider;
@@ -77,6 +90,46 @@ public class GoogleIndexationService implements HealthIndicator {
         this.meterRegistry = meterRegistry;
         this.httpClient = httpClient;
         this.credentialsProvider = credentialsProvider != null ? credentialsProvider : this::loadCredentials;
+        this.submitExecutor = Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "google-indexation-submit");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
+
+    /**
+     * Submit a URL for asynchronous publication with deduplication and retry.
+     *
+     * @param url URL to submit
+     */
+    public void submitUrl(String url) {
+        if (!StringUtils.hasText(url)) {
+            return;
+        }
+        if (wasSubmittedRecently(url, Instant.now())) {
+            meterRegistry.counter("google.indexation.submit.deduplicated").increment();
+            return;
+        }
+        submitExecutor.submit(() -> {
+            GoogleIndexationResultItem result = publishUrl(url);
+            if (!result.success()) {
+                GoogleIndexationResultItem retryResult = publishUrl(url);
+                if (!retryResult.success()) {
+                    LOGGER.warn("Google indexation submit failed for {} after retry: {}", url, retryResult.message());
+                }
+            }
+        });
+    }
+
+    private boolean wasSubmittedRecently(String url, Instant now) {
+        synchronized (recentSubmissions) {
+            recentSubmissions.entrySet().removeIf(entry -> entry.getValue().isBefore(now.minusSeconds(300)));
+            if (recentSubmissions.containsKey(url)) {
+                return true;
+            }
+            recentSubmissions.put(url, now);
+            return false;
+        }
     }
 
     /**

--- a/services/review-generation/README.md
+++ b/services/review-generation/README.md
@@ -11,6 +11,7 @@ via the batch API.
 - Realtime and batch review generation flows.
 - Scheduled processing of batch jobs.
 - Exposes health metrics.
+- Triggers Google URL indexation hook when review generation completes successfully.
 
 ## Configuration
 

--- a/services/review-generation/pom.xml
+++ b/services/review-generation/pom.xml
@@ -44,6 +44,12 @@
 
         <dependency>
             <groupId>org.open4goods</groupId>
+            <artifactId>google-indexation</artifactId>
+            <version>${global.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.open4goods</groupId>
             <artifactId>googlesearch</artifactId>
             <version>${global.version}</version>
             <classifier>tests</classifier>

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/GoogleIndexationReviewGenerationHook.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/GoogleIndexationReviewGenerationHook.java
@@ -1,0 +1,43 @@
+package org.open4goods.services.reviewgeneration.service;
+
+import org.open4goods.model.product.Product;
+import org.open4goods.services.googleindexation.service.GoogleIndexationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Hook that submits generated product URLs to the Google Indexing API once AI review generation succeeds.
+ */
+@Component
+public class GoogleIndexationReviewGenerationHook implements ReviewGenerationHook {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GoogleIndexationReviewGenerationHook.class);
+
+    private final GoogleIndexationService googleIndexationService;
+
+    /**
+     * Build the hook with the Google indexation service dependency.
+     *
+     * @param googleIndexationService service used to submit URL updates
+     */
+    public GoogleIndexationReviewGenerationHook(GoogleIndexationService googleIndexationService) {
+        this.googleIndexationService = googleIndexationService;
+    }
+
+    /**
+     * Trigger asynchronous URL submission after successful review generation.
+     *
+     * @param product product that has just received an AI review
+     */
+    @Override
+    public void onReviewGenerated(Product product) {
+        String url = product == null ? null : product.url("fr");
+        if (!StringUtils.hasText(url)) {
+            LOGGER.debug("Skipping Google indexation hook because product URL is blank");
+            return;
+        }
+        googleIndexationService.submitUrl(url);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an asynchronous, resilient way to submit URLs to the Google Indexing API and integrate it with the review generation flow.
- Avoid duplicate submissions from rapid, repeated events by applying a short deduplication window.

### Description

- Added `submitUrl(String)` to `GoogleIndexationService` which runs submissions on a single-threaded daemon `ExecutorService`, applies a 5-minute deduplication window, and performs a single immediate retry on failure, while emitting a deduplication metric `google.indexation.submit.deduplicated`.
- Introduced a synchronized `recentSubmissions` map to track recent URL submissions and the helper `wasSubmittedRecently(...)` to prune and check entries.
- Extended `GoogleIndexationService` constructor to initialize the executor and updated class JavaDoc to document the asynchronous API surface (`submitUrl`, `publishUrl`, `publishUrls`).
- Updated `services/google-indexation/README.md` with a short note about using `GoogleIndexationService.submitUrl(...)` from hooks/listeners.
- Added a new Spring `Component` `GoogleIndexationReviewGenerationHook` that implements `ReviewGenerationHook` and calls `googleIndexationService.submitUrl(url)` after a successful review generation.
- Added the `google-indexation` dependency to the `review-generation` module `pom.xml` and noted the hook in the `review-generation/README.md`.

### Testing

- Ran module unit tests with Maven for the modified modules using `mvn -pl services/google-indexation,services/review-generation test` and all tests passed.
- Verified basic startup and bean wiring locally for the `review-generation` module to ensure the hook can be autowired and invoked during review events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca5c77d6c832bac2c1e31f70d8296)