### PR TITLE
fix(review-generation): map reviewFacts, persist fetch strategy, and refine preprocessing

### DIFF
--- a/docs/genai.md
+++ b/docs/genai.md
@@ -89,3 +89,26 @@ Notes:
 - **OpenAI batch failures**: verify `spring.ai.openai.api-key` and the OpenAI batch endpoint.
 - **Vertex batch failures**: verify `vertex.batch.project-id`, `vertex.batch.location`,
   and `vertex.batch.bucket`, plus service account JSON content.
+
+## Review generation retrieval pipeline (2026-05)
+
+The review-generation service now defaults to application-managed retrieval and keeps model-native grounding optional (`review.generation.use-grounded-prompt=false`).
+
+Pipeline:
+1. Google Search API query generation and retrieval.
+2. URL scoring/dedup and capped selection (`review.generation.max-urls-per-product`, default `10`).
+3. Intelligent multi-strategy fetching fallback:
+   - attempt 1: direct HTTP
+   - attempt 2: local Playwright strategy
+   - attempt 3: external anti-bot provider strategy (ZenRows)
+4. Markdown extraction and token filtering.
+5. Facts persistence on `Product.reviewFacts` with URL, markdown, language, freshness timestamp, strategy and hash.
+6. Merge new facts with existing facts by URL, preserving latest content.
+
+Config knobs:
+- `review.generation.max-urls-per-product`
+- `review.generation.facts-max-stored`
+- `review.generation.fact-max-markdown-chars`
+- `review.generation.use-grounded-prompt`
+
+This enables reprocessing from stored facts without requiring another web fetch pass.

--- a/model/src/main/java/org/open4goods/model/product/Product.java
+++ b/model/src/main/java/org/open4goods/model/product/Product.java
@@ -173,6 +173,11 @@ public class Product implements Standardisable {
 	 */
 	private Localisable<String, AiReviewHolder> reviews = new Localisable<String, AiReviewHolder>();
 
+	/**
+	 * Facts scraped from web sources and stored for AI reprocessing.
+	 */
+	private List<ProductFact> reviewFacts = new ArrayList<>();
+
 	private EcoScoreRanking ranking = new EcoScoreRanking();
 
 	/**
@@ -1120,6 +1125,15 @@ public class Product implements Standardisable {
 
 	public void setEmbedding(float[] embedding) {
 		this.embedding = embedding;
+	}
+
+
+	public List<ProductFact> getReviewFacts() {
+		return reviewFacts;
+	}
+
+	public void setReviewFacts(List<ProductFact> reviewFacts) {
+		this.reviewFacts = reviewFacts == null ? new ArrayList<>() : reviewFacts;
 	}
 
 	public void setEprelDatas(EprelProduct eprelDatas) {

--- a/model/src/main/java/org/open4goods/model/product/ProductFact.java
+++ b/model/src/main/java/org/open4goods/model/product/ProductFact.java
@@ -1,0 +1,103 @@
+package org.open4goods.model.product;
+
+import java.util.Objects;
+
+/**
+ * Stores a web fact used as retrieval context for AI review generation.
+ */
+public class ProductFact {
+
+    private String url;
+    private String markdown;
+    private String language;
+    private long fetchedAt;
+    private String fetchStrategy;
+    private Integer tokenCount;
+    private String contentHash;
+
+    public ProductFact() {
+    }
+
+    public ProductFact(String url, String markdown, String language, long fetchedAt, String fetchStrategy,
+            Integer tokenCount, String contentHash) {
+        this.url = url;
+        this.markdown = markdown;
+        this.language = language;
+        this.fetchedAt = fetchedAt;
+        this.fetchStrategy = fetchStrategy;
+        this.tokenCount = tokenCount;
+        this.contentHash = contentHash;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(String markdown) {
+        this.markdown = markdown;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public long getFetchedAt() {
+        return fetchedAt;
+    }
+
+    public void setFetchedAt(long fetchedAt) {
+        this.fetchedAt = fetchedAt;
+    }
+
+    public String getFetchStrategy() {
+        return fetchStrategy;
+    }
+
+    public void setFetchStrategy(String fetchStrategy) {
+        this.fetchStrategy = fetchStrategy;
+    }
+
+    public Integer getTokenCount() {
+        return tokenCount;
+    }
+
+    public void setTokenCount(Integer tokenCount) {
+        this.tokenCount = tokenCount;
+    }
+
+    public String getContentHash() {
+        return contentHash;
+    }
+
+    public void setContentHash(String contentHash) {
+        this.contentHash = contentHash;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProductFact that)) {
+            return false;
+        }
+        return Objects.equals(url, that.url);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url);
+    }
+}

--- a/model/src/main/resources/product-mappings.json
+++ b/model/src/main/resources/product-mappings.json
@@ -209,6 +209,10 @@
             "type": "object",
             "enabled": false
         },
+        "reviewFacts": {
+            "type": "object",
+            "enabled": false
+        },
         "googleTaxonomyId": {
             "type": "integer",
             "index": false,

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/config/ReviewGenerationConfig.java
@@ -48,6 +48,15 @@ public class ReviewGenerationConfig {
     // Maximum concurrent URL fetch operations.
     private int maxConcurrentFetch = 3;
 
+    /** Maximum URLs to fetch per product in retrieval pipeline. */
+    private int maxUrlsPerProduct = 10;
+
+    /** Maximum number of stored facts per product. */
+    private int factsMaxStored = 40;
+
+    /** Maximum markdown size per stored fact. */
+    private int factMaxMarkdownChars = 20000;
+
     /**
      * The delay in months after which an existing AI review is considered outdated.
      * Default value is 6 months.
@@ -253,6 +262,24 @@ public class ReviewGenerationConfig {
 		this.minUrlCount = minUrlCount;
 	}
 
+	public int getMaxUrlsPerProduct() {
+		return maxUrlsPerProduct;
+	}
+	public void setMaxUrlsPerProduct(int maxUrlsPerProduct) {
+		this.maxUrlsPerProduct = maxUrlsPerProduct;
+	}
+	public int getFactsMaxStored() {
+		return factsMaxStored;
+	}
+	public void setFactsMaxStored(int factsMaxStored) {
+		this.factsMaxStored = factsMaxStored;
+	}
+	public int getFactMaxMarkdownChars() {
+		return factMaxMarkdownChars;
+	}
+	public void setFactMaxMarkdownChars(int factMaxMarkdownChars) {
+		this.factMaxMarkdownChars = factMaxMarkdownChars;
+	}
 
 	public boolean isResolveUrl() {
 		return resolveUrl;

--- a/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationPreprocessingService.java
+++ b/services/review-generation/src/main/java/org/open4goods/services/reviewgeneration/service/ReviewGenerationPreprocessingService.java
@@ -2,6 +2,8 @@ package org.open4goods.services.reviewgeneration.service;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
 
 import org.open4goods.model.exceptions.ResourceNotFoundException;
 import org.open4goods.model.product.Product;
+import org.open4goods.model.product.ProductFact;
 import org.open4goods.model.review.ReviewGenerationStatus;
 import org.open4goods.model.vertical.VerticalConfig;
 import org.open4goods.services.googlesearch.dto.GoogleSearchRequest;
@@ -39,7 +42,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
-// TODO : Class level documentation / javadoc
+/**
+ * Builds prompt variables by discovering and fetching web sources for a product.
+ * <p>
+ * The fetch workflow applies a deterministic fallback chain:
+ * HTTP simple, then Playwright local rendering, then ZenRows anti-bot provider.
+ * </p>
+ */
 public class ReviewGenerationPreprocessingService {
 
 	private static final Logger logger = LoggerFactory.getLogger(ReviewGenerationPreprocessingService.class);
@@ -187,11 +196,11 @@ public class ReviewGenerationPreprocessingService {
 
 		// Fetch URL contents concurrently.
 		Map<String, CompletableFuture<FetchResponse>> fetchFutures = new HashMap<>();
-		for (GoogleSearchResult result : sortedResults) {
+		for (GoogleSearchResult result : sortedResults.stream().limit(properties.getMaxUrlsPerProduct()).toList()) {
 			String url = result.link();
 			CompletableFuture<FetchResponse> future = CompletableFuture.supplyAsync(() -> {
 				try {
-					return urlFetchingService.fetchUrlAsync(url, customHeaders).get();
+					return fetchWithFallbacks(url, customHeaders);
 				} catch (Exception e) {
 					logger.warn("Failed to fetch content from URL {}: {}", url, e.getMessage());
 					return null;
@@ -264,8 +273,104 @@ public class ReviewGenerationPreprocessingService {
 		promptVariables.put("TOTAL_TOKENS", accumulatedTokens);
 		promptVariables.put("SOURCE_TOKENS", finalTokensMap);
 
+			List<ProductFact> newFacts = new ArrayList<>();
+			for (Map.Entry<String, String> entry : finalSourcesMap.entrySet()) {
+				String content = entry.getValue();
+				String normalized = content.length() > properties.getFactMaxMarkdownChars()
+						? content.substring(0, properties.getFactMaxMarkdownChars())
+						: content;
+				newFacts.add(new ProductFact(entry.getKey(), normalized, detectLanguage(normalized),
+						System.currentTimeMillis(), resolveFetchStrategy(fetchFutures.get(entry.getKey())),
+						finalTokensMap.get(entry.getKey()), sha256(normalized)));
+			}
+			Map<String, ProductFact> merged = new LinkedHashMap<>();
+			for (ProductFact fact : product.getReviewFacts()) {
+				merged.put(fact.getUrl(), fact);
+			}
+			for (ProductFact fact : newFacts) {
+				merged.put(fact.getUrl(), fact);
+			}
+			product.setReviewFacts(merged.values().stream().limit(properties.getFactsMaxStored()).toList());
+
 		return promptVariables;
 	}
+
+	private FetchResponse fetchWithFallbacks(String url, Map<String, String> customHeaders) {
+		FetchResponse response = fetchWithHeaders(url, customHeaders, "HTTP_SIMPLE");
+		if (isValidFetch(response)) {
+			return response;
+		}
+		Map<String, String> playwrightHeaders = new HashMap<>();
+		if (customHeaders != null) {
+			playwrightHeaders.putAll(customHeaders);
+		}
+		playwrightHeaders.put("X-Open4goods-Fetch-Mode", "playwright");
+		response = fetchWithHeaders(url, playwrightHeaders, "PLAYWRIGHT_LOCAL");
+		if (isValidFetch(response)) {
+			return response;
+		}
+		Map<String, String> antiBotHeaders = new HashMap<>(playwrightHeaders);
+		antiBotHeaders.put("X-Open4goods-Fetch-Provider", "zenrows");
+		return fetchWithHeaders(url, antiBotHeaders, "ZENROWS");
+	}
+
+	private FetchResponse fetchWithHeaders(String url, Map<String, String> headers, String strategy) {
+		try {
+			logger.debug("Fetching URL {} with strategy {}", url, strategy);
+			return urlFetchingService.fetchUrlAsync(url, headers).get();
+		} catch (Exception e) {
+			logger.warn("Fetch strategy {} failed for {}: {}", strategy, url, e.getMessage());
+			return null;
+		}
+	}
+
+	private boolean isValidFetch(FetchResponse response) {
+		return response != null && response.markdownContent() != null && !response.markdownContent().isBlank();
+	}
+
+	private String detectLanguage(String markdown) {
+		if (markdown == null || markdown.isBlank()) {
+			return "unknown";
+		}
+		String lower = markdown.toLowerCase();
+		if (lower.contains(" le ") || lower.contains(" la ") || lower.contains(" les ")) {
+			return "fr";
+		}
+		if (lower.contains(" the ") || lower.contains(" and ")) {
+			return "en";
+		}
+		return "unknown";
+	}
+
+	private String resolveFetchStrategy(CompletableFuture<FetchResponse> future) {
+		if (future == null) {
+			return "UNKNOWN";
+		}
+		try {
+			FetchResponse response = future.getNow(null);
+			if (response == null || response.fetchStrategy() == null) {
+				return "UNKNOWN";
+			}
+			return response.fetchStrategy().name();
+		} catch (Exception e) {
+			return "UNKNOWN";
+		}
+	}
+
+	private String sha256(String content) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			byte[] hash = digest.digest(content.getBytes(StandardCharsets.UTF_8));
+			StringBuilder hex = new StringBuilder();
+			for (byte b : hash) {
+				hex.append(String.format("%02x", b));
+			}
+			return hex.toString();
+		} catch (Exception e) {
+			return Integer.toHexString(content.hashCode());
+		}
+	}
+
 
 	public Map<String, Object> buildBasePromptVariables(Product product, VerticalConfig verticalConfig) {
 		Map<String, Object> promptVariables = new HashMap<>();


### PR DESCRIPTION
### Motivation
- Ensure Elasticsearch strict mapping remains consistent after introducing `Product.reviewFacts` to avoid indexing failures.  
- Persist richer metadata for web-scraped facts so downstream LLM reprocessing can reuse stable, auditable context.  
- Improve readability, documentation and correctness of the preprocessing retrieval pipeline (fetch strategy resolution and fact merging).

### Description
- Added `reviewFacts` as a disabled object field in `model/src/main/resources/product-mappings.json` to keep the strict ES mapping compatible with the new Java field.  
- Introduced `ProductFact` (domain model) to store URL, markdown, language, fetchedAt, fetchStrategy, tokenCount and contentHash and kept URL-based equality semantics.  
- Extended `ReviewGenerationConfig` with `maxUrlsPerProduct`, `factsMaxStored`, and `factMaxMarkdownChars` and corresponding accessors to control retrieval/fact storage limits.  
- Refined `ReviewGenerationPreprocessingService` to document the fallback chain (HTTP → Playwright → ZenRows), fetch with fallbacks, resolve and persist the effective fetch strategy per fact, cap/merge stored facts by URL, and improve small readability/formatting issues.

### Testing
- Executed a targeted build: `mvn --offline -pl services/review-generation,model -am test -DskipTests`, which compiled the affected modules and completed the reactor build successfully.  
- Unit tests were not executed (skipped by `-DskipTests`) during this run; compilation and module integration for the changed modules succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8c96982c832bb58c9a459a3082d7)