### PR TITLE
Backend-provided product `metaTitle` and shared SEO resolvers (frontend + backend)

### DIFF
--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/dto/product/ProductNamesDto.java
@@ -14,6 +14,9 @@ public record ProductNamesDto(
         String pageTitle,
         @Schema(description = "Compact product name used as the base for SEO metadata", example = "Samsung Galaxy S24")
         String seoName,
+        @Schema(description = "Backend-computed SEO meta title aligned with the requested language",
+                example = "Samsung Galaxy S24 - score impact 14/20 | Nudger")
+        String metaTitle,
         @Schema(description = "Meta description aligned with the requested language")
         String metaDescription,
         @Schema(description = "OpenGraph title for social sharing")

--- a/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
+++ b/front-api/src/main/java/org/open4goods/nudgerfrontapi/service/ProductMappingService.java
@@ -534,9 +534,147 @@ public class ProductMappingService {
                 safeCanonicalName(product, resolveLocalisedString(product.getNames().getCardName(), domainLanguage, locale)),
                 safeCanonicalName(product, resolveLocalisedString(product.getNames().getPageTitle(), domainLanguage, locale)),
                 safeCanonicalName(product, resolveLocalisedString(product.getNames().getSeoName(), domainLanguage, locale)),
+                buildProductMetaTitle(product, domainLanguage, locale, vConfig),
                 resolveLocalisedString(product.getNames().getMetaDescription(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphTitle(), domainLanguage, locale),
                 resolveLocalisedString(product.getNames().getProductMetaOpenGraphDescription(), domainLanguage, locale));
+    }
+
+    /**
+     * Build the canonical SEO title for product pages server-side so the Nuxt
+     * application can consume it directly and keep local title logic as a
+     * resilience fallback only.
+     *
+     * @param product product being mapped
+     * @param domainLanguage requested domain language
+     * @param locale requested locale
+     * @param vConfig resolved vertical configuration
+     * @return SEO title trimmed to a SERP-safe length, or {@code null}
+     */
+    private String buildProductMetaTitle(Product product, DomainLanguage domainLanguage, Locale locale, VerticalConfig vConfig) {
+        String productName = resolveProductSeoName(product, domainLanguage, locale);
+        if (!StringUtils.hasText(productName)) {
+            return null;
+        }
+
+        String verticalTitle = resolveVerticalTitle(vConfig, domainLanguage);
+        Double impactScore = Optional.ofNullable(product.ecoscore()).map(Score::getValue).orElse(null);
+        String candidate;
+        if (impactScore != null && StringUtils.hasText(verticalTitle)) {
+            candidate = String.format(Locale.ROOT, "%s - score impact %s/20 | %s", productName,
+                    formatSeoScore(impactScore), verticalTitle);
+        } else if (impactScore != null) {
+            candidate = String.format(Locale.ROOT, "%s - score impact %s/20 | Nudger", productName,
+                    formatSeoScore(impactScore));
+        } else if (StringUtils.hasText(verticalTitle)) {
+            candidate = String.format("%s | %s", productName, verticalTitle);
+        } else {
+            candidate = String.format("%s | Nudger", productName);
+        }
+
+        return truncateAtWordBoundary(candidate, 60);
+    }
+
+    /**
+     * Resolve the most SEO-friendly product name from localized product texts.
+     *
+     * @param product product being mapped
+     * @param domainLanguage requested domain language
+     * @param locale requested locale
+     * @return localized SEO name or fallback display name
+     */
+    private String resolveProductSeoName(Product product, DomainLanguage domainLanguage, Locale locale) {
+        ProductTexts names = product == null ? null : product.getNames();
+        if (names == null) {
+            return null;
+        }
+
+        String resolved = safeCanonicalName(product, resolveLocalisedString(names.getSeoName(), domainLanguage, locale));
+        if (StringUtils.hasText(resolved)) {
+            return resolved;
+        }
+
+        resolved = safeCanonicalName(product, resolveLocalisedString(names.getPageTitle(), domainLanguage, locale));
+        if (StringUtils.hasText(resolved)) {
+            return resolved;
+        }
+
+        return safeCanonicalName(product, resolvePreferredName(names, domainLanguage, locale));
+    }
+
+    /**
+     * Resolve a localized vertical label suitable for title suffixes.
+     *
+     * @param vConfig resolved vertical configuration
+     * @param domainLanguage requested domain language
+     * @return title suffix or {@code null}
+     */
+    private String resolveVerticalTitle(VerticalConfig vConfig, DomainLanguage domainLanguage) {
+        if (vConfig == null) {
+            return null;
+        }
+        String lang = domainLanguage != null ? domainLanguage.languageTag() : null;
+        ProductI18nElements i18n = lang == null ? null : vConfig.i18n(lang);
+        if (i18n == null) {
+            return null;
+        }
+        return firstText(i18n.getVerticalMetaTitle(), i18n.getVerticalHomeTitle());
+    }
+
+    /**
+     * Pick the first non-blank text value.
+     *
+     * @param values candidate values ordered by priority
+     * @return first non-blank value or {@code null}
+     */
+    private String firstText(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Format impact score without unnecessary trailing decimals.
+     *
+     * @param score impact score on a 20-point scale
+     * @return compact score string
+     */
+    private String formatSeoScore(double score) {
+        double rounded = Math.round(score * 10.0d) / 10.0d;
+        if (rounded == Math.rint(rounded)) {
+            return String.valueOf((int) rounded);
+        }
+        return String.format(Locale.ROOT, "%.1f", rounded);
+    }
+
+    /**
+     * Truncate text without cutting the last word when a safe boundary exists.
+     *
+     * @param value text to truncate
+     * @param maxLength maximum length including the ellipsis
+     * @return normalized and truncated text
+     */
+    private String truncateAtWordBoundary(String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim().replaceAll("\\s+", " ");
+        if (normalized.length() <= maxLength) {
+            return normalized;
+        }
+        int safeLimit = Math.max(1, maxLength - 1);
+        String truncated = normalized.substring(0, safeLimit);
+        int lastSpace = truncated.lastIndexOf(' ');
+        if (lastSpace > Math.floor(safeLimit * 0.6d)) {
+            truncated = truncated.substring(0, lastSpace);
+        }
+        return truncated.stripTrailing() + "…";
     }
 
     /**

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -131,6 +131,33 @@ class ProductMappingServiceTest {
     }
 
     @Test
+    void getProductNamesIncludesBackendComputedMetaTitle() throws Exception {
+        long gtin = 1234567890123L;
+        Product product = new Product(gtin);
+        product.setVertical("phones");
+        ProductTexts names = new ProductTexts();
+        Localisable<String, String> seoName = new Localisable<>();
+        seoName.put("fr", "Fairphone 6");
+        names.setSeoName(seoName);
+        product.setNames(names);
+        product.setScores(Map.of("ECOSCORE", new Score("ECOSCORE", 14.25)));
+
+        VerticalConfig verticalConfig = new VerticalConfig();
+        ProductI18nElements frI18n = new ProductI18nElements();
+        frI18n.setVerticalMetaTitle("Smartphones durables");
+        verticalConfig.getI18n().put("fr", frI18n);
+
+        when(repository.getByIdWithoutEmbedding(gtin)).thenReturn(product);
+        when(verticalsConfigService.getConfigByIdOrDefault("phones")).thenReturn(verticalConfig);
+        when(verticalsConfigService.getConfigById("phones")).thenReturn(verticalConfig);
+
+        ProductDto dto = service.getProduct(gtin, Locale.FRENCH, Set.of("names"), DomainLanguage.fr);
+
+        assertThat(dto.names()).isNotNull();
+        assertThat(dto.names().metaTitle()).isEqualTo("Fairphone 6 - score impact 14.3/20 | Smartphones durables");
+    }
+
+    @Test
     void scoresIncludeReferencedProducts() throws Exception {
         long gtin = 555L;
         Product product = new Product(gtin);

--- a/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
+++ b/front-api/src/test/java/org/open4goods/nudgerfrontapi/service/ProductMappingServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.open4goods.icecat.services.IcecatService;
+import org.open4goods.model.attribute.ReferentielKey;
 import org.open4goods.model.constants.CacheConstants;
 import org.open4goods.model.price.AggregatedPrice;
 import org.open4goods.model.price.AggregatedPrices;
@@ -135,6 +136,8 @@ class ProductMappingServiceTest {
         long gtin = 1234567890123L;
         Product product = new Product(gtin);
         product.setVertical("phones");
+        product.getAttributes().addReferentielAttribute(ReferentielKey.BRAND, "Fairphone");
+        product.getAttributes().addReferentielAttribute(ReferentielKey.MODEL, "6");
         ProductTexts names = new ProductTexts();
         Localisable<String, String> seoName = new Localisable<>();
         seoName.put("fr", "Fairphone 6");

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,8 @@ Use this document as the bible for:
 
 > 📄 **Need to update the sitemap?** See [docs/sitemap-generation.md](docs/sitemap-generation.md) for the end-to-end workflow and configuration reference.
 
+> 🔎 **Need to update page metadata?** See [docs/seo-metadata.md](docs/seo-metadata.md) for the backend-first SEO metadata contract and fallback rules.
+
 ## Getting Started: Installation & Setup
 
 To get the project up and running locally, follow these steps:

--- a/frontend/app/components/pages/CategoryPage.vue
+++ b/frontend/app/components/pages/CategoryPage.vue
@@ -555,6 +555,7 @@ import {
 } from '~/utils/_field-options-normalizer'
 import { deduplicateSortItemsByTitle } from '~/utils/_sort-options-normalizer'
 import { hasAdminAccess } from '~~/shared/utils/_roles'
+import { resolveCategorySeoMeta } from '~/utils/seo/category-meta'
 
 const route = useRoute()
 const router = useRouter()
@@ -710,13 +711,6 @@ const category = computed<VerticalConfigFullDto | null>(() => {
   return fallback ? (toRaw(fallback) as VerticalConfigFullDto) : null
 })
 const errorMessage = computed(() => categoriesError.value)
-const stripMarkdownSyntax = (value: string) =>
-  value
-    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/[`*_~>#]+/g, '')
-    .replace(/\s+/g, ' ')
-    .trim()
 const activeSubCategory = computed(() => {
   if (!subCategorySlug) {
     return null
@@ -823,43 +817,20 @@ const shouldRestrictCategoryProducts = computed(
 const canonicalUrl = computed(() =>
   new URL(route.path, requestURL.origin).toString()
 )
-const seoTitle = computed(
-  () =>
-    activeSubCategory.value?.metaTitle ??
-    activeSubCategory.value?.h1Title ??
-    category.value?.verticalMetaTitle ??
-    category.value?.verticalHomeTitle ??
-    siteName.value
+const categorySeoMeta = computed(() =>
+  resolveCategorySeoMeta({
+    category: category.value,
+    subCategory: activeSubCategory.value,
+    siteName: siteName.value,
+  })
 )
-const seoDescription = computed(() =>
-  stripMarkdownSyntax(
-    activeSubCategory.value?.metaDescription ??
-      activeSubCategory.value?.description ??
-      category.value?.verticalMetaDescription ??
-      category.value?.verticalHomeDescription ??
-      ''
-  )
-)
+const seoTitle = computed(() => categorySeoMeta.value.title)
+const seoDescription = computed(() => categorySeoMeta.value.description)
 const robotsContent = computed(() =>
   shouldRestrictCategoryProducts.value ? 'noindex, nofollow' : undefined
 )
-const ogTitle = computed(
-  () =>
-    activeSubCategory.value?.metaOpenGraphTitle ??
-    activeSubCategory.value?.metaTitle ??
-    activeSubCategory.value?.h1Title ??
-    category.value?.verticalMetaOpenGraphTitle ??
-    seoTitle.value
-)
-const ogDescription = computed(() =>
-  stripMarkdownSyntax(
-    activeSubCategory.value?.metaOpenGraphDescription ??
-      activeSubCategory.value?.metaDescription ??
-      activeSubCategory.value?.description ??
-      category.value?.verticalMetaOpenGraphDescription ??
-      seoDescription.value
-  )
-)
+const ogTitle = computed(() => categorySeoMeta.value.ogTitle)
+const ogDescription = computed(() => categorySeoMeta.value.ogDescription)
 const ogImage = computed(() => {
   if (!heroImage.value) {
     return undefined

--- a/frontend/app/components/pages/ProductPage.vue
+++ b/frontend/app/components/pages/ProductPage.vue
@@ -918,7 +918,7 @@ const productMetaDescription = computed(() => {
     return explicit
   }
 
-  return seoMetaDescription.value
+  return fallbackSeoMetaDescription.value
 })
 
 const toAbsoluteUrl = (value?: string | null) => {
@@ -2411,18 +2411,26 @@ const socialMetaBase = computed(() =>
   })
 )
 
-const seoMetaTitle = computed(() => seoMetaBase.value.title)
-const seoMetaDescription = computed(() => seoMetaBase.value.description)
+const fallbackSeoMetaTitle = computed(() => seoMetaBase.value.title)
+const fallbackSeoMetaDescription = computed(() => seoMetaBase.value.description)
 
-const socialMetaTitle = computed(() => socialMetaBase.value.title)
-const socialMetaDescription = computed(() => socialMetaBase.value.description)
+const fallbackSocialMetaTitle = computed(() => socialMetaBase.value.title)
+const fallbackSocialMetaDescription = computed(() => socialMetaBase.value.description)
+
+const productSeoMeta = computed(() => ({
+  title: product.value?.names?.metaTitle?.trim() || fallbackSeoMetaTitle.value,
+  description: productMetaDescription.value,
+  ogTitle: product.value?.names?.ogTitle?.trim() || fallbackSocialMetaTitle.value,
+  ogDescription:
+    product.value?.names?.ogDescription?.trim() ||
+    fallbackSocialMetaDescription.value,
+}))
 
 useSeoMeta({
-  title: () => seoMetaTitle.value,
-  description: () => productMetaDescription.value,
-  ogTitle: () => product.value?.names?.ogTitle ?? socialMetaTitle.value,
-  ogDescription: () =>
-    product.value?.names?.ogDescription ?? socialMetaDescription.value,
+  title: () => productSeoMeta.value.title,
+  description: () => productSeoMeta.value.description,
+  ogTitle: () => productSeoMeta.value.ogTitle,
+  ogDescription: () => productSeoMeta.value.ogDescription,
   ogUrl: () => canonicalUrl.value,
   ogType: 'product',
   ogImage: () => ogImageUrl.value,

--- a/frontend/app/components/shared/header/composables/useHeaderSeo.ts
+++ b/frontend/app/components/shared/header/composables/useHeaderSeo.ts
@@ -39,8 +39,11 @@ export function useHeaderSeo(options: UseHeaderSeoOptions) {
   const { locale } = useI18n()
   const requestURL = useRequestURL()
 
-  // Canonical URL
-  const canonicalUrl = computed(() => requestURL.href)
+  // Canonical URL: keep origin + pathname and drop query/hash noise by default.
+  const canonicalUrl = computed(() => {
+    const url = new URL(requestURL.pathname, requestURL.origin)
+    return url.toString()
+  })
 
   // Meta description (subtitle > description fallback)
   const metaDescription = computed(

--- a/frontend/app/utils/seo/category-meta.spec.ts
+++ b/frontend/app/utils/seo/category-meta.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCategorySeoMeta } from './category-meta'
+
+describe('resolveCategorySeoMeta', () => {
+  it('prioritises sub-category backend SEO and Open Graph fields', () => {
+    const meta = resolveCategorySeoMeta({
+      siteName: 'Nudger',
+      category: {
+        verticalMetaTitle: 'Category SEO title',
+        verticalMetaDescription: 'Category SEO description',
+        verticalMetaOpenGraphTitle: 'Category OG title',
+        verticalMetaOpenGraphDescription: 'Category OG description',
+        verticalHomeTitle: 'Category home title',
+      },
+      subCategory: {
+        metaTitle: 'Sub SEO title',
+        metaDescription: 'Sub **SEO** description',
+        metaOpenGraphTitle: 'Sub OG title',
+        metaOpenGraphDescription: 'Sub [OG](https://example.test) description',
+        h1Title: 'Sub H1',
+      },
+    })
+
+    expect(meta).toEqual({
+      title: 'Sub SEO title',
+      description: 'Sub SEO description',
+      ogTitle: 'Sub OG title',
+      ogDescription: 'Sub OG description',
+    })
+  })
+
+  it('falls back to category and site fields when specific metadata is absent', () => {
+    const meta = resolveCategorySeoMeta({
+      siteName: 'Nudger',
+      category: {
+        verticalHomeTitle: 'Category home title',
+        verticalHomeDescription: 'Category _home_ description',
+      },
+    })
+
+    expect(meta).toEqual({
+      title: 'Category home title',
+      description: 'Category home description',
+      ogTitle: 'Category home title',
+      ogDescription: 'Category home description',
+    })
+  })
+})

--- a/frontend/app/utils/seo/category-meta.ts
+++ b/frontend/app/utils/seo/category-meta.ts
@@ -1,0 +1,81 @@
+import type {
+  VerticalConfigFullDto,
+  VerticalSubCategoryDto,
+} from '~~/shared/api-client'
+
+export interface CategorySeoMetaOptions {
+  category?: VerticalConfigFullDto | null
+  subCategory?: VerticalSubCategoryDto | null
+  siteName: string
+}
+
+export interface CategorySeoMeta {
+  title: string
+  description: string
+  ogTitle: string
+  ogDescription: string
+}
+
+const stripMarkdownSyntax = (value?: string | null) =>
+  (value ?? '')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/[`*_~>#]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const firstText = (...values: Array<string | null | undefined>) =>
+  values.find(value => typeof value === 'string' && value.trim().length > 0)
+    ?.trim() ?? ''
+
+/**
+ * Resolve category page SEO metadata with backend fields first and visible
+ * content fields as resilience fallbacks.
+ */
+export const resolveCategorySeoMeta = ({
+  category,
+  subCategory,
+  siteName,
+}: CategorySeoMetaOptions): CategorySeoMeta => {
+  const title = firstText(
+    subCategory?.metaTitle,
+    subCategory?.h1Title,
+    category?.verticalMetaTitle,
+    category?.verticalHomeTitle,
+    siteName
+  )
+
+  const description = stripMarkdownSyntax(
+    firstText(
+      subCategory?.metaDescription,
+      subCategory?.description,
+      category?.verticalMetaDescription,
+      category?.verticalHomeDescription
+    )
+  )
+
+  const ogTitle = firstText(
+    subCategory?.metaOpenGraphTitle,
+    subCategory?.metaTitle,
+    subCategory?.h1Title,
+    category?.verticalMetaOpenGraphTitle,
+    title
+  )
+
+  const ogDescription = stripMarkdownSyntax(
+    firstText(
+      subCategory?.metaOpenGraphDescription,
+      subCategory?.metaDescription,
+      subCategory?.description,
+      category?.verticalMetaOpenGraphDescription,
+      description
+    )
+  )
+
+  return {
+    title,
+    description,
+    ogTitle,
+    ogDescription,
+  }
+}

--- a/frontend/docs/seo-metadata.md
+++ b/frontend/docs/seo-metadata.md
@@ -1,0 +1,56 @@
+# SEO metadata generation
+
+This document describes how the Nuxt frontend consumes SEO metadata and where
+fallbacks are still generated locally.
+
+## Product pages
+
+Product pages use backend data as the source of truth for user-facing SEO
+metadata. The `ProductNamesDto` contract exposes:
+
+- `metaTitle`: backend-computed SERP title.
+- `metaDescription`: backend-computed meta description.
+- `ogTitle`: backend-computed Open Graph title.
+- `ogDescription`: backend-computed Open Graph description.
+
+The frontend keeps local product templates only as resilience fallbacks when a
+legacy API response or partially populated product does not contain these
+fields. New product title improvements should be implemented in `front-api`, not
+in `ProductPage.vue`.
+
+## Category pages
+
+Category and sub-category pages resolve SEO metadata from backend category DTOs
+with visible content as the fallback chain. The shared resolver is
+`app/utils/seo/category-meta.ts`.
+
+Resolution order:
+
+1. sub-category SEO/Open Graph fields;
+2. sub-category visible title or description;
+3. vertical SEO/Open Graph fields;
+4. vertical visible title or description;
+5. site name for empty titles.
+
+Markdown is stripped from descriptions before writing meta tags.
+
+## Static and editorial pages
+
+Static pages, documentation pages, blog pages and CMS/XWiki pages still provide
+metadata from localized frontend resources or their dedicated content APIs. They
+should use shared helpers such as `PageHeader`/`useHeaderSeo` where possible and
+avoid duplicating canonical, Open Graph and JSON-LD boilerplate.
+
+## Canonical URLs
+
+Shared header SEO canonical URLs use the request origin and pathname only. Query
+parameters and fragments are intentionally dropped unless a page implements its
+own explicit canonical URL for indexable query states.
+
+## Rules for future changes
+
+- Backend metadata wins over frontend-generated strings.
+- Frontend fallbacks should be small, explicit and documented near their use.
+- Twitter-specific tags are not allowed.
+- Open Graph fields should be set together with title, description, URL and
+  image when available.

--- a/frontend/shared/api-client/models/ProductNamesDto.ts
+++ b/frontend/shared/api-client/models/ProductNamesDto.ts
@@ -44,6 +44,12 @@ export interface ProductNamesDto {
    */
   seoName?: string
   /**
+   * Backend-computed SEO meta title aligned with the requested language
+   * @type {string}
+   * @memberof ProductNamesDto
+   */
+  metaTitle?: string
+  /**
    * Meta description aligned with the requested language
    * @type {string}
    * @memberof ProductNamesDto
@@ -88,6 +94,7 @@ export function ProductNamesDtoFromJSONTyped(
     cardName: json['cardName'] == null ? undefined : json['cardName'],
     pageTitle: json['pageTitle'] == null ? undefined : json['pageTitle'],
     seoName: json['seoName'] == null ? undefined : json['seoName'],
+    metaTitle: json['metaTitle'] == null ? undefined : json['metaTitle'],
     metaDescription:
       json['metaDescription'] == null ? undefined : json['metaDescription'],
     ogTitle: json['ogTitle'] == null ? undefined : json['ogTitle'],
@@ -113,6 +120,7 @@ export function ProductNamesDtoToJSONTyped(
     cardName: value['cardName'],
     pageTitle: value['pageTitle'],
     seoName: value['seoName'],
+    metaTitle: value['metaTitle'],
     metaDescription: value['metaDescription'],
     ogTitle: value['ogTitle'],
     ogDescription: value['ogDescription'],


### PR DESCRIPTION
### Motivation

- Provide a backend-computed, SERP-safe product title so the frontend can consume authoritative SEO metadata and keep local title templates as a resilience fallback.
- Centralise category SEO resolution on the frontend and normalise canonical URL generation to avoid duplicated logic and markdown noise in meta descriptions.

### Description

- Added `metaTitle` to the backend `ProductNamesDto` and populated it in `ProductMappingService` via `buildProductMetaTitle` with helper methods `resolveProductSeoName`, `resolveVerticalTitle`, `formatSeoScore`, and `truncateAtWordBoundary` to produce a compact, localized SEO title.
- Added a unit test `getProductNamesIncludesBackendComputedMetaTitle` in `ProductMappingServiceTest` to validate the server-side meta title generation.
- Updated generated frontend API model `shared/api-client/models/ProductNamesDto.ts` to include `metaTitle` and updated `ProductPage.vue` to prefer `product.names.metaTitle` when present while preserving fallback templates as `fallbackSeoMeta*` values.
- Introduced a shared frontend resolver `app/utils/seo/category-meta.ts` with `category-meta.spec.ts` tests and changed `CategoryPage.vue` to use `resolveCategorySeoMeta`; also updated `useHeaderSeo` to normalise canonical URLs and added `frontend/docs/seo-metadata.md` with the backend-first SEO contract.

### Testing

- Added and ran the backend unit test `ProductMappingServiceTest#getProductNamesIncludesBackendComputedMetaTitle`, which succeeded.
- Added and ran the frontend Vitest `category-meta.spec.ts`, which succeeded.
- Ran the repository unit test suites for both backend and frontend locally and observed that new and existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd44dad08832996104eb92b740343)