### PR TITLE
fix: b2b-api dead auth surface + GTIN-14 checksum regression

### DIFF
--- a/b2b-api/src/main/java/org/open4goods/b2bapi/config/DashboardJwtAuthenticationFilter.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/config/DashboardJwtAuthenticationFilter.java
@@ -10,7 +10,6 @@ import org.open4goods.b2bapi.service.AuthTokenResolver;
 import org.open4goods.b2bapi.service.DashboardAuthenticationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/controller/AdminController.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/controller/AdminController.java
@@ -13,7 +13,6 @@ import org.open4goods.b2bapi.dto.billing.B2bTransactionDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.open4goods.b2bapi.service.AdminService;
 import org.open4goods.b2bapi.service.DashboardPrincipal;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -32,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Platform Administration", description = "Endpoints for B2B platform administrators")
 @RestController
 @RequestMapping("/api/v1/admin")
-@ConditionalOnBean(name = "entityManagerFactory")
 @PreAuthorize("@organizationRbacService.isPlatformAdmin(authentication)")
 public class AdminController {
 

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/controller/ApiKeyController.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/controller/ApiKeyController.java
@@ -8,7 +8,6 @@ import org.open4goods.b2bapi.dto.ApiKeySecretResponse;
 import org.open4goods.b2bapi.dto.CreateApiKeyRequest;
 import org.open4goods.b2bapi.service.ApiKeyService;
 import org.open4goods.b2bapi.service.DashboardPrincipal;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerBillingController.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerBillingController.java
@@ -12,7 +12,6 @@ import org.open4goods.b2bapi.service.BillingCatalogService;
 import org.open4goods.b2bapi.service.CustomerBillingService;
 import org.open4goods.b2bapi.service.DashboardPrincipal;
 import org.open4goods.b2bapi.service.StripeBillingService;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -28,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/customer/billing")
-@ConditionalOnBean(name = "entityManagerFactory")
 public class CustomerBillingController {
 
     private final BillingCatalogService billingCatalogService;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerPlaygroundController.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerPlaygroundController.java
@@ -29,7 +29,6 @@ import org.open4goods.b2bapi.service.B2bBarcodeCheckService;
 import org.open4goods.b2bapi.service.B2bBarcodeService;
 import org.open4goods.b2bapi.service.B2bProductService;
 import org.open4goods.b2bapi.service.DashboardPrincipal;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.access.AccessDeniedException;
@@ -45,7 +44,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/customer/playground")
-@ConditionalOnBean(name = "entityManagerFactory")
 public class CustomerPlaygroundController {
 
     private final ApiKeyRepository apiKeyRepository;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerSubscriptionController.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/controller/CustomerSubscriptionController.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.open4goods.b2bapi.dto.billing.B2bSubscriptionDto;
 import org.open4goods.b2bapi.service.CustomerBillingService;
 import org.open4goods.b2bapi.service.DashboardPrincipal;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/customer/subscriptions")
-@ConditionalOnBean(name = "entityManagerFactory")
 public class CustomerSubscriptionController {
 
     private final CustomerBillingService customerBillingService;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/AdminService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/AdminService.java
@@ -29,7 +29,6 @@ import org.open4goods.b2bapi.repository.OrganizationRepository;
 import org.open4goods.b2bapi.repository.UsageEventRepository;
 import org.open4goods.b2bapi.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -39,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
  * Service providing administrative functions for platform oversight.
  */
 @Service
-@ConditionalOnBean(name = "entityManagerFactory")
 public class AdminService {
 
     private final OrganizationRepository organizationRepository;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/ApiKeyService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/ApiKeyService.java
@@ -15,7 +15,6 @@ import org.open4goods.b2bapi.repository.OrganizationRepository;
 import org.open4goods.b2bapi.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/AuthService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/AuthService.java
@@ -2,14 +2,12 @@ package org.open4goods.b2bapi.service;
 
 import org.open4goods.b2bapi.dto.AuthResponse;
 import org.open4goods.b2bapi.model.OidcProvider;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 
 /**
  * Coordinates provider verification, provisioning, and JWT issuance.
  */
 @Service
-@ConditionalOnBean(name = "entityManagerFactory")
 public class AuthService {
 
     private final OidcVerifierService oidcVerifierService;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/DashboardAuthenticationService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/DashboardAuthenticationService.java
@@ -3,7 +3,6 @@ package org.open4goods.b2bapi.service;
 import java.util.ArrayList;
 import java.util.List;
 import org.open4goods.b2bapi.model.OrganizationRole;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/DashboardSessionService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/DashboardSessionService.java
@@ -6,7 +6,6 @@ import org.open4goods.b2bapi.repository.CreditBucketRepository;
 import org.open4goods.b2bapi.repository.OrganizationMemberRepository;
 import org.open4goods.b2bapi.repository.OrganizationRepository;
 import org.open4goods.b2bapi.repository.UserRepository;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/b2b-api/src/main/java/org/open4goods/b2bapi/service/UserProvisioningService.java
+++ b/b2b-api/src/main/java/org/open4goods/b2bapi/service/UserProvisioningService.java
@@ -14,7 +14,6 @@ import org.open4goods.b2bapi.repository.OrganizationMemberRepository;
 import org.open4goods.b2bapi.repository.OrganizationRepository;
 import org.open4goods.b2bapi.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -23,7 +22,6 @@ import org.springframework.util.StringUtils;
  * Provisions and updates dashboard users from verified OIDC identities.
  */
 @Service
-@ConditionalOnBean(name = "entityManagerFactory")
 public class UserProvisioningService {
 
     private final B2bApiProperties properties;

--- a/commons/src/main/java/org/open4goods/commons/services/BarcodeValidationService.java
+++ b/commons/src/main/java/org/open4goods/commons/services/BarcodeValidationService.java
@@ -6,7 +6,6 @@ import java.util.AbstractMap.SimpleEntry;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.ISBNValidator;
-import org.apache.commons.validator.routines.checkdigit.EAN13CheckDigit;
 import org.open4goods.model.product.BarcodeType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,8 +60,10 @@ public class BarcodeValidationService {
 		}
 
 
-		// EAN13
-		if (EAN13CheckDigit.EAN13_CHECK_DIGIT.isValid(barcode)) {
+		// GTIN (EAN/UPC family). The GS1 check-digit algorithm is the same weighted
+		// modulus-10 sum regardless of length (8/12/13/14 digits), so it is computed
+		// directly here rather than delegated to a length-specific validator class.
+		if (isValidGtinCheckDigit(barcode)) {
 
 			if (barcode.length() == 8 ) {
 				return new AbstractMap.SimpleEntry<BarcodeType, String>(BarcodeType.GTIN_8, barcode);
@@ -79,6 +80,32 @@ public class BarcodeValidationService {
 		return new AbstractMap.SimpleEntry<BarcodeType, String>(BarcodeType.UNKNOWN, barcode);
 	}
 
+	/**
+	 * Validates the GS1 check digit (used by EAN-8/12/13 and GTIN-14 barcodes).
+	 * <p>
+	 * Working from the digit immediately left of the check digit, weights alternate
+	 * 3/1; this is independent of the total barcode length, unlike
+	 * {@code org.apache.commons.validator.routines.checkdigit.EAN13CheckDigit},
+	 * which as of commons-validator 1.11.0 only accepts 13-digit input.
+	 *
+	 * @param barcode digits-only barcode, including its trailing check digit
+	 * @return {@code true} when the trailing digit matches the computed check digit
+	 */
+	private static boolean isValidGtinCheckDigit(String barcode) {
+		if (!StringUtils.isNumeric(barcode) || barcode.length() < 8) {
+			return false;
+		}
 
+		int sum = 0;
+		boolean weightThree = true;
+		for (int i = barcode.length() - 2; i >= 0; i--) {
+			sum += Character.digit(barcode.charAt(i), 10) * (weightThree ? 3 : 1);
+			weightThree = !weightThree;
+		}
+
+		int checkDigit = Character.digit(barcode.charAt(barcode.length() - 1), 10);
+		int computedCheckDigit = (10 - (sum % 10)) % 10;
+		return computedCheckDigit == checkDigit;
+	}
 
 }


### PR DESCRIPTION
## Summary

Two independent build-blocking / production-affecting bugs found while chasing the CI failure on #3313.

**1. `@ConditionalOnBean(name = "entityManagerFactory")` never worked (b2b-api)**

11 classes (`AuthService`, `AdminService`, `UserProvisioningService`, `AuthController`*, `DashboardSessionService`*, `DashboardAuthenticationService`*, `DashboardJwtAuthenticationFilter`*, `AdminController`, `CustomerBillingController`, `CustomerSubscriptionController`, `CustomerPlaygroundController`) used this guard to stay absent without a datasource. Confirmed via Spring's condition-evaluation report against a real Postgres testcontainer: it **always** resolves to "bean not found," DB configured or not, because component-scanned bean definitions are registered before deferred auto-configurations (JPA's included) run.

Practical effect: `/api/v1/auth/**`, `/api/v1/admin/**`, `/api/v1/customer/billing/**`, `/api/v1/customer/subscription/**`, `/api/v1/customer/playground/**` have likely 404'd in every environment, prod included — `spring.datasource.url` always has a default, there's no real no-DB deployment mode. This also caused a startup crash (`AuthController` needs the now-permanently-absent `AuthService` but had no guard of its own), which is what broke `ApiKeyControllerIntegrationTest` / `BarcodeControllerIntegrationTest` / `CreditGrantServiceTest` (52 errors) in CI on #3313.

Removed the annotation (and dangling import) from all 11, plus the same dangling unused import from `ApiKeyService`/`ApiKeyController` (never had the annotation, just the leftover import — same partial-refactor fingerprint). `B2bApiApplicationTests` and `BillingCatalogPropertiesTest` already mock every JPA repository these classes need, so both keep passing unchanged with `DataSourceAutoConfiguration` excluded.

*(classes marked * were added by me in a first pass to fix the startup crash before finding the guard itself was broken — see conversation history on #3313)*

**2. GTIN-14 checksum broken by `commons-validator` 1.10.1 → 1.11.0** (`#3312`)

`EAN13CheckDigit.isValid()` now rejects non-13-digit input (verified against both jar versions directly). `BarcodeValidationService` relied on the old leniency to validate GTIN-8/12/14 too, since the GS1 checksum algorithm is length-independent. Replaced the delegated call with a direct, length-agnostic implementation of that same algorithm, hand-verified against the GTIN-13 and GTIN-14 test vectors. This was blocking the reactor at `commons`, before any downstream module (including b2b-api) could even build.

## Test plan
- [x] `mvn -pl commons test -Dtest=BarcodeTest,BarcodeForensicsServiceTest` — pass
- [x] `mvn -pl b2b-api test` — 161/161 pass (was 52 errors + 5 failures before this PR)
- [x] `mvn -T 1C clean install` (full reactor) — exit 0, zero `[ERROR]` lines
- [ ] Confirm on beta that `/api/v1/auth/**` etc. actually respond post-deploy (previously 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBUc2aZKir1uzzZfXNxS4W