### PR TITLE
fix: pin opentelemetry-semconv to the version elasticsearch-java expects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,14 @@
                 <sleepycat-je.version>18.3.12</sleepycat-je.version>
                 <commons-io.version>2.22.0</commons-io.version>
                 <commons-text.version>1.15.0</commons-text.version>
+                <!-- co.elastic.clients:elasticsearch-java (via spring-data-elasticsearch) itself
+                     depends on opentelemetry-semconv:1.41.1, but Spring Boot's dependency-management
+                     BOM pins an older 1.29.0-alpha that Maven's nearest-wins mediation prefers,
+                     shading a version without io.opentelemetry.semconv.DbAttributes into the fat
+                     jar. That crashes SimpleElasticsearchRepository construction with a
+                     NoClassDefFoundError at boot. Pin the version elasticsearch-java itself asks
+                     for; see elasticsearch-java-9.4.5.pom. -->
+                <opentelemetry-semconv.version>1.41.1</opentelemetry-semconv.version>
                 <maven-compiler-plugin.version>3.16.0</maven-compiler-plugin.version>
                 <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
                 <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
@@ -175,6 +183,11 @@
 				<groupId>com.sleepycat</groupId>
 				<artifactId>je</artifactId>
 				<version>${sleepycat-je.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.opentelemetry.semconv</groupId>
+				<artifactId>opentelemetry-semconv</artifactId>
+				<version>${opentelemetry-semconv.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Problem

`co.elastic.clients:elasticsearch-java` (via `spring-data-elasticsearch`, currently resolving to 9.4.5) declares `io.opentelemetry.semconv:opentelemetry-semconv:1.41.1` as its own runtime dependency, but Spring Boot's dependency-management BOM pins the older `1.29.0-alpha`, which wins under Maven's nearest-wins mediation. The fat jar ships a semconv version missing `io.opentelemetry.semconv.DbAttributes`, which elasticsearch-java's OpenTelemetry instrumentation references the first time any `SimpleElasticsearchRepository` is constructed.

**Live impact confirmed on beta today**: `api` failed this way after a routine restart, got stuck retrying instead of exiting, and never came back up. Only prod avoided it because it's currently on a release predating the elasticsearch-java bump to 9.4.x — this same crash is latent for prod's next release too.

## Fix

Pin `io.opentelemetry.semconv:opentelemetry-semconv` in the root `dependencyManagement` to `1.41.1`, the version elasticsearch-java itself asks for.

## Verification

- `mvn -pl api -am dependency:tree`: every occurrence of the artifact now resolves to `1.41.1` (previously two versions coexisted in the tree)
- `mvn -pl api -am install`: the resulting jar bundles only `opentelemetry-semconv-1.41.1.jar` under `BOOT-INF/lib/`
- `mvn -pl api -am test`: passes
- Deployed the fixed jar to beta by hand (CI is currently red for unrelated reasons) and restarted `api`, `front-api`, `ui`: all three boot clean, zero `NoClassDefFoundError`, all healthchecks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)