### PR TITLE
chore(work): block owner-gated WorkOrders; feat: Nuxt-native blog sitemap

### DIFF
--- a/.o4g/corpus-budget.json
+++ b/.o4g/corpus-budget.json
@@ -26,7 +26,7 @@
     "non_normative_lines": 6011,
     "rule_shaped_statements_in_non_normative": 136,
     "normative_documents": 11,
-    "work_open_lines": 595,
+    "work_open_lines": 569,
     "work_ledger_lines": 689,
     "adr_lines_max": 120
   }

--- a/.o4g/corpus-budget.json
+++ b/.o4g/corpus-budget.json
@@ -26,7 +26,7 @@
     "non_normative_lines": 6011,
     "rule_shaped_statements_in_non_normative": 136,
     "normative_documents": 11,
-    "work_open_lines": 569,
+    "work_open_lines": 582,
     "work_ledger_lines": 689,
     "adr_lines_max": 120
   }

--- a/.o4g/work/config-contract-and-environments.yml
+++ b/.o4g/work/config-contract-and-environments.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   purpose: Classify every legacy configuration asset and establish public defaults and private environment inputs.
   roadmapRef: m1-config-autonomy
-  state: IN_PROGRESS
+  state: BLOCKED
   dependsOn:
     - governance-kit-bootstrap
   decisionRefs:
@@ -20,29 +20,29 @@ spec:
     - scripts/python/lint_suite.py
   acceptanceCriteria:
     - id: AC1
-      statement: >-
-        DONE. docs/operations/legacy-config-inventory.md classifies all 157 tracked assets of open4good/open4goods-config (git ls-files
-        ground truth at origin/main HEAD e9ebc878f) by file glob, with a key-level appendix for the files that mix classes (the ten
-        application-active.yml, the .env files, kibana.yml, server.xml/xwiki.cfg*). Surfaced three findings outside this AC's scope,
-        recorded in the document rather than acted on -- a live kibana_system Elasticsearch password in docker-compose/beta/kibana.yml (new
-        exposure, candidate for a new leaked-credential-rotation AC), a likely-stale literal GitHub runner token in two doc/example files,
-        and configs/prod/infra/.env being 0 bytes versus beta's four keys (an AC2 candidate for one of the "four missing references").
-        Untracked local content in the audited checkout (personal documents, provisioning artifacts) is out of AC1's "tracked legacy asset"
-        scope, noted separately.
+      statement: DONE. docs/operations/legacy-config-inventory.md classifies all 157 tracked assets of open4good/open4goods-config
+        (git ls-files ground truth at origin/main HEAD e9ebc878f) by file glob, with a key-level appendix for the files that
+        mix classes (the ten application-active.yml, the .env files, kibana.yml, server.xml/xwiki.cfg*). Surfaced three findings
+        outside this AC's scope, recorded in the document rather than acted on -- a live kibana_system Elasticsearch password
+        in docker-compose/beta/kibana.yml (new exposure, candidate for a new leaked-credential-rotation AC), a likely-stale
+        literal GitHub runner token in two doc/example files, and configs/prod/infra/.env being 0 bytes versus beta's four
+        keys (an AC2 candidate for one of the "four missing references"). Untracked local content in the audited checkout
+        (personal documents, provisioning artifacts) is out of AC1's "tracked legacy asset" scope, noted separately.
     - id: AC2
       statement: Environments beta and prod hold nine legacy-only secrets, reuse five organization secrets and resolve four
         missing references.
     - id: AC3
-      statement: >-
-        DONE. All 7 services (@SpringBootApplication) ship a packaged application.yml with only non-secret defaults:
-        admin had none (added one, moved secrets to devsec); front-api's shared-token gained jwt-secret's indirection.
+      statement: 'DONE. All 7 services (@SpringBootApplication) ship a packaged application.yml with only non-secret defaults:
+        admin had none (added one, moved secrets to devsec); front-api''s shared-token gained jwt-secret''s indirection.'
     - id: AC4
-      statement: >-
-        PARTIAL. scripts/verify/check_deployment_inputs.py (in lint.sh) checks workflow secrets./vars. refs against
-        ops/config/deployment-inputs.yml: fails unclassified names, cross-store/literal-fallback duplicates and
-        log-printing steps. All 8 refs pass; cross-environment duplication isn't checkable without a GitHub Environment.
+      statement: 'PARTIAL. scripts/verify/check_deployment_inputs.py (in lint.sh) checks workflow secrets./vars. refs against
+        ops/config/deployment-inputs.yml: fails unclassified names, cross-store/literal-fallback duplicates and log-printing
+        steps. All 8 refs pass; cross-environment duplication isn''t checkable without a GitHub Environment.'
   evidenceRefs:
-    - 'note: 2026-09-09 -- AC1 read-only audit, no writes. AC2 needs undelegated secret-admin access. AC3/AC4:
-        admin/front-api compile+boot clean, lint.sh (incl. deployment-inputs check) passed; no prod/secret access.
-        AC4 widened pathScope to scripts/verify/** and scripts/python/lint_suite.py (the check and its lint.sh
-        wiring) and raised work_open_lines via check_corpus_budget.py --update, both in this commit.'
+    - 'note: 2026-09-09 -- AC1 read-only audit, no writes. AC2 needs undelegated secret-admin access. AC3/AC4: admin/front-api
+      compile+boot clean, lint.sh (incl. deployment-inputs check) passed; no prod/secret access. AC4 widened pathScope to
+      scripts/verify/** and scripts/python/lint_suite.py (the check and its lint.sh wiring) and raised work_open_lines via
+      check_corpus_budget.py --update, both in this commit.'
+    - 'note: 2026-09-09 -- `gh api repos/open4good/open4goods/environments` shows only github-pages/test-github-pages: no
+      beta or prod Environment exists. AC2 and AC4''s remainder need creating and populating those, which is repository
+      administration withheld by prompts/nudger-dev.md. Formalized as BLOCKED so next-workorder.py stops resurfacing it.'

--- a/.o4g/work/leaked-credential-rotation.yml
+++ b/.o4g/work/leaked-credential-rotation.yml
@@ -1,17 +1,17 @@
 apiVersion: open4goods.org/v1
 kind: WorkOrder
-metadata: {id: leaked-credential-rotation, name: Leaked credential rotation}
+metadata:
+  id: leaked-credential-rotation
+  name: Leaked credential rotation
 spec:
-  purpose: >-
-    A production password was in this public repository's main-branch history since 2024-01-15
-    and was still live on both beta and prod. Live inspection of the running servers (root SSH)
-    found it reused far wider than the config repo alone suggested: it was the literal value, or
-    the shared base of a composite value, behind eleven distinct config entries across four
-    services and both environments. XWiki's share of that (AC4) is rotated end to end on both real
-    hosts. The rest (AC3: SBA password, api's admin-key/feed.api-key, the icecat apiKey, front-api's
-    two matching api-keys) and the independent AWIN leak (AC5) remain open.
+  purpose: 'A production password was in this public repository''s main-branch history since 2024-01-15 and was still live
+    on both beta and prod. Live inspection of the running servers (root SSH) found it reused far wider than the config repo
+    alone suggested: it was the literal value, or the shared base of a composite value, behind eleven distinct config entries
+    across four services and both environments. XWiki''s share of that (AC4) is rotated end to end on both real hosts. The
+    rest (AC3: SBA password, api''s admin-key/feed.api-key, the icecat apiKey, front-api''s two matching api-keys) and the
+    independent AWIN leak (AC5) remain open.'
   roadmapRef: m1-config-autonomy
-  state: IN_PROGRESS
+  state: BLOCKED
   pathScope:
     - docs/operations/**
     - .gitleaks.toml
@@ -19,143 +19,108 @@ spec:
     - .gitignore
   acceptanceCriteria:
     - id: AC1
-      statement: >-
-        Confirmed by direct pickaxe against origin/main and by live inspection of both hosts
-        (2026-09-08): the value from 1c52414e3 (removed six minutes later in 3bc7194e5, both
-        ancestors of origin/main) is today's XWiki password on api/front-api/ui, today's Spring
-        Boot Admin instance-auth/client password on admin/api/front-api/ui, and the shared base of
-        api's admin-key (grants ROLE_ADMIN via a URL parameter -- see WebSecurityConfig), api's
-        feed.api-key, an icecat completion apiKey, and front-api's affiliation-partners and
-        review-generation api-keys (which exist only because they must equal api's admin-key for
-        front-api's calls into api to authenticate). Eleven lines on prod, matching on beta.
+      statement: 'Confirmed by direct pickaxe against origin/main and by live inspection of both hosts (2026-09-08): the value
+        from 1c52414e3 (removed six minutes later in 3bc7194e5, both ancestors of origin/main) is today''s XWiki password
+        on api/front-api/ui, today''s Spring Boot Admin instance-auth/client password on admin/api/front-api/ui, and the shared
+        base of api''s admin-key (grants ROLE_ADMIN via a URL parameter -- see WebSecurityConfig), api''s feed.api-key, an
+        icecat completion apiKey, and front-api''s affiliation-partners and review-generation api-keys (which exist only because
+        they must equal api''s admin-key for front-api''s calls into api to authenticate). Eleven lines on prod, matching
+        on beta.'
     - id: AC2
-      statement: >-
-        A SECOND, independently-confirmed leak: AWIN's affiliate access-token (and the same value
-        embedded as an apikey path segment in the AWIN catalog URL) is readable in a 89,330-line
-        application log (devsec-api.log) committed to origin/main from 2026-06-10 to 2026-06-12,
-        and still matches the live AWIN credential today. Found by discovering that this repository
-        has committed at least 25 debug/startup log files across its history, none of them via a
-        general *.log gitignore rule -- only three specific filenames were ever excluded.
+      statement: 'A SECOND, independently-confirmed leak: AWIN''s affiliate access-token (and the same value embedded as an
+        apikey path segment in the AWIN catalog URL) is readable in a 89,330-line application log (devsec-api.log) committed
+        to origin/main from 2026-06-10 to 2026-06-12, and still matches the live AWIN credential today. Found by discovering
+        that this repository has committed at least 25 debug/startup log files across its history, none of them via a general
+        *.log gitignore rule -- only three specific filenames were ever excluded.'
     - id: AC3
-      statement: >-
-        Every non-XWiki occurrence in AC1 (the SBA password, api's admin-key, api's feed.api-key,
-        the icecat apiKey, and front-api's two matching api-keys) is rotated to one new shared
-        value across beta and prod. This is self-contained: both ends of each of these are our own
-        Spring config, so no external system needs to separately learn the new value. BLOCKED
-        pending a decision on execution mechanism -- see the note below.
+      statement: 'Every non-XWiki occurrence in AC1 (the SBA password, api''s admin-key, api''s feed.api-key, the icecat apiKey,
+        and front-api''s two matching api-keys) is rotated to one new shared value across beta and prod. This is self-contained:
+        both ends of each of these are our own Spring config, so no external system needs to separately learn the new value.
+        BLOCKED pending a decision on execution mechanism -- see the note below.'
     - id: AC4
-      statement: >-
-        DONE on prod and on the config directory for beta held on the prod host (2026-09-08). The
-        correct REST base was found by reading XWikiConstantsResourcesPath and
-        XWikiServiceProperties: XWiki runs at the Tomcat ROOT context, so the real path is
-        `{baseUrl}/rest/...` with no `/xwiki/` segment -- the original probe's `/xwiki/rest/...` was
-        wrong. The residual 401-for-both-passwords turned out to be a real account lockout, not a
-        probing artifact; the owner unlocked the `o4g` account directly, after which the current
-        (leaked) password authenticated cleanly. Rotated via XWiki's own documented REST mechanism
-        -- PUT a new value to .../objects/XWiki.XWikiUsers/0/properties/password, authenticated with
-        the current password -- verified old-password-401 / new-password-200 before touching any
-        config file. The new value was then written into xwiki.password in
-        prod/{api,front-api,ui}/application-active.yml and beta/{api,front-api,ui}/application-active.yml
-        on the prod host (owner-authorized SSH write, after the harness blocked the earlier
-        unattended attempt), and prod's three services were restarted and confirmed calling XWiki's
-        real REST endpoints successfully (200) post-restart, with only a pre-existing, unrelated 401
-        on a dead code path (XWikiAuthenticationService.login(), which targets a wiki page --
-        testGroups.currentUserGroups -- that a REST query confirms does not exist; same failure
-        before and after rotation).
+      statement: 'DONE on prod and on the config directory for beta held on the prod host (2026-09-08). The correct REST base
+        was found by reading XWikiConstantsResourcesPath and XWikiServiceProperties: XWiki runs at the Tomcat ROOT context,
+        so the real path is `{baseUrl}/rest/...` with no `/xwiki/` segment -- the original probe''s `/xwiki/rest/...` was
+        wrong. The residual 401-for-both-passwords turned out to be a real account lockout, not a probing artifact; the owner
+        unlocked the `o4g` account directly, after which the current (leaked) password authenticated cleanly. Rotated via
+        XWiki''s own documented REST mechanism -- PUT a new value to .../objects/XWiki.XWikiUsers/0/properties/password, authenticated
+        with the current password -- verified old-password-401 / new-password-200 before touching any config file. The new
+        value was then written into xwiki.password in prod/{api,front-api,ui}/application-active.yml and beta/{api,front-api,ui}/application-active.yml
+        on the prod host (owner-authorized SSH write, after the harness blocked the earlier unattended attempt), and prod''s
+        three services were restarted and confirmed calling XWiki''s real REST endpoints successfully (200) post-restart,
+        with only a pre-existing, unrelated 401 on a dead code path (XWikiAuthenticationService.login(), which targets a wiki
+        page -- testGroups.currentUserGroups -- that a REST query confirms does not exist; same failure before and after rotation).'
     - id: AC4a
-      statement: >-
-        INCIDENT, self-caused, resolved same session. Attempting to apply the same restart to
-        "beta's api" on the prod host (root@136.243.46.60) -- there is no separate beta instance
-        running there; beta and prod share that host's ports and this script's PID/stop handling --
-        killed the *running prod* api process instead. publish-jars.sh's stop step is not
-        environment-scoped and matched whichever "api" process it found, leaving prod's api down for
-        roughly 4 minutes (10:37:59-10:42 UTC) before `publish-jars.sh prod restart api` restored it.
-        All five prod services confirmed healthy immediately after. The three application-active.yml
-        edits made on this host under configs/beta/** were harmless residue in a directory nothing
-        reads -- see AC4b for the real beta host.
+      statement: INCIDENT, self-caused, resolved same session. Attempting to apply the same restart to "beta's api" on the
+        prod host (root@136.243.46.60) -- there is no separate beta instance running there; beta and prod share that host's
+        ports and this script's PID/stop handling -- killed the *running prod* api process instead. publish-jars.sh's stop
+        step is not environment-scoped and matched whichever "api" process it found, leaving prod's api down for roughly 4
+        minutes (10:37:59-10:42 UTC) before `publish-jars.sh prod restart api` restored it. All five prod services confirmed
+        healthy immediately after. The three application-active.yml edits made on this host under configs/beta/** were harmless
+        residue in a directory nothing reads -- see AC4b for the real beta host.
     - id: AC4b
-      statement: >-
-        DONE. The owner supplied the real beta host (root@148.251.124.144, hostname NUDGER-BETA,
-        distinct machine, confirmed via the deployConfiguration.yml run that had already rsynced
-        configs/beta/** there -- see the config-repository-elimination sync note). Verified its
-        xwiki.password already carried the new value (delivered by that same config-repo push, not
-        by any SSH edit) before touching anything. Restarting api there surfaced an UNRELATED,
-        pre-existing production bug (see AC10) that left api stuck retrying and off port 8081 for the
-        rest of this AC's duration; fixed and redeployed per AC10, after which api, front-api and ui
-        were each restarted individually and confirmed healthy (401/302/400 in the expected pattern
-        for this host) with zero XWiki-auth failures in any of their logs. sbadmin and b2b-api were
-        untouched (b2b-api holds no XWiki credential; sbadmin was already healthy). XWiki rotation is
-        now fully propagated: every one of the six config locations from AC1 carries the new value,
-        and every process that reads one has been restarted since.
+      statement: 'DONE. The owner supplied the real beta host (root@148.251.124.144, hostname NUDGER-BETA, distinct machine,
+        confirmed via the deployConfiguration.yml run that had already rsynced configs/beta/** there -- see the config-repository-elimination
+        sync note). Verified its xwiki.password already carried the new value (delivered by that same config-repo push, not
+        by any SSH edit) before touching anything. Restarting api there surfaced an UNRELATED, pre-existing production bug
+        (see AC10) that left api stuck retrying and off port 8081 for the rest of this AC''s duration; fixed and redeployed
+        per AC10, after which api, front-api and ui were each restarted individually and confirmed healthy (401/302/400 in
+        the expected pattern for this host) with zero XWiki-auth failures in any of their logs. sbadmin and b2b-api were untouched
+        (b2b-api holds no XWiki credential; sbadmin was already healthy). XWiki rotation is now fully propagated: every one
+        of the six config locations from AC1 carries the new value, and every process that reads one has been restarted since.'
     - id: AC10
-      statement: >-
-        DONE, filed here because it was found while executing AC4b, not because it is related to the
-        leak. api on the real beta host failed every restart with `NoClassDefFoundError:
-        io/opentelemetry/semconv/DbAttributes`: elasticsearch-java (resolving to 9.4.5 at HEAD,
-        confirmed with `mvn dependency:tree`) declares opentelemetry-semconv:1.41.1 as its own
-        runtime dependency, but Spring Boot's BOM pins the older 1.29.0-alpha, which wins under
-        Maven's nearest-wins mediation and lacks that class. This is latent for prod's next release
-        too -- prod is simply still on an older build that resolves elasticsearch-java 9.2.8, which
-        doesn't hit the code path. Fixed at the source (pom.xml dependencyManagement pins
-        opentelemetry-semconv to 1.41.1) in PR #3317, verified by `mvn test` and by a hand-deployed
-        jar restoring beta (CI is red for unrelated reasons, so the normal build-and-deploy path
-        wasn't available for the immediate fix).
+      statement: 'DONE, filed here because it was found while executing AC4b, not because it is related to the leak. api on
+        the real beta host failed every restart with `NoClassDefFoundError: io/opentelemetry/semconv/DbAttributes`: elasticsearch-java
+        (resolving to 9.4.5 at HEAD, confirmed with `mvn dependency:tree`) declares opentelemetry-semconv:1.41.1 as its own
+        runtime dependency, but Spring Boot''s BOM pins the older 1.29.0-alpha, which wins under Maven''s nearest-wins mediation
+        and lacks that class. This is latent for prod''s next release too -- prod is simply still on an older build that resolves
+        elasticsearch-java 9.2.8, which doesn''t hit the code path. Fixed at the source (pom.xml dependencyManagement pins
+        opentelemetry-semconv to 1.41.1) in PR #3317, verified by `mvn test` and by a hand-deployed jar restoring beta (CI
+        is red for unrelated reasons, so the normal build-and-deploy path wasn''t available for the immediate fix).'
     - id: AC5
-      statement: >-
-        DEFERRED by owner decision (2026-09-08). The AWIN access-token is rotated. This cannot be
-        done from here at all: AWIN only issues a new token through the affiliate's own dashboard, a
-        third party we have no credentials for.
+      statement: 'DEFERRED by owner decision (2026-09-08). The AWIN access-token is rotated. This cannot be done from here
+        at all: AWIN only issues a new token through the affiliate''s own dashboard, a third party we have no credentials
+        for.'
     - id: AC6
-      statement: >-
-        DONE. A general `*.log` rule is added to .gitignore, verified to ignore an untracked
-        excalidraw.log left over from this session. pathScope widened to include .gitignore itself,
-        which the original contract omitted. One pre-existing tracked log survives
-        (b2b-frontend/build.log, harmless build output, no secret content) -- gitignore does not
-        retroactively untrack it, and untracking it is a separate concern outside this AC's
-        statement.
+      statement: DONE. A general `*.log` rule is added to .gitignore, verified to ignore an untracked excalidraw.log left
+        over from this session. pathScope widened to include .gitignore itself, which the original contract omitted. One pre-existing
+        tracked log survives (b2b-frontend/build.log, harmless build output, no secret content) -- gitignore does not retroactively
+        untrack it, and untracking it is a separate concern outside this AC's statement.
     - id: AC7
-      statement: >-
-        DONE, no action required. Re-verified 2026-09-09: `git log -p --follow` on
-        b2b-api/src/main/resources/application.yml shows the jwt-secret line has exactly one
-        revision, its introduction in ac4583147, and the value committed there already was the
-        placeholder `change-me-dev-only-change-me-dev-only` -- there was never a real secret in this
-        file to regenerate. Combined with production's B2B_JWT_SECRET env-var override (previously
-        confirmed absent from every config file on the host), this was never a live production
-        exposure.
+      statement: 'DONE, no action required. Re-verified 2026-09-09: `git log -p --follow` on b2b-api/src/main/resources/application.yml
+        shows the jwt-secret line has exactly one revision, its introduction in ac4583147, and the value committed there already
+        was the placeholder `change-me-dev-only-change-me-dev-only` -- there was never a real secret in this file to regenerate.
+        Combined with production''s B2B_JWT_SECRET env-var override (previously confirmed absent from every config file on
+        the host), this was never a live production exposure.'
     - id: AC8
-      statement: >-
-        The production Elasticsearch IP is removed from docs/operations/product-data-api-local-runbook.md.
-        DONE.
+      statement: The production Elasticsearch IP is removed from docs/operations/product-data-api-local-runbook.md. DONE.
     - id: AC9
-      statement: >-
-        A secret-scanning gate runs in CI (gitleaks, a rule matching the shape that actually leaked
-        here plus the default ruleset) so a commit reintroducing a bare credential fails before
-        merge, and a weekly scheduled run covers what a PR-scoped scan cannot. DONE and committed
-        (0cb0de7c0, "security: add secret scanning, scrub a public IP, record the real rotation
-        scope") -- this statement's earlier "not yet committed" was stale; corrected 2026-09-09.
+      statement: 'A secret-scanning gate runs in CI (gitleaks, a rule matching the shape that actually leaked here plus the
+        default ruleset) so a commit reintroducing a bare credential fails before merge, and a weekly scheduled run covers
+        what a PR-scoped scan cannot. DONE and committed (0cb0de7c0, "security: add secret scanning, scrub a public IP, record
+        the real rotation scope") -- this statement''s earlier "not yet committed" was stale; corrected 2026-09-09.'
   evidenceRefs:
-    - 'note: 2026-09-08 -- attempted to execute AC3 end-to-end via the already-approved root SSH
-        to the prod host: generated a new value, wrote a verified line-by-line replacement script
-        (refuses if a target line does not match its expected key, so a drifted file fails loudly
-        rather than corrupting something else), took an on-host backup of all eight files. The
-        harness auto-mode classifier blocked every attempt to transfer or run that script against
-        the live host, distinctly from the many read-only SSH commands used for diagnosis, which
-        all went through. Read that as a deliberate boundary on unattended production-secret
-        mutation rather than something to route around -- stopped and handed the decision to the
-        owner instead of retrying under a different shape. Backups exist at
-        /root/config-backup-<date>/ on the prod host; nothing was written beyond that.'
-    - 'note: 2026-09-08 -- owner unlocked the o4g XWiki account and authorized the SSH config write
-        explicitly. XWiki password rotated and verified via the product REST API (not a file edit)
-        before any config file was touched, per canonical decision 9''s standard of verifying a
-        claim before writing it down. Config files updated via owner-authorized inline SSH edits
-        (single command per file, current value read back and length-checked, not printed). See
-        AC4a for the same-session incident this caused on prod and its resolution.'
-    - 'note: 2026-09-09 -- resumed IN_PROGRESS lot, no production access. Closed AC6 (general *.log
-        .gitignore rule, pathScope widened to include .gitignore), re-verified and closed AC7 (b2b-api
-        jwt-secret was always the dev-only placeholder, never a live secret -- git log -p --follow
-        confirms a single revision), and corrected AC9''s stale "not yet committed" note against
-        current git history (0cb0de7c0). AC3 remains BLOCKED: this session''s "go ahead on workorders
-        implementation" instruction did not name production credential rotation, and prompts/nudger-
-        dev.md explicitly withholds authorization for secret rotation from the autonomous loop --
-        deferred to the owner, unchanged from the 2026-09-08 note above. AC5 unchanged (owner-deferred,
-        third-party dependency). test: ./scripts/lint.sh passed after these edits.'
+    - 'note: 2026-09-08 -- attempted to execute AC3 end-to-end via the already-approved root SSH to the prod host: generated
+      a new value, wrote a verified line-by-line replacement script (refuses if a target line does not match its expected
+      key, so a drifted file fails loudly rather than corrupting something else), took an on-host backup of all eight files.
+      The harness auto-mode classifier blocked every attempt to transfer or run that script against the live host, distinctly
+      from the many read-only SSH commands used for diagnosis, which all went through. Read that as a deliberate boundary
+      on unattended production-secret mutation rather than something to route around -- stopped and handed the decision to
+      the owner instead of retrying under a different shape. Backups exist at /root/config-backup-<date>/ on the prod host;
+      nothing was written beyond that.'
+    - 'note: 2026-09-08 -- owner unlocked the o4g XWiki account and authorized the SSH config write explicitly. XWiki password
+      rotated and verified via the product REST API (not a file edit) before any config file was touched, per canonical decision
+      9''s standard of verifying a claim before writing it down. Config files updated via owner-authorized inline SSH edits
+      (single command per file, current value read back and length-checked, not printed). See AC4a for the same-session incident
+      this caused on prod and its resolution.'
+    - 'note: 2026-09-09 -- resumed IN_PROGRESS lot, no production access. Closed AC6 (general *.log .gitignore rule, pathScope
+      widened to include .gitignore), re-verified and closed AC7 (b2b-api jwt-secret was always the dev-only placeholder,
+      never a live secret -- git log -p --follow confirms a single revision), and corrected AC9''s stale "not yet committed"
+      note against current git history (0cb0de7c0). AC3 remains BLOCKED: this session''s "go ahead on workorders implementation"
+      instruction did not name production credential rotation, and prompts/nudger- dev.md explicitly withholds authorization
+      for secret rotation from the autonomous loop -- deferred to the owner, unchanged from the 2026-09-08 note above. AC5
+      unchanged (owner-deferred, third-party dependency). test: ./scripts/lint.sh passed after these edits.'
+    - 'note: 2026-09-09 -- resumed IN_PROGRESS lot. AC1,2,4,4a,4b,6,7,8,9,10 are DONE. AC3 (rotate the SBA/admin-key/feed.api-key/icecat/front-api
+      values) is production secret rotation, explicitly withheld from the autonomous loop by prompts/nudger-dev.md; AC5 (AWIN
+      token) needs the affiliate dashboard, a third party we hold no credentials for. Both are owner-gated, unchanged since
+      2026-09-08/09. Formalized as BLOCKED so next-workorder.py stops resurfacing this ahead of unblocked work.'

--- a/.o4g/work/xwiki-editorial-content-to-nuxt-content.yml
+++ b/.o4g/work/xwiki-editorial-content-to-nuxt-content.yml
@@ -26,9 +26,18 @@ spec:
         and SSR coverage tests pass against the new authored content. Dropped the original "parity" framing: with no XWiki
         export as source of truth for this content, there is nothing to hold parity against.'
     - id: AC3
-      statement: Nuxt owns editorial and blog sitemaps while ui retains product, brand, image and open-data responsibilities.
+      statement: 'PARTIAL. Blog now has a real Nuxt-native sitemap (server/plugins/sitemap-blog-posts.ts): the reserved
+        blog-posts.xml was never written by ui, so blog had zero coverage before. Editorial routes were already Nuxt-owned
+        via main-pages.xml''s static-route scan. Remaining: ui''s wiki-pages.xml still duplicates those routes via a live-XWiki
+        call unverifiable from here -- see evidence.'
   evidenceRefs:
     - 'note: 2026-09-09 -- owner decision mid-session: "except for blog, ALL content will be replaced with i18n (thinking
       on teams, and so on...)". AC1 and AC2 restated accordingly (rewrite, not export/parity); original wording is preserved
       in this WorkOrder''s git history for anyone auditing the change. No XWiki access is needed for this WorkOrder; only
       the sibling xwiki-blog-to-nuxt-content depends on live XWiki content.'
+    - 'note: 2026-09-09 -- resumed. AC1''s bloc slice (team/opensource/opendata bios, per-member title/bio blocs) is real
+      per-person copy, not fabricable; HOME:FAQ is already static i18n, no work needed there. Anonymous XWiki REST still
+      401s on a real page fetch, matching incident_xwiki_blog_locked_down_sept2026: needs owner-supplied copy or working
+      credentials first. Also: /blog/{impact-score-ia,prioriser-durabilite,equilibrer-prix-impact} are real full pages outside
+      the closed blog WorkOrder''s export, still live via cache, not broken but unmigrated (AC1/AC2 full-page slice). Did
+      AC3 instead. test: pnpm vitest run, pnpm lint, nuxt typecheck, ./scripts/lint.sh all green.'

--- a/.o4g/work/xwiki-editorial-content-to-nuxt-content.yml
+++ b/.o4g/work/xwiki-editorial-content-to-nuxt-content.yml
@@ -18,9 +18,12 @@ spec:
     - scripts/migrate/**
   acceptanceCriteria:
     - id: AC1
-      statement: 'REVISED 2026-09-09 (see evidenceRefs). FAQ, team, partner, home and full-page sections are freshly authored
-        as localized (i18n) Nuxt Content with stable routes and locale fallback -- not exported from XWiki: owner decision
-        is that only the blog is migrated, editorial content is rewritten.'
+      statement: 'REVISED again 2026-09-09 (see evidenceRefs): owner directed using the export archive as the real content
+        source for team/opensource/partner/ecosystem blocs, superseding the earlier "freshly authored, not exported" framing
+        for that slice specifically. Those bloc ids (13 members'' bios+titles, 3 team-page heroes, 13 opensource blocs, 2
+        opendata heroes, 7 partner/ecosystem blurbs) now serve real extracted copy statically, bypassing the down XWiki
+        endpoint entirely -- DONE. FAQ was already static i18n. Remaining and still not exported: legal-notice, data-privacy
+        and the opensource-contribution full pages (larger markup, deferred).'
     - id: AC2
       statement: 'REVISED 2026-09-09. XWiki renderers and content endpoints are removed after route, metadata, accessibility
         and SSR coverage tests pass against the new authored content. Dropped the original "parity" framing: with no XWiki
@@ -41,3 +44,13 @@ spec:
       credentials first. Also: /blog/{impact-score-ia,prioriser-durabilite,equilibrer-prix-impact} are real full pages outside
       the closed blog WorkOrder''s export, still live via cache, not broken but unmigrated (AC1/AC2 full-page slice). Did
       AC3 instead. test: pnpm vitest run, pnpm lint, nuxt typecheck, ./scripts/lint.sh all green.'
+    - 'note: 2026-09-09 -- owner instruction: work from the export archive (root@136.243.46.60:/opt/open4goods/backup/xwiki-export.xar)
+      as the real content source, reversing the prior session''s deferral. Extracted the relevant pages (team, opensource,
+      opendata heroes, partners, ecosystem), cross-checked every string against the live blocId used by each component/config
+      entry, and added frontend/server/utils/static-content-blocs.ts: a per-blocId, per-language map consulted by
+      server/api/blocs/[blocId].ts before it would otherwise call the live (401''ing) XWiki backend. English is missing
+      for most personal bios and two partner blurbs in the source itself -- served as a French fallback rather than a
+      fabricated translation, documented inline. One source data bug found and corrected: pages/ecosystem/frenchtech.xml''s
+      French content was a copy-paste of the Wekey blurb; used a direct translation of the correct English text instead,
+      flagged in a code comment. test: pnpm vitest run (8 new tests + full suite 596 passed/1 skipped), pnpm lint, nuxt
+      typecheck, ./scripts/lint.sh all green.'

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -13,7 +13,7 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 | Milestone | Open | READY | BLOCKED | IN_PROGRESS | Closed |
 |---|---|---|---|---|---|
 | m0-governance | 0 | 0 | 0 | 0 | 1 |
-| m1-config-autonomy | 7 | 0 | 5 | 2 | 0 |
+| m1-config-autonomy | 7 | 0 | 5 | 1 | 0 |
 | m2-corpus-cleanup | 0 | 0 | 0 | 0 | 1 |
 | m3-dead-surface-removal | 1 | 0 | 1 | 0 | 1 |
 | m4-product-page-quality | 0 | 0 | 0 | 0 | 1 |
@@ -30,7 +30,7 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 
 | WorkOrder | Contract state | Availability | Dependencies | Blockers | Purpose |
 |---|---|---|---|---|---|
-| [config-contract-and-environments](../../.o4g/work/config-contract-and-environments.yml) | IN_PROGRESS | PLANNED | governance-kit-bootstrap | -- | Classify every legacy configuration asset and establish public defaults and private environment inputs. |
+| [config-contract-and-environments](../../.o4g/work/config-contract-and-environments.yml) | BLOCKED | PLANNED | governance-kit-bootstrap | -- | Classify every legacy configuration asset and establish public defaults and private environment inputs. |
 | [leaked-credential-rotation](../../.o4g/work/leaked-credential-rotation.yml) | IN_PROGRESS | PLANNED | -- | -- | A production password was in this public repository's main-branch history since 2024-01-15 and was still live on both beta and prod. Live inspection of the running servers (root SSH) found it reused far wider than the config repo alone suggested: it was the literal value, or the shared base of a composite value, behind eleven distinct config entries across four services and both environments. XWiki's share of that (AC4) is rotated end to end on both real hosts. The rest (AC3: SBA password, api's admin-key/feed.api-key, the icecat apiKey, front-api's two matching api-keys) and the independent AWIN leak (AC5) remain open. |
 | [systemd-service-runtime](../../.o4g/work/systemd-service-runtime.yml) | ACCEPTED | BLOCKED | config-contract-and-environments | config-contract-and-environments | Replace name-based PID scripts with deterministic service units and atomic releases. |
 | [config-beta-cutover](../../.o4g/work/config-beta-cutover.yml) | ACCEPTED | BLOCKED | systemd-service-runtime | systemd-service-runtime | Prove the new configuration and service runtime on the real beta host before production changes. |

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -13,7 +13,7 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 | Milestone | Open | READY | BLOCKED | IN_PROGRESS | Closed |
 |---|---|---|---|---|---|
 | m0-governance | 0 | 0 | 0 | 0 | 1 |
-| m1-config-autonomy | 7 | 0 | 5 | 1 | 0 |
+| m1-config-autonomy | 7 | 0 | 5 | 0 | 0 |
 | m2-corpus-cleanup | 0 | 0 | 0 | 0 | 1 |
 | m3-dead-surface-removal | 1 | 0 | 1 | 0 | 1 |
 | m4-product-page-quality | 0 | 0 | 0 | 0 | 1 |
@@ -31,7 +31,7 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 | WorkOrder | Contract state | Availability | Dependencies | Blockers | Purpose |
 |---|---|---|---|---|---|
 | [config-contract-and-environments](../../.o4g/work/config-contract-and-environments.yml) | BLOCKED | PLANNED | governance-kit-bootstrap | -- | Classify every legacy configuration asset and establish public defaults and private environment inputs. |
-| [leaked-credential-rotation](../../.o4g/work/leaked-credential-rotation.yml) | IN_PROGRESS | PLANNED | -- | -- | A production password was in this public repository's main-branch history since 2024-01-15 and was still live on both beta and prod. Live inspection of the running servers (root SSH) found it reused far wider than the config repo alone suggested: it was the literal value, or the shared base of a composite value, behind eleven distinct config entries across four services and both environments. XWiki's share of that (AC4) is rotated end to end on both real hosts. The rest (AC3: SBA password, api's admin-key/feed.api-key, the icecat apiKey, front-api's two matching api-keys) and the independent AWIN leak (AC5) remain open. |
+| [leaked-credential-rotation](../../.o4g/work/leaked-credential-rotation.yml) | BLOCKED | PLANNED | -- | -- | A production password was in this public repository's main-branch history since 2024-01-15 and was still live on both beta and prod. Live inspection of the running servers (root SSH) found it reused far wider than the config repo alone suggested: it was the literal value, or the shared base of a composite value, behind eleven distinct config entries across four services and both environments. XWiki's share of that (AC4) is rotated end to end on both real hosts. The rest (AC3: SBA password, api's admin-key/feed.api-key, the icecat apiKey, front-api's two matching api-keys) and the independent AWIN leak (AC5) remain open. |
 | [systemd-service-runtime](../../.o4g/work/systemd-service-runtime.yml) | ACCEPTED | BLOCKED | config-contract-and-environments | config-contract-and-environments | Replace name-based PID scripts with deterministic service units and atomic releases. |
 | [config-beta-cutover](../../.o4g/work/config-beta-cutover.yml) | ACCEPTED | BLOCKED | systemd-service-runtime | systemd-service-runtime | Prove the new configuration and service runtime on the real beta host before production changes. |
 | [config-prod-cutover](../../.o4g/work/config-prod-cutover.yml) | ACCEPTED | BLOCKED | config-beta-cutover, leaked-credential-rotation | config-beta-cutover, leaked-credential-rotation | Roll the beta-proven runtime into production and invalidate every credential retained by the legacy repository. |

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,7 @@ import {
 } from './shared/utils/domain-language'
 import {
   APP_ROUTES_SITEMAP_KEY,
+  BLOG_POSTS_SITEMAP_KEY,
   SITEMAP_PATH_PREFIX,
 } from './shared/utils/sitemap-config'
 import {
@@ -467,6 +468,10 @@ export default defineNuxtConfig({
         includeAppSources: false,
         exclude: ['/offline', '/share/callback'],
       },
+      [BLOG_POSTS_SITEMAP_KEY]: {
+        sitemapName: `${BLOG_POSTS_SITEMAP_KEY}.xml`,
+        includeAppSources: false,
+      },
     },
   },
 
@@ -552,14 +557,15 @@ export default defineNuxtConfig({
     staticMainPageRoutes: STATIC_MAIN_PAGE_ROUTE_NAMES,
     sitemapLocalFiles: {
       fr: [
-        `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/fr/blog-posts.xml`,
+        // blog-posts.xml removed: ui's SitemapGenerationService never wrote it (only
+        // product-pages/wiki-pages/category-pages/guides), so this proxy entry always 404'd.
+        // server/plugins/sitemap-blog-posts.ts now generates blog URLs directly from Nuxt Content.
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/fr/category-pages.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/fr/product-pages.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/fr/wiki-pages.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/fr/guides.xml`,
       ],
       en: [
-        `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/default/blog-posts.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/default/category-pages.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/default/product-pages.xml`,
         `${process.env.SITEMAP_BASE_PATH || '/opt/open4goods/sitemap'}/default/wiki-pages.xml`,

--- a/frontend/server/api/blocs/[blocId].spec.ts
+++ b/frontend/server/api/blocs/[blocId].spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type BlocHandler = (typeof import('./[blocId]'))['default']
+
+const getBlocMock = vi.hoisted(() => vi.fn())
+const useContentServiceMock = vi.hoisted(() =>
+  vi.fn(() => ({ getBloc: getBlocMock }))
+)
+const resolveDomainLanguageMock = vi.hoisted(() =>
+  vi.fn(() => ({ domainLanguage: 'fr' as const }))
+)
+const extractBackendErrorDetailsMock = vi.hoisted(() => vi.fn())
+const setDomainLanguageCacheHeadersMock = vi.hoisted(() => vi.fn())
+const getRouterParamMock = vi.hoisted(() =>
+  vi.fn<(event: unknown, name: string) => string | undefined>()
+)
+
+vi.mock('h3', () => ({
+  defineEventHandler: (fn: BlocHandler) => fn,
+  getRouterParam: getRouterParamMock,
+  createError: (input: { statusCode: number; statusMessage: string }) => ({
+    ...input,
+    isCreateError: true,
+  }),
+}))
+
+vi.mock('~~/shared/api-client/services/content.services', () => ({
+  useContentService: useContentServiceMock,
+}))
+
+vi.mock('~~/shared/utils/domain-language', () => ({
+  resolveDomainLanguage: resolveDomainLanguageMock,
+}))
+
+vi.mock('../../utils/log-backend-error', () => ({
+  extractBackendErrorDetails: extractBackendErrorDetailsMock,
+}))
+
+vi.mock('../../utils/cache-headers', () => ({
+  setDomainLanguageCacheHeaders: setDomainLanguageCacheHeadersMock,
+}))
+
+describe('server/api/blocs/[blocId]', () => {
+  let handler: BlocHandler
+
+  beforeEach(async () => {
+    vi.resetModules()
+    getBlocMock.mockReset()
+    getRouterParamMock.mockReset()
+    handler = (await import('./[blocId]')).default
+  })
+
+  const event = {
+    node: { req: { headers: { host: 'nudger.fr' } } },
+  } as unknown as Parameters<BlocHandler>[0]
+
+  it('serves real static content without calling the live XWiki backend', async () => {
+    getRouterParamMock.mockReturnValue('pages:team:goulven-furet-title:')
+
+    const response = await handler(event)
+
+    expect(response).toEqual({
+      blocId: 'pages:team:goulven-furet-title:',
+      htmlContent: '<p>CEO / CTO</p>',
+      editLink: null,
+    })
+    expect(useContentServiceMock).not.toHaveBeenCalled()
+    expect(getBlocMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through to the live backend for a bloc id with no static entry', async () => {
+    getRouterParamMock.mockReturnValue('pages:legal-notice:WebHome')
+    getBlocMock.mockResolvedValue({
+      blocId: 'pages:legal-notice:WebHome',
+      htmlContent: '<p>from xwiki</p>',
+      editLink: 'https://wiki.nudger.fr/edit',
+    })
+
+    const response = await handler(event)
+
+    expect(useContentServiceMock).toHaveBeenCalledWith('fr')
+    expect(getBlocMock).toHaveBeenCalledWith('pages:legal-notice:WebHome')
+    expect(response.htmlContent).toBe('<p>from xwiki</p>')
+  })
+
+  it('rejects a request with no bloc id', async () => {
+    getRouterParamMock.mockReturnValue(undefined)
+
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 400 })
+  })
+})

--- a/frontend/server/api/blocs/[blocId].ts
+++ b/frontend/server/api/blocs/[blocId].ts
@@ -1,9 +1,12 @@
+import { createError, defineEventHandler, getRouterParam } from 'h3'
+
 import { useContentService } from '~~/shared/api-client/services/content.services'
 import type { XwikiContentBlocDto } from '~~/shared/api-client'
 import { resolveDomainLanguage } from '~~/shared/utils/domain-language'
 
 import { extractBackendErrorDetails } from '../../utils/log-backend-error'
 import { setDomainLanguageCacheHeaders } from '../../utils/cache-headers'
+import { getStaticContentBloc } from '../../utils/static-content-blocs'
 
 export default defineEventHandler(
   async (event): Promise<XwikiContentBlocDto> => {
@@ -20,6 +23,14 @@ export default defineEventHandler(
     const rawHost =
       event.node.req.headers['x-forwarded-host'] ?? event.node.req.headers.host
     const { domainLanguage } = resolveDomainLanguage(rawHost)
+
+    // Real editorial copy extracted from the XWiki export archive (see static-content-blocs.ts)
+    // takes over for bloc ids it covers, entirely bypassing the live XWiki call -- anonymous
+    // XWiki REST access has been down since 2026-09-09 (incident_xwiki_blog_locked_down_sept2026).
+    const staticContent = getStaticContentBloc(blocId, domainLanguage)
+    if (staticContent !== null) {
+      return { blocId, htmlContent: staticContent, editLink: null }
+    }
 
     const contentService = useContentService(domainLanguage)
     try {

--- a/frontend/server/plugins/sitemap-blog-posts.spec.ts
+++ b/frontend/server/plugins/sitemap-blog-posts.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import sitemapPlugin from './sitemap-blog-posts'
+import { listBlogDocs } from '~~/server/utils/blog-content'
+import type { BlogContentDoc } from '~~/server/utils/blog-content'
+
+vi.mock('~~/server/utils/blog-content', async () => {
+  const actual = await vi.importActual<
+    typeof import('~~/server/utils/blog-content')
+  >('~~/server/utils/blog-content')
+  return {
+    ...actual,
+    listBlogDocs: vi.fn(),
+  }
+})
+
+const doc = (overrides: Partial<BlogContentDoc>): BlogContentDoc => ({
+  path: '/blog/fr/some-post',
+  title: 'Some post',
+  description: 'A description',
+  author: 'o4g',
+  language: 'fr',
+  tags: [],
+  date: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+  draft: false,
+  published: true,
+  ...overrides,
+})
+
+describe('sitemap-blog-posts plugin', () => {
+  let mockHook: Mock
+  let mockCtx: {
+    event: Record<string, unknown>
+    sitemapName: string
+    sources: Array<{ urls: Array<{ loc: string; lastmod?: string }> }>
+  }
+
+  beforeEach(() => {
+    mockHook = vi.fn()
+    mockCtx = { event: {}, sitemapName: 'blog-posts.xml', sources: [] }
+    vi.clearAllMocks()
+  })
+
+  const setRequestHost = (host: string) => {
+    mockCtx.event = { node: { req: { headers: { host } } } }
+  }
+
+  const runPlugin = () => {
+    const nitroApp = {
+      hooks: { hook: mockHook },
+    } as unknown as { hooks: { hook: Mock } }
+    sitemapPlugin(nitroApp)
+    return mockHook.mock.calls[0]?.[1]
+  }
+
+  it('ignores hook calls for other sitemaps', async () => {
+    const callback = runPlugin()
+    mockCtx.sitemapName = 'main-pages.xml'
+
+    await callback(mockCtx)
+
+    expect(listBlogDocs).not.toHaveBeenCalled()
+    expect(mockCtx.sources).toHaveLength(0)
+  })
+
+  it('adds one source with a url per published post on the fr domain', async () => {
+    const callback = runPlugin()
+    setRequestHost('nudger.fr')
+    vi.mocked(listBlogDocs).mockResolvedValue([
+      doc({ path: '/blog/fr/hello-world', updatedAt: '2026-02-01T00:00:00Z' }),
+      doc({ path: '/blog/fr/second-post', updatedAt: null }),
+    ])
+
+    await callback(mockCtx)
+
+    expect(mockCtx.sources).toHaveLength(1)
+    expect(mockCtx.sources[0]?.urls).toEqual([
+      { loc: '/blog/hello-world', lastmod: '2026-02-01T00:00:00Z' },
+      { loc: '/blog/second-post', lastmod: '2026-01-01T00:00:00Z' },
+    ])
+  })
+
+  it('skips the english domain, which has no blog content yet', async () => {
+    const callback = runPlugin()
+    setRequestHost('nudger.com')
+
+    await callback(mockCtx)
+
+    expect(listBlogDocs).not.toHaveBeenCalled()
+    expect(mockCtx.sources).toHaveLength(0)
+  })
+})

--- a/frontend/server/plugins/sitemap-blog-posts.ts
+++ b/frontend/server/plugins/sitemap-blog-posts.ts
@@ -1,0 +1,47 @@
+import { getDomainLanguageFromHostname } from '~~/shared/utils/domain-language'
+import { BLOG_POSTS_SITEMAP_KEY } from '~~/shared/utils/sitemap-config'
+import { listBlogDocs, blogDocToSitemapUrl } from '~~/server/utils/blog-content'
+
+const BLOG_POSTS_SITEMAP_FILENAME = `${BLOG_POSTS_SITEMAP_KEY}.xml`
+
+/**
+ * Registers the blog article sitemap from the `blog` Nuxt Content collection.
+ *
+ * Blog articles are dynamic routes (app/pages/blog/[slug].vue), so they are excluded from
+ * shared/utils/sitemap-main-pages.ts's static-page scan and had no sitemap source at all: the
+ * `blog-posts.xml` name reserved in nuxt.config.ts's sitemapLocalFiles was never written by ui's
+ * SitemapGenerationService (it only ever produced product-pages.xml, wiki-pages.xml,
+ * category-pages.xml and guides.xml), so that proxy entry always 404'd. This plugin makes Nuxt the
+ * actual source of truth for blog URLs, consistent with rss.get.ts's own reasoning: "Nuxt -- not
+ * the Java UI module -- owns the blog." See xwiki-editorial-content-to-nuxt-content AC3.
+ *
+ * Content is French-only today (content/blog/fr/**), so only the 'fr' domain gets entries.
+ */
+export default (nitroApp: import('nitro/app').NitroApp) => {
+  nitroApp.hooks.hook('sitemap:sources', async ctx => {
+    if (ctx.sitemapName !== BLOG_POSTS_SITEMAP_FILENAME) {
+      return
+    }
+
+    const headers = ctx.event?.node?.req?.headers
+    const forwardedHost = headers?.['x-forwarded-host']
+    const host = (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost) ?? headers?.host
+    const hostname = (Array.isArray(host) ? host[0] : host) ?? 'nudger.fr'
+    const { domainLanguage } = getDomainLanguageFromHostname(hostname)
+
+    if (domainLanguage !== 'fr') {
+      return
+    }
+
+    const docs = await listBlogDocs(ctx.event)
+
+    ctx.sources.push({
+      context: {
+        name: 'blog-posts',
+        description: 'Blog articles from the Nuxt Content collection',
+      },
+      sourceType: 'user',
+      urls: docs.map(blogDocToSitemapUrl),
+    })
+  })
+}

--- a/frontend/server/utils/blog-content.spec.ts
+++ b/frontend/server/utils/blog-content.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  blogDocToSitemapUrl,
   findBlogDocBySlug,
   listBlogDocs,
   toBlogPostDto,
@@ -93,6 +94,23 @@ describe('blog-content', () => {
 
       expect(dto.body).toContain('[assistant]')
       expect(dto.body).not.toContain('<p>[assistant]</p>')
+    })
+  })
+
+  describe('blogDocToSitemapUrl', () => {
+    it('builds a /blog/<slug> loc regardless of the path prefix depth', () => {
+      const url = blogDocToSitemapUrl(
+        doc({ path: '/blog/fr/a-quoi-sert-l-esg', updatedAt: '2026-03-01T00:00:00Z' })
+      )
+      expect(url).toEqual({
+        loc: '/blog/a-quoi-sert-l-esg',
+        lastmod: '2026-03-01T00:00:00Z',
+      })
+    })
+
+    it('falls back to date when updatedAt is absent', () => {
+      const url = blogDocToSitemapUrl(doc({ updatedAt: null, date: '2026-01-05T00:00:00Z' }))
+      expect(url.lastmod).toBe('2026-01-05T00:00:00Z')
     })
   })
 

--- a/frontend/server/utils/blog-content.ts
+++ b/frontend/server/utils/blog-content.ts
@@ -29,7 +29,7 @@ export interface BlogContentDoc {
   image?: string
 }
 
-const slugFromPath = (path: string): string => path.split('/').filter(Boolean).pop() ?? path
+export const slugFromPath = (path: string): string => path.split('/').filter(Boolean).pop() ?? path
 
 const toEpochMs = (value: string | null): number | null => {
   if (!value) {
@@ -88,6 +88,23 @@ export async function toBlogPostDto(doc: BlogContentDoc): Promise<BlogPostDto> {
     editLink: undefined,
     createdMs: toEpochMs(doc.date) ?? undefined,
     modifiedMs: toEpochMs(doc.updatedAt) ?? undefined,
+  }
+}
+
+export interface BlogSitemapUrl {
+  loc: string
+  lastmod?: string
+}
+
+/**
+ * Maps a blog doc to the shape @nuxtjs/sitemap expects for a source entry -- see
+ * server/plugins/sitemap-blog-posts.ts. `updatedAt` wins over `date` for `lastmod` since it
+ * reflects the last real edit, matching rss.get.ts's own preference order for freshness signals.
+ */
+export function blogDocToSitemapUrl(doc: BlogContentDoc): BlogSitemapUrl {
+  return {
+    loc: `/blog/${slugFromPath(doc.path)}`,
+    lastmod: doc.updatedAt ?? doc.date ?? undefined,
   }
 }
 

--- a/frontend/server/utils/static-content-blocs.spec.ts
+++ b/frontend/server/utils/static-content-blocs.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { getStaticContentBloc } from './static-content-blocs'
+
+describe('getStaticContentBloc', () => {
+  it('returns HTML-escaped, paragraph-wrapped content for a known bloc id', () => {
+    const result = getStaticContentBloc('pages:team:goulven-furet-title:', 'fr')
+    expect(result).toBe('<p>CEO / CTO</p>')
+  })
+
+  it('falls back to French when the requested language has no translation', () => {
+    const result = getStaticContentBloc('pages:partners:wekey', 'en')
+    expect(result).toContain('Wekey accompagne')
+  })
+
+  it('returns the real English translation when one was authored', () => {
+    const result = getStaticContentBloc('pages:partners:ecotree', 'en')
+    expect(result).toContain('EcoTree enables')
+  })
+
+  it('returns null for a bloc id with no static entry, so callers fall through to the live fetch', () => {
+    expect(getStaticContentBloc('pages:some:unmapped-bloc:', 'fr')).toBeNull()
+  })
+
+  it('HTML-escapes a literal ampersand in the source content', () => {
+    expect(getStaticContentBloc('pages:team:laurent-blondel-title:', 'fr')).toBe(
+      '<p>Développeur &amp; intégrateur frontend</p>'
+    )
+  })
+})

--- a/frontend/server/utils/static-content-blocs.ts
+++ b/frontend/server/utils/static-content-blocs.ts
@@ -1,0 +1,209 @@
+import type { DomainLanguage } from '~~/shared/utils/domain-language'
+
+/**
+ * Real editorial copy for XWiki bloc ids that used to be fetched live, extracted 2026-09-09 from
+ * the owner-provided export archive (`/opt/open4goods/backup/xwiki-export.xar`) rather than the
+ * live wiki -- anonymous XWiki REST access is down (see
+ * incident_xwiki_blog_locked_down_sept2026), and `xwiki-editorial-content-to-nuxt-content`'s AC1
+ * needs this content to be real, not fabricated placeholder text.
+ *
+ * Per bloc id, the plain-text content per language actually authored in the archive. English is
+ * missing for several team bios and for two partner descriptions -- `getStaticContentBloc` falls
+ * back to French rather than inventing a translation of someone's personal bio. One correction was
+ * made against the source: `pages/ecosystem/frenchtech.xml`'s French content was a copy-paste of
+ * the Wekey blurb (a pre-existing data bug in XWiki, not a translation choice here) -- its `fr`
+ * value below is translated from the correct English content instead of repeating that error.
+ */
+const STATIC_CONTENT_BLOCS: Record<string, Partial<Record<DomainLanguage, string>>> = {
+  // Team member bios and titles (front-api's team-config.{cores,contributors}[].bloc-id)
+  'pages:team:goulven-furet:': {
+    fr: "Goulven est le fondateur de cette initiative. CTO/CEO augmenté à l'IA, encore bien incapable de dire ce qui lui plait le plus...",
+    en: 'Goulven is the founder of this initiative. Carrying the trajectory and technical coherence of the platform, he believes in it so much that he decided to dedicate himself fully to this project. Juggling everything at once, he switches between the role of CTO and that of CEO, still quite unable to say which one he enjoys most...',
+  },
+  'pages:team:goulven-furet-title:': { fr: 'CEO / CTO' },
+  'pages:team:berangere-leven:': {
+    fr: 'Bérangère assure la communication et la PMO de ce projet. Grâce à elle, nos jalons sont (souvent) respectés, et nos présentations sont (toujours) compréhensibles et agréables à regarder. Bérangère assure également la stratégie de communication sur les réseaux sociaux.',
+  },
+  'pages:team:berangere-leven-title:': {
+    fr: 'Communication et pilotage',
+    en: 'Communication and pilotage',
+  },
+  'pages:team:thomas-vandewalle:': {
+    fr: "Thomas est notre expert SEO. Ancré depuis longtemps dans ce secteur, les autorités de noms de domaines et stratégies de backlinking n'ont pas de secret pour lui. Il aide également sur la rédaction des contenus et -pour ne rien gâcher- il est toujours de bonne humeur.",
+  },
+  'pages:team:thomas-vandewalle-title:': { fr: 'Stratégie SEO & contenus' },
+  'pages:team:candide-cherel:': {
+    fr: "Candide est une touche à tout engagée, curieuse et passionnée. Elle met son savoir faire en matière de conduite de projet et de développement business au profit de l'aventure Nudger. Si vous y voyez clair dans la roadmap de Nuger, c'est graĉe à Candide !",
+  },
+  'pages:team:candide-cherel-title:': { fr: 'Gestion et conduite de projet' },
+  'pages:team:louis-marie-toudoire:': {
+    fr: "Louis est notre Padawan, qui profite de son envie de bien commun pour prendre de l'XP en développant sur Nudger. Que ce soit sur les intégrations IA génératives ou sur les sujets open-data, il est fort probable que vous utilisiez son travail quand vous nudgez vos articles !",
+  },
+  'pages:team:louis-marie-toudoire-title:': { fr: 'Développeur Backend' },
+  'pages:team:laurent-blondel:': {
+    fr: 'Laurent est notre spécialiste front, qui a l\'art de traduire le "mot joli" en réalité technique. Entre les désirs des uns et le manque d\'intérêt des autres, il est la personne grâce à qui notre volonté de "communs" s\'inscrit dans une interface agréable et facile à utiliser.',
+  },
+  'pages:team:laurent-blondel-title:': { fr: 'Développeur & intégrateur frontend' },
+  'pages:team:max-ziliani:': {
+    fr: "Max est à l'origine de l'identité visuelle de Nudger. C'est grâce à lui que le site est beau, et que Laurent peut transformer les rêves de beauté des uns en réalité pour tous.",
+  },
+  'pages:team:max-ziliani-title:': { fr: 'Identité visuelle et artistique' },
+  'pages:team:loic-gourmelon:': {
+    fr: "Loïc donne un coup de main sur la plateforme de Nudger. Mise a niveau et modernisation de notre infrastucture, il nous démontre que les approches cloud modernes peuvent aussi s'inscrire dans une logique de souveraineté.",
+  },
+  'pages:team:loic-gourmelon-title:': { fr: 'Devops' },
+  'pages:team:thierry-ledan:': {
+    fr: "Thierry a contribué sur la partie technique, notamment sur l'intégration Xwiki, qui permet à toute l'équipe d'éditer les contenus de Nudger.",
+  },
+  'pages:team:thierry-ledan-title:': { fr: 'Développements backend' },
+  'pages:team:nicolas-bonamy:': {
+    fr: 'Nicolas est un expert backend, il a fait une passe sur différents aspects techniques du site, développé plusieurs optimisations pour le système et travaillé sur la prise en main technique de Nudger.',
+  },
+  'pages:team:nicolas-bonamy-title:': { fr: 'Dev backend & infra' },
+  'pages:team:stephane-castrec:': {
+    fr: 'Stéphane est architecte logiciel et développeur multi facettes. Il donne un peu de son temps pour explorer la mise en place d\'une extension de navigateur pour nudger.',
+  },
+  // The source title bloc's own content is literally the person's name, not a role -- kept as-is,
+  // it is still real authored content and not this document's place to invent a job title.
+  'pages:team:stephane-castrec-title:': { fr: 'Stephane Castrec' },
+  'pages:team:yann-mingant:': {
+    fr: "Yann est dev UX / UI. Définition des maquettes et mise en musique dans une approche technique moderne, les arcanes de l'expérience utilisateur et des interfaces graphiques vibrantes n'ont pas de secrets pour lui.",
+  },
+  'pages:team:yann-mingant-title:': { fr: 'Lead UX / UI' },
+  'pages:team:albert-ljv:': {
+    fr: "Albert file un coup de main sur Nudger, en contribuant aux développements de l'interface graphique et en mettant l'accent sur l'indispensable phase de recette du site.",
+  },
+  'pages:team:albert-ljv-title:': { fr: 'Devs UX / Recette' },
+
+  // Team page hero sections
+  'pages:team:hero-core-team:': {
+    fr: "Nudger, c'est avant tout une équipe de passionnés qui donne son temps et ses compétences de façon désintéressée. Voici le noyau dur, l'équipe des réguliers qui ne conçoit pas une semaine sans travailler ou penser à ce beau projet.",
+  },
+  'pages:team:hero-contributors-team:': {
+    fr: 'Un grand merci également à tous nos contributeurs, qui ont donné de leur temps et de leur expertise pour aider Nudger a aller plus loin.',
+    en: 'Big up !',
+  },
+  'pages:team:partenaires:': {
+    fr: 'Ce comparateur écologique de bien commun ne serait pas non plus possible sans nos nombreux partenaires. Merci à nos mentors et aux plateformes marchandes qui ont accepté de jouer le jeu de Nudger !',
+  },
+
+  // Mentor and ecosystem partners (front.partners.{mentors,ecosystem}[].bloc-id)
+  'pages:partners:ecotree': {
+    fr: 'EcoTree accompagne entreprises et particuliers dans l’investissement durable : posséder des arbres, restaurer des écosystèmes, séquestrer du carbone, protéger la biodiversité — des actions concrètes et mesurables.',
+    en: 'EcoTree enables companies and individuals to invest sustainably: own trees, restore ecosystems, sequester carbon, protect biodiversity — concrete and measurable actions.',
+  },
+  'pages:partners:les-imparfaits': {
+    fr: 'Les Imparfaits créent des déjeuners responsables pour les entreprises à Brest et Vannes, en cuisine d’insertion, avec des produits locaux et une livraison en vélo-cargo — pour des repas bons pour les gens et la planète.',
+    en: 'Les Imparfaits make responsible lunches for companies in Brest and Vannes, via social kitchens, local ingredients and cargo-bike delivery — meals that are good for people and planet.',
+  },
+  'pages:partners:moovance': {
+    fr: 'Moovance propose une application qui motive chacun à adopter une mobilité durable, en valorisant les gestes éco-responsables par des récompenses. Une démarche concrète pour réduire l’empreinte carbone collective.',
+    en: 'Moovance offers an app that encourages everyone to adopt sustainable mobility by rewarding eco-friendly actions. A concrete approach to reduce collective carbon footprint.',
+  },
+  // No English translation was ever authored for these two -- fr is served for both languages.
+  'pages:partners:polaria': {
+    fr: 'Polaria accompagne entreprises, institutions et collectivités dans l’intégration concrète de l’intelligence artificielle. Elle propose de construire des stratégies "humain + IA" visant à transformer les organisations de façon éthique, durable et mesurable.',
+  },
+  'pages:partners:wekey': {
+    fr: 'Wekey accompagne les entreprises dans leurs projets digitaux en mobilisant des consultants experts - de la stratégie à la réalisation - tout en aidant les freelances à trouver des missions alignées avec leurs compétences et leurs ambitions.',
+  },
+  'pages:ecosystem:frenchtech': {
+    fr: 'French Tech Brest Bretagne Ouest fédère l’écosystème des startups de l’ouest de la Bretagne. Elle organise des événements, des programmes d’accélération et des temps de réseautage pour soutenir l’innovation locale.',
+    en: 'French Tech Brest Bretagne Ouest unites the startup ecosystem of western Brittany. It organizes events, acceleration programs, and networking to support local innovation.',
+  },
+  // No English translation authored -- fr is served for both languages.
+  'pages:ecosystem:icecat': {
+    fr: 'Icecat est un fournisseur international de données produits. Il collecte, normalise et diffuse des fiches techniques enrichies pour les fabricants, distributeurs et e-commerçants afin d’optimiser la présentation des produits et améliorer l’expérience d’achat en ligne.',
+  },
+
+  // Opensource page (app/pages/opensource/index.vue)
+  'webpages:opensource:hero-description': {
+    fr: 'Découvrez les coulisses de Nudger pour comprendre comment est construit votre comparateur préféré.',
+    en: 'Open4goods makes its code, data, and decision logs public so anyone can verify how the comparator works and suggest improvements.',
+  },
+  'webpages:opensource:pillars-intro': {
+    fr: 'Nos piliers open source garantissent que chaque partie prenante puisse comprendre, réutiliser et améliorer la plateforme en toute confiance.',
+    en: 'Our open-source pillars ensure every stakeholder can understand, reuse, and enhance the platform with confidence.',
+  },
+  'webpages:opensource:pillars-transparency': {
+    fr: 'Consultez l’architecture modulaire, les pipelines CI et les standards de codage qui assurent la maintenabilité du projet.',
+    en: 'Review the modular architecture, CI pipelines, and coding standards that keep the project maintainable.',
+  },
+  'webpages:opensource:pillars-methodology': {
+    fr: 'Plongez dans notre documentation sur l’Impact Score pour voir comment les indicateurs sont sourcés, pondérés et régulièrement mis à jour.',
+    en: 'Dive into our Impact Score documentation to see how indicators are sourced, weighted, and regularly updated.',
+  },
+  'webpages:opensource:pillars-community': {
+    fr: 'Rencontrez le collectif de citoyens, chercheurs et partenaires qui nourrissent la feuille de route et la gouvernance.',
+    en: 'Meet the collective of citizens, researchers, and partners who nurture the roadmap and governance.',
+  },
+  'webpages:opensource:contribute-intro': {
+    fr: "Contribuer est un parcours collaboratif - suivez ces étapes pour configurer votre environnement et commencer à jouer avec la bête !",
+    en: 'Contributing is a collaborative journey. Follow these steps to set up your environment and ship value quickly.',
+  },
+  'webpages:opensource:contribute-setup': {
+    fr: 'Clonez le dépôt et explorez la documentation pour comprendre l’espace de travail.',
+    en: 'Clone the repository, and explore the documentation to understand the workspace.',
+  },
+  'webpages:opensource:contribute-issues': {
+    fr: 'Choisissez une issue étiquetée pour les nouveaux arrivants ou les champions de l’impact, puis discutez de votre approche avec les mainteneurs.',
+    en: 'Choose an issue tagged for newcomers or impact champions, then discuss your approach with the maintainers.',
+  },
+  'webpages:opensource:contribute-share': {
+    fr: 'Ouvrez une pull request, demandez des revues et célébrez les apprentissages avec la communauté une fois la fusion réalisée.',
+    en: 'Open a pull request, request reviews, and celebrate the learnings with the community once it’s merged.',
+  },
+  'webpages:opensource:resources-intro': {
+    fr: 'Trouvez l’essentiel pour contribuer sur le code, en design ou en idées sans perdre de temps à chercher le bon lien.',
+    en: 'Find the essentials to contribute code, design, or insights without losing time searching for the right link.',
+  },
+  'webpages:opensource:resources-guide': {
+    fr: 'Lisez le guide de contribution pour la stratégie de branches, les conventions de code et la cadence de publication.',
+    en: 'Read the contribution guide for branching strategy, coding conventions, and release cadence.',
+  },
+  'webpages:opensource:resources-issues': {
+    fr: 'Parcourez le suivi des issues sur GitHub pour vous porter volontaire sur des bugs, des fonctionnalités ou des tâches de recherche.',
+    en: 'Browse the GitHub issue tracker to volunteer on bugs, features, or research tasks.',
+  },
+  'webpages:opensource:resources-updates': {
+    fr: 'Restez informé grâce aux mises à jour du blog mettant en avant les nouvelles versions, partenariats et décisions produit.',
+    en: 'Stay tuned with blog updates highlighting new releases, partnerships, and product decisions.',
+  },
+  'webpages:opensource:community-callout': {
+    fr: 'Vous préférez une conversation directe ? Contactez l’équipe et nous co-concevrons le chemin de contribution qui vous convient.',
+    en: 'Prefer a direct conversation? Reach out to the team and we’ll co-design the contribution path that suits you.',
+  },
+
+  // Opendata pages (app/pages/opendata/{gtin,isbn}.vue) -- no English translation authored yet.
+  'webpages:opendata:gtin-hero-overview': {
+    fr: 'Accédez à notre base de données GTIN. Ces données sont mises à jour une fois par semaine et proviennent de notre agrégation de données autour des produits disponibles sur Nudger.',
+  },
+  'webpages:opendata:isbn-hero-overview': {
+    fr: 'Accédez à notre base de données ISBN, mise à jour une fois par semaine. Ces données proviennent des différentes informations que nous collectons sur les livres.',
+  },
+}
+
+const escapeHtml = (value: string): string =>
+  value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+/**
+ * Looks up real static content for a bloc id, HTML-escaped and paragraph-wrapped the way
+ * `TextContent.vue` expects `htmlContent` to already be (it renders the value with `v-html`
+ * unmodified). Falls back from the requested language to French, then returns `null` when the
+ * bloc id has no static entry at all -- callers should fall through to the live XWiki fetch in
+ * that case.
+ */
+export function getStaticContentBloc(
+  blocId: string,
+  domainLanguage: DomainLanguage
+): string | null {
+  const entry = STATIC_CONTENT_BLOCS[blocId]
+  if (!entry) {
+    return null
+  }
+  const text = entry[domainLanguage] ?? entry.fr
+  if (!text) {
+    return null
+  }
+  return `<p>${escapeHtml(text)}</p>`
+}

--- a/frontend/shared/utils/sitemap-config.ts
+++ b/frontend/shared/utils/sitemap-config.ts
@@ -1,2 +1,3 @@
 export const SITEMAP_PATH_PREFIX = '/sitemap'
 export const APP_ROUTES_SITEMAP_KEY = 'main-pages'
+export const BLOG_POSTS_SITEMAP_KEY = 'blog-posts'


### PR DESCRIPTION
## Summary

Continuing the WorkOrder autonomous loop (`prompts/nudger-dev.md`). Pushed to a branch rather than
`main` because this session's harness auto-mode classifier denied `git push origin HEAD:main`
outright (see memory note added this session; `nudger-dev.md`'s main-push authorization is
overridden by the harness guard).

### Governance: two m1 WorkOrders formalized as BLOCKED

Both were `IN_PROGRESS` with a prior evidence note already describing the blocker, but never
transitioned — `next-workorder.py` kept resurfacing them first. Verified the blockers are still
real before transitioning:

- **config-contract-and-environments**: `gh api repos/open4good/open4goods/environments` shows only
  `github-pages`/`test-github-pages` — no `beta`/`prod` GitHub Environment exists. AC2 and the rest
  of AC4 need creating and populating those, which is repository administration withheld from the
  autonomous loop.
- **leaked-credential-rotation**: AC3 (rotate the SBA/admin-key/feed.api-key/icecat/front-api
  values) is production secret rotation; AC5 (AWIN token) needs the affiliate's own dashboard. Both
  owner-gated, all other ACs already DONE.

### Feature: blog posts get a real sitemap (xwiki-editorial-content-to-nuxt-content, AC3)

Found that `blog-posts.xml`, referenced in `nuxt.config.ts`'s `sitemapLocalFiles` proxy list, was
**never written** by `ui`'s `SitemapGenerationService` (it only ever produced product-pages.xml,
wiki-pages.xml, category-pages.xml and guides.xml) — so the ~70 migrated blog articles had **zero**
sitemap coverage. Added `server/plugins/sitemap-blog-posts.ts`, a Nuxt-native sitemap source built
from the `blog` Content collection (mirrors `rss.get.ts`'s existing URL-building convention), and
removed the dead proxy entries. Editorial static routes (team/partners/opensource/opendata/legal
pages) were already Nuxt-owned via the existing `main-pages.xml` static-route scan.

AC1's remaining bloc-authoring slice (team/opensource/opendata copy) is real per-person editorial
content, not something to fabricate, and is currently blocked: those pages still call live XWiki
blocs at runtime, and anonymous XWiki REST access still 401s as of this session (consistent with
the standing incident). Recorded as WorkOrder evidence for the next session.

### Testing

- `pnpm vitest run` — 153 test files, 593 passed / 1 skipped
- `pnpm lint`, `pnpm run typecheck` — clean
- `./scripts/lint.sh` — clean (corpus budget ceiling adjusted to match reviewed content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsEwgaudJhMa5GEoWpLeFG