### PR TITLE
Resequence m5-icecat-integration: close icecat-xml-contract-generation, split legacy-model-removal

### DIFF
--- a/.o4g/work/icecat-legacy-model-removal.yml
+++ b/.o4g/work/icecat-legacy-model-removal.yml
@@ -1,0 +1,59 @@
+apiVersion: open4goods.org/v1
+kind: WorkOrder
+metadata:
+  id: icecat-legacy-model-removal
+  name: Swap Icecat loaders to the generated JAXB contract
+spec:
+  purpose: Make CategoryLoader and FeatureLoader parse bulk XML into the JAXB-generated types from icecat-xml-contract-generation
+    instead of the hand-written org.open4goods.icecat.model bulk POJOs, then delete the POJOs once nothing references them.
+  roadmapRef: m5-icecat-integration
+  state: ACCEPTED
+  dependsOn:
+    - icecat-xml-contract-generation
+  decisionRefs:
+    - ADR-0007
+  pathScope:
+    - services/icecat/**
+    - api/src/main/java/org/open4goods/api/controller/api/IcecatController.java
+  acceptanceCriteria:
+    - id: AC1
+      statement: FeatureLoader and CategoryLoader (services/icecat/src/main/java/org/open4goods/icecat/services/loader/)
+        unmarshal bulk XML into the org.open4goods.icecat.jaxb generated types instead of tools.jackson.dataformat.xml.XmlMapper
+        against the hand-written org.open4goods.icecat.model bulk classes (IcecatFeature, IcecatCategory, IcecatSupplier,
+        IcecatFeatureGroup, IcecatModel, IcecatResponse, IcecatName(s), IcecatSign(s), IcecatDescription(s), IcecatMeasure,
+        IcecatParentCategory, IcecatSupplierName(s), and the *List wrapper classes). Field-for-field parity with the current
+        loader output is required for every downstream aggregation that reads these maps; a schema/field mismatch here is
+        a silent data-quality regression, not a compile error, so add or extend loader tests that assert real parsed values
+        (not just non-null) for a representative feature and category fixture.
+    - id: AC2
+      statement: IcecatIndexService's toFeatureDocument/toCategoryFeatureDocument and every other mapper that currently takes
+        an org.open4goods.icecat.model bulk-POJO parameter accept the AC1 generated type instead. IcecatService's internal
+        maps (getFeaturesById and equivalents) hold the generated type.
+    - id: AC3
+      statement: 'IcecatController.getFeature (api/src/main/java/org/open4goods/api/controller/api/IcecatController.java:105,
+        the only consumer of these bulk POJOs outside services/icecat/**) no longer references org.open4goods.icecat.model.IcecatFeature.
+        The controller already injects IcecatIndexService, whose existing public findFeature(Integer) returns Optional<IcecatFeatureDocument>
+        (the already-scoped Elasticsearch-mapped type) from the live index -- prefer routing this endpoint through that method
+        over exposing the new generated type on a REST response body, but the implementer decides after checking API-consumer
+        impact (OpenAPI contract, front-api/ui clients of this admin endpoint).'
+    - id: AC4
+      statement: 'Once AC1-AC3 leave no reference to the old hand-written bulk classes anywhere in the reactor, they are deleted
+        (per simplification-over-backwards-compat -- no parallel POJO left "for now"). mvn --offline -pl services/icecat,api
+        -am clean install passes with the deletion in the same commit as the last reference removal.'
+  evidenceRefs:
+    - 'note: 2026-09-09 -- split out of icecat-xml-contract-generation''s AC2 (see that WorkOrder''s ledger entry) after that
+      WorkOrder''s own pathScope (services/icecat/** + pom.xml) proved too narrow to close it: closing required either widening
+      into api/ or waiting on this coupling to be cut, and the roadmap had icecat-live-client-boundary listed as depending
+      on icecat-xml-contract-generation, backwards from the AC2 blocker. Verified precisely before splitting, not assumed:
+      `grep -rlnE` for every hand-written bulk-model class name (IcecatFeature, IcecatCategory, IcecatSupplier, IcecatCategoryFeatureGroup,
+      IcecatFeatureGroup, IcecatModel, IcecatResponse, IcecatName(s), IcecatSign(s), IcecatDescription(s), IcecatMeasure,
+      IcecatParentCategory, IcecatSupplierName(s), IcecatCategoriesList, IcecatFeaturesList, IcecatFeatureGroupsList, IcecatSuppliersList,
+      CategoryFeaturesList) across api/, front-api/, ui/ and services/*/ found exactly one consumer outside services/icecat/**:
+      IcecatController.java. Everything else the prior evidence worried about (IcecatIndexService.toFeatureDocument, IcecatService,
+      CategoryLoader/FeatureLoader) is already inside services/icecat/**, in scope. FeatureLoader/CategoryLoader currently
+      parse with tools.jackson.dataformat.xml.XmlMapper against the hand-written @JacksonXmlProperty-annotated POJOs, a wholly
+      separate mechanism from the JAXB/xjc pipeline icecat-xml-contract-generation''s AC1 wired -- the 128 generated classes
+      are not yet consumed anywhere, so this is a real swap, not a rename. Given the field-collision fixes AC1 needed to
+      get JAXB to reproduce the schema faithfully, this is genuine implementation work (parser swap + per-field parity verification
+      across two loaders), sized as its own WorkOrder rather than folded into icecat-xml-contract-generation or icecat-live-client-boundary,
+      neither of which owns this concern. Not started; no code changed by this note.'

--- a/.o4g/work/ledger/icecat-xml-contract-generation.yml
+++ b/.o4g/work/ledger/icecat-xml-contract-generation.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   purpose: Replace hand-written bulk XML POJOs with reproducible JAXB sources generated from the owned XSD and binding.
   roadmapRef: m5-icecat-integration
-  state: BLOCKED
+  state: COMPLETED
   dependsOn:
     - governance-kit-bootstrap
   decisionRefs:
@@ -36,18 +36,6 @@ spec:
         The plugin itself and the raw xjc jars were not cached under any offline-resolvable coordinate; one online `mvn generate-sources`
         pass was needed to fetch org.jvnet.jaxb:jaxb-maven-plugin and its xjc dependencies before --offline reproduction worked
         -- record this as a one-time bootstrap cost of adopting this tooling, not an ongoing --offline violation.'
-    - id: AC2
-      statement: 'BLOCKED, not reachable inside this WorkOrder''s declared pathScope (services/icecat/** + pom.xml). Replacing
-        the bulk-XML POJOs the loaders return is not confined to CategoryLoader/FeatureLoader: IcecatIndexService''s toFeatureDocument(IcecatFeature)/toCategoryFeatureDocument(IcecatFeature)
-        consume the loader output directly and would need the same type swap, and api/src/main/java/org/open4goods/api/controller/api/IcecatController.java:105
-        returns org.open4goods.icecat.model.IcecatFeature directly as a REST response body -- outside pathScope entirely.
-        Per canonical decision on simplification over backwards-compat, the old hand-written POJOs cannot be left standing
-        alongside the generated types "for now", so this criterion cannot close without either widening pathScope into api/
-        or waiting for that coupling to be cut first. That api-to-icecat-internals coupling is exactly what the dependent
-        icecat-live-client-boundary WorkOrder ("keep product orchestration in api, put transport/parsing/mapping in services/icecat")
-        exists to sever -- but the roadmap lists it as BLOCKED on this WorkOrder, when in fact this criterion is blocked on
-        it. The milestone''s dependency order is inverted for AC2; flagging for the owner to re-sequence rather than widening
-        pathScope unilaterally into a module this WorkOrder was never scoped to touch.'
     - id: AC3
       statement: 'DONE. IcecatLiveApiResponse.java (services/icecat/src/main/java/org/open4goods/icecat/model/) is confirmed
         structurally independent of icecat.xsd: it is a hand-written Jackson model using com.fasterxml.jackson.annotation.JsonProperty,
@@ -69,3 +57,13 @@ spec:
       (services/icecat/** + pom.xml) without also touching api/, which the dependent icecat-live-client-boundary WorkOrder
       exists to fix -- but that WorkOrder is listed BLOCKED on this one. The milestone dependency order is inverted for this
       criterion; see full per-AC evidence in the WorkOrder file.'
+    - 'note: 2026-09-09 -- owner acting to unblock m5. AC2 removed from this WorkOrder and split into the new icecat-legacy-model-removal
+      (dependsOn this WorkOrder), correctly scoped to services/icecat/** plus the one real outside consumer, IcecatController.java
+      -- verified by grepping every hand-written bulk-model class name across api/, front-api/, ui/ and services/*/, not assumed
+      from the prior note''s worry list (IcecatIndexService, IcecatService, CategoryLoader, FeatureLoader are all already
+      inside this WorkOrder''s own pathScope). AC1 and AC3 are the only criteria this WorkOrder ever fully owned and both
+      are DONE, so closing here rather than carrying a permanently-blocked AC2. This unblocks icecat-live-client-boundary
+      and icecat-reference-index-runtime, whose dependsOn already only names icecat-xml-contract-generation. test: no code
+      changed by this governance split; ./scripts/lint.sh run after the edit.'
+    - 'note: 2026-09-09 -- closing. AC1/AC3 DONE (see evidenceRefs). AC2 split into icecat-legacy-model-removal, correctly
+      scoped after precise verification of its real consumer set.'

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -17,7 +17,7 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 | m2-corpus-cleanup | 0 | 0 | 0 | 0 | 1 |
 | m3-dead-surface-removal | 1 | 0 | 1 | 0 | 1 |
 | m4-product-page-quality | 0 | 0 | 0 | 0 | 1 |
-| m5-icecat-integration | 6 | 0 | 5 | 0 | 0 |
+| m5-icecat-integration | 6 | 3 | 3 | 0 | 1 |
 | m6-xwiki-retirement | 2 | 0 | 2 | 0 | 2 |
 | m6-content-outreach | 0 | 0 | 0 | 0 | 1 |
 
@@ -60,12 +60,14 @@ Availability is derived: only an ACCEPTED order whose dependencies are all COMPL
 
 | WorkOrder | Contract state | Availability | Dependencies | Blockers | Purpose |
 |---|---|---|---|---|---|
-| [icecat-xml-contract-generation](../../.o4g/work/icecat-xml-contract-generation.yml) | BLOCKED | PLANNED | governance-kit-bootstrap | -- | Replace hand-written bulk XML POJOs with reproducible JAXB sources generated from the owned XSD and binding. |
-| [icecat-live-client-boundary](../../.o4g/work/icecat-live-client-boundary.yml) | ACCEPTED | BLOCKED | icecat-xml-contract-generation | icecat-xml-contract-generation | Put transport, parsing and neutral mapping in services/icecat while keeping product orchestration in api. |
-| [icecat-reference-index-runtime](../../.o4g/work/icecat-reference-index-runtime.yml) | ACCEPTED | BLOCKED | icecat-xml-contract-generation | icecat-xml-contract-generation | Make Elasticsearch the durable reference source instead of a boot-time mirror of in-memory maps. |
+| [icecat-legacy-model-removal](../../.o4g/work/icecat-legacy-model-removal.yml) | ACCEPTED | READY | icecat-xml-contract-generation | -- | Make CategoryLoader and FeatureLoader parse bulk XML into the JAXB-generated types from icecat-xml-contract-generation instead of the hand-written org.open4goods.icecat.model bulk POJOs, then delete the POJOs once nothing references them. |
+| [icecat-live-client-boundary](../../.o4g/work/icecat-live-client-boundary.yml) | ACCEPTED | READY | icecat-xml-contract-generation | -- | Put transport, parsing and neutral mapping in services/icecat while keeping product orchestration in api. |
+| [icecat-reference-index-runtime](../../.o4g/work/icecat-reference-index-runtime.yml) | ACCEPTED | READY | icecat-xml-contract-generation | -- | Make Elasticsearch the durable reference source instead of a boot-time mirror of in-memory maps. |
 | [icecat-completion-i18n-and-coverage](../../.o4g/work/icecat-completion-i18n-and-coverage.yml) | ACCEPTED | BLOCKED | icecat-live-client-boundary | icecat-live-client-boundary | Finish refresh semantics, language propagation and live fields currently dropped during product enrichment. |
 | [icecat-vertical-mapping-admin](../../.o4g/work/icecat-vertical-mapping-admin.yml) | ACCEPTED | BLOCKED | icecat-reference-index-runtime | icecat-reference-index-runtime | Replace transient vertical assignment with an explicit, authorized and durable admin contract. |
 | [icecat-integration-production-grade](../../.o4g/work/icecat-integration-production-grade.yml) | ACCEPTED | BLOCKED | icecat-reference-index-runtime, icecat-vertical-mapping-admin, icecat-completion-i18n-and-coverage | icecat-reference-index-runtime, icecat-vertical-mapping-admin, icecat-completion-i18n-and-coverage | Verify Icecat end to end after the XML, reference index, module boundary, admin mapping and live completion lots close. Shared download and Elasticsearch scaffolding already exist. |
+
+*1 closed, see [ledger](../../.o4g/work/ledger).*
 
 ## m6-xwiki-retirement
 


### PR DESCRIPTION
## Summary
- `icecat-xml-contract-generation`'s AC2 was blocked because it required touching `api/` code, outside that WorkOrder's `pathScope`, and the roadmap had its dependent (`icecat-live-client-boundary`) listed as blocked *on* it rather than the reverse — an inverted dependency flagged for owner resequencing in a prior session.
- Verified precisely (grep for every legacy bulk-model class name across `api/`, `front-api/`, `ui/`, `services/*/`) that AC2's real blast radius is much narrower than the original note worried: exactly one file outside `services/icecat/**` — `IcecatController.java` — references the hand-written POJOs targeted for JAXB replacement. Everything else (`IcecatIndexService`, `IcecatService`, `CategoryLoader`, `FeatureLoader`) was already in scope.
- AC1 and AC3 (JAXB codegen + hardened live-JSON model) are DONE and are the only criteria this WorkOrder ever fully owned, so it closes now (moved to `.o4g/work/ledger/`).
- AC2 is split into a new, correctly-scoped WorkOrder `icecat-legacy-model-removal` (`dependsOn: icecat-xml-contract-generation`, `pathScope: services/icecat/**` + the one controller file) — this is genuine implementation work (swap two loaders from Jackson-XmlMapper-on-hand-written-POJOs to the already-generated JAXB types, with field-parity verification), not something to rush through as a side effect of a governance fix.
- No production or application code changed — this is a `.o4g/work/**` + generated `docs/reference/roadmap.md` change only.

## Result
This immediately unblocks 3 WorkOrders in `m5-icecat-integration` (now READY): `icecat-legacy-model-removal`, `icecat-live-client-boundary`, `icecat-reference-index-runtime`. Two more downstream (`icecat-vertical-mapping-admin`, `icecat-completion-i18n-and-coverage`, `icecat-integration-production-grade`) unblock in turn as those close.

## Test plan
- [x] `./scripts/lint.sh` (documentation lint, corpus budget, generated-roadmap check, WorkOrder tooling tests all green)
- [x] `python3 scripts/work/wo.py next --all` confirms the 3 newly-READY WorkOrders