### PR TITLE
config-contract-and-environments: record GitHub Environments, scope the AC2 mapping gap

### DIFF
--- a/.o4g/work/config-contract-and-environments.yml
+++ b/.o4g/work/config-contract-and-environments.yml
@@ -44,5 +44,24 @@ spec:
       scripts/verify/** and scripts/python/lint_suite.py (the check and its lint.sh wiring) and raised work_open_lines via
       check_corpus_budget.py --update, both in this commit.'
     - 'note: 2026-09-09 -- `gh api repos/open4good/open4goods/environments` shows only github-pages/test-github-pages: no
-      beta or prod Environment exists. AC2 and AC4''s remainder need creating and populating those, which is repository
-      administration withheld by prompts/nudger-dev.md. Formalized as BLOCKED so next-workorder.py stops resurfacing it.'
+      beta or prod Environment exists. AC2 and AC4''s remainder need creating and populating those, which is repository administration
+      withheld by prompts/nudger-dev.md. Formalized as BLOCKED so next-workorder.py stops resurfacing it.'
+    - 'note: 2026-09-09 -- owner acting to unblock: created both GitHub Environments (`gh api repos/open4good/open4goods/environments`
+      now lists `beta` and `prod`). Re-verified read-only, names only, no values touched: both are currently empty (`gh secret
+      list --env beta`/`--env prod`: zero entries). The org already holds 13 relevant Actions secrets (`gh api orgs/open4good/actions/secrets`):
+      API_URL, BETA_API_URL, BETA_HCAPTCHA_SITE_KEY, BETA_MACHINE_TOKEN, GEMINI_KEY, HCAPTCHA_SITE_KEY, MACHINE_TOKEN, PROJECT_PAT,
+      REMOTE_BETA_HOST, REMOTE_BETA_USER, REMOTE_HOST, REMOTE_USER, SSH_PRIVATE_KEY -- this is why repo-level `gh secret list`
+      showed only 5 unrelated OIDC/SSO entries even though ops/config/deployment-inputs.yml''s 8 inputs pass: they are org-inherited,
+      not repo-level. Creating the Environments was necessary but is not sufficient for AC2: the statement''s "nine legacy-only
+      secrets / five reused org secrets / four missing references" is a specific name-to-name mapping that was never actually
+      written down anywhere in this WorkOrder or legacy-config-inventory.md (that document explicitly defers it, "these deltas
+      are AC2 material... not resolved further here"). Real application-config secret keys needing an Environment home (from
+      the inventory''s key-level appendix) number well over nine once xwiki, Spring Boot Admin, Elasticsearch, Redis, datasource,
+      mail, OpenAI, admin-key, EPREL, Icecat, affiliation providers, Amazon, proxy, Vertex, front.security, captcha, GitHub
+      feedback-token and feed-provider keys are each counted -- deciding which of those collapse into one shared Environment
+      secret, which stay per-service, and which of the 13 org secrets above are the "five reused" is a naming/architecture
+      decision (ADR-0006 territory), not a classification exercise AC1 already finished. Did not invent that mapping unilaterally.
+      Left IN_PROGRESS -> BLOCKED again rather than COMPLETED: AC2 needs that mapping decided (owner or a dedicated session)
+      before any real value is entered, and AC4''s "cross-environment duplication" check is only meaningful once AC2 populates
+      something to check. No secret value was requested, displayed, or handled in this note.'
+    - 'see evidenceRefs: Environments created, AC2 mapping decision still needed, no secret values touched'


### PR DESCRIPTION
## Summary
- The owner created the `beta`/`prod` GitHub Environments this session (confirmed via `gh api repos/open4good/open4goods/environments`).
- Read-only, names-only verification (no secret values touched): both Environments are currently empty; the org already holds 13 relevant Actions secrets (SSH_PRIVATE_KEY, REMOTE_HOST/USER, REMOTE_BETA_HOST/USER, API_URL, BETA_API_URL, HCAPTCHA_SITE_KEY, BETA_HCAPTCHA_SITE_KEY, MACHINE_TOKEN, BETA_MACHINE_TOKEN, GEMINI_KEY, PROJECT_PAT) inherited at repo level.
- Creating the Environments is necessary but not sufficient for AC2: the WorkOrder's "nine legacy-only secrets / five reused org secrets / four missing references" is a specific name-to-name mapping that was never actually written down — `legacy-config-inventory.md` explicitly defers it. The real set of application-config secret keys needing an Environment home is well over nine once every service's credentials are counted; deciding which collapse into a shared Environment secret is an architecture decision (ADR-0006), not classification AC1 already finished.
- Did not invent that mapping unilaterally, and did not request, display or handle any secret value. WorkOrder stays BLOCKED with this evidence recorded rather than force-closed.

## Test plan
- [x] `./scripts/lint.sh` all green